### PR TITLE
fix(gemini): P1 batch — model aliases, parse robustness, docs/security, test coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,12 +148,12 @@ When enabled and the review returns `needs-attention`, Claude Code is blocked fr
 
 | Alias | Resolved Model | Notes |
 |---|---|---|
-| `flash` / `flash3` | `gemini-3.5-flash` | Latest stable Flash (GA) |
-| `pro` / `pro3` | `gemini-3.1-pro` | Gemini 3.1 Pro |
-| `flash25` | `gemini-2.5-flash` | Stable 2.5 Flash |
-| `pro25` | `gemini-2.5-pro` | Stable 2.5 Pro |
-| `lite` / `fast` | `gemini-2.5-flash-lite` | Cost-efficient |
-| `lite3` | `gemini-3.1-flash-lite` | Gemini 3.1 cost-efficient |
+| `flash` / `flash3` | `gemini-3-flash-preview` | Latest Gemini 3 Flash (preview) |
+| `pro` / `pro3` | `gemini-3.1-pro-preview` | Gemini 3.1 Pro (preview) |
+| `flash25` | `gemini-2.5-flash` | Stable 2.5 Flash (GA) |
+| `pro25` | `gemini-2.5-pro` | Stable 2.5 Pro (GA) |
+| `lite` / `fast` | `gemini-2.5-flash-lite` | Cost-efficient (GA) |
+| `lite3` | `gemini-3.1-flash-lite-preview` | Gemini 3.1 cost-efficient (preview) |
 
 ---
 
@@ -165,6 +165,8 @@ In `auto` mode the plugin selects the first available engine in this order:
 2. **`agy`** — fallback; note that AGY in non-interactive mode does not write to a pipe, so explicit `--engine agy` is required to use it.
 
 Override via `--engine` flag or the `GEMINI_ENGINE` environment variable.
+
+> `--model` and `--effort` apply to the **gemini** engine only. AGY selects its model and tier interactively, so the plugin ignores `--model`/`--effort` when `--engine agy` is active.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ Ported from [openai/codex-plugin-cc](https://github.com/openai/codex-plugin-cc) 
 ## Features
 
 - **`/gemini:rescue`** — Delegate investigation, debugging, or implementation tasks to Gemini. Runs in the foreground or detached in the background.
-- **`/gemini:adversarial-review`** — Adversarial code review over the current diff or branch. Returns structured findings with severity ratings.
+- **`/gemini:review`** — Standard (pragmatic) code review over the current diff or branch. Finds real bugs, missing error handling, and incomplete code paths.
+- **`/gemini:adversarial-review`** — Adversarial code review that challenges design decisions over the current diff or branch. Returns structured findings with severity ratings.
 - **`/gemini:setup`** — Check Gemini CLI / AGY availability and OAuth status.
 - **`/gemini:status`** — Inspect active and completed background jobs.
 - **`/gemini:result`** / **`/gemini:cancel`** — Retrieve or cancel a background job.
@@ -26,7 +27,7 @@ Ported from [openai/codex-plugin-cc](https://github.com/openai/codex-plugin-cc) 
 | Requirement | Version | Install |
 |---|---|---|
 | Node.js | ≥ 18 | [nodejs.org](https://nodejs.org) |
-| Gemini CLI | ≥ 0.40 | `npm install -g @google/generative-ai-cli` |
+| Gemini CLI | ≥ 0.40 | `npm install -g @google/gemini-cli` |
 | AGY _(optional)_ | ≥ 1.0 | `npm install -g agy` |
 | Claude Code | any | [claude.ai/code](https://claude.ai/code) |
 
@@ -41,10 +42,10 @@ Ported from [openai/codex-plugin-cc](https://github.com/openai/codex-plugin-cc) 
 /plugin marketplace add arcobaleno64/gemini-plugin-cc
 
 # 2. Install the plugin
-/plugin install arcobaleno64/gemini-plugin-cc
+/plugin install gemini@gemini-plugin-cc
 
 # 3. Reload plugins
-/plugins reload
+/reload-plugins
 ```
 
 Then run `/gemini:setup` — it will check whether Gemini CLI is ready. If Gemini is missing and npm is available, it will offer to install it for you.
@@ -91,6 +92,18 @@ Delegates a task to Gemini. Reads from stdin if no prompt is given.
 | `--engine <gemini\|agy\|auto>` | Override engine selection |
 | `--model <alias\|id>` | Model override (`flash`, `pro`, `lite`) |
 | `--effort <low\|medium\|high\|xhigh>` | Map effort level to a model |
+
+### `/gemini:review`
+
+Runs a standard, pragmatic review over the current working tree or branch diff — real bugs, missing error handling, and incomplete code paths. Not steerable and takes no focus text; use `/gemini:adversarial-review` to challenge a specific decision.
+
+| Flag | Description |
+|---|---|
+| `--wait` / `--background` | Run in the foreground or detached |
+| `--base <ref>` | Compare against a specific git ref |
+| `--scope <auto\|working-tree\|branch>` | Diff scope |
+| `--engine <gemini\|agy\|auto>` | Override engine |
+| `--model <alias\|id>` | Model override |
 
 ### `/gemini:adversarial-review [focus]`
 
@@ -172,9 +185,8 @@ Override via `--engine` flag or the `GEMINI_ENGINE` environment variable.
 
 ## Security
 
-- **Stdin delivery**: Prompts are never interpolated into shell command strings. They are passed to the Gemini CLI via `stdin` (using Node's `spawnSync` `input` option), which eliminates shell-injection risk regardless of prompt content.
-- **No secrets in code**: OAuth credentials live in `~/.gemini/oauth_creds.json` and are never read into process memory by this plugin.
-- **Token expiry detection**: `getGeminiLoginStatus()` parses the credential file and reports expired tokens before any invocation attempt.
+- **Stdin delivery (gemini engine)**: For the `gemini` engine, prompts are passed via `stdin` (Node's `spawnSync` `input` option) and never interpolated into a shell string, eliminating shell-injection risk regardless of prompt content. The `agy` engine has no stdin mode and receives the prompt as a CLI argument, so prefer the default `gemini` engine for untrusted input.
+- **Credential handling**: OAuth credentials in `~/.gemini/oauth_creds.json` are read only to check token expiry via `getGeminiLoginStatus()`; they are never logged, copied elsewhere, or transmitted by this plugin.
 - **`.gitignore`**: The `.omc/` state directory (job logs, session state) is excluded from version control.
 
 ---
@@ -189,7 +201,7 @@ Claude Code
             ├─ buildCliArgs()        → args (no prompt in args for gemini)
             ├─ runCommand()          → spawnSync, prompt via stdin
             │    shell: true (Win)   ← fixes Windows .cmd wrapper
-            │    input: prompt       ← fixes shell injection
+            │    input: prompt       ← gemini engine: prompt via stdin (no shell parsing)
             └─ renderTaskResult()   → Markdown output to Claude
 ```
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -146,12 +146,12 @@
 
 | 別名 | 對應模型 | 說明 |
 |---|---|---|
-| `flash` / `flash3` | `gemini-3.5-flash` | 最新穩定 Flash（GA） |
-| `pro` / `pro3` | `gemini-3.1-pro` | Gemini 3.1 Pro |
-| `flash25` | `gemini-2.5-flash` | 穩定 2.5 Flash |
-| `pro25` | `gemini-2.5-pro` | 穩定 2.5 Pro |
-| `lite` / `fast` | `gemini-2.5-flash-lite` | 高效低成本 |
-| `lite3` | `gemini-3.1-flash-lite` | Gemini 3.1 低成本版 |
+| `flash` / `flash3` | `gemini-3-flash-preview` | 最新 Gemini 3 Flash（preview） |
+| `pro` / `pro3` | `gemini-3.1-pro-preview` | Gemini 3.1 Pro（preview） |
+| `flash25` | `gemini-2.5-flash` | 穩定 2.5 Flash（GA） |
+| `pro25` | `gemini-2.5-pro` | 穩定 2.5 Pro（GA） |
+| `lite` / `fast` | `gemini-2.5-flash-lite` | 高效低成本（GA） |
+| `lite3` | `gemini-3.1-flash-lite-preview` | Gemini 3.1 低成本版（preview） |
 
 ---
 
@@ -163,6 +163,8 @@
 2. **`agy`** — 備援引擎；注意 AGY 在非互動模式下無法寫入 pipe，需明確使用 `--engine agy` 才能強制啟用。
 
 可透過 `--engine` 旗標或 `GEMINI_ENGINE` 環境變數覆蓋。
+
+> `--model` 與 `--effort` 僅適用於 **gemini** 引擎。AGY 之模型與分級由其互動選擇，故 `--engine agy` 時外掛會忽略 `--model`/`--effort`。
 
 ---
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -9,7 +9,8 @@
 ## 功能特色
 
 - **`/gemini:rescue`** — 將調查、除錯或實作任務委派給 Gemini。可在前景執行或以背景工作方式分離執行。
-- **`/gemini:adversarial-review`** — 對當前 diff 或分支執行對抗性程式碼審查，回傳含嚴重程度評級的結構化發現。
+- **`/gemini:review`** — 對當前 diff 或分支執行標準（務實）程式碼審查，找出真實 bug、缺漏之錯誤處理與未竟之程式路徑。
+- **`/gemini:adversarial-review`** — 對當前 diff 或分支執行對抗性程式碼審查，挑戰設計決策，回傳含嚴重程度評級的結構化發現。
 - **`/gemini:setup`** — 檢查 Gemini CLI / AGY 的可用性與 OAuth 狀態。
 - **`/gemini:status`** — 查看作用中與已完成的背景工作。
 - **`/gemini:result`** / **`/gemini:cancel`** — 取得或取消背景工作。
@@ -24,7 +25,7 @@
 | 項目 | 版本 | 安裝方式 |
 |---|---|---|
 | Node.js | ≥ 18 | [nodejs.org](https://nodejs.org) |
-| Gemini CLI | ≥ 0.40 | `npm install -g @google/generative-ai-cli` |
+| Gemini CLI | ≥ 0.40 | `npm install -g @google/gemini-cli` |
 | AGY _(選用)_ | ≥ 1.0 | `npm install -g agy` |
 | Claude Code | 任意版本 | [claude.ai/code](https://claude.ai/code) |
 
@@ -39,10 +40,10 @@
 /plugin marketplace add arcobaleno64/gemini-plugin-cc
 
 # 2. 安裝外掛
-/plugin install arcobaleno64/gemini-plugin-cc
+/plugin install gemini@gemini-plugin-cc
 
 # 3. 重新載入外掛
-/plugins reload
+/reload-plugins
 ```
 
 接著執行 `/gemini:setup`——若 Gemini CLI 尚未安裝且 npm 可用，指令會提供自動安裝選項。
@@ -89,6 +90,18 @@
 | `--engine <gemini\|agy\|auto>` | 覆蓋引擎選擇 |
 | `--model <別名\|ID>` | 指定模型（`flash`、`pro`、`lite`） |
 | `--effort <low\|medium\|high\|xhigh>` | 以努力等級對應模型選擇 |
+
+### `/gemini:review`
+
+對當前工作樹或分支 diff 執行標準、務實之審查——真實 bug、缺漏之錯誤處理、未竟之程式路徑。不可導向、不接受焦點文字；如需挑戰特定決策請用 `/gemini:adversarial-review`。
+
+| 旗標 | 說明 |
+|---|---|
+| `--wait` / `--background` | 前景或分離執行 |
+| `--base <ref>` | 與特定 git ref 比較 |
+| `--scope <auto\|working-tree\|branch>` | Diff 範圍 |
+| `--engine <gemini\|agy\|auto>` | 覆蓋引擎 |
+| `--model <別名\|ID>` | 指定模型 |
 
 ### `/gemini:adversarial-review [焦點]`
 
@@ -170,9 +183,8 @@
 
 ## 安全性
 
-- **Stdin 傳遞**：提示從不插入 shell 命令字串，而是透過 stdin（Node.js `spawnSync` 的 `input` 選項）傳遞給 Gemini CLI，無論提示內容為何都不存在 shell injection 風險。
-- **無 secrets 入碼**：OAuth 憑證保存於 `~/.gemini/oauth_creds.json`，本外掛從不將其讀入記憶體。
-- **Token 有效期偵測**：`getGeminiLoginStatus()` 解析憑證檔案並在任何呼叫前回報已過期的 token。
+- **Stdin 傳遞（gemini 引擎）**：`gemini` 引擎之提示透過 stdin（Node.js `spawnSync` 的 `input` 選項）傳遞、從不插入 shell 命令字串，故無論內容為何皆無 shell injection 風險。`agy` 引擎無 stdin 模式，提示以 CLI 引數傳入；處理不可信輸入時請優先使用預設之 `gemini` 引擎。
+- **憑證處理**：`~/.gemini/oauth_creds.json` 之 OAuth 憑證僅用於 `getGeminiLoginStatus()` 檢查 token 是否過期；本外掛從不記錄、複製或傳輸之。
 - **`.gitignore`**：`.omc/` 狀態目錄（工作日誌、會話狀態）已排除於版本控制之外。
 
 ---
@@ -187,7 +199,7 @@ Claude Code
             ├─ buildCliArgs()        → 引數（gemini 模式不含提示）
             ├─ runCommand()          → spawnSync，提示透過 stdin 傳入
             │    shell: true (Win)   ← 修復 Windows .cmd wrapper 問題
-            │    input: prompt       ← 修復 shell injection 風險
+            │    input: prompt       ← gemini 引擎：提示經 stdin（不經 shell 解析）
             └─ renderTaskResult()   → Markdown 輸出至 Claude
 ```
 

--- a/plugins/gemini/commands/setup.md
+++ b/plugins/gemini/commands/setup.md
@@ -1,7 +1,7 @@
 ---
 description: Check whether Gemini CLI / AGY is ready and optionally toggle the stop-time review gate
 argument-hint: '[--engine <agy|gemini>] [--enable-review-gate|--disable-review-gate]'
-allowed-tools: Bash(node:*), AskUserQuestion
+allowed-tools: Bash(node:*), Bash(npm:*), AskUserQuestion
 ---
 
 Run:
@@ -37,7 +37,7 @@ If Gemini CLI is unavailable and AGY is also unavailable:
 - If the user chooses install, run:
 
 ```bash
-npm install -g @google/generative-ai-cli
+npm install -g @google/gemini-cli
 ```
 
 - Then rerun:

--- a/plugins/gemini/scripts/gemini-companion.mjs
+++ b/plugins/gemini/scripts/gemini-companion.mjs
@@ -156,7 +156,7 @@ function buildSetupReport(cwd, actionsTaken = []) {
 
   const nextSteps = [];
   if (!geminiStatus.available && !agyStatus.available) {
-    nextSteps.push("Install gemini CLI: `npm install -g @google/generative-ai-cli` or install agy.");
+    nextSteps.push("Install gemini CLI: `npm install -g @google/gemini-cli` or install agy.");
   }
   if (geminiStatus.available && !geminiAuth.loggedIn) {
     nextSteps.push("Run `gemini` once to authenticate via OAuth.");

--- a/plugins/gemini/scripts/lib/engine.mjs
+++ b/plugins/gemini/scripts/lib/engine.mjs
@@ -5,18 +5,18 @@ import { binaryAvailable } from "./process.mjs";
 export const ENGINE_ENV = "GEMINI_ENGINE";
 
 export const MODEL_ALIASES = new Map([
-  // Gemini 3.x — current generation (May 2026)
-  ["flash", "gemini-3.5-flash"],    // latest stable Flash (GA)
-  ["flash3", "gemini-3.5-flash"],
-  ["pro", "gemini-3.1-pro"],        // Gemini 3.1 Pro (renamed from -preview)
-  ["pro3", "gemini-3.1-pro"],
-  // Gemini 2.5 — stable GA aliases for backward compatibility
+  // Gemini 3.x — current generation (preview channel; IDs verified against gemini CLI 0.44.1)
+  ["flash", "gemini-3-flash-preview"],
+  ["flash3", "gemini-3-flash-preview"],
+  ["pro", "gemini-3.1-pro-preview"],
+  ["pro3", "gemini-3.1-pro-preview"],
+  ["lite3", "gemini-3.1-flash-lite-preview"],
+  // Gemini 2.5 — stable GA aliases
   ["flash25", "gemini-2.5-flash"],
   ["pro25", "gemini-2.5-pro"],
-  // Cost-efficient options
+  // Cost-efficient (stable GA)
   ["lite", "gemini-2.5-flash-lite"],
   ["fast", "gemini-2.5-flash-lite"],
-  ["lite3", "gemini-3.1-flash-lite"],
 ]);
 
 export const VALID_EFFORT_LEVELS = new Set(["none", "minimal", "low", "medium", "high", "xhigh"]);
@@ -25,8 +25,8 @@ export function mapEffortToModel(effort) {
   if (!effort) return null;
   const e = String(effort).trim().toLowerCase();
   if (e === "none" || e === "minimal") return "gemini-2.5-flash-lite";
-  if (e === "low" || e === "medium") return "gemini-3.5-flash";
-  if (e === "high" || e === "xhigh") return "gemini-3.1-pro";
+  if (e === "low" || e === "medium") return "gemini-3-flash-preview";
+  if (e === "high" || e === "xhigh") return "gemini-3.1-pro-preview";
   return null;
 }
 

--- a/plugins/gemini/scripts/lib/gemini.mjs
+++ b/plugins/gemini/scripts/lib/gemini.mjs
@@ -28,13 +28,51 @@ function extractReasoningSummary(stderr) {
   return lines.slice(-5).join("\n");
 }
 
-function tryParseJsonFromText(text) {
-  // Try direct parse
-  try { return JSON.parse(text.trim()); } catch {}
-  // Try finding last {...} block
-  const match = text.match(/\{[\s\S]*\}(?=[^}]*$)/);
-  if (match) {
-    try { return JSON.parse(match[0]); } catch {}
+function stripControlChars(str) {
+  // Strip C0 control chars (keep tab/newline/CR). Some gemini CLI builds emit
+  // control tokens / thought markers around the JSON that break JSON.parse.
+  return String(str ?? "").replace(/[\x00-\x08\x0B\x0C\x0E-\x1F]/g, "");
+}
+
+function extractBalancedJsonObjects(text) {
+  const objects = [];
+  let depth = 0;
+  let start = -1;
+  let inStr = false;
+  let esc = false;
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+    if (inStr) {
+      if (esc) esc = false;
+      else if (ch === "\\") esc = true;
+      else if (ch === '"') inStr = false;
+      continue;
+    }
+    if (ch === '"') { inStr = true; continue; }
+    if (ch === "{") {
+      if (depth === 0) start = i;
+      depth++;
+    } else if (ch === "}" && depth > 0) {
+      depth--;
+      if (depth === 0 && start >= 0) {
+        objects.push(text.slice(start, i + 1));
+        start = -1;
+      }
+    }
+  }
+  return objects;
+}
+
+export function tryParseJsonFromText(text) {
+  const cleaned = stripControlChars(text);
+  // 1. Direct parse of the whole payload.
+  try { return JSON.parse(cleaned.trim()); } catch {}
+  // 2. Some CLI versions prepend a non-JSON preamble (e.g. `update_topic{...}`)
+  //    before the real object. Scan for balanced top-level {...} blocks and
+  //    return the LAST one that parses.
+  const candidates = extractBalancedJsonObjects(cleaned);
+  for (let i = candidates.length - 1; i >= 0; i--) {
+    try { return JSON.parse(candidates[i]); } catch {}
   }
   return null;
 }
@@ -47,16 +85,19 @@ export async function runGeminiTurn(cwd, options = {}) {
 
   const engineInfo = detectEngine(requestedEngine ?? null);
 
-  if (engineInfo.engine === "agy" && model) {
-    process.stderr.write(`[gemini-companion] Warning: --model is not supported by AGY engine; ignoring.\n`);
+  if (engineInfo.engine === "agy") {
+    // AGY selects its model and effort tier interactively; its non-interactive
+    // CLI exposes no --model/effort flag, so both are ignored here.
+    if (model || effort) {
+      process.stderr.write(`[gemini-companion] Note: AGY chooses its model and effort interactively; ignoring --model/--effort for the AGY engine.\n`);
+    }
     model = null;
+  } else {
+    if (!model && effort) {
+      model = mapEffortToModel(effort);
+    }
+    model = normalizeRequestedModel(model) ?? model;
   }
-
-  if (!model && effort) {
-    model = mapEffortToModel(effort);
-  }
-
-  model = normalizeRequestedModel(model) ?? model;
 
   // Gemini CLI reads from stdin to avoid shell injection on Windows (shell:true + args array)
   const useStdin = engineInfo.engine === "gemini";

--- a/plugins/gemini/skills/gemini-cli-runtime/SKILL.md
+++ b/plugins/gemini/skills/gemini-cli-runtime/SKILL.md
@@ -20,7 +20,7 @@ Execution rules:
 - That prompt drafting is the only Claude-side work allowed. Do not inspect the repo, solve the task yourself, or add independent analysis outside the forwarded prompt text.
 - Leave `--effort` unset unless the user explicitly requests a specific effort.
 - Leave model unset by default. Add `--model` only when the user explicitly asks for one.
-- Model aliases: `flash` → gemini-2.5-flash, `pro` → gemini-2.5-pro, `lite` → gemini-2.5-flash-lite.
+- Model aliases: `flash` → gemini-3-flash-preview, `pro` → gemini-3.1-pro-preview, `lite` → gemini-2.5-flash-lite.
 - Default to a write-capable run by adding `--write` unless the user explicitly asks for read-only behavior.
 
 Command selection:
@@ -34,10 +34,10 @@ Command selection:
 - `task --resume-last`: for "keep going", "resume", "apply the top fix", or "dig deeper".
 
 Engine routing:
-- Default engine: auto-detect (agy preferred, gemini fallback).
+- Default engine: auto-detect (gemini preferred, agy fallback).
 - Force AGY: add `--engine agy`.
 - Force Gemini CLI: add `--engine gemini`.
-- Note: `--model` is silently ignored when AGY engine is active.
+- Note: `--model` and `--effort` are ignored when the AGY engine is active; AGY selects its model and tier interactively.
 
 Safety rules:
 - Default to write-capable work in `gemini:gemini-rescue` unless the user explicitly asks for read-only behavior.

--- a/plugins/gemini/skills/gemini-prompting/SKILL.md
+++ b/plugins/gemini/skills/gemini-prompting/SKILL.md
@@ -25,9 +25,9 @@ Default prompt recipe:
 - `<grounding_rules>` or `<citation_rules>`: required for review, research, or anything that could drift into unsupported claims.
 
 Model selection guidance (`<model_selection>` block):
-- Debug or fix tasks → `--effort high` (→ gemini-2.5-pro)
-- Research or review tasks → `--effort medium` (→ gemini-2.5-flash)
-- Quick formatting or structure tasks → `--effort low` (→ gemini-2.5-flash)
+- Debug or fix tasks → `--effort high` (→ gemini-3.1-pro-preview)
+- Research or review tasks → `--effort medium` (→ gemini-3-flash-preview)
+- Quick formatting or structure tasks → `--effort low` (→ gemini-3-flash-preview)
 - AGY engine: `--model` is ignored; effort controls are irrelevant. Use AGY for speed and simplicity.
 
 When to add blocks:

--- a/tests/engine.test.mjs
+++ b/tests/engine.test.mjs
@@ -1,0 +1,47 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { MODEL_ALIASES, normalizeRequestedModel, mapEffortToModel } from "../plugins/gemini/scripts/lib/engine.mjs";
+
+// These two IDs return 404 ModelNotFound on the gemini CLI (verified 0.44.1).
+// No alias or effort tier may resolve to them.
+const DEAD_MODEL_IDS = ["gemini-3.5-flash", "gemini-3.1-pro"];
+
+test("model aliases resolve to verified-valid IDs", () => {
+  assert.equal(normalizeRequestedModel("flash"), "gemini-3-flash-preview");
+  assert.equal(normalizeRequestedModel("flash3"), "gemini-3-flash-preview");
+  assert.equal(normalizeRequestedModel("pro"), "gemini-3.1-pro-preview");
+  assert.equal(normalizeRequestedModel("pro3"), "gemini-3.1-pro-preview");
+  assert.equal(normalizeRequestedModel("lite3"), "gemini-3.1-flash-lite-preview");
+  assert.equal(normalizeRequestedModel("flash25"), "gemini-2.5-flash");
+  assert.equal(normalizeRequestedModel("pro25"), "gemini-2.5-pro");
+  assert.equal(normalizeRequestedModel("lite"), "gemini-2.5-flash-lite");
+  assert.equal(normalizeRequestedModel("fast"), "gemini-2.5-flash-lite");
+});
+
+test("no alias maps to a known-dead 404 model id", () => {
+  for (const [alias, id] of MODEL_ALIASES) {
+    assert.ok(!DEAD_MODEL_IDS.includes(id), `alias '${alias}' resolves to dead model '${id}'`);
+  }
+});
+
+test("effort tiers map to verified-valid IDs", () => {
+  assert.equal(mapEffortToModel("high"), "gemini-3.1-pro-preview");
+  assert.equal(mapEffortToModel("xhigh"), "gemini-3.1-pro-preview");
+  assert.equal(mapEffortToModel("medium"), "gemini-3-flash-preview");
+  assert.equal(mapEffortToModel("low"), "gemini-3-flash-preview");
+  assert.equal(mapEffortToModel("none"), "gemini-2.5-flash-lite");
+  assert.equal(mapEffortToModel("minimal"), "gemini-2.5-flash-lite");
+  assert.equal(mapEffortToModel(""), null);
+  assert.equal(mapEffortToModel(undefined), null);
+  for (const tier of ["none", "minimal", "low", "medium", "high", "xhigh"]) {
+    assert.ok(!DEAD_MODEL_IDS.includes(mapEffortToModel(tier)), `effort '${tier}' maps to a dead model`);
+  }
+});
+
+test("unknown / explicit model strings pass through unchanged", () => {
+  assert.equal(normalizeRequestedModel("gemini-2.5-pro"), "gemini-2.5-pro");
+  assert.equal(normalizeRequestedModel("some-custom-model"), "some-custom-model");
+  assert.equal(normalizeRequestedModel(null), null);
+  assert.equal(normalizeRequestedModel(""), null);
+});

--- a/tests/git.test.mjs
+++ b/tests/git.test.mjs
@@ -1,0 +1,91 @@
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { collectReviewContext, getWorkingTreeState, resolveReviewTarget } from "../plugins/gemini/scripts/lib/git.mjs";
+import { initGitRepo, makeTempDir, run } from "./helpers.mjs";
+
+function commitInitial(cwd) {
+  fs.writeFileSync(path.join(cwd, "app.js"), "console.log('v1');\n");
+  run("git", ["add", "app.js"], { cwd });
+  run("git", ["commit", "-m", "init"], { cwd });
+}
+
+test("resolveReviewTarget prefers the working tree when the repo is dirty", () => {
+  const cwd = makeTempDir();
+  initGitRepo(cwd);
+  commitInitial(cwd);
+  fs.writeFileSync(path.join(cwd, "app.js"), "console.log('v2');\n");
+
+  const target = resolveReviewTarget(cwd, {});
+  assert.equal(target.mode, "working-tree");
+});
+
+test("resolveReviewTarget falls back to a branch diff when the repo is clean", () => {
+  const cwd = makeTempDir();
+  initGitRepo(cwd);
+  commitInitial(cwd);
+  run("git", ["checkout", "-b", "feature/test"], { cwd });
+  fs.writeFileSync(path.join(cwd, "app.js"), "console.log('v2');\n");
+  run("git", ["add", "app.js"], { cwd });
+  run("git", ["commit", "-m", "change"], { cwd });
+
+  const target = resolveReviewTarget(cwd, {});
+  const context = collectReviewContext(cwd, target);
+
+  assert.equal(target.mode, "branch");
+  assert.match(target.label, /main/);
+  assert.match(context.content, /## Branch Diff/);
+  assert.match(context.content, /## Commit Log/);
+});
+
+test("resolveReviewTarget honors an explicit base override", () => {
+  const cwd = makeTempDir();
+  initGitRepo(cwd);
+  commitInitial(cwd);
+
+  const target = resolveReviewTarget(cwd, { base: "main" });
+  assert.equal(target.mode, "branch");
+  assert.equal(target.baseRef, "main");
+  assert.equal(target.explicit, true);
+});
+
+test("resolveReviewTarget throws when no default branch can be inferred", () => {
+  const cwd = makeTempDir();
+  initGitRepo(cwd);
+  commitInitial(cwd);
+  run("git", ["branch", "-m", "feature-only"], { cwd });
+
+  assert.throws(
+    () => resolveReviewTarget(cwd, {}),
+    /Unable to detect the repository default branch\. Pass --base <ref> or use --scope working-tree\./
+  );
+});
+
+test("collectReviewContext includes untracked file content in a working-tree review", () => {
+  const cwd = makeTempDir();
+  initGitRepo(cwd);
+  commitInitial(cwd);
+  fs.writeFileSync(path.join(cwd, "new-risk.js"), "const secret = 'UNTRACKED_MARKER';\n");
+
+  const target = resolveReviewTarget(cwd, { scope: "working-tree" });
+  const context = collectReviewContext(cwd, target);
+
+  assert.equal(context.mode, "working-tree");
+  assert.match(context.content, /## Untracked Files/);
+  assert.match(context.content, /UNTRACKED_MARKER/);
+});
+
+test("getWorkingTreeState reflects staged, unstaged, and untracked files", () => {
+  const cwd = makeTempDir();
+  initGitRepo(cwd);
+  commitInitial(cwd);
+  fs.writeFileSync(path.join(cwd, "app.js"), "console.log('v2');\n");
+  fs.writeFileSync(path.join(cwd, "untracked.js"), "console.log('new');\n");
+
+  const state = getWorkingTreeState(cwd);
+  assert.equal(state.isDirty, true);
+  assert.ok(state.unstaged.includes("app.js"));
+  assert.ok(state.untracked.includes("untracked.js"));
+});

--- a/tests/helpers.mjs
+++ b/tests/helpers.mjs
@@ -1,0 +1,28 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
+import { spawnSync } from "node:child_process";
+
+export function makeTempDir(prefix = "gemini-plugin-test-") {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+export function run(command, args, options = {}) {
+  return spawnSync(command, args, {
+    cwd: options.cwd,
+    env: options.env,
+    encoding: "utf8",
+    input: options.input,
+    shell: process.platform === "win32" && !path.isAbsolute(command),
+    windowsHide: true
+  });
+}
+
+export function initGitRepo(cwd) {
+  run("git", ["init", "-b", "main"], { cwd });
+  run("git", ["config", "user.name", "Gemini Plugin Tests"], { cwd });
+  run("git", ["config", "user.email", "tests@example.com"], { cwd });
+  run("git", ["config", "commit.gpgsign", "false"], { cwd });
+  run("git", ["config", "tag.gpgsign", "false"], { cwd });
+}

--- a/tests/parse-robustness.test.mjs
+++ b/tests/parse-robustness.test.mjs
@@ -1,0 +1,40 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { tryParseJsonFromText } from "../plugins/gemini/scripts/lib/gemini.mjs";
+
+test("parses a clean JSON payload", () => {
+  const obj = tryParseJsonFromText('{"verdict":"approve","summary":"s","findings":[],"next_steps":[]}');
+  assert.equal(obj.verdict, "approve");
+});
+
+test("recovers the real JSON after a non-JSON preamble and control chars", () => {
+  // Mirrors the observed gemini 0.44.1 pollution: control tokens + an
+  // `update_topic{...}` block emitted before the actual review JSON.
+  const polluted =
+    "\x1b\x1b\x1bupdate_topic{strategic_intent:Review the diff,summary:The user provided context}" +
+    '\n{"verdict":"needs-attention","summary":"x",' +
+    '"findings":[{"severity":"high","title":"t","body":"b","file":"f","line_start":1,"line_end":2,"confidence":0.9,"recommendation":"r"}],' +
+    '"next_steps":[]}';
+  const obj = tryParseJsonFromText(polluted);
+  assert.ok(obj, "should recover the trailing JSON object");
+  assert.equal(obj.verdict, "needs-attention");
+  assert.equal(obj.findings[0].severity, "high");
+  assert.equal(obj.findings[0].title, "t");
+});
+
+test("returns the LAST balanced JSON object when several appear", () => {
+  const obj = tryParseJsonFromText('{"a":1} some noise {"b":2}');
+  assert.equal(obj.b, 2);
+});
+
+test("ignores braces inside JSON strings", () => {
+  const obj = tryParseJsonFromText('prefix {"summary":"has } and { braces","verdict":"approve"} suffix');
+  assert.equal(obj.verdict, "approve");
+  assert.equal(obj.summary, "has } and { braces");
+});
+
+test("returns null when no JSON object is present", () => {
+  assert.equal(tryParseJsonFromText("no json here"), null);
+  assert.equal(tryParseJsonFromText(""), null);
+});

--- a/tests/process.test.mjs
+++ b/tests/process.test.mjs
@@ -1,0 +1,92 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import process from "node:process";
+
+import {
+  terminateProcessTree,
+  binaryAvailable,
+  formatCommandFailure
+} from "../plugins/gemini/scripts/lib/process.mjs";
+
+test("terminateProcessTree uses taskkill on Windows", () => {
+  let captured = null;
+  const outcome = terminateProcessTree(1234, {
+    platform: "win32",
+    runCommandImpl(command, args) {
+      captured = { command, args };
+      return { command, args, status: 0, signal: null, stdout: "", stderr: "", error: null };
+    },
+    killImpl() {
+      throw new Error("kill fallback should not run");
+    }
+  });
+
+  assert.deepEqual(captured, { command: "taskkill", args: ["/PID", "1234", "/T", "/F"] });
+  assert.equal(outcome.delivered, true);
+  assert.equal(outcome.method, "taskkill");
+});
+
+test("terminateProcessTree treats a missing Windows process as already stopped", () => {
+  const outcome = terminateProcessTree(1234, {
+    platform: "win32",
+    runCommandImpl(command, args) {
+      return {
+        command,
+        args,
+        status: 128,
+        signal: null,
+        stdout: 'ERROR: The process "1234" not found.',
+        stderr: "",
+        error: null
+      };
+    }
+  });
+
+  assert.equal(outcome.attempted, true);
+  assert.equal(outcome.delivered, false);
+  assert.equal(outcome.method, "taskkill");
+});
+
+test("terminateProcessTree skips a non-finite pid", () => {
+  const outcome = terminateProcessTree(Number.NaN);
+  assert.equal(outcome.attempted, false);
+  assert.equal(outcome.delivered, false);
+  assert.equal(outcome.method, null);
+});
+
+test("terminateProcessTree signals the process group on POSIX", () => {
+  const signals = [];
+  const outcome = terminateProcessTree(4321, {
+    platform: "linux",
+    killImpl(pid, signal) {
+      signals.push({ pid, signal });
+    }
+  });
+  assert.deepEqual(signals, [{ pid: -4321, signal: "SIGTERM" }]);
+  assert.equal(outcome.method, "process-group");
+  assert.equal(outcome.delivered, true);
+});
+
+test("binaryAvailable detects an available binary", () => {
+  // Use a bare command resolved via PATH (how the plugin invokes gemini/agy);
+  // an absolute path with spaces would break under runCommand's win32 shell:true.
+  const result = binaryAvailable("git", ["--version"]);
+  assert.equal(result.available, true);
+  assert.match(result.detail, /\d+\.\d+/);
+});
+
+test("binaryAvailable reports an unavailable binary", () => {
+  const result = binaryAvailable("definitely-not-a-real-binary-xyz-123", ["--version"]);
+  assert.equal(result.available, false);
+});
+
+test("formatCommandFailure formats exit-code and signal failures", () => {
+  assert.equal(
+    formatCommandFailure({ command: "git", args: ["status"], status: 1, signal: null, stderr: "boom", stdout: "" }),
+    "git status: exit=1: boom"
+  );
+  assert.equal(
+    formatCommandFailure({ command: "node", args: [], status: null, signal: "SIGKILL", stderr: "", stdout: "" }),
+    "node: signal=SIGKILL"
+  );
+});

--- a/tests/render.test.mjs
+++ b/tests/render.test.mjs
@@ -1,0 +1,115 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  renderSetupReport,
+  renderStatusReport,
+  renderJobStatusReport,
+  renderTaskResult,
+  renderCancelReport,
+  renderStoredJobResult
+} from "../plugins/gemini/scripts/lib/render.mjs";
+
+function setupReport(overrides = {}) {
+  return {
+    ready: true,
+    node: { detail: "v24.0.0" },
+    npm: { detail: "11.0.0" },
+    gemini: { detail: "0.44.1" },
+    geminiAuth: { detail: "logged in" },
+    agy: { detail: "1.0.2" },
+    agyAuth: { detail: "logged in" },
+    sessionRuntime: { label: "gemini 0.44.1" },
+    reviewGateEnabled: false,
+    actionsTaken: [],
+    nextSteps: [],
+    ...overrides
+  };
+}
+
+test("renderSetupReport lists every check and the review-gate state", () => {
+  const out = renderSetupReport(setupReport({ reviewGateEnabled: true, nextSteps: ["Run `gemini`"] }));
+  assert.match(out, /# Gemini Setup/);
+  assert.match(out, /Status: ready/);
+  assert.match(out, /- node: v24\.0\.0/);
+  assert.match(out, /- gemini: 0\.44\.1/);
+  assert.match(out, /- agy: 1\.0\.2/);
+  assert.match(out, /- review gate: enabled/);
+  assert.match(out, /Next steps:/);
+});
+
+test("renderSetupReport reports needs-attention when not ready", () => {
+  const out = renderSetupReport(setupReport({ ready: false }));
+  assert.match(out, /Status: needs attention/);
+  assert.match(out, /- review gate: disabled/);
+});
+
+test("renderStatusReport shows empty state when there are no jobs", () => {
+  const out = renderStatusReport({
+    sessionRuntime: { label: "gemini 0.44.1" },
+    running: [],
+    latestFinished: null,
+    recent: [],
+    needsReview: false
+  });
+  assert.match(out, /# Gemini Status/);
+  assert.match(out, /Session runtime: gemini 0\.44\.1/);
+  assert.match(out, /No jobs recorded yet\./);
+});
+
+test("renderStatusReport announces the stop-time review gate when enabled", () => {
+  const out = renderStatusReport({
+    sessionRuntime: { label: "gemini 0.44.1" },
+    running: [],
+    latestFinished: null,
+    recent: [],
+    needsReview: true
+  });
+  assert.match(out, /stop-time review gate is enabled/);
+});
+
+test("renderJobStatusReport renders a single job's id and status", () => {
+  const out = renderJobStatusReport({ id: "task-1", status: "completed", title: "Investigate flake" });
+  assert.match(out, /# Gemini Job Status/);
+  assert.match(out, /task-1/);
+  assert.match(out, /completed/);
+});
+
+test("renderTaskResult returns the raw output verbatim with a trailing newline", () => {
+  assert.equal(renderTaskResult({ rawOutput: "hello world" }, {}), "hello world\n");
+  assert.equal(renderTaskResult({ rawOutput: "ends with newline\n" }, {}), "ends with newline\n");
+});
+
+test("renderTaskResult falls back to a failure message when there is no output", () => {
+  assert.equal(renderTaskResult({ failureMessage: "boom" }, {}), "boom\n");
+  assert.equal(renderTaskResult({}, {}), "Gemini did not return a final message.\n");
+});
+
+test("renderCancelReport confirms cancellation and points at status", () => {
+  const out = renderCancelReport({ id: "task-7", title: "Big task", summary: "wip" });
+  assert.match(out, /# Gemini Cancel/);
+  assert.match(out, /Cancelled task-7\./);
+  assert.match(out, /\/gemini:status/);
+});
+
+test("renderStoredJobResult prefers the structured rendered review output", () => {
+  const out = renderStoredJobResult(
+    { id: "review-1", status: "completed", title: "Gemini Review" },
+    { result: { result: { verdict: "approve" } }, rendered: "RENDERED REVIEW\n" }
+  );
+  assert.match(out, /RENDERED REVIEW/);
+});
+
+test("renderStoredJobResult falls back to result.gemini.stdout and appends the resume hint", () => {
+  const out = renderStoredJobResult(
+    { id: "task-2", status: "completed", title: "Task" },
+    { threadId: "sess-1", result: { gemini: { stdout: "RAW OUTPUT" } } }
+  );
+  assert.match(out, /RAW OUTPUT/);
+  assert.match(out, /Resume in Gemini: gemini resume sess-1/);
+});
+
+test("renderStoredJobResult reports when no payload was stored", () => {
+  const out = renderStoredJobResult({ id: "task-9", status: "failed", title: "X" }, {});
+  assert.match(out, /No captured result payload was stored/);
+});

--- a/tests/state.test.mjs
+++ b/tests/state.test.mjs
@@ -1,0 +1,79 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { makeTempDir } from "./helpers.mjs";
+import {
+  resolveJobFile,
+  resolveJobLogFile,
+  resolveStateDir,
+  resolveStateFile,
+  saveState
+} from "../plugins/gemini/scripts/lib/state.mjs";
+
+test("resolveStateDir uses a temp-backed per-workspace directory", () => {
+  const workspace = makeTempDir();
+  const stateDir = resolveStateDir(workspace);
+
+  assert.equal(stateDir.startsWith(os.tmpdir()), true);
+  assert.match(path.basename(stateDir), /.+-[a-f0-9]{16}$/);
+});
+
+test("resolveStateDir honors GEMINI_COMPANION_DATA when provided", () => {
+  const workspace = makeTempDir();
+  const pluginDataDir = makeTempDir();
+  const previous = process.env.GEMINI_COMPANION_DATA;
+  process.env.GEMINI_COMPANION_DATA = pluginDataDir;
+
+  try {
+    const stateDir = resolveStateDir(workspace);
+    assert.equal(stateDir.startsWith(path.join(pluginDataDir, "state")), true);
+    assert.match(path.basename(stateDir), /.+-[a-f0-9]{16}$/);
+  } finally {
+    if (previous == null) {
+      delete process.env.GEMINI_COMPANION_DATA;
+    } else {
+      process.env.GEMINI_COMPANION_DATA = previous;
+    }
+  }
+});
+
+test("saveState prunes dropped job artifacts when indexed jobs exceed the cap", () => {
+  const workspace = makeTempDir();
+  const stateFile = resolveStateFile(workspace);
+  fs.mkdirSync(path.dirname(stateFile), { recursive: true });
+
+  const jobs = Array.from({ length: 51 }, (_, index) => {
+    const jobId = `job-${index}`;
+    const updatedAt = new Date(Date.UTC(2026, 0, 1, 0, index, 0)).toISOString();
+    const logFile = resolveJobLogFile(workspace, jobId);
+    const jobFile = resolveJobFile(workspace, jobId);
+    fs.writeFileSync(logFile, `log ${jobId}\n`, "utf8");
+    fs.writeFileSync(jobFile, JSON.stringify({ id: jobId, status: "completed" }, null, 2), "utf8");
+    return { id: jobId, status: "completed", logFile, updatedAt, createdAt: updatedAt };
+  });
+
+  fs.writeFileSync(stateFile, `${JSON.stringify({ version: 1, config: {}, jobs }, null, 2)}\n`, "utf8");
+
+  saveState(workspace, { version: 1, config: {}, jobs });
+
+  const jobsDir = path.dirname(resolveJobFile(workspace, "job-0"));
+  const savedState = JSON.parse(fs.readFileSync(stateFile, "utf8"));
+
+  assert.equal(savedState.jobs.length, 50);
+  assert.deepEqual(
+    savedState.jobs.map((job) => job.id),
+    Array.from({ length: 50 }, (_, index) => `job-${50 - index}`)
+  );
+  assert.equal(fs.existsSync(resolveJobFile(workspace, "job-50")), true);
+  assert.equal(fs.existsSync(resolveJobFile(workspace, "job-0")), false);
+  assert.equal(fs.existsSync(resolveJobLogFile(workspace, "job-0")), false);
+  assert.deepEqual(
+    fs.readdirSync(jobsDir).sort(),
+    Array.from({ length: 50 }, (_, index) => `job-${index + 1}`)
+      .flatMap((jobId) => [`${jobId}.json`, `${jobId}.log`])
+      .sort()
+  );
+});


### PR DESCRIPTION
## Summary

Second mirror-parity batch (P1), on top of the merged P0 work. Three grouped commits:
model-alias correctness + JSON-parse hardening, documentation/security accuracy, and a
test-coverage port. Strictly P1/P2/P3-scoped — no version bump, no CHANGELOG edit.

## Model aliases & runtime (`39d114e`)

- The `flash` / `pro` aliases and `--effort low/medium/high/xhigh` resolved to
  `gemini-3.5-flash` / `gemini-3.1-pro`, which return **404 ModelNotFound** on the Gemini CLI.
  Repointed every alias and effort tier to IDs verified against the live `gemini` CLI (0.44.1):
  `gemini-3-flash-preview`, `gemini-3.1-pro-preview`, `gemini-3.1-flash-lite-preview`, and the
  2.5 GA models. README (EN/zh-TW) and the `gemini-cli-runtime` / `gemini-prompting` skills are
  synced; the engine-order note is corrected to gemini-first.
- Hardened `tryParseJsonFromText`: strip C0 control characters and extract the last balanced
  JSON object, so reviews survive the `update_topic{…}` / control-token preamble emitted by
  gemini 0.44.1.
- AGY: skip the effort→model mapping and clearly note that `--model` / `--effort` are ignored
  for AGY (its CLI exposes no model flag; model/tier is chosen interactively).

## Docs & security accuracy (`4865d4b`)

- Use the real CLI package `@google/gemini-cli` (the previously documented
  `@google/generative-ai-cli` is **404 on npm**) in README (EN/zh-TW), `setup.md`, and the
  companion install hint.
- Fix the install command to `/plugin install gemini@gemini-plugin-cc` and reload to
  `/reload-plugins`.
- Document `/gemini:review` in README Features and Commands.
- Scope the stdin no-injection guarantee to the `gemini` engine and correct the
  credential-handling claim (credentials are read only to check token expiry, never stored or
  transmitted).
- Add `Bash(npm:*)` to `setup.md` `allowed-tools` so npm installs are not permission-blocked.

## Test coverage (`e6983d6`)

- Port render / process / state / git suites plus shared fixtures, adapted to gemini's actual
  modules (codex-only behavior — broker, inline-vs-self-collect, symlink/dir guards — is
  intentionally excluded). The suite grows from 7 → **53 tests, all passing**.

## Verification

- `npm test` → **53/53 passing**; `git show --check` clean.
- New model IDs confirmed live: `gemini -m gemini-3-flash-preview` /
  `-m gemini-3.1-pro-preview` / `-m gemini-3.1-flash-lite-preview -p ok` all exit 0, while the
  old `gemini-3.5-flash` / `gemini-3.1-pro` return 404.

## Out of scope (tracked follow-ups)

- `runtime.test.mjs` port (needs a fake-binary fixture) — dedicated effort.
- P2/P3 items: AGY argv-injection hardening, git symlink/dir guards in `formatUntrackedFile`,
  the stale `result.codex` payload key, `package-lock.json` version drift, CI action pinning,
  and the version bump / CHANGELOG entry that should accompany release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
