### PR TITLE
fix(gemini): P2/P3 hardening — AGY argv safety, git guards, validation, cleanup

### DIFF
--- a/.github/workflows/pull-request-ci.yml
+++ b/.github/workflows/pull-request-ci.yml
@@ -8,8 +8,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 22
           cache: npm

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@arcobaleno64/gemini-plugin-cc",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@arcobaleno64/gemini-plugin-cc",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"

--- a/plugins/gemini/commands/cancel.md
+++ b/plugins/gemini/commands/cancel.md
@@ -5,4 +5,4 @@ disable-model-invocation: true
 allowed-tools: Bash(node:*)
 ---
 
-!`node "${CLAUDE_PLUGIN_ROOT}/scripts/gemini-companion.mjs" cancel $ARGUMENTS`
+!`node "${CLAUDE_PLUGIN_ROOT}/scripts/gemini-companion.mjs" cancel "$ARGUMENTS"`

--- a/plugins/gemini/commands/result.md
+++ b/plugins/gemini/commands/result.md
@@ -5,7 +5,7 @@ disable-model-invocation: true
 allowed-tools: Bash(node:*)
 ---
 
-!`node "${CLAUDE_PLUGIN_ROOT}/scripts/gemini-companion.mjs" result $ARGUMENTS`
+!`node "${CLAUDE_PLUGIN_ROOT}/scripts/gemini-companion.mjs" result "$ARGUMENTS"`
 
 Present the full command output to the user. Do not summarize or condense it. Preserve all details including:
 - Job ID and status

--- a/plugins/gemini/commands/status.md
+++ b/plugins/gemini/commands/status.md
@@ -5,7 +5,7 @@ disable-model-invocation: true
 allowed-tools: Bash(node:*)
 ---
 
-!`node "${CLAUDE_PLUGIN_ROOT}/scripts/gemini-companion.mjs" status $ARGUMENTS`
+!`node "${CLAUDE_PLUGIN_ROOT}/scripts/gemini-companion.mjs" status "$ARGUMENTS"`
 
 If the user did not pass a job ID:
 - Render the command output as a single Markdown table for the current and past runs in this session.

--- a/plugins/gemini/scripts/gemini-companion.mjs
+++ b/plugins/gemini/scripts/gemini-companion.mjs
@@ -265,7 +265,7 @@ async function executeReviewRun(request) {
   const payload = {
     review: reviewName,
     target: context.target,
-    codex: { status: result.status, stdout: result.reviewText },
+    gemini: { status: result.status, stdout: result.reviewText },
     result: parsed.parsed
   };
 
@@ -538,6 +538,9 @@ async function handleTask(argv) {
   const workspaceRoot = resolveCommandWorkspace(options);
   const model = normalizeRequestedModel(options.model);
   const engine = options.engine ?? null;
+  if (options.effort != null && !VALID_EFFORT_LEVELS.has(String(options.effort).trim().toLowerCase())) {
+    throw new Error(`Invalid --effort "${options.effort}". Valid values: ${[...VALID_EFFORT_LEVELS].join(", ")}.`);
+  }
   const prompt = readTaskPrompt(cwd, options, positionals);
 
   const resumeLast = Boolean(options["resume-last"] || options.resume);

--- a/plugins/gemini/scripts/lib/engine.mjs
+++ b/plugins/gemini/scripts/lib/engine.mjs
@@ -1,6 +1,6 @@
 import process from "node:process";
 
-import { binaryAvailable } from "./process.mjs";
+import { binaryAvailable, resolveBinaryPath } from "./process.mjs";
 
 export const ENGINE_ENV = "GEMINI_ENGINE";
 
@@ -49,7 +49,7 @@ export function detectEngine(requestedEngine = null) {
   if (normalized === "agy") {
     const status = binaryAvailable("agy", ["--version"]);
     if (!status.available) throw new Error("AGY engine requested but agy binary is not available.");
-    return { engine: "agy", binary: "agy", version: status.detail ?? "unknown" };
+    return { engine: "agy", binary: resolveBinaryPath("agy") ?? "agy", version: status.detail ?? "unknown" };
   }
 
   if (normalized === "gemini") {
@@ -66,7 +66,7 @@ export function detectEngine(requestedEngine = null) {
 
   const agyStatus = binaryAvailable("agy", ["--version"]);
   if (agyStatus.available) {
-    return { engine: "agy", binary: "agy", version: agyStatus.detail ?? "unknown" };
+    return { engine: "agy", binary: resolveBinaryPath("agy") ?? "agy", version: agyStatus.detail ?? "unknown" };
   }
 
   throw new Error("No Gemini or AGY engine found. Install agy or gemini CLI and retry.");

--- a/plugins/gemini/scripts/lib/fs.mjs
+++ b/plugins/gemini/scripts/lib/fs.mjs
@@ -6,7 +6,7 @@ export function ensureAbsolutePath(cwd, maybePath) {
   return path.isAbsolute(maybePath) ? maybePath : path.resolve(cwd, maybePath);
 }
 
-export function createTempDir(prefix = "codex-plugin-") {
+export function createTempDir(prefix = "gemini-plugin-") {
   return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
 }
 

--- a/plugins/gemini/scripts/lib/git.mjs
+++ b/plugins/gemini/scripts/lib/git.mjs
@@ -71,11 +71,19 @@ export function getWorkingTreeState(cwd) {
   };
 }
 
+function isSafeGitRef(ref) {
+  // Reject a leading dash (git option injection) and shell metacharacters.
+  return /^[A-Za-z0-9_][A-Za-z0-9._/~^@{}+-]*$/.test(String(ref));
+}
+
 export function resolveReviewTarget(cwd, options = {}) {
   ensureGitRepository(cwd);
 
   const requestedScope = options.scope ?? "auto";
   const baseRef = options.base ?? null;
+  if (baseRef != null && !isSafeGitRef(baseRef)) {
+    throw new Error(`Invalid --base ref "${baseRef}". Use a plain git ref (no leading dash or shell metacharacters).`);
+  }
   const state = getWorkingTreeState(cwd);
   const supportedScopes = new Set(["auto", "working-tree", "branch"]);
 
@@ -133,14 +141,35 @@ function formatSection(title, body) {
   return [`## ${title}`, "", body.trim() ? body.trim() : "(none)", ""].join("\n");
 }
 
-function formatUntrackedFile(cwd, relativePath) {
+export function formatUntrackedFile(cwd, relativePath) {
   const absolutePath = path.join(cwd, relativePath);
-  const stat = fs.statSync(absolutePath);
+
+  let stat;
+  try {
+    const linkStat = fs.lstatSync(absolutePath);
+    if (linkStat.isSymbolicLink() && !fs.existsSync(absolutePath)) {
+      return `### ${relativePath}\n(skipped: broken symlink or unreadable file)`;
+    }
+    stat = fs.statSync(absolutePath);
+  } catch {
+    return `### ${relativePath}\n(skipped: broken symlink or unreadable file)`;
+  }
+
+  if (stat.isDirectory()) {
+    return `### ${relativePath}\n(skipped: directory)`;
+  }
+
   if (stat.size > MAX_UNTRACKED_BYTES) {
     return `### ${relativePath}\n(skipped: ${stat.size} bytes exceeds ${MAX_UNTRACKED_BYTES} byte limit)`;
   }
 
-  const buffer = fs.readFileSync(absolutePath);
+  let buffer;
+  try {
+    buffer = fs.readFileSync(absolutePath);
+  } catch {
+    return `### ${relativePath}\n(skipped: broken symlink or unreadable file)`;
+  }
+
   if (!isProbablyText(buffer)) {
     return `### ${relativePath}\n(skipped: binary file)`;
   }
@@ -149,7 +178,7 @@ function formatUntrackedFile(cwd, relativePath) {
 }
 
 function collectWorkingTreeContext(cwd, state) {
-  const status = gitChecked(cwd, ["status", "--short"]).stdout.trim();
+  const status = gitChecked(cwd, ["status", "--short", "--untracked-files=all"]).stdout.trim();
   const stagedDiff = gitChecked(cwd, ["diff", "--cached", "--binary", "--no-ext-diff", "--submodule=diff"]).stdout;
   const unstagedDiff = gitChecked(cwd, ["diff", "--binary", "--no-ext-diff", "--submodule=diff"]).stdout;
   const untrackedBody = state.untracked.map((file) => formatUntrackedFile(cwd, file)).join("\n\n");

--- a/plugins/gemini/scripts/lib/job-control.mjs
+++ b/plugins/gemini/scripts/lib/job-control.mjs
@@ -231,6 +231,7 @@ export function buildStatusSnapshot(cwd, options = {}) {
   return {
     workspaceRoot,
     config,
+    needsReview: Boolean(config.stopReviewGateEnabled),
     sessionRuntime: getSessionRuntimeStatus(options.env),
     running,
     latestFinished,

--- a/plugins/gemini/scripts/lib/process.mjs
+++ b/plugins/gemini/scripts/lib/process.mjs
@@ -1,4 +1,5 @@
 import { spawnSync } from "node:child_process";
+import path from "node:path";
 import process from "node:process";
 
 export function runCommand(command, args = [], options = {}) {
@@ -8,7 +9,10 @@ export function runCommand(command, args = [], options = {}) {
     encoding: "utf8",
     input: options.input,
     stdio: options.stdio ?? "pipe",
-    shell: process.platform === "win32",
+    // Absolute paths are spawned directly (shell:false) so arguments are passed
+    // literally and never re-parsed by the shell. Bare command names still use the
+    // shell on Windows to resolve .cmd/.ps1 wrappers (npm global bins).
+    shell: options.shell ?? (process.platform === "win32" && !path.isAbsolute(command)),
     windowsHide: true,
     ...(options.maxBuffer != null && { maxBuffer: options.maxBuffer }),
     ...(options.timeout != null && { timeout: options.timeout }),
@@ -50,6 +54,22 @@ export function binaryAvailable(command, versionArgs = ["--version"], options = 
     return { available: false, detail };
   }
   return { available: true, detail: result.stdout.trim() || result.stderr.trim() || "ok" };
+}
+
+export function resolveBinaryPath(command) {
+  if (path.isAbsolute(command)) {
+    return command;
+  }
+  const finder = process.platform === "win32" ? "where" : "which";
+  const result = runCommand(finder, [command]);
+  if (result.status !== 0) {
+    return null;
+  }
+  const first = result.stdout
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)[0];
+  return first || null;
 }
 
 function looksLikeMissingProcessMessage(text) {

--- a/plugins/gemini/scripts/lib/render.mjs
+++ b/plugins/gemini/scripts/lib/render.mjs
@@ -98,7 +98,7 @@ function escapeMarkdownCell(value) {
     .trim();
 }
 
-function formatCodexResumeCommand(job) {
+function formatGeminiResumeCommand(job) {
   if (!job?.threadId) {
     return null;
   }
@@ -137,7 +137,7 @@ function pushJobDetails(lines, job, options = {}) {
   if (job.threadId) {
     lines.push(`  Gemini session ID: ${job.threadId}`);
   }
-  const resumeCommand = formatCodexResumeCommand(job);
+  const resumeCommand = formatGeminiResumeCommand(job);
   if (resumeCommand) {
     lines.push(`  Resume in Gemini: ${resumeCommand}`);
   }

--- a/plugins/gemini/scripts/lib/state.mjs
+++ b/plugins/gemini/scripts/lib/state.mjs
@@ -1,4 +1,4 @@
-import { createHash } from "node:crypto";
+import { createHash, randomBytes } from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -120,7 +120,7 @@ export function updateState(cwd, mutate) {
 }
 
 export function generateJobId(prefix = "job") {
-  const random = Math.random().toString(36).slice(2, 8);
+  const random = randomBytes(5).toString("hex");
   return `${prefix}-${Date.now().toString(36)}-${random}`;
 }
 

--- a/tests/git.test.mjs
+++ b/tests/git.test.mjs
@@ -3,7 +3,7 @@ import path from "node:path";
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { collectReviewContext, getWorkingTreeState, resolveReviewTarget } from "../plugins/gemini/scripts/lib/git.mjs";
+import { collectReviewContext, formatUntrackedFile, getWorkingTreeState, resolveReviewTarget } from "../plugins/gemini/scripts/lib/git.mjs";
 import { initGitRepo, makeTempDir, run } from "./helpers.mjs";
 
 function commitInitial(cwd) {
@@ -88,4 +88,26 @@ test("getWorkingTreeState reflects staged, unstaged, and untracked files", () =>
   assert.equal(state.isDirty, true);
   assert.ok(state.unstaged.includes("app.js"));
   assert.ok(state.untracked.includes("untracked.js"));
+});
+
+test("resolveReviewTarget rejects an unsafe --base ref", () => {
+  const cwd = makeTempDir();
+  initGitRepo(cwd);
+  commitInitial(cwd);
+  assert.throws(() => resolveReviewTarget(cwd, { base: "--upload-pack=evil" }), /Invalid --base ref/);
+  assert.throws(() => resolveReviewTarget(cwd, { base: "x; rm -rf /" }), /Invalid --base ref/);
+});
+
+test("formatUntrackedFile skips a directory instead of crashing", () => {
+  const cwd = makeTempDir();
+  fs.mkdirSync(path.join(cwd, "a-dir"));
+  assert.match(formatUntrackedFile(cwd, "a-dir"), /\(skipped: directory\)/);
+});
+
+test("formatUntrackedFile inlines a small text file", () => {
+  const cwd = makeTempDir();
+  fs.writeFileSync(path.join(cwd, "note.txt"), "hello content\n");
+  const out = formatUntrackedFile(cwd, "note.txt");
+  assert.match(out, /### note\.txt/);
+  assert.match(out, /hello content/);
 });

--- a/tests/job-control.test.mjs
+++ b/tests/job-control.test.mjs
@@ -1,0 +1,21 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { makeTempDir } from "./helpers.mjs";
+import { setConfig } from "../plugins/gemini/scripts/lib/state.mjs";
+import { buildStatusSnapshot } from "../plugins/gemini/scripts/lib/job-control.mjs";
+
+test("buildStatusSnapshot surfaces the stop-review-gate flag", () => {
+  const cwd = makeTempDir();
+  setConfig(cwd, "stopReviewGateEnabled", true);
+  const snapshot = buildStatusSnapshot(cwd);
+  assert.equal(snapshot.needsReview, true);
+});
+
+test("buildStatusSnapshot reports an empty job list for a fresh workspace", () => {
+  const cwd = makeTempDir();
+  const snapshot = buildStatusSnapshot(cwd);
+  assert.equal(snapshot.needsReview, false);
+  assert.deepEqual(snapshot.running, []);
+  assert.equal(snapshot.latestFinished, null);
+});

--- a/tests/process.test.mjs
+++ b/tests/process.test.mjs
@@ -5,7 +5,8 @@ import process from "node:process";
 import {
   terminateProcessTree,
   binaryAvailable,
-  formatCommandFailure
+  formatCommandFailure,
+  resolveBinaryPath
 } from "../plugins/gemini/scripts/lib/process.mjs";
 
 test("terminateProcessTree uses taskkill on Windows", () => {
@@ -78,6 +79,13 @@ test("binaryAvailable detects an available binary", () => {
 test("binaryAvailable reports an unavailable binary", () => {
   const result = binaryAvailable("definitely-not-a-real-binary-xyz-123", ["--version"]);
   assert.equal(result.available, false);
+});
+
+test("resolveBinaryPath finds a PATH command and passes absolute paths through", () => {
+  const git = resolveBinaryPath("git");
+  assert.equal(typeof git, "string");
+  assert.match(git, /git/i);
+  assert.equal(resolveBinaryPath("/already/absolute/tool"), "/already/absolute/tool");
 });
 
 test("formatCommandFailure formats exit-code and signal failures", () => {

--- a/tests/state.test.mjs
+++ b/tests/state.test.mjs
@@ -10,7 +10,8 @@ import {
   resolveJobLogFile,
   resolveStateDir,
   resolveStateFile,
-  saveState
+  saveState,
+  generateJobId
 } from "../plugins/gemini/scripts/lib/state.mjs";
 
 test("resolveStateDir uses a temp-backed per-workspace directory", () => {
@@ -76,4 +77,10 @@ test("saveState prunes dropped job artifacts when indexed jobs exceed the cap", 
       .flatMap((jobId) => [`${jobId}.json`, `${jobId}.log`])
       .sort()
   );
+});
+
+test("generateJobId produces a prefixed id with a crypto-random suffix", () => {
+  const id = generateJobId("task");
+  assert.match(id, /^task-[0-9a-z]+-[0-9a-f]{10}$/);
+  assert.notEqual(generateJobId("task"), generateJobId("task"));
 });


### PR DESCRIPTION
## Summary

Third mirror-parity batch — P2/P3 hardening and cleanup — on top of the merged P0 and P1
work. Single commit; no version bump or CHANGELOG edit.

## Changes

- **S1 (security)**: spawn absolute-path binaries with `shell:false` and resolve the AGY engine
  to its absolute `.exe`, so the AGY prompt is passed as literal argv and never re-parsed by
  `cmd.exe` (Windows command-injection fix). The `gemini` engine continues to use stdin.
  Verified live — agy still runs after the change.
- **S2**: validate `--base` git refs (reject a leading dash and shell metacharacters).
- **S5**: guard `formatUntrackedFile` against directories, broken symlinks, and unreadable
  files; add `--untracked-files=all` to `git status`.
- **C1**: rename the review payload key `codex` → `gemini` so the `/gemini:result` raw fallback
  matches the renderer.
- **C2**: validate `--effort` against `VALID_EFFORT_LEVELS`.
- **C5**: surface `needsReview` in the status snapshot so the gate-enabled status line renders.
- **C6**: drop leftover codex strings (`createTempDir` prefix, `formatCodexResumeCommand`).
- **M3**: quote `$ARGUMENTS` in the cancel/status/result commands.
- **S7**: generate job ids with `crypto.randomBytes`.
- Pin CI action SHAs; sync `package-lock.json` to 0.5.0.

## Tests

- Added regression tests: `resolveBinaryPath`, `--base` validation, untracked-file guards,
  `generateJobId` format, and the status review-gate flag. Suite is now **60 passing**.

## Out of scope (tracked follow-up)

- `runtime.test.mjs` port (needs a fake-binary fixture) — separate effort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
