### PR TITLE
release: v0.6.3 — fix true-color reasoning-noise filter

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,13 +6,13 @@
   },
   "metadata": {
     "description": "Gemini/AGY companion plugin for Claude Code — delegate tasks, adversarial reviews, and rescue. Mirrors openai/codex-plugin-cc with Google Gemini.",
-    "version": "0.6.2"
+    "version": "0.6.3"
   },
   "plugins": [
     {
       "name": "gemini",
       "description": "Gemini/AGY companion plugin — delegation, adversarial review, rescue agent",
-      "version": "0.6.2",
+      "version": "0.6.3",
       "author": {
         "name": "arcobaleno64"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@arcobaleno64/gemini-plugin-cc",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@arcobaleno64/gemini-plugin-cc",
-      "version": "0.6.2",
+      "version": "0.6.3",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arcobaleno64/gemini-plugin-cc",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "private": true,
   "type": "module",
   "description": "Use Gemini/AGY from Claude Code to review code or delegate tasks.",

--- a/plugins/gemini/.claude-plugin/plugin.json
+++ b/plugins/gemini/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gemini",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Use Gemini/AGY from Claude Code to review code or delegate tasks.",
   "author": {
     "name": "arcobaleno64",

--- a/plugins/gemini/CHANGELOG.md
+++ b/plugins/gemini/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.6.3 — 2026-06-02 — reasoning-noise filter fix
+
+### Fixed
+- **True-color terminal warning leaked into review "Reasoning:".** `REASONING_NOISE` (`lib/gemini.mjs`) only matched the `256-color` terminal-capability warning, but gemini CLI 0.44.1 emits the `True color (24-bit) support not detected` variant. That line matched none of the patterns, so `extractReasoningSummary` kept it and it surfaced as a bogus model-reasoning bullet in review output. Added a `/true color/i` pattern. (The DEP0190 lines seen alongside it during diagnosis were the parent process's own deprecation warning surfaced via a `2>&1` redirect, **not** a filter failure — the v0.6.1 DEP0190 filter works correctly on the subprocess stderr it targets.)
+
+### Tests
+- Extended the `review-noisy` fixture/test: it now emits the true-color line on stderr and asserts genuine reasoning still surfaces (`Considering empty-state`) while the true-color warning is filtered out. 166 tests pass.
+
 ## 0.6.2 — 2026-06-02 — model resilience, agentic review, transparency
 
 ### Added

--- a/plugins/gemini/scripts/lib/gemini.mjs
+++ b/plugins/gemini/scripts/lib/gemini.mjs
@@ -55,6 +55,7 @@ const REASONING_NOISE = [
   /--trace-deprecation/,
   /256-color support not detected/i,
   /Using a terminal with at least 256-color/i,
+  /true color/i,
   /Ripgrep is not available/i,
   /Falling back to GrepTool/i
 ];

--- a/tests/fixtures/fake-gemini.cjs
+++ b/tests/fixtures/fake-gemini.cjs
@@ -126,6 +126,9 @@ function respond(prompt) {
 
   if (SCENARIO === "review-noisy") {
     // Reasoning/thought noise on stderr must NOT pollute the stdout JSON parse.
+    // The terminal-capability warning (true-color variant emitted by gemini CLI
+    // 0.44.1) must be filtered out of the Reasoning section, not surfaced as it.
+    process.stderr.write("Warning: True color (24-bit) support not detected. Using a terminal with true color enabled will result in a better visual experience.\n");
     process.stderr.write("Considering empty-state edge cases...\nReasoning complete.\n");
   }
 

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -1178,6 +1178,10 @@ test("review parses cleanly even when gemini writes reasoning noise to stderr", 
   assert.match(result.stdout, /Missing empty-state guard/);
   // ...and the reasoning is surfaced separately, not mixed into the JSON.
   assert.match(result.stdout, /Reasoning:/);
+  // ...genuine reasoning survives the noise filter...
+  assert.match(result.stdout, /Considering empty-state/);
+  // ...but the terminal-capability (true-color) warning is filtered out of it.
+  assert.doesNotMatch(result.stdout, /True color/i);
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Release **v0.6.3**. Single fix plus the version bump and CHANGELOG entry.

## Fix: true-color terminal warning leaked into review "Reasoning:"
A `/gemini:review` run surfaced a bogus reasoning line:

```
Reasoning:
- Warning: True color (24-bit) support not detected. Using a terminal with true color enabled will result in a better visual experience.
```

### Root cause
`REASONING_NOISE` (`lib/gemini.mjs`) filters the terminal-capability warning, but only matched the **256-color** variant:

```js
/256-color support not detected/i,
/Using a terminal with at least 256-color/i,
```

gemini CLI 0.44.1 emits the **true-color (24-bit)** variant instead, which matches none of the patterns. So `extractReasoningSummary` keeps the line and it surfaces as a spurious model-reasoning bullet.

> The DEP0190 lines seen alongside it during investigation were **not** a filter failure — they are the parent process's own deprecation warning, surfaced only because the diagnostic run used `2>&1`. The v0.6.1 DEP0190 filter works correctly on the subprocess stderr it targets.

### Change
- Add `/true color/i` to `REASONING_NOISE` (catches both "True color (24-bit) support not detected" and "terminal with true color enabled").
- Extend the `review-noisy` fixture to emit the true-color line on stderr.
- Add assertions: genuine reasoning survives the filter (`Considering empty-state`) **and** the true-color warning is filtered out (`assert.doesNotMatch(.../True color/i)`).

## Release
- Version `0.6.2` → `0.6.3` across all four manifests (`package.json`, `package-lock.json`, `plugin.json`, `marketplace.json`) via `scripts/bump-version.mjs`.
- CHANGELOG: new `## 0.6.3 — 2026-06-02 — reasoning-noise filter fix` entry.

## Commits
- `e3f4b39` fix(gemini): filter true-color terminal warning from review reasoning
- `5fd43ab` release: v0.6.3

## Verification
- `npm test` → **166 pass / 0 fail**
- `npm run verify-contracts` → passed for v0.6.3
- `npm run check-version` → all metadata matches 0.6.3

## After merge
Tag `v0.6.3` on `main` to trigger `.github/workflows/release.yml` and publish the GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)