### PR TITLE
release: v0.6.4 — empty-diff review guard

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,13 +6,13 @@
   },
   "metadata": {
     "description": "Gemini/AGY companion plugin for Claude Code — delegate tasks, adversarial reviews, and rescue. Mirrors openai/codex-plugin-cc with Google Gemini.",
-    "version": "0.6.3"
+    "version": "0.6.4"
   },
   "plugins": [
     {
       "name": "gemini",
       "description": "Gemini/AGY companion plugin — delegation, adversarial review, rescue agent",
-      "version": "0.6.3",
+      "version": "0.6.4",
       "author": {
         "name": "arcobaleno64"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@arcobaleno64/gemini-plugin-cc",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@arcobaleno64/gemini-plugin-cc",
-      "version": "0.6.3",
+      "version": "0.6.4",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arcobaleno64/gemini-plugin-cc",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "private": true,
   "type": "module",
   "description": "Use Gemini/AGY from Claude Code to review code or delegate tasks.",

--- a/plugins/gemini/.claude-plugin/plugin.json
+++ b/plugins/gemini/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gemini",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "Use Gemini/AGY from Claude Code to review code or delegate tasks.",
   "author": {
     "name": "arcobaleno64",

--- a/plugins/gemini/CHANGELOG.md
+++ b/plugins/gemini/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.6.4 — 2026-06-04 — empty-diff review guard
+
+### Fixed
+- **Background review of a clean/empty diff no longer passes vacuously.** `executeReviewRun` now short-circuits when the resolved review target has no changes — a working tree with nothing staged/unstaged/untracked, or a branch diff with no commits and an empty patch — returning an explicit `empty: true` / `result: null` payload rendered as `Nothing to review — <target> has no changes.` instead of asking Gemini to review an empty diff (which it rubber-stamps as "approved"). This closes the v0.6.1-audit gap where a detached `--background` review re-resolved the diff at run time and, if the tree was clean when the worker started, silently persisted a vacuous approve only visible at `/gemini:result`. The foreground and background paths share `executeReviewRun`, so both are covered, and the stop-review-gate stays non-blocking on an empty result (`result: null` → verdict is not `needs-attention`). New `isEmpty` flag on the working-tree/branch review context. (`lib/git.mjs`, `gemini-companion.mjs`)
+
+### Tests
+- 166 → 168: an empty working tree review surfaces "nothing to review" without invoking Gemini (the fake-gemini state file is never written); a `--json` empty review carries `empty:true` / `result:null` so the gate proceeds. The pre-existing "adversarial review forwards focus text" test now diverges onto a feature branch so `--base main` resolves to a non-empty diff — it previously exercised the empty-branch-diff path this fix targets.
+
 ## 0.6.3 — 2026-06-02 — reasoning-noise filter fix
 
 ### Fixed

--- a/plugins/gemini/scripts/gemini-companion.mjs
+++ b/plugins/gemini/scripts/gemini-companion.mjs
@@ -359,6 +359,35 @@ async function executeReviewRun(request) {
     scope: request.scope
   });
   const context = collectReviewContext(request.cwd, target);
+
+  // Nothing-to-review guard: if the resolved target has no changes, short-circuit
+  // instead of asking Gemini to review an empty diff (which it rubber-stamps as
+  // "approved"). This matters most for a detached --background review, where the
+  // worker re-resolves the diff at run time and a now-clean tree would otherwise
+  // persist a vacuous approve that only surfaces at /gemini:result.
+  if (context.isEmpty) {
+    const targetLabel = context.target?.label ?? "the requested scope";
+    const message = `Nothing to review — ${targetLabel} has no changes.`;
+    return {
+      exitStatus: 0,
+      threadId: null,
+      turnId: null,
+      engine: null,
+      payload: {
+        review: reviewName,
+        target: context.target,
+        empty: true,
+        gemini: null,
+        result: null
+      },
+      rendered: `# Gemini ${reviewName}\n\nTarget: ${targetLabel}\n\n${message}\n`,
+      summary: message,
+      jobTitle: `Gemini ${reviewName}`,
+      jobClass: "review",
+      targetLabel
+    };
+  }
+
   const template = loadPromptTemplate(ROOT_DIR, templateName);
   const basePrompt = interpolateTemplate(template, {
     TARGET_LABEL: context.target.label,

--- a/plugins/gemini/scripts/lib/git.mjs
+++ b/plugins/gemini/scripts/lib/git.mjs
@@ -192,6 +192,8 @@ function collectWorkingTreeContext(cwd, state) {
 
   return {
     mode: "working-tree",
+    isEmpty:
+      state.staged.length === 0 && state.unstaged.length === 0 && state.untracked.length === 0,
     summary: `Reviewing ${state.staged.length} staged, ${state.unstaged.length} unstaged, and ${state.untracked.length} untracked file(s).`,
     content: parts.join("\n")
   };
@@ -207,6 +209,7 @@ function collectBranchContext(cwd, baseRef) {
 
   return {
     mode: "branch",
+    isEmpty: diff.trim() === "" && logOutput === "",
     summary: `Reviewing branch ${currentBranch} against ${baseRef} from merge-base ${mergeBase}.`,
     content: [
       formatSection("Commit Log", logOutput),

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -326,6 +326,39 @@ test("review honors --scope working-tree even when the tree is clean", () => {
   assert.match(result.stdout, /Target: working tree diff/);
 });
 
+test("review surfaces 'nothing to review' on an empty working tree without invoking Gemini", () => {
+  const { repo, binDir } = setupRepo("review-clean");
+  commit(repo, "src/app.js", "export const value = 1;\n");
+  // Clean tree + explicit working-tree scope: there is no diff to review.
+
+  const result = run("node", [SCRIPT, "review", "--scope", "working-tree"], { cwd: repo, env: buildEnv(binDir) });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /Nothing to review/i);
+  // The vacuous-approve bug: Gemini must NOT be asked to review an empty diff.
+  assert.ok(
+    !fs.existsSync(path.join(binDir, "fake-gemini-state.json")),
+    "Gemini must not be invoked when there is nothing to review"
+  );
+});
+
+test("empty-diff review --json marks empty:true with a null result so the gate does not block", () => {
+  const { repo, binDir } = setupRepo("review-clean");
+  commit(repo, "src/app.js", "export const value = 1;\n");
+
+  const result = run("node", [SCRIPT, "adversarial-review", "--scope", "working-tree", "--json"], {
+    cwd: repo,
+    env: buildEnv(binDir)
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  const payload = JSON.parse(result.stdout);
+  assert.equal(payload.empty, true);
+  assert.equal(payload.result, null);
+  // result.verdict is undefined (not "needs-attention"), so stop-review-gate proceeds.
+  assert.notEqual(payload.result?.verdict, "needs-attention");
+});
+
 test("review honors --scope branch even when the tree is dirty", () => {
   const { repo, binDir } = setupRepo("review-clean");
   commit(repo, "src/app.js", "export const value = 1;\n");
@@ -354,7 +387,10 @@ test("standard review ignores trailing focus text", () => {
 test("adversarial review keeps focus text out of flag parsing and forwards it", () => {
   const { repo, binDir } = setupRepo("review-findings");
   commit(repo, "src/app.js", "export const value = items[0];\n");
-  fs.writeFileSync(path.join(repo, "src", "app.js"), "export const value = items[0].id;\n");
+  // Diverge from main so --base main resolves to a non-empty branch diff (an
+  // empty diff would now short-circuit as "nothing to review" before the model).
+  run("git", ["checkout", "-b", "feature"], { cwd: repo });
+  commit(repo, "src/app.js", "export const value = items[0].id;\n");
 
   const result = run(
     "node",


### PR DESCRIPTION
## What

Addresses the last open candidate from the v0.6.1 parity audit: a **background review of a clean/empty diff passed vacuously** (the detached `review-worker` re-resolved the diff at run time and silently persisted an "approved" verdict on an empty diff, only visible at `/gemini:result`).

`executeReviewRun` now short-circuits when the resolved review target has no changes — an empty working tree (nothing staged/unstaged/untracked) or an empty branch diff (no commits, empty patch) — returning an explicit `empty: true` / `result: null` payload rendered as `Nothing to review — <target> has no changes.` instead of asking Gemini to review an empty diff. Because the foreground and background paths share `executeReviewRun`, both are covered, and the stop-review-gate stays non-blocking on an empty result (`result: null` → verdict is not `needs-attention`).

## Changes

- `lib/git.mjs`: new `isEmpty` flag on the working-tree / branch review context.
- `gemini-companion.mjs`: empty-diff short-circuit in `executeReviewRun`.
- `CHANGELOG.md` + version bump to **0.6.4** (4 manifests in lockstep via `bump-version`).

## Tests (166 → 168, all green)

- Empty working-tree review surfaces "nothing to review" **without invoking Gemini** (fake-gemini state file is never written).
- `--json` empty review carries `empty:true` / `result:null` so the gate proceeds.
- The pre-existing "adversarial review forwards focus text" test now diverges onto a feature branch so `--base main` resolves to a non-empty diff (it previously exercised the empty-branch-diff path this fix targets).

`npm test` 168/168 · `npm run check-version` ✓ · `npm run verify-contracts` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)