### PR TITLE
fix(gemini): restore P0 mirror parity for reviews and licensing

### DIFF
--- a/LICENSE-APACHE-2.0
+++ b/LICENSE-APACHE-2.0
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1.  Definitions.
+
+    "License" shall mean the terms and conditions for use, reproduction,
+    and distribution as defined by Sections 1 through 9 of this document.
+
+    "Licensor" shall mean the copyright owner or entity authorized by
+    the copyright owner that is granting the License.
+
+    "Legal Entity" shall mean the union of the acting entity and all
+    other entities that control, are controlled by, or are under common
+    control with that entity. For the purposes of this definition,
+    "control" means (i) the power, direct or indirect, to cause the
+    direction or management of such entity, whether by contract or
+    otherwise, or (ii) ownership of fifty percent (50%) or more of the
+    outstanding shares, or (iii) beneficial ownership of such entity.
+
+    "You" (or "Your") shall mean an individual or Legal Entity
+    exercising permissions granted by this License.
+
+    "Source" form shall mean the preferred form for making modifications,
+    including but not limited to software source code, documentation
+    source, and configuration files.
+
+    "Object" form shall mean any form resulting from mechanical
+    transformation or translation of a Source form, including but
+    not limited to compiled object code, generated documentation,
+    and conversions to other media types.
+
+    "Work" shall mean the work of authorship, whether in Source or
+    Object form, made available under the License, as indicated by a
+    copyright notice that is included in or attached to the work
+    (an example is provided in the Appendix below).
+
+    "Derivative Works" shall mean any work, whether in Source or Object
+    form, that is based on (or derived from) the Work and for which the
+    editorial revisions, annotations, elaborations, or other modifications
+    represent, as a whole, an original work of authorship. For the purposes
+    of this License, Derivative Works shall not include works that remain
+    separable from, or merely link (or bind by name) to the interfaces of,
+    the Work and Derivative Works thereof.
+
+    "Contribution" shall mean any work of authorship, including
+    the original version of the Work and any modifications or additions
+    to that Work or Derivative Works thereof, that is intentionally
+    submitted to Licensor for inclusion in the Work by the copyright owner
+    or by an individual or Legal Entity authorized to submit on behalf of
+    the copyright owner. For the purposes of this definition, "submitted"
+    means any form of electronic, verbal, or written communication sent
+    to the Licensor or its representatives, including but not limited to
+    communication on electronic mailing lists, source code control systems,
+    and issue tracking systems that are managed by, or on behalf of, the
+    Licensor for the purpose of discussing and improving the Work, but
+    excluding communication that is conspicuously marked or otherwise
+    designated in writing by the copyright owner as "Not a Contribution."
+
+    "Contributor" shall mean Licensor and any individual or Legal Entity
+    on behalf of whom a Contribution has been received by Licensor and
+    subsequently incorporated within the Work.
+
+2.  Grant of Copyright License. Subject to the terms and conditions of
+    this License, each Contributor hereby grants to You a perpetual,
+    worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+    copyright license to reproduce, prepare Derivative Works of,
+    publicly display, publicly perform, sublicense, and distribute the
+    Work and such Derivative Works in Source or Object form.
+
+3.  Grant of Patent License. Subject to the terms and conditions of
+    this License, each Contributor hereby grants to You a perpetual,
+    worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+    (except as stated in this section) patent license to make, have made,
+    use, offer to sell, sell, import, and otherwise transfer the Work,
+    where such license applies only to those patent claims licensable
+    by such Contributor that are necessarily infringed by their
+    Contribution(s) alone or by combination of their Contribution(s)
+    with the Work to which such Contribution(s) was submitted. If You
+    institute patent litigation against any entity (including a
+    cross-claim or counterclaim in a lawsuit) alleging that the Work
+    or a Contribution incorporated within the Work constitutes direct
+    or contributory patent infringement, then any patent licenses
+    granted to You under this License for that Work shall terminate
+    as of the date such litigation is filed.
+
+4.  Redistribution. You may reproduce and distribute copies of the
+    Work or Derivative Works thereof in any medium, with or without
+    modifications, and in Source or Object form, provided that You
+    meet the following conditions:
+
+    (a) You must give any other recipients of the Work or
+    Derivative Works a copy of this License; and
+
+    (b) You must cause any modified files to carry prominent notices
+    stating that You changed the files; and
+
+    (c) You must retain, in the Source form of any Derivative Works
+    that You distribute, all copyright, patent, trademark, and
+    attribution notices from the Source form of the Work,
+    excluding those notices that do not pertain to any part of
+    the Derivative Works; and
+
+    (d) If the Work includes a "NOTICE" text file as part of its
+    distribution, then any Derivative Works that You distribute must
+    include a readable copy of the attribution notices contained
+    within such NOTICE file, excluding those notices that do not
+    pertain to any part of the Derivative Works, in at least one
+    of the following places: within a NOTICE text file distributed
+    as part of the Derivative Works; within the Source form or
+    documentation, if provided along with the Derivative Works; or,
+    within a display generated by the Derivative Works, if and
+    wherever such third-party notices normally appear. The contents
+    of the NOTICE file are for informational purposes only and
+    do not modify the License. You may add Your own attribution
+    notices within Derivative Works that You distribute, alongside
+    or as an addendum to the NOTICE text from the Work, provided
+    that such additional attribution notices cannot be construed
+    as modifying the License.
+
+    You may add Your own copyright statement to Your modifications and
+    may provide additional or different license terms and conditions
+    for use, reproduction, or distribution of Your modifications, or
+    for any such Derivative Works as a whole, provided Your use,
+    reproduction, and distribution of the Work otherwise complies with
+    the conditions stated in this License.
+
+5.  Submission of Contributions. Unless You explicitly state otherwise,
+    any Contribution intentionally submitted for inclusion in the Work
+    by You to the Licensor shall be under the terms and conditions of
+    this License, without any additional terms or conditions.
+    Notwithstanding the above, nothing herein shall supersede or modify
+    the terms of any separate license agreement you may have executed
+    with Licensor regarding such Contributions.
+
+6.  Trademarks. This License does not grant permission to use the trade
+    names, trademarks, service marks, or product names of the Licensor,
+    except as required for reasonable and customary use in describing the
+    origin of the Work and reproducing the content of the NOTICE file.
+
+7.  Disclaimer of Warranty. Unless required by applicable law or
+    agreed to in writing, Licensor provides the Work (and each
+    Contributor provides its Contributions) on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+    implied, including, without limitation, any warranties or conditions
+    of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+    PARTICULAR PURPOSE. You are solely responsible for determining the
+    appropriateness of using or redistributing the Work and assume any
+    risks associated with Your exercise of permissions under this License.
+
+8.  Limitation of Liability. In no event and under no legal theory,
+    whether in tort (including negligence), contract, or otherwise,
+    unless required by applicable law (such as deliberate and grossly
+    negligent acts) or agreed to in writing, shall any Contributor be
+    liable to You for damages, including any direct, indirect, special,
+    incidental, or consequential damages of any character arising as a
+    result of this License or out of the use or inability to use the
+    Work (including but not limited to damages for loss of goodwill,
+    work stoppage, computer failure or malfunction, or any and all
+    other commercial damages or losses), even if such Contributor
+    has been advised of the possibility of such damages.
+
+9.  Accepting Warranty or Additional Liability. While redistributing
+    the Work or Derivative Works thereof, You may choose to offer,
+    and charge a fee for, acceptance of support, warranty, indemnity,
+    or other liability obligations and/or rights consistent with this
+    License. However, in accepting such obligations, You may act only
+    on Your own behalf and on Your sole responsibility, not on behalf
+    of any other Contributor, and only if You agree to indemnify,
+    defend, and hold each Contributor harmless for any liability
+    incurred by, or claims asserted against, such Contributor by reason
+    of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,16 @@
+gemini-plugin-cc
+Copyright (c) 2026 arcobaleno64
+
+This product is a derivative work of openai/codex-plugin-cc
+(https://github.com/openai/codex-plugin-cc), Copyright 2026 OpenAI,
+licensed under the Apache License, Version 2.0.
+
+Portions of this software (its repository structure, runtime orchestration,
+command and skill contracts, and companion scripts) are adapted from that
+project and remain subject to the Apache License, Version 2.0; a copy is
+provided in LICENSE-APACHE-2.0. These files have been modified from the
+originals.
+
+Gemini/AGY-specific modifications and additions are
+Copyright (c) 2026 arcobaleno64 and are distributed under the MIT License
+(see LICENSE).

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [繁體中文說明 →](README.zh-TW.md)
 
-Mirrors the [openai-codex](https://github.com/openai/codex) skill architecture — same slash-command UX, same background job model, same skill contract — powered by the Gemini ecosystem instead of OpenAI.
+Ported from [openai/codex-plugin-cc](https://github.com/openai/codex-plugin-cc) (Apache-2.0) — same slash-command UX, same background job model, same skill contract — powered by the Gemini ecosystem instead of OpenAI.
 
 ---
 
@@ -215,4 +215,6 @@ See [CHANGELOG.md](plugins/gemini/CHANGELOG.md).
 
 ## License
 
-MIT © 2026
+MIT © 2026 arcobaleno64.
+
+This project is a derivative work of [openai/codex-plugin-cc](https://github.com/openai/codex-plugin-cc), Copyright 2026 OpenAI, licensed under the Apache License, Version 2.0. Adapted portions remain under Apache-2.0 (see [`LICENSE-APACHE-2.0`](LICENSE-APACHE-2.0) and [`NOTICE`](NOTICE)); Gemini/AGY-specific changes are MIT (see [`LICENSE`](LICENSE)).

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -2,7 +2,7 @@
 
 > 直接從 Claude Code 將任務與對抗性程式碼審查委派給 Google Gemini / AGY。
 
-本外掛鏡像 [openai-codex](https://github.com/openai/codex) 的技能架構——相同的斜線命令 UX、相同的背景工作模型、相同的技能合約——由 Gemini 生態系統驅動。
+本外掛移植自 [openai/codex-plugin-cc](https://github.com/openai/codex-plugin-cc)（Apache-2.0）的技能架構——相同的斜線命令 UX、相同的背景工作模型、相同的技能合約——由 Gemini 生態系統驅動。
 
 ---
 
@@ -213,4 +213,6 @@ Claude Code
 
 ## 授權
 
-MIT © 2026
+MIT © 2026 arcobaleno64。
+
+本專案為 [openai/codex-plugin-cc](https://github.com/openai/codex-plugin-cc)（Copyright 2026 OpenAI，Apache License 2.0）之衍生作品。沿用部分仍受 Apache-2.0 規範（見 [`LICENSE-APACHE-2.0`](LICENSE-APACHE-2.0) 與 [`NOTICE`](NOTICE)）；Gemini/AGY 專屬之變更採 MIT（見 [`LICENSE`](LICENSE)）。

--- a/plugins/gemini/NOTICE
+++ b/plugins/gemini/NOTICE
@@ -1,0 +1,16 @@
+gemini-plugin-cc
+Copyright (c) 2026 arcobaleno64
+
+This product is a derivative work of openai/codex-plugin-cc
+(https://github.com/openai/codex-plugin-cc), Copyright 2026 OpenAI,
+licensed under the Apache License, Version 2.0.
+
+Portions of this software (its repository structure, runtime orchestration,
+command and skill contracts, and companion scripts) are adapted from that
+project and remain subject to the Apache License, Version 2.0; a copy is
+provided in LICENSE-APACHE-2.0 at the repository root. These files have been
+modified from the originals.
+
+Gemini/AGY-specific modifications and additions are
+Copyright (c) 2026 arcobaleno64 and are distributed under the MIT License
+(see LICENSE).

--- a/plugins/gemini/commands/adversarial-review.md
+++ b/plugins/gemini/commands/adversarial-review.md
@@ -1,27 +1,66 @@
 ---
-description: Run an adversarial code review of recent git changes using Gemini/AGY
-argument-hint: '[--background|--wait] [--engine <agy|gemini>] [--model <flash|pro>] [--effort <low|medium|high>] [optional scope or focus]'
-context: fork
-allowed-tools: Bash(node:*), AskUserQuestion
+description: Run an adversarial Gemini code review that challenges the implementation approach and design choices
+argument-hint: '[--wait|--background] [--base <ref>] [--scope auto|working-tree|branch] [--engine <agy|gemini>] [--model <flash|pro>] [focus ...]'
+disable-model-invocation: true
+allowed-tools: Read, Glob, Grep, Bash(node:*), Bash(git:*), AskUserQuestion
 ---
 
-Route this request to the `gemini:gemini-rescue` subagent with adversarial-review framing.
+Run an adversarial Gemini review through the shared plugin runtime.
+Position it as a challenge review that questions the chosen implementation, design choices, tradeoffs, and assumptions.
+It is not just a stricter pass over implementation defects.
 
-Raw user request:
-$ARGUMENTS
+Raw slash-command arguments:
+`$ARGUMENTS`
 
-Execution mode:
+Core constraint:
+- This command is review-only.
+- Do not fix issues, apply patches, or suggest that you are about to make changes.
+- Your only job is to run the review and return Gemini's output verbatim to the user.
+- Keep the framing focused on whether the current approach is the right one, what assumptions it depends on, and where the design could fail under real-world conditions.
+- After presenting the review findings, STOP. You MUST explicitly ask the user which issues, if any, they want fixed before touching a single file.
 
-- If the request includes `--background`, run the `gemini:gemini-rescue` subagent in the background.
-- If the request includes `--wait`, run it in the foreground.
-- If neither flag is present, default to foreground.
+Execution mode rules:
+- If the raw arguments include `--wait`, do not ask. Run in the foreground.
+- If the raw arguments include `--background`, do not ask. Run in a Claude background task.
+- Otherwise, estimate the review size before asking:
+  - For working-tree review, start with `git status --short --untracked-files=all`.
+  - For working-tree review, also inspect both `git diff --shortstat --cached` and `git diff --shortstat`.
+  - For base-branch review, use `git diff --shortstat <base>...HEAD`.
+  - Treat untracked files or directories as reviewable work even when `git diff --shortstat` is empty.
+  - Only conclude there is nothing to review when the relevant scope is actually empty.
+  - Recommend waiting only when the scoped review is clearly tiny, roughly 1-2 files total and no sign of a broader directory-sized change.
+  - In every other case, including unclear size, recommend background.
+  - When in doubt, run the review instead of declaring that there is nothing to review.
+- Then use `AskUserQuestion` exactly once with two options, putting the recommended option first and suffixing its label with `(Recommended)`:
+  - `Wait for results`
+  - `Run in background`
 
-Operating rules:
+Argument handling:
+- Preserve the user's arguments exactly.
+- Do not strip `--wait` or `--background` yourself.
+- Do not weaken the adversarial framing or rewrite the user's focus text.
+- The companion script parses `--wait` and `--background`, but Claude Code's `Bash(..., run_in_background: true)` is what actually detaches the run.
+- `/gemini:adversarial-review` uses the same review target selection as `/gemini:review` (including `--base <ref>` and `--scope`).
+- Unlike `/gemini:review`, it can take extra focus text after the flags.
 
-- Forward the request to `gemini:gemini-rescue` with the instruction to run an adversarial review of the current git diff.
-- Pass `--model pro` by default unless the user specifies otherwise, because adversarial review benefits from deeper reasoning.
-- Tell the subagent to use the `adversarial-review` prompt template from `${CLAUDE_PLUGIN_ROOT}/prompts/adversarial-review.md` as the review framing.
-- Return the Gemini companion stdout verbatim to the user.
-- Do not paraphrase, summarize, rewrite, or add commentary before or after it.
-- After presenting review findings, STOP. Do not make any code changes. You MUST explicitly ask the user which issues, if any, they want fixed before touching a single file.
+Foreground flow:
+- Run:
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/scripts/gemini-companion.mjs" adversarial-review "$ARGUMENTS"
+```
+- Return the command stdout verbatim, exactly as-is.
+- Do not paraphrase, summarize, or add commentary before or after it.
+- Do not fix any issues mentioned in the review output.
 - If the helper reports that Gemini/AGY is missing or unauthenticated, stop and tell the user to run `/gemini:setup`.
+
+Background flow:
+- Launch the review with `Bash` in the background:
+```typescript
+Bash({
+  command: `node "${CLAUDE_PLUGIN_ROOT}/scripts/gemini-companion.mjs" adversarial-review "$ARGUMENTS"`,
+  description: "Gemini adversarial review",
+  run_in_background: true
+})
+```
+- Do not call `BashOutput` or wait for completion in this turn.
+- After launching the command, tell the user: "Gemini adversarial review started in the background. Check `/gemini:status` for progress."

--- a/plugins/gemini/commands/rescue.md
+++ b/plugins/gemini/commands/rescue.md
@@ -1,11 +1,11 @@
 ---
 description: Delegate investigation, an explicit fix request, or follow-up rescue work to the Gemini rescue subagent
 argument-hint: "[--background|--wait] [--resume|--fresh] [--engine <agy|gemini>] [--model <flash|pro|lite>] [--effort <none|minimal|low|medium|high|xhigh>] [what Gemini should investigate, solve, or continue]"
-context: fork
-allowed-tools: Bash(node:*), AskUserQuestion
+allowed-tools: Bash(node:*), AskUserQuestion, Agent
 ---
 
-Route this request to the `gemini:gemini-rescue` subagent.
+Invoke the `gemini:gemini-rescue` subagent via the `Agent` tool (`subagent_type: "gemini:gemini-rescue"`), forwarding the raw user request as the prompt.
+`gemini:gemini-rescue` is a subagent, not a skill — do not call `Skill(gemini:gemini-rescue)` (no such skill) or `Skill(gemini:rescue)` (that re-enters this command and hangs the session). The command runs inline so the `Agent` tool stays in scope; forked general-purpose subagents do not expose it.
 The final user-visible response must be Gemini's output verbatim.
 
 Raw user request:

--- a/plugins/gemini/commands/review.md
+++ b/plugins/gemini/commands/review.md
@@ -1,28 +1,64 @@
 ---
 description: Run a standard Gemini code review of recent git changes
-argument-hint: '[--background|--wait] [--engine <agy|gemini>] [--model <flash|pro>] [--base <ref>] [--scope <auto|working-tree|branch>]'
-context: fork
-allowed-tools: Bash(node:*), AskUserQuestion
+argument-hint: '[--wait|--background] [--base <ref>] [--scope auto|working-tree|branch] [--engine <agy|gemini>] [--model <flash|pro>]'
+disable-model-invocation: true
+allowed-tools: Read, Glob, Grep, Bash(node:*), Bash(git:*), AskUserQuestion
 ---
 
-Run a standard Gemini code review against the current git state.
+Run a standard Gemini code review against the current git state through the shared plugin runtime.
+It is a pragmatic reviewer that finds real bugs, missing error handling, and incomplete code paths.
 
-Raw user request:
-$ARGUMENTS
+Raw slash-command arguments:
+`$ARGUMENTS`
 
-Execution mode:
+Core constraint:
+- This command is review-only.
+- Do not fix issues, apply patches, or suggest that you are about to make changes.
+- Your only job is to run the review and return Gemini's output verbatim to the user.
+- After presenting the review findings, STOP. You MUST explicitly ask the user which issues, if any, they want fixed before touching a single file.
 
-- If the request includes `--background`, run in the background.
-- If the request includes `--wait`, run in the foreground.
-- If neither flag is present, default to foreground.
+Execution mode rules:
+- If the raw arguments include `--wait`, do not ask. Run the review in the foreground.
+- If the raw arguments include `--background`, do not ask. Run the review in a Claude background task.
+- Otherwise, estimate the review size before asking:
+  - For working-tree review, start with `git status --short --untracked-files=all`.
+  - For working-tree review, also inspect both `git diff --shortstat --cached` and `git diff --shortstat`.
+  - For base-branch review, use `git diff --shortstat <base>...HEAD`.
+  - Treat untracked files or directories as reviewable work even when `git diff --shortstat` is empty.
+  - Only conclude there is nothing to review when the relevant working-tree status is empty or the explicit branch diff is empty.
+  - Recommend waiting only when the review is clearly tiny, roughly 1-2 files total and no sign of a broader directory-sized change.
+  - In every other case, including unclear size, recommend background.
+  - When in doubt, run the review instead of declaring that there is nothing to review.
+- Then use `AskUserQuestion` exactly once with two options, putting the recommended option first and suffixing its label with `(Recommended)`:
+  - `Wait for results`
+  - `Run in background`
 
-Operating rules:
+Argument handling:
+- Preserve the user's arguments exactly.
+- Do not strip `--wait` or `--background` yourself.
+- Do not add extra review instructions or rewrite the user's intent.
+- The companion script parses `--wait` and `--background`, but Claude Code's `Bash(..., run_in_background: true)` is what actually detaches the run.
+- `/gemini:review` is native-review only. It does not take custom focus text.
+- For an adversarial review that challenges design decisions, use `/gemini:adversarial-review`.
 
-- Call `node "${CLAUDE_PLUGIN_ROOT}/scripts/gemini-companion.mjs" review "$ARGUMENTS"` via Bash.
-- Return the Gemini companion stdout verbatim to the user.
-- Do not paraphrase, summarize, rewrite, or add commentary before or after it.
-- After presenting review findings, STOP. Do not fix issues. You MUST explicitly ask the user which issues, if any, they want fixed before touching a single file.
+Foreground flow:
+- Run:
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/scripts/gemini-companion.mjs" review "$ARGUMENTS"
+```
+- Return the command stdout verbatim, exactly as-is.
+- Do not paraphrase, summarize, or add commentary before or after it.
+- Do not fix any issues mentioned in the review output.
 - If the helper reports that Gemini/AGY is missing or unauthenticated, stop and tell the user to run `/gemini:setup`.
 
-Note: `/gemini:review` is a pragmatic reviewer that finds real bugs, missing error handling, and incomplete code paths.
-For an adversarial review that challenges design decisions, use `/gemini:adversarial-review`.
+Background flow:
+- Launch the review with `Bash` in the background:
+```typescript
+Bash({
+  command: `node "${CLAUDE_PLUGIN_ROOT}/scripts/gemini-companion.mjs" review "$ARGUMENTS"`,
+  description: "Gemini review",
+  run_in_background: true
+})
+```
+- Do not call `BashOutput` or wait for completion in this turn.
+- After launching the command, tell the user: "Gemini review started in the background. Check `/gemini:status` for progress."

--- a/plugins/gemini/prompts/adversarial-review.md
+++ b/plugins/gemini/prompts/adversarial-review.md
@@ -52,13 +52,13 @@ Return ONLY a valid JSON object with exactly this shape — no markdown fences, 
   "summary": "<one terse ship/no-ship sentence>",
   "findings": [
     {
+      "severity": "critical" | "high" | "medium" | "low",
+      "title": "<short finding title>",
+      "body": "<what can go wrong, why this path is vulnerable, and the likely impact>",
       "file": "<relative path>",
       "line_start": <integer>,
       "line_end": <integer>,
       "confidence": <0.0–1.0>,
-      "what_can_go_wrong": "<string>",
-      "why_vulnerable": "<string>",
-      "likely_impact": "<string>",
       "recommendation": "<concrete actionable change>"
     }
   ],

--- a/plugins/gemini/prompts/review.md
+++ b/plugins/gemini/prompts/review.md
@@ -41,13 +41,13 @@ Return ONLY a valid JSON object with exactly this shape — no markdown fences, 
   "summary": "<one terse sentence>",
   "findings": [
     {
+      "severity": "critical" | "high" | "medium" | "low",
+      "title": "<short finding title>",
+      "body": "<what is wrong, where, and the likely impact>",
       "file": "<relative path>",
       "line_start": <integer>,
       "line_end": <integer>,
       "confidence": <0.0–1.0>,
-      "what_can_go_wrong": "<string>",
-      "why_vulnerable": "<string>",
-      "likely_impact": "<string>",
       "recommendation": "<concrete actionable change>"
     }
   ],

--- a/tests/commands.test.mjs
+++ b/tests/commands.test.mjs
@@ -55,3 +55,28 @@ test("review and adversarial-review use different prompt templates", () => {
   assert.match(adversarial, /adversarial-review/);
   assert.notEqual(review, adversarial);
 });
+
+// --- P0 mirror-parity regression guards ---
+
+test("rescue invokes the subagent via the Agent tool, not a fork", () => {
+  const source = readCommand("rescue.md");
+  assert.match(source, /allowed-tools:.*\bAgent\b/);
+  assert.match(source, /subagent_type:\s*"gemini:gemini-rescue"/);
+  assert.doesNotMatch(source, /context:\s*fork/);
+});
+
+test("review and adversarial-review are deterministic runners (no fork)", () => {
+  for (const name of ["review.md", "adversarial-review.md"]) {
+    const source = readCommand(name);
+    assert.match(source, /disable-model-invocation:\s*true/, `${name} must disable model invocation`);
+    assert.match(source, /Bash\(git:\*\)/, `${name} must allow git`);
+    assert.doesNotMatch(source, /context:\s*fork/, `${name} must not use context: fork`);
+  }
+});
+
+test("adversarial-review calls the companion adversarial-review subcommand directly", () => {
+  const source = readCommand("adversarial-review.md");
+  assert.match(source, /gemini-companion\.mjs"?\s+adversarial-review/);
+  // It must NOT route through the task-only rescue subagent.
+  assert.doesNotMatch(source, /gemini-rescue/);
+});

--- a/tests/license.test.mjs
+++ b/tests/license.test.mjs
@@ -1,0 +1,25 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = path.resolve(fileURLToPath(new URL("..", import.meta.url)));
+
+test("root NOTICE exists and attributes the upstream copyright", () => {
+  const notice = fs.readFileSync(path.join(ROOT, "NOTICE"), "utf8");
+  assert.match(notice, /Copyright 2026 OpenAI/);
+  assert.match(notice, /Apache License, Version 2\.0/);
+  assert.match(notice, /codex-plugin-cc/);
+});
+
+test("Apache-2.0 license text is bundled at the repo root", () => {
+  const apache = fs.readFileSync(path.join(ROOT, "LICENSE-APACHE-2.0"), "utf8");
+  assert.match(apache, /Apache License/);
+  assert.match(apache, /Version 2\.0/);
+});
+
+test("the distributed plugin subtree carries a NOTICE", () => {
+  const notice = fs.readFileSync(path.join(ROOT, "plugins", "gemini", "NOTICE"), "utf8");
+  assert.match(notice, /Copyright 2026 OpenAI/);
+});

--- a/tests/review-render.test.mjs
+++ b/tests/review-render.test.mjs
@@ -1,0 +1,75 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { renderReviewResult } from "../plugins/gemini/scripts/lib/render.mjs";
+
+const ROOT = path.resolve(fileURLToPath(new URL("..", import.meta.url)));
+const PROMPTS_DIR = path.join(ROOT, "plugins", "gemini", "prompts");
+
+function makeParsed(finding) {
+  return {
+    parsed: {
+      verdict: "needs-attention",
+      summary: "One issue found.",
+      findings: [finding],
+      next_steps: []
+    },
+    rawOutput: "{}",
+    parseError: null
+  };
+}
+
+const meta = { reviewLabel: "Review", targetLabel: "working tree" };
+
+test("renderReviewResult shows severity/title/body for schema-shaped findings", () => {
+  const out = renderReviewResult(
+    makeParsed({
+      severity: "high",
+      title: "Unvalidated input",
+      body: "User input flows into a shell command.",
+      file: "src/app.js",
+      line_start: 10,
+      line_end: 12,
+      confidence: 0.9,
+      recommendation: "Validate and escape input."
+    }),
+    meta
+  );
+  assert.match(out, /\[high\] Unvalidated input/);
+  assert.match(out, /User input flows into a shell command\./);
+  assert.match(out, /Validate and escape input\./);
+  assert.doesNotMatch(out, /No details provided/);
+});
+
+test("renderReviewResult degrades for the OLD what_can_go_wrong shape (contract lock)", () => {
+  const out = renderReviewResult(
+    makeParsed({
+      file: "src/app.js",
+      line_start: 10,
+      line_end: 12,
+      confidence: 0.9,
+      what_can_go_wrong: "x",
+      why_vulnerable: "y",
+      likely_impact: "z",
+      recommendation: "fix"
+    }),
+    meta
+  );
+  // The renderer reads severity/title/body; with the old keys those are absent,
+  // so it must fall back to placeholders. This locks prompt<->render alignment.
+  assert.match(out, /No details provided/);
+  assert.match(out, /\[low\] Finding 1/);
+});
+
+for (const name of ["review.md", "adversarial-review.md"]) {
+  test(`${name} output contract uses schema keys (severity/title/body)`, () => {
+    const src = fs.readFileSync(path.join(PROMPTS_DIR, name), "utf8");
+    assert.match(src, /"severity"/);
+    assert.match(src, /"title"/);
+    assert.match(src, /"body"/);
+    assert.doesNotMatch(src, /what_can_go_wrong/);
+  });
+}


### PR DESCRIPTION
## Summary

Fixes the four P0 issues found in a mirror-parity audit of this plugin against its
upstream `openai/codex-plugin-cc` (Apache-2.0). Two are runtime-breaking, two are
release/legal blockers. Scope is strictly P0 — no P1/P2/P3 changes, no version bump,
no CHANGELOG edit.

## Runtime-breaking fixes

- **Review output contract aligned (prompts ↔ renderer ↔ schema).** The review and
  adversarial-review prompt templates instructed the model to emit findings keyed
  `what_can_go_wrong` / `why_vulnerable` / `likely_impact`, but `lib/render.mjs`
  (`normalizeReviewFinding`) and `schemas/review-output.schema.json` expect
  `severity` / `title` / `body` / `file` / `line_start` / `line_end` / `confidence` /
  `recommendation`. Every finding therefore rendered as `[low] Finding N / "No details
  provided."` The prompt contracts now match the renderer and schema, so review
  findings render correctly.
- **`/gemini:rescue` routed through the `Agent` tool instead of `context: fork`.**
  A forked general-purpose subagent does not expose the `Agent` tool, so the command
  could not reliably invoke the `gemini:gemini-rescue` subagent. The command now runs
  inline with `Agent` in `allowed-tools` and invokes `subagent_type: "gemini:gemini-rescue"`,
  mirroring the upstream pattern.
- **`/gemini:review` and `/gemini:adversarial-review` are now deterministic companion
  runners.** Both used `context: fork` with a too-narrow tool set, and
  adversarial-review routed through the `task`-only rescue subagent (which is
  contractually forbidden from running reviews), so it never reached the companion's
  `adversarial-review` subcommand. Both now use `disable-model-invocation: true`,
  the full `Read, Glob, Grep, Bash(node:*), Bash(git:*), AskUserQuestion` tool set,
  the foreground/background size-estimation flow, and call
  `gemini-companion.mjs review` / `adversarial-review` directly.

## Release / legal / compliance fixes

- This project is a derivative of `openai/codex-plugin-cc` (Apache-2.0) but shipped
  pure MIT with no NOTICE. Added `LICENSE-APACHE-2.0`, a root `NOTICE`, and
  `plugins/gemini/NOTICE` that retain the upstream "Copyright 2026 OpenAI" attribution
  and state the modifications (Apache-2.0 §4(a)/(c)/(d)). Outbound license stays MIT
  (`LICENSE`, `package.json`, and `plugin.json` unchanged). README attribution links
  corrected from `openai/codex` to `openai/codex-plugin-cc`.

## Tests

- Added `tests/review-render.test.mjs` (renderer shows severity/title/body; contract
  lock that the old keys degrade), `tests/license.test.mjs` (NOTICE + Apache text
  present), and command-metadata regression guards in `tests/commands.test.mjs`.
- `npm test` → **17/17 passing**. `git show --check HEAD` clean.

## Out of scope (deliberately untouched)

P1/P2/P3 items remain for follow-up: model-alias cross-file mismatch (R3), npm
package name (R1), README security claims/install commands, package-lock version
drift, CI action pinning, and CHANGELOG/version bump.

> Note: the previous `--model pro` default-injection in `/gemini:adversarial-review`
> was intentionally dropped (the `--model` flag remains in the argument hint) to avoid
> depending on the unresolved R3 model-alias issue. The default model strategy will be
> revisited once R3 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
