### PR TITLE
release: v0.6.5 — low-severity cleanup (honest /cancel, narrowed DEP filter, known-limitations docs)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,13 +6,13 @@
   },
   "metadata": {
     "description": "Gemini/AGY companion plugin for Claude Code — delegate tasks, adversarial reviews, and rescue. Mirrors openai/codex-plugin-cc with Google Gemini.",
-    "version": "0.6.4"
+    "version": "0.6.5"
   },
   "plugins": [
     {
       "name": "gemini",
       "description": "Gemini/AGY companion plugin — delegation, adversarial review, rescue agent",
-      "version": "0.6.4",
+      "version": "0.6.5",
       "author": {
         "name": "arcobaleno64"
       },

--- a/README.md
+++ b/README.md
@@ -298,6 +298,16 @@ Three skills are bundled for Claude Code to consume:
 
 ---
 
+## Known limitations
+
+Documented, non-blocking constraints — see the linked sections for detail:
+
+- **macOS AGY is unverified.** AGY transcript recovery is verified on Windows/Linux only; the macOS "brain" path is unknown, so `--engine agy` may not start there. The `gemini` engine is unaffected. See [Engine Routing](#engine-routing).
+- **Gemini 3.5 is not served by the gemini CLI, and the free CLI sunsets 2026-06-18.** `gemini-3.5-*` returns 404 on CLI 0.44.1 (reach it via AGY); a requested id that is not served degrades gracefully to the GA fallback `gemini-2.5-flash`. After 2026-06-18 the free/personal CLI tier ends. See [Model Alias Notes](#model-alias-notes) and [docs/MODEL_COMPARISON.md](docs/MODEL_COMPARISON.md).
+- **`/gemini:review` is a prompt/CLI adapter, not a native reviewer.** It sends the diff with a review prompt and parses the structured JSON, rather than using an app-server reviewer, so its feedback depth differs from a native one. See [Codex app server vs Gemini CLI adapter](#codex-app-server-vs-gemini-cli-adapter).
+
+---
+
 ## Changelog
 
 See [CHANGELOG.md](plugins/gemini/CHANGELOG.md).

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -296,6 +296,16 @@ Claude Code
 
 ---
 
+## 已知限制
+
+以下為已記錄之非阻塞限制——詳見所連結之章節：
+
+- **macOS 之 AGY 未驗證。** AGY transcript 恢復僅於 Windows／Linux 驗證；macOS 之「brain」路徑未知，故 `--engine agy` 於其上或無法啟動。`gemini` 引擎不受影響。詳見 [引擎路由](#引擎路由)。
+- **gemini CLI 不提供 Gemini 3.5，且免費 CLI 於 2026-06-18 終止。** `gemini-3.5-*` 於 CLI 0.44.1 回 404（改走 AGY）；不被提供之 model id 會優雅降級至 GA fallback `gemini-2.5-flash`。2026-06-18 後免費／個人版 CLI 層級終止。詳見 [模型別名說明](#模型別名說明) 與 [docs/MODEL_COMPARISON.md](docs/MODEL_COMPARISON.md)。
+- **`/gemini:review` 為 prompt／CLI adapter，非原生審查器。** 其將 diff 連同審查 prompt 送出並解析結構化 JSON，而非透過 app-server 審查器，故反饋深度有別於原生。詳見 [Codex app server 與 Gemini CLI adapter](#codex-app-server-與-gemini-cli-adapter)。
+
+---
+
 ## 更新日誌
 
 詳見 [CHANGELOG.md](plugins/gemini/CHANGELOG.md)。

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@arcobaleno64/gemini-plugin-cc",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@arcobaleno64/gemini-plugin-cc",
-      "version": "0.6.4",
+      "version": "0.6.5",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arcobaleno64/gemini-plugin-cc",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "private": true,
   "type": "module",
   "description": "Use Gemini/AGY from Claude Code to review code or delegate tasks.",

--- a/plugins/gemini/.claude-plugin/plugin.json
+++ b/plugins/gemini/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gemini",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "description": "Use Gemini/AGY from Claude Code to review code or delegate tasks.",
   "author": {
     "name": "arcobaleno64",

--- a/plugins/gemini/CHANGELOG.md
+++ b/plugins/gemini/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.6.5 — 2026-06-04 — low-severity cleanup
+
+### Fixed
+- **`/gemini:cancel` no longer claims a kill it did not make.** The detached worker is `unref()`-ed, so by cancel time its PID is often already gone; `handleCancel` discarded `terminateProcessTree`'s return value and always logged "Cancelled by user." It now reports the real outcome — `terminated the running process`, `no live process (it had already exited)`, or `no live process was attached` — in the log, the `# Gemini Cancel` report (a new `- Process:` line), and a new `processTerminated` field on the `--json` payload. The job is still marked `cancelled` in every case (the user's intent is recorded). New shared `describeTermination` helper. (`gemini-companion.mjs`, `lib/render.mjs`)
+- **Narrowed the reasoning-noise `[DEP\d+]` filter.** `REASONING_NOISE` matched a bare `[DEP12]` token anywhere, which could strip a genuine reasoning line that merely contained such a bracket. It now requires Node's canonical `(node:NNN) [DEPxxx]` preamble, so real deprecation warnings are still filtered while legitimate reasoning survives. (`lib/gemini.mjs`)
+
+### Tests
+- 168 → 172: honest `/cancel` outcome (render-level wording for all three states + a no-pid integration case asserting `processTerminated:false`), the narrowed DEP filter (a `[DEP12]` reasoning line survives while a real `(node:…) [DEP0190]` line is filtered), and a multi-line focus-text round-trip through the background `review-worker`.
+
+### Documentation
+- README (EN + zh-TW): added a **Known limitations** section consolidating the documented, non-blocking constraints (macOS AGY unverified, Gemini 3.5 not served by the CLI + 2026-06-18 free-CLI sunset, `/review` prompt-adapter vs native reviewer) with cross-links to the detailed sections.
+
 ## 0.6.4 — 2026-06-04 — empty-diff review guard
 
 ### Fixed

--- a/plugins/gemini/scripts/gemini-companion.mjs
+++ b/plugins/gemini/scripts/gemini-companion.mjs
@@ -45,6 +45,7 @@ import {
   renderTaskResult,
   renderStoredJobResult,
   renderCancelReport,
+  describeTermination,
   renderJobStatusReport,
   renderSetupReport,
   renderStatusReport
@@ -924,8 +925,11 @@ async function handleCancel(argv) {
   const { workspaceRoot, job } = resolveCancelableJob(cwd, reference, { all: options.all });
   const existing = readStoredJob(workspaceRoot, job.id) ?? {};
 
-  terminateProcessTree(job.pid ?? Number.NaN);
-  appendLogLine(job.logFile, "Cancelled by user.");
+  // Be honest about whether a live process was actually killed: the detached
+  // worker is unref()-ed, so by cancel time its PID may already be gone. The job
+  // is still marked cancelled (the user's intent is recorded) in every case.
+  const termination = terminateProcessTree(job.pid ?? Number.NaN);
+  appendLogLine(job.logFile, `Cancelled by user — ${describeTermination(termination)}.`);
 
   const completedAt = nowIso();
   const nextJob = {
@@ -954,10 +958,11 @@ async function handleCancel(argv) {
   const payload = {
     jobId: job.id,
     status: "cancelled",
-    title: job.title
+    title: job.title,
+    processTerminated: termination.delivered
   };
 
-  outputCommandResult(payload, renderCancelReport(nextJob), options.json);
+  outputCommandResult(payload, renderCancelReport(nextJob, termination), options.json);
 }
 
 async function main() {

--- a/plugins/gemini/scripts/lib/gemini.mjs
+++ b/plugins/gemini/scripts/lib/gemini.mjs
@@ -51,7 +51,10 @@ function extractTouchedFiles(text) {
 const REASONING_NOISE = [
   /^\(node:\d+\)/,
   /DeprecationWarning/i,
-  /\[DEP\d+\]/,
+  // Narrowed to Node's canonical `(node:NNN) [DEPxxx]` preamble so a genuine
+  // reasoning line that merely contains a bracketed `[DEP12]`-style token is not
+  // stripped as noise (lines are trimmed before this test, so ^ is safe).
+  /^\(node:\d+\)\s+\[DEP\d+\]/,
   /--trace-deprecation/,
   /256-color support not detected/i,
   /Using a terminal with at least 256-color/i,

--- a/plugins/gemini/scripts/lib/render.mjs
+++ b/plugins/gemini/scripts/lib/render.mjs
@@ -434,7 +434,19 @@ export function renderStoredJobResult(job, storedJob) {
   return `${lines.join("\n").trimEnd()}\n`;
 }
 
-export function renderCancelReport(job) {
+// Human-readable outcome of terminateProcessTree(), so /gemini:cancel can be
+// honest about whether a live process was actually killed. The detached worker
+// is unref()-ed, so by cancel time its PID is often already gone.
+export function describeTermination(termination) {
+  if (!termination || termination.attempted !== true) {
+    return "no live process was attached";
+  }
+  return termination.delivered
+    ? "terminated the running process"
+    : "no live process (it had already exited)";
+}
+
+export function renderCancelReport(job, termination) {
   const lines = [
     "# Gemini Cancel",
     "",
@@ -448,6 +460,7 @@ export function renderCancelReport(job) {
   if (job.summary) {
     lines.push(`- Summary: ${job.summary}`);
   }
+  lines.push(`- Process: ${describeTermination(termination)}`);
   lines.push("- Check `/gemini:status` for the updated queue.");
 
   return `${lines.join("\n").trimEnd()}\n`;

--- a/tests/fixtures/fake-gemini.cjs
+++ b/tests/fixtures/fake-gemini.cjs
@@ -127,9 +127,13 @@ function respond(prompt) {
   if (SCENARIO === "review-noisy") {
     // Reasoning/thought noise on stderr must NOT pollute the stdout JSON parse.
     // The terminal-capability warning (true-color variant emitted by gemini CLI
-    // 0.44.1) must be filtered out of the Reasoning section, not surfaced as it.
+    // 0.44.1) and the Node deprecation preamble must be filtered out of the
+    // Reasoning section, not surfaced as it.
     process.stderr.write("Warning: True color (24-bit) support not detected. Using a terminal with true color enabled will result in a better visual experience.\n");
-    process.stderr.write("Considering empty-state edge cases...\nReasoning complete.\n");
+    process.stderr.write("(node:12345) [DEP0190] DeprecationWarning: Passing args to a child process with shell option true can lead to security vulnerabilities.\n");
+    // Genuine reasoning that merely contains a bracketed [DEPnn] token must survive
+    // the narrowed noise filter.
+    process.stderr.write("Considering empty-state edge cases...\nCross-checking [DEP12] handling in the retry path.\nReasoning complete.\n");
   }
 
   const response = buildResponse();

--- a/tests/render.test.mjs
+++ b/tests/render.test.mjs
@@ -7,6 +7,7 @@ import {
   renderJobStatusReport,
   renderTaskResult,
   renderCancelReport,
+  describeTermination,
   renderStoredJobResult
 } from "../plugins/gemini/scripts/lib/render.mjs";
 
@@ -99,10 +100,38 @@ test("renderTaskResult falls back to a failure message when there is no output",
 });
 
 test("renderCancelReport confirms cancellation and points at status", () => {
-  const out = renderCancelReport({ id: "task-7", title: "Big task", summary: "wip" });
+  const out = renderCancelReport(
+    { id: "task-7", title: "Big task", summary: "wip" },
+    { attempted: true, delivered: true, method: "process-group" }
+  );
   assert.match(out, /# Gemini Cancel/);
   assert.match(out, /Cancelled task-7\./);
+  assert.match(out, /- Process: terminated the running process/);
   assert.match(out, /\/gemini:status/);
+});
+
+test("describeTermination is honest about whether a live process was killed", () => {
+  assert.equal(
+    describeTermination({ attempted: true, delivered: true }),
+    "terminated the running process"
+  );
+  assert.equal(
+    describeTermination({ attempted: true, delivered: false }),
+    "no live process (it had already exited)"
+  );
+  // Non-finite pid path: terminateProcessTree returns attempted:false.
+  assert.equal(describeTermination({ attempted: false, delivered: false }), "no live process was attached");
+  assert.equal(describeTermination(undefined), "no live process was attached");
+});
+
+test("renderCancelReport does not claim a kill when the process had already exited", () => {
+  const out = renderCancelReport(
+    { id: "review-9" },
+    { attempted: true, delivered: false, method: "taskkill" }
+  );
+  assert.match(out, /Cancelled review-9\./);
+  assert.match(out, /- Process: no live process \(it had already exited\)/);
+  assert.doesNotMatch(out, /terminated the running process/);
 });
 
 test("renderStoredJobResult prefers the structured rendered review output", () => {

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -713,6 +713,40 @@ test("adversarial-review --background serializes focus text through the worker",
   assert.match(state.lastInvocation.prompt, /challenge the retry design/);
 });
 
+test("adversarial-review --background preserves multi-line focus text through the worker", async () => {
+  const { repo, binDir } = setupRepo("review-findings");
+  commit(repo, "src/app.js", "export const value = items[0];\n");
+  fs.writeFileSync(path.join(repo, "src", "app.js"), "export const value = items[0].id;\n");
+
+  const focus = "challenge the retry design\nand the backoff jitter";
+  // Launch node by absolute path so the test's own shell (shell:true for a bare
+  // "node" on Windows) cannot split the newline before it reaches the companion;
+  // we are asserting the companion's JSON round-trip, not the OS shell.
+  const launched = run(
+    process.execPath,
+    [SCRIPT, "adversarial-review", "--background", "--json", focus],
+    { cwd: repo, env: buildEnv(binDir) }
+  );
+  assert.equal(launched.status, 0, launched.stderr);
+  const launchPayload = JSON.parse(launched.stdout);
+  assert.match(launchPayload.jobId, /^review-/);
+
+  const waited = run(
+    "node",
+    [SCRIPT, "status", launchPayload.jobId, "--wait", "--timeout-ms", "15000", "--json"],
+    { cwd: repo, env: buildEnv(binDir) }
+  );
+  assert.equal(waited.status, 0, waited.stderr);
+  assert.equal(JSON.parse(waited.stdout).job.status, "completed");
+
+  // The embedded newline must survive JSON serialization through the stored job.
+  const state = readFakeState(binDir);
+  assert.ok(
+    state.lastInvocation.prompt.includes("challenge the retry design\nand the backoff jitter"),
+    "multi-line focus text must reach the model prompt intact"
+  );
+});
+
 // ---------------------------------------------------------------------------
 // status / result / cancel / task-resume-candidate (seeded state)
 // ---------------------------------------------------------------------------
@@ -902,6 +936,36 @@ test("cancel stops an active job and marks it cancelled", async (t) => {
 
   const state = JSON.parse(fs.readFileSync(path.join(resolveStateDir(workspace), "state.json"), "utf8"));
   assert.equal(state.jobs.find((job) => job.id === "task-live").status, "cancelled");
+});
+
+test("cancel is honest when there is no live process to terminate", () => {
+  const workspace = makeTempDir();
+  // A detached worker is unref()-ed, so by cancel time its PID is often gone.
+  // Seed a job with no pid: terminateProcessTree never attempts a kill.
+  seedState(workspace, [
+    {
+      id: "task-stale",
+      status: "running",
+      jobClass: "task",
+      kindLabel: "rescue",
+      title: "Gemini Task",
+      pid: null,
+      createdAt: "2026-03-18T15:30:00.000Z"
+    }
+  ]);
+  writeJobFile(workspace, "task-stale", { id: "task-stale", status: "running", pid: null });
+
+  const result = run("node", [SCRIPT, "cancel", "task-stale", "--json"], { cwd: workspace, env: envWithoutSession() });
+
+  assert.equal(result.status, 0, result.stderr);
+  const payload = JSON.parse(result.stdout);
+  // The job is still marked cancelled (intent recorded), but the result must not
+  // claim a process was killed.
+  assert.equal(payload.status, "cancelled");
+  assert.equal(payload.processTerminated, false);
+
+  const state = JSON.parse(fs.readFileSync(path.join(resolveStateDir(workspace), "state.json"), "utf8"));
+  assert.equal(state.jobs.find((job) => job.id === "task-stale").status, "cancelled");
 });
 
 test("task-resume-candidate returns the latest completed task thread", () => {
@@ -1216,8 +1280,13 @@ test("review parses cleanly even when gemini writes reasoning noise to stderr", 
   assert.match(result.stdout, /Reasoning:/);
   // ...genuine reasoning survives the noise filter...
   assert.match(result.stdout, /Considering empty-state/);
-  // ...but the terminal-capability (true-color) warning is filtered out of it.
+  // ...including a real reasoning line that merely contains a bracketed [DEPnn]
+  // token (the narrowed noise regex must not strip it)...
+  assert.match(result.stdout, /Cross-checking \[DEP12\] handling/);
+  // ...but the terminal-capability (true-color) warning and the genuine Node
+  // deprecation preamble are filtered out of it.
   assert.doesNotMatch(result.stdout, /True color/i);
+  assert.doesNotMatch(result.stdout, /DEP0190/);
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Clears the actionable low-severity items from the v0.6.1 parity-audit critic table, plus a consolidated **Known limitations** doc section for the items that cannot be code-fixed.

### Fixes
- **Honest `/gemini:cancel`.** The detached worker is `unref()`-ed, so by cancel time its PID is often already gone. `handleCancel` discarded `terminateProcessTree`'s return and always logged "Cancelled by user." It now reports the real outcome — `terminated the running process`, `no live process (it had already exited)`, or `no live process was attached` — in the log, the cancel report (`- Process:` line), and a new `processTerminated` field on `--json`. The job is still marked `cancelled` in every case. New shared `describeTermination` helper.
- **Narrowed the `[DEP\d+]` reasoning-noise filter.** It matched a bare `[DEP12]` token anywhere and could strip genuine reasoning containing such a bracket. Now requires Node's canonical `(node:NNN) [DEPxxx]` preamble; real deprecation warnings are still filtered.

### Docs
- **Known limitations** section in both READMEs (macOS AGY unverified; Gemini 3.5 not served by the CLI + 2026-06-18 free-CLI sunset; `/gemini:review` is a prompt/CLI adapter, not native), each cross-linking the existing detailed section. zh-TW prose uses full-width punctuation.

### Out of scope (documented known limitations, no code fix possible)
macOS AGY brain-path discovery (needs a Mac), the upstream Gemini-3.5/sunset risk (external), and native `/review` (no app-server) — now consolidated under **Known limitations** rather than fixed.

## Tests (168 → 172, all green)

- `/cancel` honest wording for all three termination states (render unit) + a no-pid integration case asserting `processTerminated:false` while the job is still `cancelled`.
- Narrowed DEP filter: a `[DEP12]` reasoning line survives while a real `(node:…) [DEP0190]` line is filtered (extended `review-noisy` fixture).
- Multi-line focus-text round-trip through the background `review-worker`.

`npm test` 172/172 · `npm run check-version` ✓ · `npm run verify-contracts` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)