### PR TITLE
fix: address parity-audit P0–P3 findings

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ When enabled and the review returns `needs-attention`, Claude Code is blocked fr
 - Aliases and effort tiers live in a single source of truth — `plugins/gemini/scripts/lib/model-map.mjs` — and `npm test` verifies the table above against it, so the two cannot drift.
 - **Effort mapping** (applied when `--effort` is given without `--model`): `none`/`minimal` → `gemini-2.5-flash-lite`; `low`/`medium` → `gemini-3-flash-preview`; `high`/`xhigh` → `gemini-3.1-pro-preview`.
 - **Preview IDs may change.** Model IDs ending in `-preview` track Google's preview channel (last verified against gemini CLI 0.44.1). If an alias stops resolving, override it with `--model <exact-id>` — any value that is not a known alias is passed through to the CLI unchanged.
-- **AGY ignores `--model` and `--effort`.** AGY selects its model and reasoning tier interactively; the plugin prints a note and ignores both flags when `--engine agy` is active.
+- **AGY ignores `--model` and `--effort`.** `agy --print` is locked to Gemini 3.5 Flash (High) and exposes no model/effort selection; the plugin prints a note and ignores both flags when `--engine agy` is active.
 
 ---
 
@@ -202,7 +202,9 @@ In `auto` mode the plugin selects the first available engine in this order:
 
 Override via `--engine` flag or the `GEMINI_ENGINE` environment variable.
 
-> `--model` and `--effort` apply to the **gemini** engine only. AGY selects its model and tier interactively, so the plugin ignores `--model`/`--effort` when `--engine agy` is active.
+> `--model` and `--effort` apply to the **gemini** engine only. `agy --print` is locked to Gemini 3.5 Flash (High) and has no model/effort flag, so the plugin ignores `--model`/`--effort` when `--engine agy` is active.
+
+> **AGY transcript recovery is platform-verified on Windows and Linux only.** Because `agy --print` does not pipe its output (upstream [google-gemini/gemini-cli#27466](https://github.com/google-gemini/gemini-cli/issues/27466)), the plugin recovers AGY responses from the on-disk "brain" transcript under `~/.gemini/antigravity-cli/brain` (Windows 1.0.3, verified) or `~/.antigravity-cli/brain` (Linux 1.0.2, reported). **macOS is unverified** — its brain path is unknown, so `--engine agy` may fail to start on macOS. If you run AGY on macOS, please open an issue with the actual brain directory so the path can be added.
 
 ---
 
@@ -210,6 +212,7 @@ Override via `--engine` flag or the `GEMINI_ENGINE` environment variable.
 
 - **Stdin delivery (gemini engine)**: For the `gemini` engine, prompts are passed via `stdin` (Node's `spawnSync` `input` option) and never interpolated into a shell string, eliminating shell-injection risk regardless of prompt content. The `agy` engine has no stdin mode and receives the prompt as a CLI argument, so prefer the default `gemini` engine for untrusted input.
 - **Windows `.cmd` wrappers**: npm installs `gemini`/`agy` as `.cmd` shims, which require `shell: true` to launch. Because the gemini prompt travels on stdin (never in argv), `shell: true` never exposes it to `cmd.exe` parsing — only controlled flags (model id, `--yolo`, …) are ever placed in argv.
+- **DEP0190 warning is benign**: On Windows you may see `(node:NNN) [DEP0190] DeprecationWarning: Passing args to a child process with shell option true can lead to security vulnerabilities, as the arguments are not escaped, only concatenated.` This is **safe to ignore here** — the deprecation is about *prompt content* placed in argv under `shell: true`, but this plugin never does that for the gemini engine: the prompt travels on stdin, and only controlled flags reach argv (each validated, e.g. model ids must match `^[A-Za-z0-9][A-Za-z0-9._-]*$`). The warning is Node flagging the general pattern, not an actual injection vector in this code path.
 - **AGY positional prompt**: AGY has no stdin mode, so under `--engine agy` the prompt is passed as a positional CLI argument and, on Windows, is subject to `cmd.exe` quoting. **Do not route untrusted prompt content through `--engine agy`** — prefer the default `gemini` engine.
 - **Credential handling**: OAuth credentials in `~/.gemini/oauth_creds.json` are read only to check token expiry via `getGeminiLoginStatus()`; they are never logged, copied elsewhere, or transmitted by this plugin.
 - **`.gitignore`**: The `.omc/` state directory (job logs, session state) is excluded from version control.
@@ -226,6 +229,7 @@ Override via `--engine` flag or the `GEMINI_ENGINE` environment variable.
 | setup shows `… token expired` | OAuth token lapsed | Run `!gemini` again to refresh credentials |
 | `Status: partial (AGY fallback only …)` | Gemini CLI unavailable but AGY present | Install Gemini CLI, or use `--engine agy` (its auth cannot be verified) |
 | Windows: command resolves but fails | `.cmd` wrapper / PATH | Confirm `where gemini` resolves; the plugin spawns bare names through `shell: true` to find `.cmd` shims |
+| `--engine agy` fails to start on macOS | AGY brain path unverified on macOS | Transcript recovery is verified on Windows/Linux only; on macOS, confirm the `agy` brain directory and open an issue with its location |
 
 To authenticate, run **`!gemini`** once — the plugin completes OAuth by invoking `gemini` itself. There is **no** `gemini login` subcommand. `setup` reports `ready: true` only when Node **and** the Gemini CLI are present **and** OAuth is valid; an installed-but-unauthenticated Gemini is reported as *not ready*.
 
@@ -245,7 +249,7 @@ Claude Code
             └─ renderTaskResult()   → Markdown output to Claude
 ```
 
-Background mode spawns a detached `task-worker` child process and returns a job ID immediately. State is persisted in `.omc/state/` and polled via `/gemini:status`.
+Background mode spawns a detached worker child process (`task-worker` for `/gemini:rescue`, `review-worker` for `/gemini:review` and `/gemini:adversarial-review`) and returns a job ID immediately. State is persisted in `.omc/state/` and polled via `/gemini:status`, so a background result survives even if the Claude session is interrupted.
 
 ---
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -187,7 +187,7 @@
 - 別名與努力等級集中於單一來源——`plugins/gemini/scripts/lib/model-map.mjs`——且 `npm test` 會以其驗證上表，二者不致漂移。
 - **努力對映**（於提供 `--effort` 但未給 `--model` 時套用）：`none`/`minimal` → `gemini-2.5-flash-lite`；`low`/`medium` → `gemini-3-flash-preview`；`high`/`xhigh` → `gemini-3.1-pro-preview`。
 - **Preview ID 可能變動。** 以 `-preview` 結尾之 model ID 追隨 Google 的 preview channel（最後驗證於 gemini CLI 0.44.1）。若某別名無法解析，以 `--model <精確 ID>` 覆蓋——任何非已知別名之值將原樣透傳給 CLI。
-- **AGY 忽略 `--model` 與 `--effort`。** AGY 之模型與推理分級由其互動選擇；`--engine agy` 時外掛會印出提示並忽略此二旗標。
+- **AGY 忽略 `--model` 與 `--effort`。** `agy --print` 鎖定 Gemini 3.5 Flash（High）、無模型／努力選擇；`--engine agy` 時外掛會印出提示並忽略此二旗標。
 
 ---
 
@@ -200,7 +200,9 @@
 
 可透過 `--engine` 旗標或 `GEMINI_ENGINE` 環境變數覆蓋。
 
-> `--model` 與 `--effort` 僅適用於 **gemini** 引擎。AGY 之模型與分級由其互動選擇，故 `--engine agy` 時外掛會忽略 `--model`/`--effort`。
+> `--model` 與 `--effort` 僅適用於 **gemini** 引擎。`agy --print` 鎖定 Gemini 3.5 Flash（High）、無 model/effort 旗標，故 `--engine agy` 時外掛會忽略 `--model`/`--effort`。
+
+> **AGY 紀錄恢復僅在 Windows 與 Linux 驗證通過。** 因 `agy --print` 不透過 pipe 輸出（上游 [google-gemini/gemini-cli#27466](https://github.com/google-gemini/gemini-cli/issues/27466)），外掛改從磁碟上的「brain」紀錄恢復回應——`~/.gemini/antigravity-cli/brain`（Windows 1.0.3，已驗證）或 `~/.antigravity-cli/brain`（Linux 1.0.2，回報）。**macOS 尚未驗證**——其 brain 路徑未知，故 `--engine agy` 在 macOS 上可能無法啟動。若於 macOS 使用 AGY，請開 issue 回報實際的 brain 目錄，以便補上該路徑。
 
 ---
 
@@ -208,6 +210,7 @@
 
 - **Stdin 傳遞（gemini 引擎）**：`gemini` 引擎之提示透過 stdin（Node.js `spawnSync` 的 `input` 選項）傳遞、從不插入 shell 命令字串，故無論內容為何皆無 shell injection 風險。`agy` 引擎無 stdin 模式，提示以 CLI 引數傳入；處理不可信輸入時請優先使用預設之 `gemini` 引擎。
 - **Windows `.cmd` wrapper**：npm 將 `gemini`／`agy` 安裝為 `.cmd` shim，需 `shell: true` 方能啟動。因 gemini 提示走 stdin（從不進 argv），`shell: true` 永不將其暴露給 `cmd.exe` 解析——argv 中僅有受控旗標（model id、`--yolo` 等）。
+- **DEP0190 警告屬無害**：於 Windows 上可能見到 `(node:NNN) [DEP0190] DeprecationWarning: Passing args to a child process with shell option true can lead to security vulnerabilities, as the arguments are not escaped, only concatenated.`。此處**可安心忽略**——該 deprecation 針對的是在 `shell: true` 下把*提示內容*放入 argv，但本外掛的 gemini 引擎從不如此：提示走 stdin，僅受控旗標進入 argv（且各自驗證，如 model id 須符合 `^[A-Za-z0-9][A-Za-z0-9._-]*$`）。此警告是 Node 對該通用模式的提醒，並非本程式路徑中的實際注入點。
 - **AGY positional 提示**：AGY 無 stdin 模式，故 `--engine agy` 時提示以 positional CLI 引數傳入，於 Windows 受 `cmd.exe` 引號規則影響。**請勿將不可信提示內容經 `--engine agy` 傳遞**——應優先使用預設之 `gemini` 引擎。
 - **憑證處理**：`~/.gemini/oauth_creds.json` 之 OAuth 憑證僅用於 `getGeminiLoginStatus()` 檢查 token 是否過期；本外掛從不記錄、複製或傳輸之。
 - **`.gitignore`**：`.omc/` 狀態目錄（工作日誌、會話狀態）已排除於版本控制之外。
@@ -224,6 +227,7 @@
 | setup 顯示 `… token expired` | OAuth token 已過期 | 再次執行 `!gemini` 以更新憑證 |
 | `Status: partial (AGY fallback only …)` | Gemini CLI 不可用但 AGY 存在 | 安裝 Gemini CLI，或使用 `--engine agy`（其認證無法驗證） |
 | Windows：命令可解析但執行失敗 | `.cmd` wrapper／PATH | 確認 `where gemini` 可解析；外掛以 `shell: true` 啟動裸命令名以尋得 `.cmd` shim |
+| `--engine agy` 於 macOS 無法啟動 | macOS 上 AGY brain 路徑未驗證 | 紀錄恢復僅在 Windows/Linux 驗證；於 macOS 請確認 `agy` 的 brain 目錄並開 issue 回報其位置 |
 
 如需認證，執行一次 **`!gemini`**——外掛即以呼叫 `gemini` 自身完成 OAuth。**並無** `gemini login` 子命令。唯有 Node **且** Gemini CLI 皆存在**且** OAuth 有效時，`setup` 方回報 `ready: true`；已安裝但未認證之 Gemini 將回報為 *not ready*。
 

--- a/plugins/gemini/CHANGELOG.md
+++ b/plugins/gemini/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## Unreleased — parity-audit follow-up fixes
+
+### Fixed (P0)
+- **`/gemini:rescue` resume prompt never fired.** `handleTaskResumeCandidate` emitted `found`, but `commands/rescue.md` keys the "continue current thread?" prompt off `available` (as upstream codex does). The companion now emits `available` in all branches; a contract guard test asserts `available` is present and the legacy `found` is gone.
+
+### Added (P1)
+- **Persistent background reviews.** `/gemini:review --background` and `/gemini:adversarial-review --background` now enqueue a detached `review-worker` (mirroring `task-worker`) instead of relying on Claude-layer `run_in_background`, so a background review result survives an interrupted session and is retrievable via `/gemini:status` / `/gemini:result`. New `review-worker` subcommand; `enqueueBackgroundJob`/`spawnDetachedWorker`/`runStoredJobWorker` generalize the shared machinery.
+
+### Fixed (P1)
+- **Stop-review-gate is no longer silent on skip.** On review failure / Gemini-unavailable the gate still fails open, but now surfaces a `systemMessage` + stderr warning so the user knows the gate was skipped. It also reviews `--scope working-tree` explicitly (where `--write` task edits live) instead of relying on auto scope.
+- Removed dead `renderNativeReviewResult` from `lib/render.mjs`.
+
+### Fixed (P2)
+- **Standard `/gemini:review` mislabeled its progress as "adversarial review".** `runGeminiReview` is now mode-aware (`isAdversarial`).
+- **CLI noise leaked into the "Reasoning:" output.** `extractReasoningSummary` now drops DEP0190 deprecation, 256-color, and ripgrep-fallback lines before the last-N slice.
+- **Preview-model drift is now visible.** `/gemini:setup` reports the model-alias count, how many resolve to `*-preview` IDs, and the `lastVerified` date.
+
+### Documentation
+- README (EN + zh-TW): clarified that `agy --print` is locked to Gemini 3.5 Flash (High) and ignores `--model`/`--effort` (was incorrectly described as interactive selection); noted the DEP0190 warning is benign; documented that AGY transcript recovery is verified on Windows/Linux only (macOS unverified).
+- Added `skills/gemini-prompting/references/` (blocks, recipes, anti-patterns), matching upstream `gpt-5-4-prompting`.
+
 ## 0.6.0 — 2026-06-01 — parity audit
 
 ### Breaking

--- a/plugins/gemini/commands/adversarial-review.md
+++ b/plugins/gemini/commands/adversarial-review.md
@@ -38,7 +38,7 @@ Argument handling:
 - Preserve the user's arguments exactly.
 - Do not strip `--wait` or `--background` yourself.
 - Do not weaken the adversarial framing or rewrite the user's focus text.
-- The companion script parses `--wait` and `--background`, but Claude Code's `Bash(..., run_in_background: true)` is what actually detaches the run.
+- The companion script handles `--background` itself: it enqueues the review and spawns a detached `review-worker`, so the result persists even if this session ends. Do not use Claude's `run_in_background: true` for it.
 - `/gemini:adversarial-review` uses the same review target selection as `/gemini:review` (including `--base <ref>` and `--scope`).
 - Unlike `/gemini:review`, it can take extra focus text after the flags.
 
@@ -53,13 +53,10 @@ node "${CLAUDE_PLUGIN_ROOT}/scripts/gemini-companion.mjs" adversarial-review "$A
 - If the helper reports that Gemini/AGY is missing or unauthenticated, stop and tell the user to run `/gemini:setup`.
 
 Background flow:
-- Launch the review with `Bash` in the background:
-```typescript
-Bash({
-  command: `node "${CLAUDE_PLUGIN_ROOT}/scripts/gemini-companion.mjs" adversarial-review "$ARGUMENTS"`,
-  description: "Gemini adversarial review",
-  run_in_background: true
-})
+- Run the companion with its own `--background` flag in the FOREGROUND (the companion detaches its own worker and returns immediately):
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/scripts/gemini-companion.mjs" adversarial-review --background "$ARGUMENTS"
 ```
-- Do not call `BashOutput` or wait for completion in this turn.
-- After launching the command, tell the user: "Gemini adversarial review started in the background. Check `/gemini:status` for progress."
+- This enqueues the review, spawns a detached `review-worker`, and returns a job id right away. The result persists even if this Claude session is interrupted.
+- Do not use `run_in_background: true` and do not call `BashOutput` — the companion already detached; this call returns immediately.
+- Relay the returned job id: "Gemini adversarial review started in the background as `<job-id>`. Check `/gemini:status <job-id>` for progress and `/gemini:result <job-id>` when it finishes."

--- a/plugins/gemini/commands/review.md
+++ b/plugins/gemini/commands/review.md
@@ -36,7 +36,7 @@ Argument handling:
 - Preserve the user's arguments exactly.
 - Do not strip `--wait` or `--background` yourself.
 - Do not add extra review instructions or rewrite the user's intent.
-- The companion script parses `--wait` and `--background`, but Claude Code's `Bash(..., run_in_background: true)` is what actually detaches the run.
+- The companion script handles `--background` itself: it enqueues the review and spawns a detached `review-worker`, so the result persists even if this session ends. Do not use Claude's `run_in_background: true` for it.
 - `/gemini:review` is native-review only. It does not take custom focus text.
 - For an adversarial review that challenges design decisions, use `/gemini:adversarial-review`.
 
@@ -51,13 +51,10 @@ node "${CLAUDE_PLUGIN_ROOT}/scripts/gemini-companion.mjs" review "$ARGUMENTS"
 - If the helper reports that Gemini/AGY is missing or unauthenticated, stop and tell the user to run `/gemini:setup`.
 
 Background flow:
-- Launch the review with `Bash` in the background:
-```typescript
-Bash({
-  command: `node "${CLAUDE_PLUGIN_ROOT}/scripts/gemini-companion.mjs" review "$ARGUMENTS"`,
-  description: "Gemini review",
-  run_in_background: true
-})
+- Run the companion with its own `--background` flag in the FOREGROUND (the companion detaches its own worker and returns immediately):
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/scripts/gemini-companion.mjs" review --background "$ARGUMENTS"
 ```
-- Do not call `BashOutput` or wait for completion in this turn.
-- After launching the command, tell the user: "Gemini review started in the background. Check `/gemini:status` for progress."
+- This enqueues the review, spawns a detached `review-worker`, and returns a job id right away. The result persists even if this Claude session is interrupted.
+- Do not use `run_in_background: true` and do not call `BashOutput` — the companion already detached; this call returns immediately.
+- Relay the returned job id: "Gemini review started in the background as `<job-id>`. Check `/gemini:status <job-id>` for progress and `/gemini:result <job-id>` when it finishes."

--- a/plugins/gemini/scripts/gemini-companion.mjs
+++ b/plugins/gemini/scripts/gemini-companion.mjs
@@ -59,6 +59,7 @@ import {
   getGeminiPlanTier,
   getSessionRuntimeStatus
 } from "./lib/gemini.mjs";
+import { MODEL_MAP_METADATA, MODEL_ALIAS_ENTRIES } from "./lib/model-map.mjs";
 
 const ROOT_DIR = path.resolve(fileURLToPath(new URL("..", import.meta.url)));
 const REVIEW_SCHEMA = path.join(ROOT_DIR, "schemas", "review-output.schema.json");
@@ -228,6 +229,14 @@ function buildSetupReport(cwd, actionsTaken = [], options = {}) {
     );
   }
 
+  // Surface model-alias provenance so preview-channel drift is visible: how many
+  // aliases resolve to *-preview IDs (which can change) and when they were last
+  // verified. Defensive in case the alias table is ever malformed.
+  const modelAliasCount = Array.isArray(MODEL_ALIAS_ENTRIES) ? MODEL_ALIAS_ENTRIES.length : 0;
+  const previewAliasCount = Array.isArray(MODEL_ALIAS_ENTRIES)
+    ? MODEL_ALIAS_ENTRIES.filter((entry) => entry.preview).length
+    : 0;
+
   return {
     ready,
     readyState,
@@ -243,6 +252,11 @@ function buildSetupReport(cwd, actionsTaken = [], options = {}) {
     agyAuth,
     sessionRuntime: getSessionRuntimeStatus(),
     reviewGateEnabled: config.stopReviewGateEnabled ?? false,
+    modelAliases: {
+      total: modelAliasCount,
+      preview: previewAliasCount,
+      lastVerified: MODEL_MAP_METADATA?.lastVerified ?? "unknown"
+    },
     actionsTaken,
     nextSteps
   };
@@ -340,6 +354,7 @@ async function executeReviewRun(request) {
     prompt,
     model: request.model,
     engine: request.engine,
+    isAdversarial: templateName === "adversarial-review",
     onProgress: request.onProgress
   });
 
@@ -498,6 +513,23 @@ function buildTaskRequest({ cwd, model, effort, engine, prompt, write, resumeLas
   };
 }
 
+// Serializable review request for the detached review-worker. The diff target is
+// NOT stored — the worker re-resolves it from base/scope at run time (the same
+// re-resolution executeReviewRun already does), so the review reflects the tree
+// when the worker runs, mirroring how a background task bakes in its prompt.
+function buildReviewRequest({ cwd, base, scope, model, engine, focusText, reviewName, templateName }) {
+  return {
+    cwd,
+    base,
+    scope,
+    model,
+    engine,
+    focusText,
+    reviewName,
+    templateName
+  };
+}
+
 function readTaskPrompt(cwd, options, positionals) {
   if (options["prompt-file"]) {
     return fs.readFileSync(path.resolve(cwd, options["prompt-file"]), "utf8");
@@ -526,9 +558,9 @@ async function runForegroundCommand(job, runner, options = {}) {
   return execution;
 }
 
-function spawnDetachedTaskWorker(cwd, jobId) {
+function spawnDetachedWorker(cwd, jobId, workerCommand) {
   const scriptPath = path.join(ROOT_DIR, "scripts", "gemini-companion.mjs");
-  const child = spawn(process.execPath, [scriptPath, "task-worker", "--cwd", cwd, "--job-id", jobId], {
+  const child = spawn(process.execPath, [scriptPath, workerCommand, "--cwd", cwd, "--job-id", jobId], {
     cwd,
     env: process.env,
     detached: true,
@@ -539,11 +571,14 @@ function spawnDetachedTaskWorker(cwd, jobId) {
   return child;
 }
 
-function enqueueBackgroundTask(cwd, job, request) {
+// Persist a job and hand it to a detached worker (`task-worker` or
+// `review-worker`). Both job classes share the same enqueue/state machinery; the
+// worker subcommand only decides which executor deserializes the request.
+function enqueueBackgroundJob(cwd, job, request, workerCommand) {
   const { logFile } = createTrackedProgress(job);
   appendLogLine(logFile, "Queued for background execution.");
 
-  const child = spawnDetachedTaskWorker(cwd, job.id);
+  const child = spawnDetachedWorker(cwd, job.id, workerCommand);
   const queuedRecord = {
     ...job,
     status: "queued",
@@ -589,6 +624,25 @@ async function handleReviewCommand(argv, { reviewName, templateName, supportsFoc
     jobClass: "review",
     summary: `${reviewName} ${target.label}`
   });
+
+  if (options.background) {
+    // Persist the review to a detached review-worker so the result survives an
+    // interrupted Claude session (parity with background tasks). Returns a job id
+    // immediately; track via /gemini:status and /gemini:result.
+    const request = buildReviewRequest({
+      cwd,
+      base: options.base,
+      scope: options.scope,
+      model: options.model,
+      engine: options.engine,
+      focusText,
+      reviewName,
+      templateName
+    });
+    const { payload } = enqueueBackgroundJob(cwd, job, request, "review-worker");
+    outputCommandResult(payload, renderQueuedTaskLaunch(payload), options.json);
+    return;
+  }
 
   await runForegroundCommand(
     job,
@@ -655,7 +709,7 @@ async function handleTask(argv) {
       resumeLast,
       jobId: job.id
     });
-    const { payload } = enqueueBackgroundTask(cwd, job, request);
+    const { payload } = enqueueBackgroundJob(cwd, job, request, "task-worker");
     outputCommandResult(payload, renderQueuedTaskLaunch(payload), options.json);
     return;
   }
@@ -679,16 +733,18 @@ async function handleTask(argv) {
   );
 }
 
-async function handleTaskWorker(argv) {
+// Shared worker body for the detached `task-worker` / `review-worker` subcommands:
+// load the persisted job, deserialize its request, and run the matching executor
+// under runTrackedJob (which records running/completed/failed state + result).
+async function runStoredJobWorker(argv, { executor, label }) {
   const { options } = parseCommandInput(argv, {
     valueOptions: ["cwd", "job-id"]
   });
 
   if (!options["job-id"]) {
-    throw new Error("Missing required --job-id for task-worker.");
+    throw new Error(`Missing required --job-id for ${label}.`);
   }
 
-  const cwd = resolveCommandCwd(options);
   const workspaceRoot = resolveCommandWorkspace(options);
   const storedJob = readStoredJob(workspaceRoot, options["job-id"]);
   if (!storedJob) {
@@ -697,7 +753,7 @@ async function handleTaskWorker(argv) {
 
   const request = storedJob.request;
   if (!request || typeof request !== "object") {
-    throw new Error(`Stored job ${options["job-id"]} is missing its task request payload.`);
+    throw new Error(`Stored job ${options["job-id"]} is missing its request payload.`);
   }
 
   const { logFile, progress } = createTrackedProgress(
@@ -716,12 +772,20 @@ async function handleTaskWorker(argv) {
       logFile
     },
     () =>
-      executeTaskRun({
+      executor({
         ...request,
         onProgress: progress
       }),
     { logFile }
   );
+}
+
+async function handleTaskWorker(argv) {
+  return runStoredJobWorker(argv, { executor: executeTaskRun, label: "task-worker" });
+}
+
+async function handleReviewWorker(argv) {
+  return runStoredJobWorker(argv, { executor: executeReviewRun, label: "review-worker" });
 }
 
 async function handleStatus(argv) {
@@ -777,7 +841,9 @@ async function handleTaskResumeCandidate(argv) {
   const jobs = sortJobsNewestFirst(filterJobsForCurrentSession(listJobs(workspaceRoot)));
   const activeTask = jobs.find((job) => job.jobClass === "task" && (job.status === "queued" || job.status === "running"));
   if (activeTask) {
-    const payload = { found: false, blocked: true, activeJobId: activeTask.id };
+    // `available` mirrors upstream codex-companion (rescue.md keys off it). Do not
+    // rename to `found` — commands/rescue.md asks the agent to read `available`.
+    const payload = { available: false, blocked: true, activeJobId: activeTask.id };
     outputResult(
       options.json ? payload : `Task ${activeTask.id} is still running. Use /gemini:status before resuming.\n`,
       options.json
@@ -786,8 +852,8 @@ async function handleTaskResumeCandidate(argv) {
   }
   const candidate = jobs.find((job) => job.jobClass === "task" && job.status === "completed" && job.threadId);
   const payload = candidate
-    ? { found: true, jobId: candidate.id, threadId: candidate.threadId, title: candidate.title }
-    : { found: false };
+    ? { available: true, jobId: candidate.id, threadId: candidate.threadId, title: candidate.title }
+    : { available: false };
   outputResult(
     options.json ? payload : (candidate ? `Resume candidate: ${candidate.id} — ${candidate.title}\n` : "No resume candidate found.\n"),
     options.json
@@ -863,6 +929,9 @@ async function main() {
       break;
     case "task-worker":
       await handleTaskWorker(argv);
+      break;
+    case "review-worker":
+      await handleReviewWorker(argv);
       break;
     case "status":
       await handleStatus(argv);

--- a/plugins/gemini/scripts/lib/gemini.mjs
+++ b/plugins/gemini/scripts/lib/gemini.mjs
@@ -25,11 +25,29 @@ function extractTouchedFiles(text) {
   return [...new Set(matches)];
 }
 
+// CLI noise that must never surface as model "reasoning": Node deprecation
+// warnings, terminal-capability notices, and ripgrep fallbacks. Filtered BEFORE
+// the last-N slice so genuine reasoning is not evicted by trailing noise.
+const REASONING_NOISE = [
+  /^\(node:\d+\)/,
+  /DeprecationWarning/i,
+  /\[DEP\d+\]/,
+  /--trace-deprecation/,
+  /256-color support not detected/i,
+  /Using a terminal with at least 256-color/i,
+  /Ripgrep is not available/i,
+  /Falling back to GrepTool/i
+];
+
+function isReasoningNoise(line) {
+  return REASONING_NOISE.some((re) => re.test(line));
+}
+
 function extractReasoningSummary(stderr) {
   const lines = stripAnsi(String(stderr ?? ""))
     .split(/\r?\n/)
     .map((l) => l.trim())
-    .filter(Boolean);
+    .filter((l) => l && !isReasoningNoise(l));
   if (!lines.length) return null;
   return lines.slice(-5).join("\n");
 }
@@ -198,9 +216,11 @@ export async function runGeminiTurn(cwd, options = {}) {
 }
 
 export async function runGeminiReview(cwd, options = {}) {
-  const { prompt, model: requestedModel, engine: requestedEngine, onProgress } = options;
+  const { prompt, model: requestedModel, engine: requestedEngine, isAdversarial = true, onProgress } = options;
 
-  onProgress?.({ message: "Starting adversarial review...", phase: "reviewing" });
+  // Mode-aware label: the standard /review and adversarial /adversarial-review
+  // share this runner, so the progress line must reflect the actual mode.
+  onProgress?.({ message: `Starting ${isAdversarial ? "adversarial review" : "review"}...`, phase: "reviewing" });
 
   // prefer gemini for JSON output, unless forced to agy
   let engineInfo;

--- a/plugins/gemini/scripts/lib/render.mjs
+++ b/plugins/gemini/scripts/lib/render.mjs
@@ -202,6 +202,7 @@ export function renderSetupReport(report) {
     `- agy auth: ${report.agyAuth.detail}`,
     `- session runtime: ${report.sessionRuntime.label}`,
     `- review gate: ${report.reviewGateEnabled ? "enabled" : "disabled"}`,
+    `- model aliases: ${report.modelAliases?.total ?? 0} (${report.modelAliases?.preview ?? 0} preview), verified ${report.modelAliases?.lastVerified ?? "unknown"}`,
     ""
   ];
 
@@ -293,33 +294,6 @@ export function renderReviewResult(parsedResult, meta) {
     for (const step of data.next_steps) {
       lines.push(`- ${step}`);
     }
-  }
-
-  appendReasoningSection(lines, meta.reasoningSummary);
-
-  return `${lines.join("\n").trimEnd()}\n`;
-}
-
-export function renderNativeReviewResult(result, meta) {
-  const stdout = result.stdout.trim();
-  const stderr = result.stderr.trim();
-  const lines = [
-    `# Gemini ${meta.reviewLabel}`,
-    "",
-    `Target: ${meta.targetLabel}`,
-    ""
-  ];
-
-  if (stdout) {
-    lines.push(stdout);
-  } else if (result.status === 0) {
-    lines.push("Gemini review completed without any stdout output.");
-  } else {
-    lines.push("Gemini review failed.");
-  }
-
-  if (stderr) {
-    lines.push("", "stderr:", "", "```text", stderr, "```");
   }
 
   appendReasoningSection(lines, meta.reasoningSummary);

--- a/plugins/gemini/scripts/stop-review-gate-hook.mjs
+++ b/plugins/gemini/scripts/stop-review-gate-hook.mjs
@@ -33,9 +33,13 @@ function hasCompletedWriteTask(jobs) {
 
 function runAdversarialReview(cwd) {
   try {
+    // The gate fires because a --write task completed; those edits live in the
+    // working tree (the plugin never commits), so review the working tree
+    // explicitly instead of relying on auto scope (which could resolve to an
+    // empty branch diff and pass vacuously).
     const output = execFileSync(
       process.execPath,
-      [COMPANION_SCRIPT, "adversarial-review", "--json"],
+      [COMPANION_SCRIPT, "adversarial-review", "--scope", "working-tree", "--json"],
       { cwd, encoding: "utf8", timeout: GATE_REVIEW_TIMEOUT_MS }
     );
     return JSON.parse(output);
@@ -81,8 +85,14 @@ async function main() {
 
   const payload = runAdversarialReview(cwd);
   if (!payload) {
-    // Review failed or Gemini unavailable — fail open.
-    emitDecision({ decision: "proceed" });
+    // Review failed or Gemini unavailable — fail OPEN (never trap the user at
+    // Stop), but make the skip VISIBLE instead of silent so they know the gate
+    // did not actually run. `systemMessage` surfaces to the user; stderr is a
+    // belt-and-suspenders fallback for hook logs.
+    const warning =
+      "Gemini review gate skipped: the adversarial review could not run (Gemini/AGY unavailable or errored). Run /gemini:adversarial-review --wait before stopping if you changed code.";
+    process.stderr.write(`${warning}\n`);
+    emitDecision({ decision: "proceed", systemMessage: warning });
     return;
   }
 

--- a/plugins/gemini/skills/gemini-prompting/SKILL.md
+++ b/plugins/gemini/skills/gemini-prompting/SKILL.md
@@ -28,7 +28,7 @@ Model selection guidance (`<model_selection>` block):
 - Debug or fix tasks → `--effort high` (→ gemini-3.1-pro-preview)
 - Research or review tasks → `--effort medium` (→ gemini-3-flash-preview)
 - Quick formatting or structure tasks → `--effort low` (→ gemini-3-flash-preview)
-- AGY engine: `--model` is ignored; effort controls are irrelevant. Use AGY for speed and simplicity.
+- AGY engine: locked to Gemini 3.5 Flash (High); `--model` and `--effort` are both ignored. Use AGY for speed when a fixed, high-capability model is acceptable.
 
 When to add blocks:
 - Coding or debugging: add `completeness_contract`, `verification_loop`, and `missing_context_gating`.
@@ -48,3 +48,9 @@ Prompt assembly checklist:
 3. Decide whether the model should keep going by default or stop for missing high-risk details.
 4. Add verification, grounding, and safety tags only where the task needs them.
 5. Remove redundant instructions before sending the prompt.
+
+## References
+
+- [references/gemini-prompt-blocks.md](references/gemini-prompt-blocks.md) — the reusable XML block catalogue (including `json_output_contract` and `model_selection`).
+- [references/gemini-prompt-recipes.md](references/gemini-prompt-recipes.md) — end-to-end templates for diagnosis, narrow fix, review, research, and prompt-patching.
+- [references/gemini-prompt-antipatterns.md](references/gemini-prompt-antipatterns.md) — failure modes to avoid, including Gemini/AGY-specific ones (AGY ignores `--model`/`--effort`; AGY has no pipeable stdout).

--- a/plugins/gemini/skills/gemini-prompting/references/gemini-prompt-antipatterns.md
+++ b/plugins/gemini/skills/gemini-prompting/references/gemini-prompt-antipatterns.md
@@ -1,0 +1,143 @@
+# Gemini Prompt Anti-Patterns
+
+Avoid these when prompting Gemini or AGY. The first six are general; the last three
+are specific to this plugin's engines.
+
+## Vague task framing
+
+Bad:
+
+```text
+Take a look at this and let me know what you think.
+```
+
+Better:
+
+```xml
+<task>
+Review this change for material correctness and regression risks.
+</task>
+```
+
+## Missing output contract
+
+Bad:
+
+```text
+Investigate and report back.
+```
+
+Better:
+
+```xml
+<structured_output_contract>
+Return:
+1. root cause
+2. evidence
+3. smallest safe next step
+</structured_output_contract>
+```
+
+## No follow-through default
+
+Bad:
+
+```text
+Debug this failure.
+```
+
+Better:
+
+```xml
+<default_follow_through_policy>
+Keep going until you have enough evidence to identify the root cause confidently.
+</default_follow_through_policy>
+```
+
+## Asking for more reasoning instead of a better contract
+
+Bad:
+
+```text
+Think harder and be very smart.
+```
+
+Better:
+
+```xml
+<verification_loop>
+Before finalizing, verify that the answer matches the observed evidence and task requirements.
+</verification_loop>
+```
+
+## Mixing unrelated jobs into one run
+
+Bad:
+
+```text
+Review this diff, fix the bug you find, update the docs, and suggest a roadmap.
+```
+
+Better:
+- Run review first.
+- Run a separate fix prompt if needed.
+- Use a third run for docs or roadmap work.
+
+## Unsupported certainty
+
+Bad:
+
+```text
+Tell me exactly why production failed.
+```
+
+Better:
+
+```xml
+<grounding_rules>
+Ground every claim in the provided context or tool outputs.
+If a point is an inference, label it clearly.
+</grounding_rules>
+```
+
+## Expecting `--model` / `--effort` to change AGY (AGY-specific)
+
+Bad:
+
+```text
+Use --engine agy --model gemini-3.1-pro-preview --effort high to force the strongest model.
+```
+
+Better:
+- Use the **gemini** engine when you need a specific model or effort tier — `--effort high` → `gemini-3.1-pro-preview`.
+- For AGY, drop `--model`/`--effort`: `agy --print` is locked to Gemini 3.5 Flash (High) and the plugin ignores both flags (it prints a note when you pass them).
+
+Explanation: AGY exposes no model/effort selection at invocation time. Choosing capability is a gemini-engine concern only.
+
+## Expecting AGY to return output on stdout (AGY-specific)
+
+Bad:
+
+```text
+Pipe `agy --print "..."` and read its stdout, or tell AGY to print only the final answer.
+```
+
+Better:
+- Let the plugin recover the response from AGY's on-disk transcript — that is the only reliable channel.
+- Prefer the **gemini** engine (`--output-format json`) when you need clean, pipeable structured output.
+
+Explanation: `agy --print` does not deliver its response over a pipe in non-interactive use (upstream google-gemini/gemini-cli#27466). No prompt instruction changes that; the plugin diffs the transcript dirs to recover the answer, and this path is verified on Windows/Linux only (macOS unverified).
+
+## Assuming Gemini/AGY behaves like Codex (parity-specific)
+
+Bad:
+
+```text
+Treat --effort high + AGY like Codex rescue mode and expect the same multi-turn, app-server behavior.
+```
+
+Better:
+- Remember this is a CLI-per-command adapter, not a persistent app-server: each run is one turn.
+- Validate Gemini/AGY output quality independently; do not assume one-to-one equivalence with Codex/GPT-5.4 routing or sandboxing.
+
+Explanation: the Gemini plugin mirrors the *interface* of `codex-plugin-cc`, but the runtime, review mechanism (prompt-based, not native), and capability profile differ. Tighten the prompt contract rather than assuming inherited behavior.

--- a/plugins/gemini/skills/gemini-prompting/references/gemini-prompt-blocks.md
+++ b/plugins/gemini/skills/gemini-prompting/references/gemini-prompt-blocks.md
@@ -1,0 +1,204 @@
+# Gemini Prompt Blocks
+
+Use these blocks selectively when composing Gemini or AGY prompts.
+Wrap each block in the XML tag shown in its heading. The blocks are model-agnostic;
+the Gemini/AGY-specific guidance lives in `model_selection` and `json_output_contract`.
+
+## Core Wrapper
+
+### `task`
+
+Use in nearly every prompt.
+
+```xml
+<task>
+Describe the concrete job, the relevant repository or failure context, and the expected end state.
+</task>
+```
+
+## Output and Format
+
+### `structured_output_contract`
+
+Use when the response shape matters.
+
+```xml
+<structured_output_contract>
+Return exactly the requested output shape and nothing else.
+Keep the answer compact.
+Put the highest-value findings or decisions first.
+</structured_output_contract>
+```
+
+### `compact_output_contract`
+
+Use when you want concise prose instead of a schema.
+
+```xml
+<compact_output_contract>
+Keep the final answer compact and structured.
+Do not include long scene-setting or repeated recap.
+</compact_output_contract>
+```
+
+### `json_output_contract`
+
+Use when the caller parses the result as JSON — this plugin's `/gemini:review` and
+`/gemini:adversarial-review` do exactly that (see `schemas/review-output.schema.json`).
+
+```xml
+<json_output_contract>
+Return ONLY valid JSON. No markdown, no code fences, no commentary before or after.
+Match the requested schema exactly; omit fields you cannot fill rather than inventing them.
+</json_output_contract>
+```
+
+## Follow-through and Completion
+
+### `default_follow_through_policy`
+
+Use when the model should act without asking routine questions.
+
+```xml
+<default_follow_through_policy>
+Default to the most reasonable low-risk interpretation and keep going.
+Only stop to ask questions when a missing detail changes correctness, safety, or an irreversible action.
+</default_follow_through_policy>
+```
+
+### `completeness_contract`
+
+Use for debugging, implementation, or any multi-step task that should not stop early.
+
+```xml
+<completeness_contract>
+Resolve the task fully before stopping.
+Do not stop at the first plausible answer.
+Check whether there are follow-on fixes, edge cases, or cleanup needed for a correct result.
+</completeness_contract>
+```
+
+### `verification_loop`
+
+Use when correctness matters.
+
+```xml
+<verification_loop>
+Before finalizing, verify the result against the task requirements and the changed files or tool outputs.
+If a check fails, revise the answer instead of reporting the first draft.
+</verification_loop>
+```
+
+## Grounding and Missing Context
+
+### `missing_context_gating`
+
+Use when the model might otherwise guess.
+
+```xml
+<missing_context_gating>
+Do not guess missing repository facts.
+If required context is absent, retrieve it with tools or state exactly what remains unknown.
+</missing_context_gating>
+```
+
+### `grounding_rules`
+
+Use for review, research, or root-cause analysis.
+
+```xml
+<grounding_rules>
+Ground every claim in the provided context or your tool outputs.
+Do not present inferences as facts.
+If a point is a hypothesis, label it clearly.
+</grounding_rules>
+```
+
+### `citation_rules`
+
+Use when external research or quotes matter.
+
+```xml
+<citation_rules>
+Back important claims with citations or explicit references to the source material you inspected.
+Prefer primary sources.
+</citation_rules>
+```
+
+## Safety and Scope
+
+### `action_safety`
+
+Use for write-capable or potentially broad tasks.
+
+```xml
+<action_safety>
+Keep changes tightly scoped to the stated task.
+Avoid unrelated refactors, renames, or cleanup unless they are required for correctness.
+Call out any risky or irreversible action before taking it.
+</action_safety>
+```
+
+### `tool_persistence_rules`
+
+Use for long-running tool-heavy tasks.
+
+```xml
+<tool_persistence_rules>
+Keep using tools until you have enough evidence to finish the task confidently.
+Do not abandon the workflow after a partial read when another targeted check would change the answer.
+</tool_persistence_rules>
+```
+
+## Task-Specific Blocks
+
+### `research_mode`
+
+Use for exploration, comparisons, or recommendations.
+
+```xml
+<research_mode>
+Separate observed facts, reasoned inferences, and open questions.
+Prefer breadth first, then go deeper only where the evidence changes the recommendation.
+</research_mode>
+```
+
+### `dig_deeper_nudge`
+
+Use for review and adversarial inspection.
+
+```xml
+<dig_deeper_nudge>
+After you find the first plausible issue, check for second-order failures, empty-state behavior, retries, stale state, and rollback paths before you finalize.
+</dig_deeper_nudge>
+```
+
+### `progress_updates`
+
+Use when the run may take a while.
+
+```xml
+<progress_updates>
+If you provide progress updates, keep them brief and outcome-based.
+Mention only major phase changes or blockers.
+</progress_updates>
+```
+
+## Engine-Specific
+
+### `model_selection`
+
+Drives `--effort` / `--model` for the **gemini** engine. AGY ignores both — see the
+anti-patterns file.
+
+```xml
+<model_selection>
+--effort high  → gemini-3.1-pro-preview   (complex reasoning, coding, adversarial review)
+--effort medium → gemini-3-flash-preview  (balanced review, research)
+--effort low   → gemini-3-flash-preview   (formatting, structure)
+--effort none  → gemini-2.5-flash-lite    (cheapest, trivial transforms)
+AGY: --model and --effort are ignored — `agy --print` is locked to Gemini 3.5 Flash (High).
+Aliases (override anytime with --model <id>): flash/pro/lite, plus *25/*3 variants. Preview
+ids ending in -preview can drift; see model-map.mjs.
+</model_selection>
+```

--- a/plugins/gemini/skills/gemini-prompting/references/gemini-prompt-recipes.md
+++ b/plugins/gemini/skills/gemini-prompting/references/gemini-prompt-recipes.md
@@ -1,0 +1,156 @@
+# Gemini Prompt Recipes
+
+Use these as starting templates for Gemini task prompts or other Gemini/AGY prompt construction.
+Copy the smallest recipe that fits the task, then trim anything you do not need.
+In `gemini:gemini-rescue`, run diagnosis and fix-oriented recipes in write mode by default unless the user explicitly asked for read-only behavior.
+
+For the **gemini** engine, pick capability with `--effort` (or an explicit `--model`); for **AGY**, both are ignored (it is locked to Gemini 3.5 Flash, High), so lean on a tight prompt contract instead of more model power.
+
+## Diagnosis
+
+```xml
+<task>
+Diagnose why the failing test or command is breaking in this repository.
+Use the available repository context and tools to identify the most likely root cause.
+</task>
+
+<compact_output_contract>
+Return a compact diagnosis with:
+1. most likely root cause
+2. evidence
+3. smallest safe next step
+</compact_output_contract>
+
+<default_follow_through_policy>
+Keep going until you have enough evidence to identify the root cause confidently.
+Only stop to ask questions when a missing detail changes correctness materially.
+</default_follow_through_policy>
+
+<verification_loop>
+Before finalizing, verify that the proposed root cause matches the observed evidence.
+</verification_loop>
+
+<missing_context_gating>
+Do not guess missing repository facts.
+If required context is absent, state exactly what remains unknown.
+</missing_context_gating>
+```
+
+Gemini engine: add `--effort high` when the diagnosis spans multiple files or call stacks.
+
+## Narrow Fix
+
+```xml
+<task>
+Implement the smallest safe fix for the identified issue in this repository.
+Preserve existing behavior outside the failing path.
+</task>
+
+<structured_output_contract>
+Return:
+1. summary of the fix
+2. touched files
+3. verification performed
+4. residual risks or follow-ups
+</structured_output_contract>
+
+<default_follow_through_policy>
+Default to the most reasonable low-risk interpretation and keep going.
+</default_follow_through_policy>
+
+<completeness_contract>
+Resolve the task fully before stopping.
+Do not stop after identifying the issue without applying the fix.
+</completeness_contract>
+
+<verification_loop>
+Before finalizing, verify that the fix matches the task requirements and that the changed code is coherent.
+</verification_loop>
+
+<action_safety>
+Keep changes tightly scoped to the stated task.
+Avoid unrelated refactors or cleanup.
+</action_safety>
+```
+
+## Root-Cause Review
+
+```xml
+<task>
+Analyze this change for the most likely correctness or regression issues.
+Focus on the provided repository context only.
+</task>
+
+<structured_output_contract>
+Return:
+1. findings ordered by severity
+2. supporting evidence for each finding
+3. brief next steps
+</structured_output_contract>
+
+<grounding_rules>
+Ground every claim in the repository context or tool outputs.
+If a point is an inference, label it clearly.
+</grounding_rules>
+
+<dig_deeper_nudge>
+Check for second-order failures, empty-state handling, retries, stale state, and rollback paths before finalizing.
+</dig_deeper_nudge>
+
+<verification_loop>
+Before finalizing, verify that each finding is material and actionable.
+</verification_loop>
+```
+
+This plugin's `/gemini:review` and `/gemini:adversarial-review` use this shape but require the result as strict JSON — add `json_output_contract` when you assemble the prompt yourself.
+
+## Research Or Recommendation
+
+```xml
+<task>
+Research the available options and recommend the best path for this task.
+</task>
+
+<structured_output_contract>
+Return:
+1. observed facts
+2. reasoned recommendation
+3. tradeoffs
+4. open questions
+</structured_output_contract>
+
+<research_mode>
+Separate observed facts, reasoned inferences, and open questions.
+Prefer breadth first, then go deeper only where the evidence changes the recommendation.
+</research_mode>
+
+<citation_rules>
+Back important claims with explicit references to the sources you inspected.
+Prefer primary sources.
+</citation_rules>
+```
+
+## Prompt-Patching
+
+```xml
+<task>
+Diagnose why this existing prompt is underperforming and propose the smallest high-leverage changes to improve it for Gemini or AGY.
+</task>
+
+<structured_output_contract>
+Return:
+1. failure modes
+2. root causes in the current prompt
+3. a revised prompt
+4. why the revision should work better
+</structured_output_contract>
+
+<grounding_rules>
+Base your diagnosis on the prompt text and the failure examples provided.
+Do not invent failure modes that are not supported by the examples.
+</grounding_rules>
+
+<verification_loop>
+Before finalizing, make sure the revised prompt resolves the cited failure modes without adding contradictory instructions.
+</verification_loop>
+```

--- a/tests/render.test.mjs
+++ b/tests/render.test.mjs
@@ -44,6 +44,19 @@ test("renderSetupReport reports needs-attention when not ready", () => {
   assert.match(out, /- review gate: disabled/);
 });
 
+test("renderSetupReport surfaces model-alias provenance so preview drift is visible", () => {
+  const out = renderSetupReport(
+    setupReport({ modelAliases: { total: 9, preview: 5, lastVerified: "2026-05" } })
+  );
+  // Match the label + structure, not just the date (the date will change over time).
+  assert.match(out, /- model aliases: 9 \(5 preview\), verified 2026-05/);
+});
+
+test("renderSetupReport renders the model-alias line gracefully when data is absent", () => {
+  const out = renderSetupReport(setupReport());
+  assert.match(out, /- model aliases: 0 \(0 preview\), verified unknown/);
+});
+
 test("renderStatusReport shows empty state when there are no jobs", () => {
   const out = renderStatusReport({
     sessionRuntime: { label: "gemini 0.44.1" },

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -561,6 +561,64 @@ test("task --background enqueues a detached worker and reports completion", asyn
   assert.match(result.stdout, /Handled the requested task/);
 });
 
+test("review --background enqueues a detached review-worker and persists the result", async () => {
+  const { repo, binDir } = setupRepo("review-clean");
+  commit(repo, "src/app.js", "export const value = 1;\n");
+  fs.writeFileSync(path.join(repo, "src", "app.js"), "export const value = 2;\n");
+
+  const launched = run("node", [SCRIPT, "review", "--background", "--json"], {
+    cwd: repo,
+    env: buildEnv(binDir)
+  });
+  assert.equal(launched.status, 0, launched.stderr);
+  const launchPayload = JSON.parse(launched.stdout);
+  assert.equal(launchPayload.status, "queued");
+  assert.match(launchPayload.jobId, /^review-/);
+
+  const waited = run(
+    "node",
+    [SCRIPT, "status", launchPayload.jobId, "--wait", "--timeout-ms", "15000", "--json"],
+    { cwd: repo, env: buildEnv(binDir) }
+  );
+  assert.equal(waited.status, 0, waited.stderr);
+  const waitedPayload = JSON.parse(waited.stdout);
+  assert.equal(waitedPayload.job.id, launchPayload.jobId);
+  assert.equal(waitedPayload.job.status, "completed");
+
+  // The persisted result is retrievable after the worker exits — the whole point
+  // of having a review-worker instead of Claude-layer run_in_background.
+  const result = run("node", [SCRIPT, "result", launchPayload.jobId], { cwd: repo, env: buildEnv(binDir) });
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /# Gemini Review/);
+});
+
+test("adversarial-review --background serializes focus text through the worker", async () => {
+  const { repo, binDir } = setupRepo("review-findings");
+  commit(repo, "src/app.js", "export const value = items[0];\n");
+  fs.writeFileSync(path.join(repo, "src", "app.js"), "export const value = items[0].id;\n");
+
+  const launched = run(
+    "node",
+    [SCRIPT, "adversarial-review", "--background", "--json", "challenge the retry design"],
+    { cwd: repo, env: buildEnv(binDir) }
+  );
+  assert.equal(launched.status, 0, launched.stderr);
+  const launchPayload = JSON.parse(launched.stdout);
+  assert.match(launchPayload.jobId, /^review-/);
+
+  const waited = run(
+    "node",
+    [SCRIPT, "status", launchPayload.jobId, "--wait", "--timeout-ms", "15000", "--json"],
+    { cwd: repo, env: buildEnv(binDir) }
+  );
+  assert.equal(waited.status, 0, waited.stderr);
+  assert.equal(JSON.parse(waited.stdout).job.status, "completed");
+
+  // Focus text survives the JSON write/read cycle and reaches the model prompt.
+  const state = readFakeState(binDir);
+  assert.match(state.lastInvocation.prompt, /challenge the retry design/);
+});
+
 // ---------------------------------------------------------------------------
 // status / result / cancel / task-resume-candidate (seeded state)
 // ---------------------------------------------------------------------------
@@ -772,7 +830,7 @@ test("task-resume-candidate returns the latest completed task thread", () => {
 
   assert.equal(result.status, 0, result.stderr);
   const payload = JSON.parse(result.stdout);
-  assert.equal(payload.found, true);
+  assert.equal(payload.available, true);
   assert.equal(payload.threadId, "thr_recent");
 });
 
@@ -783,7 +841,7 @@ test("task-resume-candidate reports nothing to resume on an empty workspace", ()
   const result = run("node", [SCRIPT, "task-resume-candidate", "--json"], { cwd: workspace });
 
   assert.equal(result.status, 0, result.stderr);
-  assert.equal(JSON.parse(result.stdout).found, false);
+  assert.equal(JSON.parse(result.stdout).available, false);
 });
 
 test("task-resume-candidate is blocked while a task is still running", () => {
@@ -805,8 +863,34 @@ test("task-resume-candidate is blocked while a task is still running", () => {
 
   assert.equal(result.status, 0, result.stderr);
   const payload = JSON.parse(result.stdout);
-  assert.equal(payload.found, false);
+  assert.equal(payload.available, false);
   assert.equal(payload.blocked, true);
+});
+
+// Contract guard: commands/rescue.md keys the resume prompt off `available`.
+// The payload must expose `available` (not the legacy `found`) so the documented
+// contract and the companion output cannot drift apart again.
+test("task-resume-candidate exposes `available` and not the legacy `found` field", () => {
+  const workspace = makeTempDir();
+  seedState(workspace, [
+    {
+      id: "task-recent",
+      status: "completed",
+      jobClass: "task",
+      kindLabel: "rescue",
+      title: "Gemini Task",
+      threadId: "thr_recent",
+      summary: "Investigate flaky test",
+      createdAt: "2026-03-18T15:30:00.000Z",
+      updatedAt: "2026-03-18T15:31:00.000Z"
+    }
+  ]);
+
+  const payload = JSON.parse(
+    run("node", [SCRIPT, "task-resume-candidate", "--json"], { cwd: workspace, env: envWithoutSession() }).stdout
+  );
+  assert.equal(payload.available, true, "rescue.md reads `available`");
+  assert.ok(!Object.prototype.hasOwnProperty.call(payload, "found"), "legacy `found` field must be gone");
 });
 
 // ---------------------------------------------------------------------------
@@ -856,7 +940,7 @@ test("task-resume-candidate prefers the current session over a newer other-sessi
   const env = { ...process.env, GEMINI_COMPANION_SESSION_ID: "sess-current" };
 
   const payload = JSON.parse(run("node", [SCRIPT, "task-resume-candidate", "--json"], { cwd: workspace, env }).stdout);
-  assert.equal(payload.found, true);
+  assert.equal(payload.available, true);
   assert.equal(payload.threadId, "thr_task-current");
 });
 
@@ -866,7 +950,7 @@ test("task-resume-candidate hides other-session threads by default", () => {
   const env = { ...process.env, GEMINI_COMPANION_SESSION_ID: "sess-current" };
 
   const payload = JSON.parse(run("node", [SCRIPT, "task-resume-candidate", "--json"], { cwd: workspace, env }).stdout);
-  assert.equal(payload.found, false);
+  assert.equal(payload.available, false);
 });
 
 // Fail closed: when no current session id is known (lifecycle hook never ran),
@@ -881,7 +965,7 @@ test("task-resume-candidate fails closed when the session id is unset and jobs a
   ]);
 
   const payload = JSON.parse(run("node", [SCRIPT, "task-resume-candidate", "--json"], { cwd: workspace, env: envWithoutSession() }).stdout);
-  assert.equal(payload.found, false);
+  assert.equal(payload.available, false);
 });
 
 test("status hides other-session jobs when the session id is unset (but --all still surfaces them)", () => {


### PR DESCRIPTION
Addresses the P0–P3 findings from `docs/PARITY_AUDIT.md` (the mirror/usability audit vs `openai/codex-plugin-cc`).

## Fixes
- **P0 — `/gemini:rescue` resume prompt never fired.** Companion now emits `available` (was `found`) so `commands/rescue.md`'s continue-thread prompt fires, matching upstream. Guard test locks the field name.
- **P1 — persistent background reviews.** `/gemini:review --background` / `--adversarial-review --background` now enqueue a detached `review-worker` (parity with `task-worker`); results survive an interrupted session and are retrievable via `/gemini:status` / `/gemini:result`.
- **P1 — stop-review-gate.** Fails open *visibly* now (`systemMessage` + stderr) instead of silently; reviews `--scope working-tree` explicitly. Removed dead `renderNativeReviewResult`.
- **P2 — output hygiene.** Mode-aware review progress label (no more "adversarial" for `/review`); CLI noise (DEP0190 / 256-color / ripgrep) filtered out of the Reasoning section.
- **P2 — preview-model drift visible.** `/gemini:setup` now reports alias count, preview count, and `lastVerified`.
- **Docs.** Corrected the AGY model claim (locked to Gemini 3.5 Flash High, ignores `--model`/`--effort` — not interactive); noted DEP0190 is benign; marked AGY macOS transcript recovery unverified. Added `skills/gemini-prompting/references/` (blocks, recipes, anti-patterns).

## Verification
- Tests **154 → 159**, all green (`node --test`); `check-version` + `verify-contracts` pass.
- Live-validated against the real Gemini CLI: corrected label, no noise leak, background review-worker `queued → completed`, setup provenance line.
- Reviewed by a 5-way adversarial pass: 4 high-confidence PASS, 1 surfaced two doc inaccuracies (incl. a pre-existing README error) — both fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
