### PR TITLE
Parity audit: P0 fixes, P1 hardening, docs, and 0.6.0 release

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,13 +6,13 @@
   },
   "metadata": {
     "description": "Gemini/AGY companion plugin for Claude Code — delegate tasks, adversarial reviews, and rescue. Mirrors openai/codex-plugin-cc with Google Gemini.",
-    "version": "0.5.0"
+    "version": "0.6.0"
   },
   "plugins": [
     {
       "name": "gemini",
       "description": "Gemini/AGY companion plugin — delegation, adversarial review, rescue agent",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "author": {
         "name": "arcobaleno64"
       },

--- a/.github/workflows/pull-request-ci.yml
+++ b/.github/workflows/pull-request-ci.yml
@@ -15,3 +15,5 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm test
+      - run: npm run check-version
+      - run: npm run verify-contracts

--- a/NOTICE
+++ b/NOTICE
@@ -5,12 +5,20 @@ This product is a derivative work of openai/codex-plugin-cc
 (https://github.com/openai/codex-plugin-cc), Copyright 2026 OpenAI,
 licensed under the Apache License, Version 2.0.
 
-Portions of this software (its repository structure, runtime orchestration,
-command and skill contracts, and companion scripts) are adapted from that
-project and remain subject to the Apache License, Version 2.0; a copy is
-provided in LICENSE-APACHE-2.0. These files have been modified from the
-originals.
+Portions of this software are adapted from that project and remain subject to
+the Apache License, Version 2.0; a copy is provided in LICENSE-APACHE-2.0.
+These files have been modified from the originals. The adapted architecture
+includes, in particular:
 
-Gemini/AGY-specific modifications and additions are
-Copyright (c) 2026 arcobaleno64 and are distributed under the MIT License
-(see LICENSE).
+  * the slash-command structure and command markdown contracts;
+  * the background job model (enqueue / worker / status / result / cancel);
+  * the .omc/state persistence layout and job-control patterns;
+  * the stop-time review-gate pattern;
+  * the skill contract layout (runtime / prompting / result-handling); and
+  * the version/manifest tooling (bump-version / check-version).
+
+Gemini/AGY-specific modifications and additions — including engine detection
+and routing, stdin prompt delivery, the model-map alias/effort source, AGY
+fallback handling, OAuth status checks, and the contract-verification script —
+are Copyright (c) 2026 arcobaleno64 and are distributed under the MIT License
+(see LICENSE). They are original work and are not part of the upstream project.

--- a/README.md
+++ b/README.md
@@ -168,6 +168,13 @@ When enabled and the review returns `needs-attention`, Claude Code is blocked fr
 | `lite` / `fast` | `gemini-2.5-flash-lite` | Cost-efficient (GA) |
 | `lite3` | `gemini-3.1-flash-lite-preview` | Gemini 3.1 cost-efficient (preview) |
 
+### Model Alias Notes
+
+- Aliases and effort tiers live in a single source of truth — `plugins/gemini/scripts/lib/model-map.mjs` — and `npm test` verifies the table above against it, so the two cannot drift.
+- **Effort mapping** (applied when `--effort` is given without `--model`): `none`/`minimal` → `gemini-2.5-flash-lite`; `low`/`medium` → `gemini-3-flash-preview`; `high`/`xhigh` → `gemini-3.1-pro-preview`.
+- **Preview IDs may change.** Model IDs ending in `-preview` track Google's preview channel (last verified against gemini CLI 0.44.1). If an alias stops resolving, override it with `--model <exact-id>` — any value that is not a known alias is passed through to the CLI unchanged.
+- **AGY ignores `--model` and `--effort`.** AGY selects its model and reasoning tier interactively; the plugin prints a note and ignores both flags when `--engine agy` is active.
+
 ---
 
 ## Engine Routing
@@ -186,8 +193,25 @@ Override via `--engine` flag or the `GEMINI_ENGINE` environment variable.
 ## Security
 
 - **Stdin delivery (gemini engine)**: For the `gemini` engine, prompts are passed via `stdin` (Node's `spawnSync` `input` option) and never interpolated into a shell string, eliminating shell-injection risk regardless of prompt content. The `agy` engine has no stdin mode and receives the prompt as a CLI argument, so prefer the default `gemini` engine for untrusted input.
+- **Windows `.cmd` wrappers**: npm installs `gemini`/`agy` as `.cmd` shims, which require `shell: true` to launch. Because the gemini prompt travels on stdin (never in argv), `shell: true` never exposes it to `cmd.exe` parsing — only controlled flags (model id, `--yolo`, …) are ever placed in argv.
+- **AGY positional prompt**: AGY has no stdin mode, so under `--engine agy` the prompt is passed as a positional CLI argument and, on Windows, is subject to `cmd.exe` quoting. **Do not route untrusted prompt content through `--engine agy`** — prefer the default `gemini` engine.
 - **Credential handling**: OAuth credentials in `~/.gemini/oauth_creds.json` are read only to check token expiry via `getGeminiLoginStatus()`; they are never logged, copied elsewhere, or transmitted by this plugin.
 - **`.gitignore`**: The `.omc/` state directory (job logs, session state) is excluded from version control.
+
+---
+
+## Setup & Auth Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `gemini: not found` | Gemini CLI not installed | `npm install -g @google/gemini-cli`, or run `/gemini:setup` and accept the install prompt |
+| `npm: not found` | Node/npm missing from PATH | Install Node.js ≥ 18 from [nodejs.org](https://nodejs.org) |
+| setup shows `gemini auth: No credentials …` | OAuth not completed | Run `!gemini` once and complete the browser login |
+| setup shows `… token expired` | OAuth token lapsed | Run `!gemini` again to refresh credentials |
+| `Status: partial (AGY fallback only …)` | Gemini CLI unavailable but AGY present | Install Gemini CLI, or use `--engine agy` (its auth cannot be verified) |
+| Windows: command resolves but fails | `.cmd` wrapper / PATH | Confirm `where gemini` resolves; the plugin spawns bare names through `shell: true` to find `.cmd` shims |
+
+To authenticate, run **`!gemini`** once — the plugin completes OAuth by invoking `gemini` itself. There is **no** `gemini login` subcommand. `setup` reports `ready: true` only when Node **and** the Gemini CLI are present **and** OAuth is valid; an installed-but-unauthenticated Gemini is reported as *not ready*.
 
 ---
 
@@ -209,6 +233,31 @@ Background mode spawns a detached `task-worker` child process and returns a job 
 
 ---
 
+## Parity with codex-plugin-cc
+
+This plugin is a high-fidelity port of [openai/codex-plugin-cc](https://github.com/openai/codex-plugin-cc). The public slash-command surface, background job model, and state/result/status/cancel flow mirror the upstream; the execution backend is the Gemini CLI (with an AGY fallback) rather than the Codex app server.
+
+### Compatibility Matrix
+
+| Upstream (Codex) | This plugin (Gemini) | Parity |
+|---|---|---|
+| `/codex:setup` | `/gemini:setup` | **Gemini-specific divergence** — checks `gemini` OAuth + optional AGY fallback instead of Codex auth |
+| `/codex:review` | `/gemini:review` | **best-effort equivalent** — prompt / CLI-adapter review, not a native reviewer |
+| `/codex:adversarial-review` | `/gemini:adversarial-review` | **best-effort equivalent** — adversarial prompt over the same diff target |
+| `/codex:rescue` | `/gemini:rescue` | **1:1 parity** — same forwarder/subagent contract and flags |
+| `/codex:status` | `/gemini:status` | **1:1 parity** — same job model; `--all` crosses Claude sessions |
+| `/codex:result` | `/gemini:result` | **Gemini-specific divergence** — surfaces the Gemini session id + `gemini resume` |
+| `/codex:cancel` | `/gemini:cancel` | **1:1 parity** — same process-tree termination (POSIX + Windows) |
+
+### Codex app server vs Gemini CLI adapter
+
+- **Runtime**: Codex uses a persistent app-server with native review and persistent threads. This plugin invokes the Gemini CLI directly *per command* (no shared runtime); AGY is an optional fallback.
+- **Standard review**: In the Codex plugin, `/codex:review` is a *native* reviewer. Here, `/gemini:review` is a **prompt-based / CLI-adapter equivalent** — it sends the diff to Gemini with a pragmatic-review prompt and parses structured JSON back. It is not a native Gemini reviewer.
+- **Sandbox**: Codex exposes `read-only` / `workspace-write` sandboxes. Gemini has no equivalent; write access is gated by `--write` (`--yolo`), and otherwise the prompt enforces read-only discipline. (`--approval-mode plan` is intentionally not used: it requires a TTY and conflicts with stdin prompt delivery.)
+- **Thread/session resume**: Codex persists threads on the app server. Here, resume relies on the Gemini CLI **session id** captured from the JSON envelope; `/gemini:result` prints `gemini resume <session-id>`, and `--resume-last` continues the latest thread *for the current Claude session*.
+
+---
+
 ## Skills
 
 Three skills are bundled for Claude Code to consume:
@@ -227,8 +276,12 @@ See [CHANGELOG.md](plugins/gemini/CHANGELOG.md).
 
 ---
 
-## License
+## License & Upstream Attribution
 
 MIT © 2026 arcobaleno64.
 
 This project is a derivative work of [openai/codex-plugin-cc](https://github.com/openai/codex-plugin-cc), Copyright 2026 OpenAI, licensed under the Apache License, Version 2.0. Adapted portions remain under Apache-2.0 (see [`LICENSE-APACHE-2.0`](LICENSE-APACHE-2.0) and [`NOTICE`](NOTICE)); Gemini/AGY-specific changes are MIT (see [`LICENSE`](LICENSE)).
+
+**Derived from upstream** (adapted, Apache-2.0): the slash-command structure, the background job model (enqueue / worker / status / result / cancel), the `.omc/state` persistence and job-control patterns, the stop-time review-gate pattern, the skill contract layout, and the version/manifest tooling (`bump-version`).
+
+**Original to this repository** (MIT): the Gemini/AGY engine detection and routing, stdin prompt delivery, the `model-map` alias/effort source, the AGY fallback handling, OAuth status checks, and the contract-verification script.

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -166,6 +166,13 @@
 | `lite` / `fast` | `gemini-2.5-flash-lite` | 高效低成本（GA） |
 | `lite3` | `gemini-3.1-flash-lite-preview` | Gemini 3.1 低成本版（preview） |
 
+### 模型別名說明
+
+- 別名與努力等級集中於單一來源——`plugins/gemini/scripts/lib/model-map.mjs`——且 `npm test` 會以其驗證上表，二者不致漂移。
+- **努力對映**（於提供 `--effort` 但未給 `--model` 時套用）：`none`/`minimal` → `gemini-2.5-flash-lite`；`low`/`medium` → `gemini-3-flash-preview`；`high`/`xhigh` → `gemini-3.1-pro-preview`。
+- **Preview ID 可能變動。** 以 `-preview` 結尾之 model ID 追隨 Google 的 preview channel（最後驗證於 gemini CLI 0.44.1）。若某別名無法解析，以 `--model <精確 ID>` 覆蓋——任何非已知別名之值將原樣透傳給 CLI。
+- **AGY 忽略 `--model` 與 `--effort`。** AGY 之模型與推理分級由其互動選擇；`--engine agy` 時外掛會印出提示並忽略此二旗標。
+
 ---
 
 ## 引擎路由
@@ -184,8 +191,25 @@
 ## 安全性
 
 - **Stdin 傳遞（gemini 引擎）**：`gemini` 引擎之提示透過 stdin（Node.js `spawnSync` 的 `input` 選項）傳遞、從不插入 shell 命令字串，故無論內容為何皆無 shell injection 風險。`agy` 引擎無 stdin 模式，提示以 CLI 引數傳入；處理不可信輸入時請優先使用預設之 `gemini` 引擎。
+- **Windows `.cmd` wrapper**：npm 將 `gemini`／`agy` 安裝為 `.cmd` shim，需 `shell: true` 方能啟動。因 gemini 提示走 stdin（從不進 argv），`shell: true` 永不將其暴露給 `cmd.exe` 解析——argv 中僅有受控旗標（model id、`--yolo` 等）。
+- **AGY positional 提示**：AGY 無 stdin 模式，故 `--engine agy` 時提示以 positional CLI 引數傳入，於 Windows 受 `cmd.exe` 引號規則影響。**請勿將不可信提示內容經 `--engine agy` 傳遞**——應優先使用預設之 `gemini` 引擎。
 - **憑證處理**：`~/.gemini/oauth_creds.json` 之 OAuth 憑證僅用於 `getGeminiLoginStatus()` 檢查 token 是否過期；本外掛從不記錄、複製或傳輸之。
 - **`.gitignore`**：`.omc/` 狀態目錄（工作日誌、會話狀態）已排除於版本控制之外。
+
+---
+
+## 安裝與認證疑難排解
+
+| 症狀 | 原因 | 解法 |
+|---|---|---|
+| `gemini: not found` | 未安裝 Gemini CLI | `npm install -g @google/gemini-cli`，或執行 `/gemini:setup` 接受安裝提示 |
+| `npm: not found` | PATH 中缺 Node/npm | 自 [nodejs.org](https://nodejs.org) 安裝 Node.js ≥ 18 |
+| setup 顯示 `gemini auth: No credentials …` | 未完成 OAuth | 執行一次 `!gemini` 並完成瀏覽器登入 |
+| setup 顯示 `… token expired` | OAuth token 已過期 | 再次執行 `!gemini` 以更新憑證 |
+| `Status: partial (AGY fallback only …)` | Gemini CLI 不可用但 AGY 存在 | 安裝 Gemini CLI，或使用 `--engine agy`（其認證無法驗證） |
+| Windows：命令可解析但執行失敗 | `.cmd` wrapper／PATH | 確認 `where gemini` 可解析；外掛以 `shell: true` 啟動裸命令名以尋得 `.cmd` shim |
+
+如需認證，執行一次 **`!gemini`**——外掛即以呼叫 `gemini` 自身完成 OAuth。**並無** `gemini login` 子命令。唯有 Node **且** Gemini CLI 皆存在**且** OAuth 有效時，`setup` 方回報 `ready: true`；已安裝但未認證之 Gemini 將回報為 *not ready*。
 
 ---
 
@@ -207,6 +231,31 @@ Claude Code
 
 ---
 
+## 與 codex-plugin-cc 的對應
+
+本外掛為 [openai/codex-plugin-cc](https://github.com/openai/codex-plugin-cc) 的高保真移植版。公開的斜線命令介面、背景工作模型，以及 state/result/status/cancel 流程皆鏡像上游；執行後端則改用 Gemini CLI（並以 AGY 為備援），而非 Codex app server。
+
+### 相容性對照表
+
+| 上游（Codex） | 本外掛（Gemini） | 對應程度 |
+|---|---|---|
+| `/codex:setup` | `/gemini:setup` | **Gemini 專屬差異** — 檢查 `gemini` OAuth 與選用之 AGY 備援，而非 Codex 認證 |
+| `/codex:review` | `/gemini:review` | **最佳等效** — prompt／CLI adapter 審查，非原生審查器 |
+| `/codex:adversarial-review` | `/gemini:adversarial-review` | **最佳等效** — 對同一 diff target 施以對抗性 prompt |
+| `/codex:rescue` | `/gemini:rescue` | **1:1 對等** — 相同的 forwarder／subagent 合約與旗標 |
+| `/codex:status` | `/gemini:status` | **1:1 對等** — 相同工作模型；`--all` 跨 Claude session |
+| `/codex:result` | `/gemini:result` | **Gemini 專屬差異** — 顯示 Gemini session id 與 `gemini resume` |
+| `/codex:cancel` | `/gemini:cancel` | **1:1 對等** — 相同的 process-tree 終止（POSIX 與 Windows） |
+
+### Codex app server 與 Gemini CLI adapter
+
+- **執行時**：Codex 使用常駐 app-server，具原生審查與持久 thread。本外掛則於*每次命令*直接呼叫 Gemini CLI（無共享執行時）；AGY 為選用備援。
+- **標準審查**：Codex 外掛之 `/codex:review` 為*原生*審查器；本外掛之 `/gemini:review` 為 **prompt／CLI adapter 等效實作**——將 diff 連同務實審查 prompt 送交 Gemini 並解析回傳之結構化 JSON，並非原生 Gemini 審查器。
+- **沙箱**：Codex 提供 `read-only`／`workspace-write` 沙箱。Gemini 無對應沙箱；寫入權由 `--write`（`--yolo`）把關，否則以 prompt 強制唯讀紀律。（不採 `--approval-mode plan`：其需 TTY，與 stdin 提示傳遞衝突。）
+- **Thread／session 接續**：Codex 於 app-server 持久化 thread。本外掛之接續依賴自 JSON 信封擷取之 Gemini CLI **session id**；`/gemini:result` 會印出 `gemini resume <session-id>`，而 `--resume-last` 接續*當前 Claude session* 之最新 thread。
+
+---
+
 ## 技能
 
 本外掛捆綁三個供 Claude Code 使用的技能：
@@ -225,8 +274,12 @@ Claude Code
 
 ---
 
-## 授權
+## 授權與上游歸屬
 
 MIT © 2026 arcobaleno64。
 
 本專案為 [openai/codex-plugin-cc](https://github.com/openai/codex-plugin-cc)（Copyright 2026 OpenAI，Apache License 2.0）之衍生作品。沿用部分仍受 Apache-2.0 規範（見 [`LICENSE-APACHE-2.0`](LICENSE-APACHE-2.0) 與 [`NOTICE`](NOTICE)）；Gemini/AGY 專屬之變更採 MIT（見 [`LICENSE`](LICENSE)）。
+
+**衍生自上游**（沿用，Apache-2.0）：斜線命令結構、背景工作模型（enqueue／worker／status／result／cancel）、`.omc/state` 持久化與 job-control 模式、停止時 review-gate 模式、skill 合約佈局，以及 version／manifest 工具（`bump-version`）。
+
+**本倉儲原創**（MIT）：Gemini/AGY 引擎偵測與路由、stdin 提示傳遞、`model-map` 別名／努力來源、AGY 備援處理、OAuth 狀態檢查，以及 contract 驗證腳本。

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@arcobaleno64/gemini-plugin-cc",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@arcobaleno64/gemini-plugin-cc",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arcobaleno64/gemini-plugin-cc",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": true,
   "type": "module",
   "description": "Use Gemini/AGY from Claude Code to review code or delegate tasks.",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "node": ">=18.0.0"
   },
   "scripts": {
-    "test": "node --test tests/*.test.mjs"
+    "test": "node --test tests/*.test.mjs",
+    "bump-version": "node scripts/bump-version.mjs",
+    "check-version": "node scripts/bump-version.mjs --check",
+    "verify-contracts": "node scripts/verify-contracts.mjs"
   }
 }

--- a/plugins/gemini/.claude-plugin/plugin.json
+++ b/plugins/gemini/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gemini",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Use Gemini/AGY from Claude Code to review code or delegate tasks.",
   "author": {
     "name": "arcobaleno64",

--- a/plugins/gemini/CHANGELOG.md
+++ b/plugins/gemini/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased — parity audit
+## 0.6.0 — 2026-06-01 — parity audit
 
 ### Breaking
 - **`/gemini:setup` readiness now requires authentication.** `ready` is `true` only when Node **and** the Gemini CLI are present **and** OAuth is valid. An installed-but-unauthenticated Gemini now reports `ready: false` (previously `true`). New JSON fields: `readyState` (`ready` | `partial` | `not-ready`), `geminiReady`, `agyFallbackAvailable`.

--- a/plugins/gemini/CHANGELOG.md
+++ b/plugins/gemini/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## Unreleased — parity audit
+
+### Breaking
+- **`/gemini:setup` readiness now requires authentication.** `ready` is `true` only when Node **and** the Gemini CLI are present **and** OAuth is valid. An installed-but-unauthenticated Gemini now reports `ready: false` (previously `true`). New JSON fields: `readyState` (`ready` | `partial` | `not-ready`), `geminiReady`, `agyFallbackAvailable`.
+
+### Fixed (P0)
+- **Review target was discarded.** `/gemini:review` and `/gemini:adversarial-review` now honour `--base <ref>` and `--scope <auto|working-tree|branch>`; `executeReviewRun` previously re-resolved the target with empty options, silently dropping the user's selection.
+- **Contradictory verbatim contract.** Removed the "STOP and ask which issues to fix" instruction from `review.md` / `adversarial-review.md`, which conflicted with the "return stdout verbatim" rule.
+- **AGY install was over-eager.** `setup.md` now installs Gemini CLI as the primary engine and only prompts for AGY when the user passes `--engine agy`. Auth guidance is unified on running `gemini` (there is no `gemini login` subcommand).
+
+### Added (P1)
+- **Claude session job filtering.** `/gemini:status --all` now crosses sessions (default stays scoped to the current Claude session); resume-candidate and active-task checks respect the session boundary.
+- **Single source of truth for models.** New `scripts/lib/model-map.mjs` holds aliases + effort tiers + provenance (`lastVerified`, `source`, preview flags); the README table is verified against it.
+- **Contract verification.** New `scripts/verify-contracts.mjs` (`npm run verify-contracts`) and ported `scripts/bump-version.mjs` (`npm run check-version` / `bump-version`). CI now runs `npm test`, `check-version`, and `verify-contracts`.
+- `getSessionRuntimeStatus` now returns a `label`/`mode` so setup/status no longer render `session runtime: undefined`.
+
+### Tests
+- 90 → 117 tests. New coverage: `--base`/`--scope` divergence, setup readiness (auth missing/expired/AGY-fallback), session filtering, stdin prompt safety (metacharacter matrix), stderr-does-not-pollute-JSON, model-map/README consistency, and contract/version verification.
+
+### Documentation
+- README (EN + zh-TW): Compatibility Matrix, Codex app server vs Gemini CLI adapter, expanded Security Notes, Setup & Auth Troubleshooting, Model Alias Notes, and Upstream Attribution.
+
 ## 0.5.0 — 2026-05-27
 
 ### Added

--- a/plugins/gemini/NOTICE
+++ b/plugins/gemini/NOTICE
@@ -5,12 +5,20 @@ This product is a derivative work of openai/codex-plugin-cc
 (https://github.com/openai/codex-plugin-cc), Copyright 2026 OpenAI,
 licensed under the Apache License, Version 2.0.
 
-Portions of this software (its repository structure, runtime orchestration,
-command and skill contracts, and companion scripts) are adapted from that
-project and remain subject to the Apache License, Version 2.0; a copy is
-provided in LICENSE-APACHE-2.0 at the repository root. These files have been
-modified from the originals.
+Portions of this software are adapted from that project and remain subject to
+the Apache License, Version 2.0; a copy is provided in LICENSE-APACHE-2.0 at
+the repository root. These files have been modified from the originals. The
+adapted architecture includes, in particular:
 
-Gemini/AGY-specific modifications and additions are
-Copyright (c) 2026 arcobaleno64 and are distributed under the MIT License
-(see LICENSE).
+  * the slash-command structure and command markdown contracts;
+  * the background job model (enqueue / worker / status / result / cancel);
+  * the .omc/state persistence layout and job-control patterns;
+  * the stop-time review-gate pattern;
+  * the skill contract layout (runtime / prompting / result-handling); and
+  * the version/manifest tooling (bump-version / check-version).
+
+Gemini/AGY-specific modifications and additions — including engine detection
+and routing, stdin prompt delivery, the model-map alias/effort source, AGY
+fallback handling, OAuth status checks, and the contract-verification script —
+are Copyright (c) 2026 arcobaleno64 and are distributed under the MIT License
+(see LICENSE). They are original work and are not part of the upstream project.

--- a/plugins/gemini/commands/adversarial-review.md
+++ b/plugins/gemini/commands/adversarial-review.md
@@ -17,7 +17,6 @@ Core constraint:
 - Do not fix issues, apply patches, or suggest that you are about to make changes.
 - Your only job is to run the review and return Gemini's output verbatim to the user.
 - Keep the framing focused on whether the current approach is the right one, what assumptions it depends on, and where the design could fail under real-world conditions.
-- After presenting the review findings, STOP. You MUST explicitly ask the user which issues, if any, they want fixed before touching a single file.
 
 Execution mode rules:
 - If the raw arguments include `--wait`, do not ask. Run in the foreground.

--- a/plugins/gemini/commands/review.md
+++ b/plugins/gemini/commands/review.md
@@ -15,7 +15,6 @@ Core constraint:
 - This command is review-only.
 - Do not fix issues, apply patches, or suggest that you are about to make changes.
 - Your only job is to run the review and return Gemini's output verbatim to the user.
-- After presenting the review findings, STOP. You MUST explicitly ask the user which issues, if any, they want fixed before touching a single file.
 
 Execution mode rules:
 - If the raw arguments include `--wait`, do not ask. Run the review in the foreground.

--- a/plugins/gemini/commands/setup.md
+++ b/plugins/gemini/commands/setup.md
@@ -10,25 +10,11 @@ Run:
 node "${CLAUDE_PLUGIN_ROOT}/scripts/gemini-companion.mjs" setup --json $ARGUMENTS
 ```
 
-If the result says AGY is unavailable and npm is available:
-- Use `AskUserQuestion` exactly once to ask whether Claude should install AGY now.
-- Put the install option first and suffix it with `(Recommended)`.
-- Use these two options:
-  - `Install AGY (Recommended)`
-  - `Skip for now`
-- If the user chooses install, run:
+Gemini CLI is the primary engine. AGY is an optional fallback that is only
+relevant when the user explicitly routes to it with `--engine agy`.
 
-```bash
-npm install -g agy
-```
-
-- Then rerun:
-
-```bash
-node "${CLAUDE_PLUGIN_ROOT}/scripts/gemini-companion.mjs" setup --json $ARGUMENTS
-```
-
-If Gemini CLI is unavailable and AGY is also unavailable:
+If the result says Gemini CLI is unavailable (`gemini.available` is false), npm
+is available, and the raw `$ARGUMENTS` do **not** include `--engine agy`:
 - Use `AskUserQuestion` exactly once to ask whether Claude should install Gemini CLI now.
 - Put the install option first and suffix it with `(Recommended)`.
 - Use these two options:
@@ -46,10 +32,33 @@ npm install -g @google/gemini-cli
 node "${CLAUDE_PLUGIN_ROOT}/scripts/gemini-companion.mjs" setup --json $ARGUMENTS
 ```
 
-If both are already installed or npm is unavailable:
-- Do not ask about installation.
+Only if the raw `$ARGUMENTS` include `--engine agy`, AGY is unavailable
+(`agy.available` is false), and npm is available:
+- Use `AskUserQuestion` exactly once to ask whether Claude should install AGY now.
+- Put the install option first and suffix it with `(Recommended)`.
+- Use these two options:
+  - `Install AGY (Recommended)`
+  - `Skip for now`
+- If the user chooses install, run:
+
+```bash
+npm install -g agy
+```
+
+- Then rerun:
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/scripts/gemini-companion.mjs" setup --json $ARGUMENTS
+```
+
+Do not ask about installation when:
+- Gemini CLI is already available (even if it still needs authentication), or
+- npm is unavailable, or
+- the only missing engine is AGY and the user did not pass `--engine agy`. In
+  that case Gemini is the default engine; mention AGY only as an optional
+  fallback, do not push its installation.
 
 Output rules:
 - Present the final setup output to the user.
 - If installation was skipped, present the original setup output.
-- If Gemini is installed but not authenticated, preserve the guidance to run `!gemini login` or `!agy login`.
+- If Gemini is installed but not authenticated, preserve the guidance to run `!gemini` once to complete OAuth authentication. The plugin authenticates by running `gemini`; there is no separate login subcommand.

--- a/plugins/gemini/scripts/gemini-companion.mjs
+++ b/plugins/gemini/scripts/gemini-companion.mjs
@@ -154,16 +154,39 @@ function buildSetupReport(cwd, actionsTaken = []) {
   const agyAuth = getAgyLoginStatus();
   const config = getConfig(workspaceRoot) ?? {};
 
+  // Readiness mirrors upstream: the primary engine (gemini) must be installed
+  // AND authenticated. AGY auth cannot be verified non-interactively, so an
+  // AGY-only environment is reported as a "partial" fallback rather than fully
+  // ready — it can run via `--engine agy` but its auth state is unknown.
+  const geminiReady = geminiStatus.available && geminiAuth.loggedIn;
+  const agyFallbackAvailable = agyStatus.available;
+  const ready = nodeStatus.available && geminiReady;
+  const readyState = !nodeStatus.available
+    ? "not-ready"
+    : geminiReady
+      ? "ready"
+      : agyFallbackAvailable
+        ? "partial"
+        : "not-ready";
+
   const nextSteps = [];
   if (!geminiStatus.available && !agyStatus.available) {
-    nextSteps.push("Install gemini CLI: `npm install -g @google/gemini-cli` or install agy.");
+    nextSteps.push("Install Gemini CLI with `npm install -g @google/gemini-cli`.");
   }
   if (geminiStatus.available && !geminiAuth.loggedIn) {
     nextSteps.push("Run `gemini` once to authenticate via OAuth.");
   }
+  if (!geminiStatus.available && agyFallbackAvailable) {
+    nextSteps.push(
+      "Gemini CLI is unavailable; AGY is present as a fallback. Use `--engine agy` to route through it (its auth state cannot be verified), or install Gemini CLI with `npm install -g @google/gemini-cli` for the default engine."
+    );
+  }
 
   return {
-    ready: nodeStatus.available && (geminiStatus.available || agyStatus.available),
+    ready,
+    readyState,
+    geminiReady,
+    agyFallbackAvailable,
     node: nodeStatus,
     npm: npmStatus,
     gemini: geminiStatus,
@@ -244,7 +267,14 @@ async function resolveLatestTrackedTaskThread(cwd, options = {}) {
 async function executeReviewRun(request) {
   const reviewName = request.reviewName ?? "Adversarial Review";
   const templateName = request.templateName ?? "adversarial-review";
-  const context = collectReviewContext(request.cwd, resolveReviewTarget(request.cwd, {}));
+  // Resolve the review target from the caller's --base/--scope so the user's
+  // selection actually reaches the diff collection. (Re-resolving with empty
+  // options here would silently discard --base/--scope.)
+  const target = request.target ?? resolveReviewTarget(request.cwd, {
+    base: request.base,
+    scope: request.scope
+  });
+  const context = collectReviewContext(request.cwd, target);
   const template = loadPromptTemplate(ROOT_DIR, templateName);
   const prompt = interpolateTemplate(template, {
     TARGET_LABEL: context.target.label,
@@ -508,6 +538,9 @@ async function handleReviewCommand(argv, { reviewName, templateName, supportsFoc
     (progress) =>
       executeReviewRun({
         cwd,
+        target,
+        base: options.base,
+        scope: options.scope,
         model: options.model,
         engine: options.engine,
         focusText,

--- a/plugins/gemini/scripts/gemini-companion.mjs
+++ b/plugins/gemini/scripts/gemini-companion.mjs
@@ -23,6 +23,7 @@ import {
 import {
   buildSingleJobSnapshot,
   buildStatusSnapshot,
+  filterJobsForCurrentSession,
   readStoredJob,
   resolveCancelableJob,
   resolveResultJob,
@@ -250,7 +251,11 @@ async function waitForSingleJobSnapshot(cwd, reference, options = {}) {
 
 async function resolveLatestTrackedTaskThread(cwd, options = {}) {
   const workspaceRoot = resolveWorkspaceRoot(cwd);
-  const jobs = sortJobsNewestFirst(listJobs(workspaceRoot)).filter((job) => job.id !== options.excludeJobId);
+  // Only consider jobs from the current Claude session so a resume never jumps
+  // into another session's (or another project's) thread.
+  const jobs = sortJobsNewestFirst(filterJobsForCurrentSession(listJobs(workspaceRoot))).filter(
+    (job) => job.id !== options.excludeJobId
+  );
   const activeTask = jobs.find((job) => job.jobClass === "task" && (job.status === "queued" || job.status === "running"));
   if (activeTask) {
     throw new Error(`Task ${activeTask.id} is still running. Use /gemini:status before continuing it.`);
@@ -716,7 +721,8 @@ async function handleTaskResumeCandidate(argv) {
   });
   const cwd = resolveCommandCwd(options);
   const workspaceRoot = resolveCommandWorkspace(options);
-  const jobs = sortJobsNewestFirst(listJobs(workspaceRoot));
+  // Resume candidates are scoped to the current Claude session by default.
+  const jobs = sortJobsNewestFirst(filterJobsForCurrentSession(listJobs(workspaceRoot)));
   const activeTask = jobs.find((job) => job.jobClass === "task" && (job.status === "queued" || job.status === "running"));
   if (activeTask) {
     const payload = { found: false, blocked: true, activeJobId: activeTask.id };

--- a/plugins/gemini/scripts/lib/engine.mjs
+++ b/plugins/gemini/scripts/lib/engine.mjs
@@ -1,33 +1,18 @@
 import process from "node:process";
 
 import { binaryAvailable, resolveBinaryPath } from "./process.mjs";
+import { EFFORT_MODEL_MAP, MODEL_ALIASES, VALID_EFFORT_LEVELS } from "./model-map.mjs";
 
 export const ENGINE_ENV = "GEMINI_ENGINE";
 
-export const MODEL_ALIASES = new Map([
-  // Gemini 3.x — current generation (preview channel; IDs verified against gemini CLI 0.44.1)
-  ["flash", "gemini-3-flash-preview"],
-  ["flash3", "gemini-3-flash-preview"],
-  ["pro", "gemini-3.1-pro-preview"],
-  ["pro3", "gemini-3.1-pro-preview"],
-  ["lite3", "gemini-3.1-flash-lite-preview"],
-  // Gemini 2.5 — stable GA aliases
-  ["flash25", "gemini-2.5-flash"],
-  ["pro25", "gemini-2.5-pro"],
-  // Cost-efficient (stable GA)
-  ["lite", "gemini-2.5-flash-lite"],
-  ["fast", "gemini-2.5-flash-lite"],
-]);
-
-export const VALID_EFFORT_LEVELS = new Set(["none", "minimal", "low", "medium", "high", "xhigh"]);
+// Model aliases and effort tiers live in model-map.mjs (single source of truth,
+// verified against the README table). Re-exported here for existing importers.
+export { MODEL_ALIASES, VALID_EFFORT_LEVELS };
 
 export function mapEffortToModel(effort) {
   if (!effort) return null;
   const e = String(effort).trim().toLowerCase();
-  if (e === "none" || e === "minimal") return "gemini-2.5-flash-lite";
-  if (e === "low" || e === "medium") return "gemini-3-flash-preview";
-  if (e === "high" || e === "xhigh") return "gemini-3.1-pro-preview";
-  return null;
+  return EFFORT_MODEL_MAP.get(e) ?? null;
 }
 
 export function normalizeRequestedModel(model) {

--- a/plugins/gemini/scripts/lib/gemini.mjs
+++ b/plugins/gemini/scripts/lib/gemini.mjs
@@ -267,7 +267,16 @@ export function getAgyLoginStatus() {
 }
 
 export function getSessionRuntimeStatus() {
+  // Unlike the Codex app-server (a shared persistent runtime), the Gemini plugin
+  // invokes the CLI directly per command, so the runtime label describes which
+  // engine the next command would use rather than a shared session endpoint.
   const gemini = getGeminiAvailability();
   const agy = getAgyAvailability();
-  return { gemini, agy, available: gemini.available || agy.available };
+  const available = gemini.available || agy.available;
+  const label = gemini.available
+    ? "gemini CLI (per-command)"
+    : agy.available
+      ? "agy fallback (per-command)"
+      : "no engine available";
+  return { mode: "direct", gemini, agy, available, label };
 }

--- a/plugins/gemini/scripts/lib/job-control.mjs
+++ b/plugins/gemini/scripts/lib/job-control.mjs
@@ -12,11 +12,14 @@ export function sortJobsNewestFirst(jobs) {
   return [...jobs].sort((left, right) => String(right.updatedAt ?? "").localeCompare(String(left.updatedAt ?? "")));
 }
 
-function getCurrentSessionId(options = {}) {
+export function getCurrentSessionId(options = {}) {
   return options.env?.[SESSION_ID_ENV] ?? process.env[SESSION_ID_ENV] ?? null;
 }
 
-function filterJobsForCurrentSession(jobs, options = {}) {
+// Restrict jobs to the current Claude session. When no session id is known
+// (e.g. the lifecycle hook never ran) this falls back to returning every job so
+// the workspace's latest thread is still reachable.
+export function filterJobsForCurrentSession(jobs, options = {}) {
   const sessionId = getCurrentSessionId(options);
   if (!sessionId) {
     return jobs;
@@ -213,7 +216,10 @@ function matchJobReference(jobs, reference, predicate = () => true) {
 export function buildStatusSnapshot(cwd, options = {}) {
   const workspaceRoot = resolveWorkspaceRoot(cwd);
   const config = getConfig(workspaceRoot);
-  const jobs = sortJobsNewestFirst(filterJobsForCurrentSession(listJobs(workspaceRoot), options));
+  // Default to the current Claude session; --all crosses every session.
+  const allJobs = listJobs(workspaceRoot);
+  const scopedJobs = options.all ? allJobs : filterJobsForCurrentSession(allJobs, options);
+  const jobs = sortJobsNewestFirst(scopedJobs);
   const maxJobs = options.maxJobs ?? DEFAULT_MAX_STATUS_JOBS;
   const maxProgressLines = options.maxProgressLines ?? DEFAULT_MAX_PROGRESS_LINES;
 

--- a/plugins/gemini/scripts/lib/model-map.mjs
+++ b/plugins/gemini/scripts/lib/model-map.mjs
@@ -1,0 +1,43 @@
+// Single source of truth for Gemini model aliases and reasoning-effort mapping.
+//
+// The README "Model Aliases" table is verified against this data by
+// tests/model-map.test.mjs, so update aliases here and the table stays in sync.
+//
+// Preview model IDs (those ending in `-preview`) track Google's Gemini preview
+// channel and can change without notice; override any alias with `--model <id>`.
+//
+//   lastVerified: model IDs last checked against gemini CLI 0.44.1.
+//   source:       gemini CLI model listing / Google Gemini API model names.
+export const MODEL_MAP_METADATA = {
+  lastVerified: "2026-05",
+  source: "gemini CLI 0.44.1 model listing / Google Gemini API model names",
+  note: "Preview model IDs (…-preview) may change; override with --model <id>."
+};
+
+// Ordered alias entries. `preview: true` marks IDs that can change.
+export const MODEL_ALIAS_ENTRIES = [
+  { alias: "flash", model: "gemini-3-flash-preview", label: "Latest Gemini 3 Flash (preview)", preview: true },
+  { alias: "flash3", model: "gemini-3-flash-preview", label: "Latest Gemini 3 Flash (preview)", preview: true },
+  { alias: "pro", model: "gemini-3.1-pro-preview", label: "Gemini 3.1 Pro (preview)", preview: true },
+  { alias: "pro3", model: "gemini-3.1-pro-preview", label: "Gemini 3.1 Pro (preview)", preview: true },
+  { alias: "lite3", model: "gemini-3.1-flash-lite-preview", label: "Gemini 3.1 cost-efficient (preview)", preview: true },
+  { alias: "flash25", model: "gemini-2.5-flash", label: "Stable 2.5 Flash (GA)", preview: false },
+  { alias: "pro25", model: "gemini-2.5-pro", label: "Stable 2.5 Pro (GA)", preview: false },
+  { alias: "lite", model: "gemini-2.5-flash-lite", label: "Cost-efficient (GA)", preview: false },
+  { alias: "fast", model: "gemini-2.5-flash-lite", label: "Cost-efficient (GA)", preview: false }
+];
+
+export const MODEL_ALIASES = new Map(MODEL_ALIAS_ENTRIES.map((entry) => [entry.alias, entry.model]));
+
+// Reasoning-effort tier -> resolved model, used when --effort is supplied
+// without an explicit --model. (AGY ignores both; see lib/gemini.mjs.)
+export const EFFORT_MODEL_MAP = new Map([
+  ["none", "gemini-2.5-flash-lite"],
+  ["minimal", "gemini-2.5-flash-lite"],
+  ["low", "gemini-3-flash-preview"],
+  ["medium", "gemini-3-flash-preview"],
+  ["high", "gemini-3.1-pro-preview"],
+  ["xhigh", "gemini-3.1-pro-preview"]
+]);
+
+export const VALID_EFFORT_LEVELS = new Set(EFFORT_MODEL_MAP.keys());

--- a/plugins/gemini/scripts/lib/render.mjs
+++ b/plugins/gemini/scripts/lib/render.mjs
@@ -176,10 +176,16 @@ function appendReasoningSection(lines, reasoningSummary) {
 }
 
 export function renderSetupReport(report) {
+  const statusLabel =
+    report.readyState === "partial"
+      ? "partial (AGY fallback only — Gemini CLI not ready)"
+      : report.ready
+        ? "ready"
+        : "needs attention";
   const lines = [
     "# Gemini Setup",
     "",
-    `Status: ${report.ready ? "ready" : "needs attention"}`,
+    `Status: ${statusLabel}`,
     "",
     "Checks:",
     `- node: ${report.node.detail}`,

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -1,0 +1,195 @@
+#!/usr/bin/env node
+// Adapted from openai/codex-plugin-cc (scripts/bump-version.mjs, Apache-2.0) for
+// the Gemini plugin layout. Keeps every manifest version in lockstep.
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+
+const PLUGIN_NAME = "gemini";
+const VERSION_PATTERN = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
+
+const TARGETS = [
+  {
+    file: "package.json",
+    values: [{ label: "version", get: (json) => json.version, set: (json, version) => { json.version = version; } }]
+  },
+  {
+    file: "package-lock.json",
+    values: [
+      { label: "version", get: (json) => json.version, set: (json, version) => { json.version = version; } },
+      {
+        label: "packages[\"\"].version",
+        get: (json) => json.packages?.[""]?.version,
+        set: (json, version) => {
+          requireObject(json.packages?.[""], "package-lock.json packages[\"\"]");
+          json.packages[""].version = version;
+        }
+      }
+    ]
+  },
+  {
+    file: `plugins/${PLUGIN_NAME}/.claude-plugin/plugin.json`,
+    values: [{ label: "version", get: (json) => json.version, set: (json, version) => { json.version = version; } }]
+  },
+  {
+    file: ".claude-plugin/marketplace.json",
+    values: [
+      {
+        label: "metadata.version",
+        get: (json) => json.metadata?.version,
+        set: (json, version) => {
+          requireObject(json.metadata, ".claude-plugin/marketplace.json metadata");
+          json.metadata.version = version;
+        }
+      },
+      {
+        label: `plugins[${PLUGIN_NAME}].version`,
+        get: (json) => findMarketplacePlugin(json).version,
+        set: (json, version) => {
+          findMarketplacePlugin(json).version = version;
+        }
+      }
+    ]
+  }
+];
+
+function usage() {
+  return [
+    "Usage:",
+    "  node scripts/bump-version.mjs <version>",
+    "  node scripts/bump-version.mjs --check [version]",
+    "",
+    "Options:",
+    "  --check       Verify manifest versions. Uses package.json when version is omitted.",
+    "  --root <dir>  Run against a different repository root.",
+    "  --help        Print this help."
+  ].join("\n");
+}
+
+function parseArgs(argv) {
+  const options = { check: false, root: process.cwd(), version: null };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--check") {
+      options.check = true;
+    } else if (arg === "--root") {
+      const root = argv[i + 1];
+      if (!root) {
+        throw new Error("--root requires a directory.");
+      }
+      options.root = root;
+      i += 1;
+    } else if (arg === "--help" || arg === "-h") {
+      options.help = true;
+    } else if (arg.startsWith("-")) {
+      throw new Error(`Unknown option: ${arg}`);
+    } else if (options.version) {
+      throw new Error(`Unexpected extra argument: ${arg}`);
+    } else {
+      options.version = arg;
+    }
+  }
+
+  options.root = path.resolve(options.root);
+  return options;
+}
+
+function validateVersion(version) {
+  if (!VERSION_PATTERN.test(version)) {
+    throw new Error(`Expected a semver-like version such as 1.0.3, got: ${version}`);
+  }
+}
+
+function requireObject(value, label) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`Expected ${label} to be an object.`);
+  }
+}
+
+function findMarketplacePlugin(json) {
+  const plugin = json.plugins?.find((entry) => entry?.name === PLUGIN_NAME);
+  requireObject(plugin, `.claude-plugin/marketplace.json plugins[${PLUGIN_NAME}]`);
+  return plugin;
+}
+
+function readJson(root, file) {
+  return JSON.parse(fs.readFileSync(path.join(root, file), "utf8"));
+}
+
+function writeJson(root, file, json) {
+  fs.writeFileSync(path.join(root, file), `${JSON.stringify(json, null, 2)}\n`);
+}
+
+function readPackageVersion(root) {
+  const packageJson = readJson(root, "package.json");
+  if (typeof packageJson.version !== "string") {
+    throw new Error("package.json version must be a string.");
+  }
+  validateVersion(packageJson.version);
+  return packageJson.version;
+}
+
+function checkVersions(root, expectedVersion) {
+  const mismatches = [];
+  for (const target of TARGETS) {
+    const json = readJson(root, target.file);
+    for (const value of target.values) {
+      const actual = value.get(json);
+      if (actual !== expectedVersion) {
+        mismatches.push(`${target.file} ${value.label}: expected ${expectedVersion}, found ${actual ?? "<missing>"}`);
+      }
+    }
+  }
+  return mismatches;
+}
+
+function bumpVersion(root, version) {
+  const changedFiles = [];
+  for (const target of TARGETS) {
+    const json = readJson(root, target.file);
+    const before = JSON.stringify(json);
+    for (const value of target.values) {
+      value.set(json, version);
+    }
+    if (JSON.stringify(json) !== before) {
+      writeJson(root, target.file, json);
+      changedFiles.push(target.file);
+    }
+  }
+  return changedFiles;
+}
+
+function main() {
+  const options = parseArgs(process.argv.slice(2));
+  if (options.help) {
+    console.log(usage());
+    return;
+  }
+
+  const version = options.version ?? (options.check ? readPackageVersion(options.root) : null);
+  if (!version) {
+    throw new Error(`Missing version.\n\n${usage()}`);
+  }
+  validateVersion(version);
+
+  if (options.check) {
+    const mismatches = checkVersions(options.root, version);
+    if (mismatches.length > 0) {
+      throw new Error(`Version metadata is out of sync:\n${mismatches.join("\n")}`);
+    }
+    console.log(`All version metadata matches ${version}.`);
+    return;
+  }
+
+  const changedFiles = bumpVersion(options.root, version);
+  const touched = changedFiles.length > 0 ? changedFiles.join(", ") : "no files changed";
+  console.log(`Set version metadata to ${version}: ${touched}.`);
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+}

--- a/scripts/verify-contracts.mjs
+++ b/scripts/verify-contracts.mjs
@@ -1,0 +1,130 @@
+#!/usr/bin/env node
+// Offline contract check for the Gemini plugin manifests and command surface.
+// Verifies version lockstep, marketplace/plugin identity, the README install
+// command, the plugin source path, and the required slash-command files.
+//
+// Runs against the repository root by default; pass --root <dir> to target a
+// fixture (used by tests/contract.test.mjs). Never touches the network.
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+
+const PLUGIN_NAME = "gemini";
+const REQUIRED_COMMANDS = [
+  "setup",
+  "review",
+  "adversarial-review",
+  "rescue",
+  "status",
+  "result",
+  "cancel"
+];
+
+function parseArgs(argv) {
+  let root = process.cwd();
+  for (let i = 0; i < argv.length; i += 1) {
+    if (argv[i] === "--root") {
+      root = argv[i + 1];
+      if (!root) {
+        throw new Error("--root requires a directory.");
+      }
+      i += 1;
+    } else if (argv[i] === "--help" || argv[i] === "-h") {
+      console.log("Usage: node scripts/verify-contracts.mjs [--root <dir>]");
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown option: ${argv[i]}`);
+    }
+  }
+  return { root: path.resolve(root) };
+}
+
+function readJson(root, file, errors) {
+  try {
+    return JSON.parse(fs.readFileSync(path.join(root, file), "utf8"));
+  } catch (error) {
+    errors.push(`Cannot read ${file}: ${error instanceof Error ? error.message : String(error)}`);
+    return null;
+  }
+}
+
+function main() {
+  const { root } = parseArgs(process.argv.slice(2));
+  const errors = [];
+
+  const pkg = readJson(root, "package.json", errors);
+  const marketplace = readJson(root, ".claude-plugin/marketplace.json", errors);
+  const plugin = readJson(root, `plugins/${PLUGIN_NAME}/.claude-plugin/plugin.json`, errors);
+
+  const expected = pkg?.version;
+  if (typeof expected !== "string") {
+    errors.push("package.json version must be a string.");
+  }
+
+  // 1. Version lockstep across every manifest.
+  const marketplacePlugin = Array.isArray(marketplace?.plugins)
+    ? marketplace.plugins.find((entry) => entry?.name === PLUGIN_NAME)
+    : null;
+  const versionChecks = [
+    [".claude-plugin/marketplace.json metadata.version", marketplace?.metadata?.version],
+    [`.claude-plugin/marketplace.json plugins[${PLUGIN_NAME}].version`, marketplacePlugin?.version],
+    [`plugins/${PLUGIN_NAME}/.claude-plugin/plugin.json version`, plugin?.version]
+  ];
+  for (const [label, actual] of versionChecks) {
+    if (expected && actual !== expected) {
+      errors.push(`${label}: expected ${expected}, found ${actual ?? "<missing>"}`);
+    }
+  }
+
+  // 2. Marketplace identity + plugin source path.
+  if (!marketplacePlugin) {
+    errors.push(`.claude-plugin/marketplace.json must list a plugin named "${PLUGIN_NAME}".`);
+  } else {
+    const source = marketplacePlugin.source;
+    if (source !== `./plugins/${PLUGIN_NAME}`) {
+      errors.push(`marketplace plugin source should be "./plugins/${PLUGIN_NAME}", found ${source ?? "<missing>"}.`);
+    } else if (!fs.existsSync(path.join(root, "plugins", PLUGIN_NAME))) {
+      errors.push(`Plugin source path ${source} does not exist.`);
+    }
+  }
+
+  // 3. README install command matches "<plugin>@<marketplace>".
+  const marketplaceName = marketplace?.name;
+  if (typeof marketplaceName === "string") {
+    const installCommand = `/plugin install ${PLUGIN_NAME}@${marketplaceName}`;
+    let readme = "";
+    try {
+      readme = fs.readFileSync(path.join(root, "README.md"), "utf8");
+    } catch {
+      errors.push("Cannot read README.md to verify the install command.");
+    }
+    if (readme && !readme.includes(installCommand)) {
+      errors.push(`README.md is missing the install command "${installCommand}".`);
+    }
+  } else {
+    errors.push(".claude-plugin/marketplace.json is missing a string `name`.");
+  }
+
+  // 4. Required slash-command files exist.
+  for (const command of REQUIRED_COMMANDS) {
+    const file = path.join(root, "plugins", PLUGIN_NAME, "commands", `${command}.md`);
+    if (!fs.existsSync(file)) {
+      errors.push(`Missing required command file: plugins/${PLUGIN_NAME}/commands/${command}.md`);
+    }
+  }
+
+  if (errors.length > 0) {
+    console.error(`Contract verification failed:\n- ${errors.join("\n- ")}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(`Contract verification passed for ${PLUGIN_NAME}@${marketplaceName} v${expected}.`);
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+}

--- a/tests/commands.test.mjs
+++ b/tests/commands.test.mjs
@@ -80,3 +80,33 @@ test("adversarial-review calls the companion adversarial-review subcommand direc
   // It must NOT route through the task-only rescue subagent.
   assert.doesNotMatch(source, /gemini-rescue/);
 });
+
+// --- P0-2: stdout verbatim must not be contradicted by a fix-selection prompt ---
+
+test("review commands enforce verbatim output without a contradictory fix prompt", () => {
+  for (const name of ["review.md", "adversarial-review.md"]) {
+    const source = readCommand(name);
+    assert.match(source, /verbatim/i, `${name} must keep the verbatim rule`);
+    assert.doesNotMatch(source, /ask the user which issues/i, `${name} must not append a fix-selection prompt`);
+    assert.doesNotMatch(
+      source,
+      /which issues, if any, they want fixed/i,
+      `${name} must not append a fix-selection prompt`
+    );
+  }
+});
+
+// --- P0-4: AGY install is gated behind --engine agy; gemini is the primary engine ---
+
+test("setup prompts Gemini CLI install primarily and gates AGY behind --engine agy", () => {
+  const source = readCommand("setup.md");
+  assert.match(source, /Install Gemini CLI \(Recommended\)/);
+  assert.match(source, /--engine agy/, "AGY install must be gated behind --engine agy");
+});
+
+test("setup authenticates by running gemini, not a nonexistent `gemini login`", () => {
+  const source = readCommand("setup.md");
+  assert.doesNotMatch(source, /!gemini login/, "must not instruct the nonexistent `!gemini login`");
+  assert.doesNotMatch(source, /!agy login/);
+  assert.match(source, /OAuth/i);
+});

--- a/tests/contract.test.mjs
+++ b/tests/contract.test.mjs
@@ -1,0 +1,106 @@
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import assert from "node:assert/strict";
+import { fileURLToPath } from "node:url";
+
+import { makeTempDir, run } from "./helpers.mjs";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const BUMP = path.join(ROOT, "scripts", "bump-version.mjs");
+const VERIFY = path.join(ROOT, "scripts", "verify-contracts.mjs");
+const COMMANDS = ["setup", "review", "adversarial-review", "rescue", "status", "result", "cancel"];
+
+function writeJson(filePath, json) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(json, null, 2)}\n`);
+}
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, "utf8"));
+}
+
+function makeFixture(version = "0.5.0") {
+  const root = makeTempDir();
+  writeJson(path.join(root, "package.json"), { name: "@arcobaleno64/gemini-plugin-cc", version });
+  writeJson(path.join(root, "package-lock.json"), {
+    name: "@arcobaleno64/gemini-plugin-cc",
+    version,
+    lockfileVersion: 3,
+    packages: { "": { name: "@arcobaleno64/gemini-plugin-cc", version } }
+  });
+  writeJson(path.join(root, "plugins", "gemini", ".claude-plugin", "plugin.json"), { name: "gemini", version });
+  writeJson(path.join(root, ".claude-plugin", "marketplace.json"), {
+    name: "gemini-plugin-cc",
+    metadata: { version },
+    plugins: [{ name: "gemini", version, source: "./plugins/gemini" }]
+  });
+  fs.writeFileSync(path.join(root, "README.md"), "# gemini-plugin-cc\n\n/plugin install gemini@gemini-plugin-cc\n");
+  for (const command of COMMANDS) {
+    const file = path.join(root, "plugins", "gemini", "commands", `${command}.md`);
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, `# ${command}\n`);
+  }
+  return root;
+}
+
+// --- verify-contracts ---
+
+test("verify-contracts passes on the real repository", () => {
+  const result = run("node", [VERIFY], { cwd: ROOT });
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+});
+
+test("verify-contracts passes on a well-formed fixture", () => {
+  const result = run("node", [VERIFY, "--root", makeFixture()], { cwd: ROOT });
+  assert.equal(result.status, 0, result.stderr);
+});
+
+test("verify-contracts fails when a manifest version is out of sync", () => {
+  const root = makeFixture();
+  const pluginFile = path.join(root, "plugins", "gemini", ".claude-plugin", "plugin.json");
+  writeJson(pluginFile, { ...readJson(pluginFile), version: "9.9.9" });
+
+  const result = run("node", [VERIFY, "--root", root], { cwd: ROOT });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /plugin\.json version/);
+});
+
+test("verify-contracts fails when a required command file is missing", () => {
+  const root = makeFixture();
+  fs.rmSync(path.join(root, "plugins", "gemini", "commands", "cancel.md"));
+
+  const result = run("node", [VERIFY, "--root", root], { cwd: ROOT });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /cancel\.md/);
+});
+
+test("verify-contracts fails when the README install command is missing", () => {
+  const root = makeFixture();
+  fs.writeFileSync(path.join(root, "README.md"), "# no install command here\n");
+
+  const result = run("node", [VERIFY, "--root", root], { cwd: ROOT });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /install command/);
+});
+
+// --- bump-version (ported from upstream, adapted for the gemini layout) ---
+
+test("bump-version updates every manifest and --check detects drift", () => {
+  const root = makeFixture("0.5.0");
+
+  const bumped = run("node", [BUMP, "--root", root, "1.2.3"], { cwd: ROOT });
+  assert.equal(bumped.status, 0, bumped.stderr);
+  assert.equal(readJson(path.join(root, "package.json")).version, "1.2.3");
+  assert.equal(readJson(path.join(root, "package-lock.json")).version, "1.2.3");
+  assert.equal(readJson(path.join(root, "package-lock.json")).packages[""].version, "1.2.3");
+  assert.equal(readJson(path.join(root, "plugins", "gemini", ".claude-plugin", "plugin.json")).version, "1.2.3");
+  assert.equal(readJson(path.join(root, ".claude-plugin", "marketplace.json")).metadata.version, "1.2.3");
+  assert.equal(readJson(path.join(root, ".claude-plugin", "marketplace.json")).plugins[0].version, "1.2.3");
+
+  // Desync package.json and confirm --check reports the mismatch.
+  writeJson(path.join(root, "package.json"), { name: "@arcobaleno64/gemini-plugin-cc", version: "1.2.4" });
+  const checked = run("node", [BUMP, "--root", root, "--check"], { cwd: ROOT });
+  assert.notEqual(checked.status, 0);
+  assert.match(checked.stderr, /out of sync/i);
+});

--- a/tests/fake-gemini-fixture.mjs
+++ b/tests/fake-gemini-fixture.mjs
@@ -55,6 +55,39 @@ export function removeGeminiCredentials(binDir) {
   fs.rmSync(path.join(binDir, "gemini-home", "oauth_creds.json"), { force: true });
 }
 
+// Write OAuth credentials whose expiry_date is already in the past so
+// getGeminiLoginStatus() reports loggedIn:false (expired token).
+export function writeExpiredGeminiCredentials(binDir) {
+  const geminiHome = path.join(binDir, "gemini-home");
+  fs.mkdirSync(geminiHome, { recursive: true });
+  fs.writeFileSync(
+    path.join(geminiHome, "oauth_creds.json"),
+    JSON.stringify({ access_token: "fake", expiry_date: Date.now() - 3_600_000 }, null, 2),
+    "utf8"
+  );
+  return geminiHome;
+}
+
+// Install a fake `agy` binary that succeeds on its --version probe so
+// getAgyAvailability() reports available:true. Does not install gemini.
+export function installFakeAgy(binDir) {
+  if (process.platform === "win32") {
+    fs.writeFileSync(path.join(binDir, "agy.cmd"), `@echo off\r\necho agy 1.0.0\r\nexit /b 0\r\n`, "utf8");
+  } else {
+    writeExecutable(path.join(binDir, "agy"), "#!/bin/sh\necho 'agy 1.0.0'\nexit 0\n");
+  }
+}
+
+// Shadow only gemini with a wrapper that fails its --version probe, leaving any
+// installed agy untouched. Pair with installFakeAgy for AGY-fallback assertions.
+export function installUnavailableGemini(binDir) {
+  if (process.platform === "win32") {
+    fs.writeFileSync(path.join(binDir, "gemini.cmd"), `@echo off\r\nexit /b 1\r\n`, "utf8");
+  } else {
+    writeExecutable(path.join(binDir, "gemini"), "#!/bin/sh\nexit 1\n");
+  }
+}
+
 export function buildEnv(binDir) {
   const sep = process.platform === "win32" ? ";" : ":";
   return {

--- a/tests/fixtures/fake-gemini.cjs
+++ b/tests/fixtures/fake-gemini.cjs
@@ -62,6 +62,7 @@ function buildResponse() {
         next_steps: []
       });
     case "review-findings":
+    case "review-noisy":
       return JSON.stringify({
         verdict: "needs-attention",
         summary: "One adversarial concern surfaced.",
@@ -100,6 +101,11 @@ function respond(prompt) {
   if (SCENARIO === "task-fail") {
     process.stderr.write("Gemini turn failed: simulated failure.\n");
     process.exit(1);
+  }
+
+  if (SCENARIO === "review-noisy") {
+    // Reasoning/thought noise on stderr must NOT pollute the stdout JSON parse.
+    process.stderr.write("Considering empty-state edge cases...\nReasoning complete.\n");
   }
 
   const response = buildResponse();

--- a/tests/model-map.test.mjs
+++ b/tests/model-map.test.mjs
@@ -1,0 +1,89 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  EFFORT_MODEL_MAP,
+  MODEL_ALIASES,
+  MODEL_ALIAS_ENTRIES,
+  MODEL_MAP_METADATA
+} from "../plugins/gemini/scripts/lib/model-map.mjs";
+import {
+  mapEffortToModel,
+  normalizeRequestedModel,
+  VALID_EFFORT_LEVELS
+} from "../plugins/gemini/scripts/lib/engine.mjs";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+test("model aliases resolve to their canonical model id", () => {
+  assert.equal(normalizeRequestedModel("flash"), "gemini-3-flash-preview");
+  assert.equal(normalizeRequestedModel("pro"), "gemini-3.1-pro-preview");
+  // Alias lookup is case-insensitive.
+  assert.equal(normalizeRequestedModel("LITE"), "gemini-2.5-flash-lite");
+  for (const { alias, model } of MODEL_ALIAS_ENTRIES) {
+    assert.equal(normalizeRequestedModel(alias), model);
+  }
+});
+
+test("effort tiers map to a model and define the valid set", () => {
+  assert.equal(mapEffortToModel("low"), "gemini-3-flash-preview");
+  assert.equal(mapEffortToModel("high"), "gemini-3.1-pro-preview");
+  assert.equal(mapEffortToModel("none"), "gemini-2.5-flash-lite");
+  assert.equal(mapEffortToModel(null), null);
+  assert.equal(mapEffortToModel("bogus"), null);
+  assert.deepEqual([...VALID_EFFORT_LEVELS].sort(), [...EFFORT_MODEL_MAP.keys()].sort());
+});
+
+test("an unknown alias passes through unchanged (trimmed)", () => {
+  assert.equal(normalizeRequestedModel("gemini-9.9-experimental"), "gemini-9.9-experimental");
+  assert.equal(normalizeRequestedModel("  custom-model  "), "custom-model");
+  assert.equal(normalizeRequestedModel(null), null);
+  assert.equal(normalizeRequestedModel(""), null);
+});
+
+test("preview entries are flagged and metadata records provenance", () => {
+  const preview = MODEL_ALIAS_ENTRIES.filter((entry) => entry.preview);
+  assert.ok(preview.every((entry) => entry.model.includes("preview")));
+  assert.ok(MODEL_MAP_METADATA.lastVerified, "metadata must record lastVerified");
+  assert.ok(MODEL_MAP_METADATA.source, "metadata must record a source");
+});
+
+function parseReadmeAliasTable(readme) {
+  const afterHeading = readme.split(/^##\s+Model Aliases\s*$/m)[1];
+  assert.ok(afterHeading, "README.md must have a `## Model Aliases` section");
+  const body = afterHeading.split(/^---\s*$/m)[0];
+  const map = new Map();
+  for (const line of body.split(/\r?\n/)) {
+    if (!/^\|\s*`/.test(line)) {
+      continue; // only table rows that begin with a backticked alias
+    }
+    const cells = line.split("|").map((cell) => cell.trim()).filter(Boolean);
+    if (cells.length < 2) {
+      continue;
+    }
+    const aliases = [...cells[0].matchAll(/`([^`]+)`/g)].map((match) => match[1]);
+    const models = [...cells[1].matchAll(/`([^`]+)`/g)].map((match) => match[1]);
+    if (!aliases.length || models.length !== 1) {
+      continue;
+    }
+    for (const alias of aliases) {
+      map.set(alias, models[0]);
+    }
+  }
+  return map;
+}
+
+test("README model alias table matches model-map.mjs exactly", () => {
+  const readme = fs.readFileSync(path.join(ROOT, "README.md"), "utf8");
+  const readmeMap = parseReadmeAliasTable(readme);
+
+  for (const [alias, model] of MODEL_ALIASES) {
+    assert.equal(readmeMap.get(alias), model, `README missing or mismatched alias \`${alias}\``);
+  }
+  for (const [alias, model] of readmeMap) {
+    assert.equal(MODEL_ALIASES.get(alias), model, `README declares unknown alias \`${alias}\``);
+  }
+});

--- a/tests/parse-robustness.test.mjs
+++ b/tests/parse-robustness.test.mjs
@@ -38,3 +38,14 @@ test("returns null when no JSON object is present", () => {
   assert.equal(tryParseJsonFromText("no json here"), null);
   assert.equal(tryParseJsonFromText(""), null);
 });
+
+test("parses the outer gemini envelope carrying a stringified response", () => {
+  const obj = tryParseJsonFromText('{"session_id":"thr_1","response":"hello world"}');
+  assert.equal(obj.session_id, "thr_1");
+  assert.equal(obj.response, "hello world");
+});
+
+test("recovers the JSON object when trailing log noise follows it", () => {
+  const obj = tryParseJsonFromText('{"verdict":"approve","summary":"s","findings":[]}\nDone. exit 0\n');
+  assert.equal(obj.verdict, "approve");
+});

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -650,7 +650,7 @@ test("task-resume-candidate returns the latest completed task thread", () => {
     }
   ]);
 
-  const result = run("node", [SCRIPT, "task-resume-candidate", "--json"], { cwd: workspace });
+  const result = run("node", [SCRIPT, "task-resume-candidate", "--json"], { cwd: workspace, env: envWithoutSession() });
 
   assert.equal(result.status, 0, result.stderr);
   const payload = JSON.parse(result.stdout);
@@ -683,10 +683,117 @@ test("task-resume-candidate is blocked while a task is still running", () => {
     }
   ]);
 
-  const result = run("node", [SCRIPT, "task-resume-candidate", "--json"], { cwd: workspace });
+  const result = run("node", [SCRIPT, "task-resume-candidate", "--json"], { cwd: workspace, env: envWithoutSession() });
 
   assert.equal(result.status, 0, result.stderr);
   const payload = JSON.parse(result.stdout);
   assert.equal(payload.found, false);
   assert.equal(payload.blocked, true);
+});
+
+// ---------------------------------------------------------------------------
+// P1-1: Claude session job filtering (--all + resume-candidate scoping)
+// ---------------------------------------------------------------------------
+
+function sessionJob(id, sessionId, updatedAt) {
+  return {
+    id,
+    status: "completed",
+    jobClass: "task",
+    kindLabel: "rescue",
+    title: "Gemini Task",
+    sessionId,
+    threadId: `thr_${id}`,
+    summary: `${sessionId} work`,
+    createdAt: updatedAt,
+    completedAt: updatedAt,
+    updatedAt
+  };
+}
+
+test("status scopes to the current session but --all crosses sessions", () => {
+  const workspace = makeTempDir();
+  seedState(workspace, [
+    sessionJob("task-current", "sess-current", "2026-03-18T15:31:00.000Z"),
+    sessionJob("task-other", "sess-other", "2026-03-18T15:21:00.000Z")
+  ]);
+  const env = { ...process.env, GEMINI_COMPANION_SESSION_ID: "sess-current" };
+
+  const scoped = JSON.parse(run("node", [SCRIPT, "status", "--json"], { cwd: workspace, env }).stdout);
+  const scopedIds = [scoped.latestFinished?.id, ...scoped.recent.map((job) => job.id)].filter(Boolean).sort();
+  assert.deepEqual(scopedIds, ["task-current"]);
+
+  const all = JSON.parse(run("node", [SCRIPT, "status", "--all", "--json"], { cwd: workspace, env }).stdout);
+  const allIds = [all.latestFinished?.id, ...all.recent.map((job) => job.id)].filter(Boolean).sort();
+  assert.deepEqual(allIds, ["task-current", "task-other"]);
+});
+
+test("task-resume-candidate prefers the current session over a newer other-session thread", () => {
+  const workspace = makeTempDir();
+  seedState(workspace, [
+    // Other-session job is newer; without scoping it would win the candidate.
+    sessionJob("task-other", "sess-other", "2026-03-18T15:35:00.000Z"),
+    sessionJob("task-current", "sess-current", "2026-03-18T15:30:00.000Z")
+  ]);
+  const env = { ...process.env, GEMINI_COMPANION_SESSION_ID: "sess-current" };
+
+  const payload = JSON.parse(run("node", [SCRIPT, "task-resume-candidate", "--json"], { cwd: workspace, env }).stdout);
+  assert.equal(payload.found, true);
+  assert.equal(payload.threadId, "thr_task-current");
+});
+
+test("task-resume-candidate hides other-session threads by default", () => {
+  const workspace = makeTempDir();
+  seedState(workspace, [sessionJob("task-other", "sess-other", "2026-03-18T15:35:00.000Z")]);
+  const env = { ...process.env, GEMINI_COMPANION_SESSION_ID: "sess-current" };
+
+  const payload = JSON.parse(run("node", [SCRIPT, "task-resume-candidate", "--json"], { cwd: workspace, env }).stdout);
+  assert.equal(payload.found, false);
+});
+
+// ---------------------------------------------------------------------------
+// P1-4: stdin prompt safety (gemini engine never puts the prompt in argv)
+// ---------------------------------------------------------------------------
+
+test("gemini engine delivers a metacharacter-laden prompt via stdin, never argv", () => {
+  const { repo, binDir } = setupRepo("task");
+  commit(repo, "README.md", "hello\n");
+
+  // Deliver the prompt over stdin so the OUTER test shell cannot reinterpret the
+  // metacharacters; this exercises the same companion -> gemini stdin path used
+  // in production (readStdinIfPiped -> runGeminiTurn input).
+  const nastyPrompt = `fix 'a' "b" \`c\` x;y|z&w $(id) %PATH% && rm -rf / \n line2`;
+  const result = run("node", [SCRIPT, "task"], { cwd: repo, env: buildEnv(binDir), input: nastyPrompt });
+
+  assert.equal(result.status, 0, result.stderr);
+  const { lastInvocation } = readFakeState(binDir);
+  // The full prompt arrives verbatim on stdin...
+  assert.equal(lastInvocation.prompt, nastyPrompt);
+  // ...and never leaks into argv.
+  assert.ok(!lastInvocation.args.includes(nastyPrompt));
+  for (const fragment of ["rm -rf /", "$(id)", "|z&w", "`c`", "%PATH%"]) {
+    assert.ok(
+      !lastInvocation.args.some((arg) => String(arg).includes(fragment)),
+      `argv must not contain prompt fragment: ${fragment}`
+    );
+  }
+});
+
+// ---------------------------------------------------------------------------
+// P1-3: reasoning noise on stderr must not pollute the stdout JSON parse
+// ---------------------------------------------------------------------------
+
+test("review parses cleanly even when gemini writes reasoning noise to stderr", () => {
+  const { repo, binDir } = setupRepo("review-noisy");
+  commit(repo, "src/app.js", "export const value = items[0];\n");
+  fs.writeFileSync(path.join(repo, "src", "app.js"), "export const value = items[0].id;\n");
+
+  const result = run("node", [SCRIPT, "adversarial-review"], { cwd: repo, env: buildEnv(binDir) });
+
+  assert.equal(result.status, 0, result.stderr);
+  // The structured verdict/finding parsed despite the stderr reasoning lines...
+  assert.match(result.stdout, /Verdict: needs-attention/);
+  assert.match(result.stdout, /Missing empty-state guard/);
+  // ...and the reasoning is surfaced separately, not mixed into the JSON.
+  assert.match(result.stdout, /Reasoning:/);
 });

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -8,10 +8,13 @@ import { fileURLToPath } from "node:url";
 import {
   buildEnv,
   buildEnvUnavailable,
+  installFakeAgy,
   installFakeGemini,
   installUnavailableEngines,
+  installUnavailableGemini,
   readFakeState,
-  removeGeminiCredentials
+  removeGeminiCredentials,
+  writeExpiredGeminiCredentials
 } from "./fake-gemini-fixture.mjs";
 import { initGitRepo, makeTempDir, run } from "./helpers.mjs";
 import {
@@ -72,7 +75,7 @@ test("setup reports ready when fake gemini is installed and authenticated", () =
   assert.equal(payload.geminiAuth.loggedIn, true);
 });
 
-test("setup flags missing gemini authentication while still reporting ready", () => {
+test("setup is not ready when gemini is installed but unauthenticated", () => {
   const binDir = makeTempDir();
   installFakeGemini(binDir, "task");
   removeGeminiCredentials(binDir);
@@ -81,9 +84,44 @@ test("setup flags missing gemini authentication while still reporting ready", ()
 
   assert.equal(result.status, 0, result.stderr);
   const payload = JSON.parse(result.stdout);
-  assert.equal(payload.ready, true);
+  // Core P0-3 contract: an unauthenticated gemini is never "ready". (readyState
+  // may be "partial" when a real AGY fallback happens to be on PATH, so it is
+  // asserted deterministically in the AGY-fallback test instead.)
+  assert.equal(payload.ready, false);
+  assert.equal(payload.gemini.available, true);
   assert.equal(payload.geminiAuth.loggedIn, false);
   assert.ok(payload.nextSteps.some((step) => /authenticate/i.test(step)));
+});
+
+test("setup is not ready when the gemini OAuth token is expired", () => {
+  const binDir = makeTempDir();
+  installFakeGemini(binDir, "task");
+  writeExpiredGeminiCredentials(binDir);
+
+  const result = run("node", [SCRIPT, "setup", "--json"], { cwd: makeTempDir(), env: buildEnv(binDir) });
+
+  assert.equal(result.status, 0, result.stderr);
+  const payload = JSON.parse(result.stdout);
+  assert.equal(payload.ready, false);
+  assert.equal(payload.geminiAuth.loggedIn, false);
+  assert.match(payload.geminiAuth.detail, /expired/i);
+});
+
+test("setup reports a partial AGY fallback when gemini is unavailable but agy is present", () => {
+  const binDir = makeTempDir();
+  installUnavailableGemini(binDir);
+  installFakeAgy(binDir);
+
+  const result = run("node", [SCRIPT, "setup", "--json"], { cwd: makeTempDir(), env: buildEnvUnavailable(binDir) });
+
+  assert.equal(result.status, 0, result.stderr);
+  const payload = JSON.parse(result.stdout);
+  assert.equal(payload.gemini.available, false);
+  assert.equal(payload.agy.available, true);
+  assert.equal(payload.ready, false);
+  assert.equal(payload.readyState, "partial");
+  assert.equal(payload.agyFallbackAvailable, true);
+  assert.ok(payload.nextSteps.some((step) => /--engine agy/.test(step)));
 });
 
 test("setup reports not ready when neither gemini nor agy is available", () => {
@@ -141,14 +179,75 @@ test("review renders a clean working-tree verdict from structured JSON", () => {
   assert.match(result.stdout, /No material findings\./);
 });
 
-test("review targets a base branch when --base is provided", () => {
+test("review honors --base over the dirty-tree auto default", () => {
   const { repo, binDir } = setupRepo("review-clean");
   commit(repo, "src/app.js", "export const value = 1;\n");
+  run("git", ["checkout", "-b", "feature"], { cwd: repo });
+  commit(repo, "src/feature.js", "export const f = 1;\n");
+  // Dirty the working tree so the auto scope would resolve to working-tree.
+  fs.writeFileSync(path.join(repo, "src", "app.js"), "export const value = 2;\n");
 
   const result = run("node", [SCRIPT, "review", "--base", "main"], { cwd: repo, env: buildEnv(binDir) });
 
   assert.equal(result.status, 0, result.stderr);
+  // The fix must route --base through to the diff target; the original bug
+  // re-resolved with empty options and reported "working tree diff" instead.
   assert.match(result.stdout, /Target: branch diff against main/);
+  assert.doesNotMatch(result.stdout, /Target: working tree/);
+});
+
+test("review honors --scope working-tree even when the tree is clean", () => {
+  const { repo, binDir } = setupRepo("review-clean");
+  commit(repo, "src/app.js", "export const value = 1;\n");
+  // Clean tree: the auto scope would resolve to a branch diff, not working-tree.
+
+  const result = run("node", [SCRIPT, "review", "--scope", "working-tree"], { cwd: repo, env: buildEnv(binDir) });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /Target: working tree diff/);
+});
+
+test("review honors --scope branch even when the tree is dirty", () => {
+  const { repo, binDir } = setupRepo("review-clean");
+  commit(repo, "src/app.js", "export const value = 1;\n");
+  // Dirty the tree: the auto scope would resolve to working-tree, not branch.
+  fs.writeFileSync(path.join(repo, "src", "app.js"), "export const value = 2;\n");
+
+  const result = run("node", [SCRIPT, "review", "--scope", "branch"], { cwd: repo, env: buildEnv(binDir) });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /Target: branch diff against main/);
+  assert.doesNotMatch(result.stdout, /Target: working tree/);
+});
+
+test("standard review ignores trailing focus text", () => {
+  const { repo, binDir } = setupRepo("review-clean");
+  commit(repo, "src/app.js", "export const value = 1;\n");
+  fs.writeFileSync(path.join(repo, "src", "app.js"), "export const value = 2;\n");
+
+  const result = run("node", [SCRIPT, "review", "please", "focus", "on", "auth"], { cwd: repo, env: buildEnv(binDir) });
+
+  assert.equal(result.status, 0, result.stderr);
+  const state = readFakeState(binDir);
+  assert.doesNotMatch(state.lastInvocation.prompt, /please focus on auth/);
+});
+
+test("adversarial review keeps focus text out of flag parsing and forwards it", () => {
+  const { repo, binDir } = setupRepo("review-findings");
+  commit(repo, "src/app.js", "export const value = items[0];\n");
+  fs.writeFileSync(path.join(repo, "src", "app.js"), "export const value = items[0].id;\n");
+
+  const result = run(
+    "node",
+    [SCRIPT, "adversarial-review", "--base", "main", "challenge", "the", "retry", "design"],
+    { cwd: repo, env: buildEnv(binDir) }
+  );
+
+  assert.equal(result.status, 0, result.stderr);
+  // --base must be parsed as a flag and the trailing words must become focus text.
+  assert.match(result.stdout, /Target: branch diff against main/);
+  const state = readFakeState(binDir);
+  assert.match(state.lastInvocation.prompt, /challenge the retry design/);
 });
 
 test("review forwards the default gemini model and JSON output flags", () => {


### PR DESCRIPTION
High-fidelity parity pass against [openai/codex-plugin-cc](https://github.com/openai/codex-plugin-cc), validated commit-by-commit against the upstream source. Four commits: **P0 fixes**, **P1 hardening**, **docs**, **0.6.0 release**.

## ⚠️ Breaking change
`/gemini:setup` now reports `ready: true` only when Node **and** the Gemini CLI are present **and** OAuth is valid. An installed-but-unauthenticated Gemini now reports `ready: false` (was `true`). New JSON fields: `readyState` (`ready`|`partial`|`not-ready`), `geminiReady`, `agyFallbackAvailable`. This matches upstream, whose `ready` already required auth. Released as **0.6.0**.

## P0 fixes (`d1de9e4`)
- **Review target was discarded** — `/gemini:review` & `/gemini:adversarial-review` now honour `--base`/`--scope`; `executeReviewRun` no longer re-resolves the target with empty options.
- **Verbatim contradiction** — removed the "STOP and ask which issues to fix" instruction that conflicted with "return stdout verbatim".
- **Setup readiness** — `ready` now requires auth (see breaking change).
- **AGY install over-eager** — `setup.md` installs Gemini CLI as the primary engine and only prompts for AGY under `--engine agy`; auth guidance unified on `gemini` (no `gemini login` subcommand).

## P1 hardening (`2bdd192`)
- **Session filtering** — `/gemini:status --all` crosses Claude sessions (default scoped); resume-candidate & active-task checks respect the session boundary, falling back to the workspace latest when no session id is present.
- **Model-map SSOT** — `scripts/lib/model-map.mjs` is the single source for aliases + effort tiers + provenance; a test keeps the README table in sync.
- **Contract verification** — new `scripts/verify-contracts.mjs` (`npm run verify-contracts`) and ported `scripts/bump-version.mjs` (`npm run check-version` / `bump-version`); CI now runs `test` + `check-version` + `verify-contracts`.
- `getSessionRuntimeStatus` returns a `label`/`mode` (no more `session runtime: undefined`).

## Docs (`06ce624`)
README (EN + zh-TW): Compatibility Matrix, Codex app server vs Gemini CLI adapter, expanded Security Notes, Setup & Auth Troubleshooting, Model Alias Notes, Upstream Attribution. CHANGELOG entry. NOTICE (root + plugin) enumerates adapted-vs-original work.

## Release (`13907e7`)
`npm run bump-version 0.6.0` — package.json, package-lock.json, plugin.json, and marketplace.json synced to **0.6.0**; CHANGELOG dated 2026-06-01.

## Tests
- `npm test`: **90 → 117** pass / 0 fail (each code commit is independently green: P0 = 99, tip = 117).
- `npm run check-version`: matches 0.6.0. `npm run verify-contracts`: passed.
- All new tests use a fake gemini CLI / fixtures — no network, no real Gemini/AGY/OAuth.

## Remaining risks (need human/real-CLI verification)
- Real Gemini CLI behaviour (preview model IDs, JSON envelope, `--resume latest`) — only fake-fixture verified.
- AGY non-interactive mode & Windows `shell:true`+positional prompt (`DEP0190`) — docs warn against untrusted prompts via `--engine agy`.
- OAuth/AGY auth detection limits; Windows on-device; Claude Code plugin runtime & review-gate stop hook.
- `engines.node` kept at `>=18.0.0` (upstream `>=18.18.0`) — intentional minor divergence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
