### PR TITLE
docs: verify macOS AGY support — brain root confirmed at ~/.gemini/antigravity-cli/brain (agy 1.0.7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ Override via `--engine` flag or the `GEMINI_ENGINE` environment variable.
 
 > `--model` and `--effort` apply to the **gemini** engine only. `agy --print` is locked to Gemini 3.5 Flash (High) and has no model/effort flag, so the plugin ignores `--model`/`--effort` when `--engine agy` is active.
 
-> **AGY transcript recovery is platform-verified on Windows and Linux only.** Because `agy --print` does not pipe its output (upstream [google-gemini/gemini-cli#27466](https://github.com/google-gemini/gemini-cli/issues/27466)), the plugin recovers AGY responses from the on-disk "brain" transcript under `~/.gemini/antigravity-cli/brain` (Windows 1.0.3, verified) or `~/.antigravity-cli/brain` (Linux 1.0.2, reported). **macOS is unverified** — its brain path is unknown, so `--engine agy` may fail to start on macOS. If you run AGY on macOS, please open an issue with the actual brain directory so the path can be added.
+> **AGY transcript recovery is platform-verified on Windows and macOS; Linux is reported working.** Because `agy --print` does not pipe its output (upstream [google-gemini/gemini-cli#27466](https://github.com/google-gemini/gemini-cli/issues/27466) — reproduced on macOS agy 1.0.7: 0 bytes reach stdout through a pipe), the plugin recovers AGY responses from the on-disk "brain" transcript under `~/.gemini/antigravity-cli/brain` (Windows 1.0.3 and macOS 1.0.7, both verified — same root) or `~/.antigravity-cli/brain` (Linux 1.0.2, reported). If `--engine agy` reports no brain root on your machine, run `agy` once so it creates the directory, or open an issue with its actual location.
 
 ---
 
@@ -237,7 +237,7 @@ Override via `--engine` flag or the `GEMINI_ENGINE` environment variable.
 | setup shows `… token expired` | OAuth token lapsed | Run `!gemini` again to refresh credentials |
 | `Status: partial (AGY fallback only …)` | Gemini CLI unavailable but AGY present | Install Gemini CLI, or use `--engine agy` (its auth cannot be verified) |
 | Windows: command resolves but fails | `.cmd` wrapper / PATH | Confirm `where gemini` resolves; the plugin spawns bare names through `shell: true` to find `.cmd` shims |
-| `--engine agy` fails to start on macOS | AGY brain path unverified on macOS | Transcript recovery is verified on Windows/Linux only; on macOS, confirm the `agy` brain directory and open an issue with its location |
+| `--engine agy` reports no brain root | AGY has not created its brain directory yet, or it lives in an unknown location | Run `agy` once so it creates the brain dir. Known roots: `~/.gemini/antigravity-cli/brain` (Windows/macOS, verified) and `~/.antigravity-cli/brain` (Linux, reported); if yours differs, open an issue with its location |
 
 To authenticate, run **`!gemini`** once — the plugin completes OAuth by invoking `gemini` itself. There is **no** `gemini login` subcommand. `setup` reports `ready: true` only when Node **and** the Gemini CLI are present **and** OAuth is valid; an installed-but-unauthenticated Gemini is reported as *not ready*.
 
@@ -302,7 +302,6 @@ Three skills are bundled for Claude Code to consume:
 
 Documented, non-blocking constraints — see the linked sections for detail:
 
-- **macOS AGY is unverified.** AGY transcript recovery is verified on Windows/Linux only; the macOS "brain" path is unknown, so `--engine agy` may not start there. The `gemini` engine is unaffected. See [Engine Routing](#engine-routing).
 - **Gemini 3.5 is not served by the gemini CLI, and the free CLI sunsets 2026-06-18.** `gemini-3.5-*` returns 404 on CLI 0.44.1 (reach it via AGY); a requested id that is not served degrades gracefully to the GA fallback `gemini-2.5-flash`. After 2026-06-18 the free/personal CLI tier ends. See [Model Alias Notes](#model-alias-notes) and [docs/MODEL_COMPARISON.md](docs/MODEL_COMPARISON.md).
 - **`/gemini:review` is a prompt/CLI adapter, not a native reviewer.** It sends the diff with a review prompt and parses the structured JSON, rather than using an app-server reviewer, so its feedback depth differs from a native one. See [Codex app server vs Gemini CLI adapter](#codex-app-server-vs-gemini-cli-adapter).
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -210,7 +210,7 @@
 
 > `--model` 與 `--effort` 僅適用於 **gemini** 引擎。`agy --print` 鎖定 Gemini 3.5 Flash（High）、無 model/effort 旗標，故 `--engine agy` 時外掛會忽略 `--model`/`--effort`。
 
-> **AGY 紀錄恢復僅在 Windows 與 Linux 驗證通過。** 因 `agy --print` 不透過 pipe 輸出（上游 [google-gemini/gemini-cli#27466](https://github.com/google-gemini/gemini-cli/issues/27466)），外掛改從磁碟上的「brain」紀錄恢復回應——`~/.gemini/antigravity-cli/brain`（Windows 1.0.3，已驗證）或 `~/.antigravity-cli/brain`（Linux 1.0.2，回報）。**macOS 尚未驗證**——其 brain 路徑未知，故 `--engine agy` 在 macOS 上可能無法啟動。若於 macOS 使用 AGY，請開 issue 回報實際的 brain 目錄，以便補上該路徑。
+> **AGY 紀錄恢復已於 Windows 與 macOS 驗證通過；Linux 為回報可用。** 因 `agy --print` 不透過 pipe 輸出（上游 [google-gemini/gemini-cli#27466](https://github.com/google-gemini/gemini-cli/issues/27466)——已於 macOS agy 1.0.7 重現：pipe 下 stdout 為 0 bytes），外掛改從磁碟上的「brain」紀錄恢復回應——`~/.gemini/antigravity-cli/brain`（Windows 1.0.3 與 macOS 1.0.7，皆已驗證、同一路徑）或 `~/.antigravity-cli/brain`（Linux 1.0.2，回報）。若 `--engine agy` 回報找不到 brain 根目錄，請先執行一次 `agy` 讓其建立該目錄，或開 issue 回報實際位置。
 
 ---
 
@@ -235,7 +235,7 @@
 | setup 顯示 `… token expired` | OAuth token 已過期 | 再次執行 `!gemini` 以更新憑證 |
 | `Status: partial (AGY fallback only …)` | Gemini CLI 不可用但 AGY 存在 | 安裝 Gemini CLI，或使用 `--engine agy`（其認證無法驗證） |
 | Windows：命令可解析但執行失敗 | `.cmd` wrapper／PATH | 確認 `where gemini` 可解析；外掛以 `shell: true` 啟動裸命令名以尋得 `.cmd` shim |
-| `--engine agy` 於 macOS 無法啟動 | macOS 上 AGY brain 路徑未驗證 | 紀錄恢復僅在 Windows/Linux 驗證；於 macOS 請確認 `agy` 的 brain 目錄並開 issue 回報其位置 |
+| `--engine agy` 回報找不到 brain 根目錄 | AGY 尚未建立 brain 目錄，或其位於未知位置 | 先執行一次 `agy` 讓其建立 brain 目錄。已知路徑：`~/.gemini/antigravity-cli/brain`（Windows/macOS，已驗證）與 `~/.antigravity-cli/brain`（Linux，回報）；若不同請開 issue 回報其位置 |
 
 如需認證，執行一次 **`!gemini`**——外掛即以呼叫 `gemini` 自身完成 OAuth。**並無** `gemini login` 子命令。唯有 Node **且** Gemini CLI 皆存在**且** OAuth 有效時，`setup` 方回報 `ready: true`；已安裝但未認證之 Gemini 將回報為 *not ready*。
 
@@ -300,7 +300,6 @@ Claude Code
 
 以下為已記錄之非阻塞限制——詳見所連結之章節：
 
-- **macOS 之 AGY 未驗證。** AGY transcript 恢復僅於 Windows／Linux 驗證；macOS 之「brain」路徑未知，故 `--engine agy` 於其上或無法啟動。`gemini` 引擎不受影響。詳見 [引擎路由](#引擎路由)。
 - **gemini CLI 不提供 Gemini 3.5，且免費 CLI 於 2026-06-18 終止。** `gemini-3.5-*` 於 CLI 0.44.1 回 404（改走 AGY）；不被提供之 model id 會優雅降級至 GA fallback `gemini-2.5-flash`。2026-06-18 後免費／個人版 CLI 層級終止。詳見 [模型別名說明](#模型別名說明) 與 [docs/MODEL_COMPARISON.md](docs/MODEL_COMPARISON.md)。
 - **`/gemini:review` 為 prompt／CLI adapter，非原生審查器。** 其將 diff 連同審查 prompt 送出並解析結構化 JSON，而非透過 app-server 審查器，故反饋深度有別於原生。詳見 [Codex app server 與 Gemini CLI adapter](#codex-app-server-與-gemini-cli-adapter)。
 

--- a/plugins/gemini/CHANGELOG.md
+++ b/plugins/gemini/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Documentation
+- **macOS AGY is now platform-verified.** On macOS (agy 1.0.7) the AGY brain root is `~/.gemini/antigravity-cli/brain` — the same path already first in `agyBrainRoots()` — so `--engine agy` works out of the box: `gemini-companion.mjs task --engine agy` was run end-to-end on macOS and recovered the response from the transcript (`<conv>/.system_generated/logs/transcript{,_full}.jsonl`, matching the expected layout), and the upstream no-pipe behavior of `agy --print` ([google-gemini/gemini-cli#27466](https://github.com/google-gemini/gemini-cli/issues/27466)) was reproduced on macOS (0 bytes reach stdout through a pipe), confirming transcript recovery is required there too. Updated README (EN + zh-TW) Engine Routing / Troubleshooting / Known limitations, the `gemini-prompting` antipatterns reference, and the `agy-transcript.mjs` platform notes; TODO-3 (platform paths) is resolved, and the "no brain root" reason string now tells the user to run `agy` once instead of pointing at an internal TODO. No behavior change — comments, docs, and one user-facing message only.
+
 ## 0.6.6 — 2026-06-09 — review retry resilience
 
 ### Fixed

--- a/plugins/gemini/scripts/lib/agy-transcript.mjs
+++ b/plugins/gemini/scripts/lib/agy-transcript.mjs
@@ -4,7 +4,8 @@
 // ---------------
 // `agy --print` does NOT deliver its response over stdout in non-TTY use
 // (upstream bug google-gemini/gemini-cli#27466; locally verified empty/hang on
-// agy 1.0.3). The response IS persisted to disk under the agy "brain" dir. We
+// agy 1.0.3 Windows and reproduced on 1.0.7 macOS — 0 bytes piped to stdout).
+// The response IS persisted to disk under the agy "brain" dir. We
 // recover it by diffing the set of conversation dirs before/after the spawn and
 // reading the new one's transcript.
 //
@@ -24,22 +25,24 @@
 //   TODO-2 (concurrency): job-control spawns one foreground agy turn at a time;
 //     pickNewConvDir() still marks confident=false if >1 new dir appears so the
 //     caller can warn. Add a hard lock if background agy turns are introduced.
-//   TODO-3 (platform paths): Windows 1.0.3 root verified (first entry below);
-//     Linux 1.0.2 reported; macOS still UNVERIFIED. Timeout grace IS applied in
-//     runGeminiTurn (agy --print-timeout window < the hard spawn kill).
+//   TODO-3 (platform paths): RESOLVED — Windows 1.0.3 and macOS 1.0.7 share
+//     the ~/.gemini/antigravity-cli/brain root (both machine-verified, macOS
+//     2026-06-12 end-to-end: task --engine agy recovered the transcript);
+//     Linux 1.0.2 reported at ~/.antigravity-cli/brain. Timeout grace IS
+//     applied in runGeminiTurn (agy --print-timeout window < the hard spawn
+//     kill).
 
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-// Candidate brain roots, newest-platform first. Verified: 1.0.3 Windows.
-// Reported: 1.0.2 Linux. macOS: UNVERIFIED — confirm via TODO-3.
+// Candidate brain roots, newest-platform first. Verified: 1.0.3 Windows and
+// 1.0.7 macOS (same root). Reported: 1.0.2 Linux.
 export function agyBrainRoots() {
   const home = os.homedir();
   return [
-    path.join(home, ".gemini", "antigravity-cli", "brain"), // 1.0.3 Windows (verified)
+    path.join(home, ".gemini", "antigravity-cli", "brain"), // 1.0.3 Windows + 1.0.7 macOS (verified)
     path.join(home, ".antigravity-cli", "brain"),           // 1.0.2 Linux (reported)
-    // path.join(home, "Library", "Application Support", "agy", "brain"), // macOS? TODO-3
   ];
 }
 
@@ -161,7 +164,7 @@ export function readAgyTranscript(brainRoot, convDir) {
 // result here AFTER the spawn returns.
 export function recoverAgyResponse(brainRoot, beforeSnapshot) {
   if (!brainRoot) {
-    return { response: null, thinking: null, done: false, confident: false, convDir: null, reason: "no agy brain root found on this platform (see TODO-3)" };
+    return { response: null, thinking: null, done: false, confident: false, convDir: null, reason: "no agy brain root found on this platform (run agy once to create it; see agyBrainRoots() for the known roots)" };
   }
   const after = listConvDirs(brainRoot);
   const picked = pickNewConvDir(beforeSnapshot, after);

--- a/plugins/gemini/skills/gemini-prompting/references/gemini-prompt-antipatterns.md
+++ b/plugins/gemini/skills/gemini-prompting/references/gemini-prompt-antipatterns.md
@@ -126,7 +126,7 @@ Better:
 - Let the plugin recover the response from AGY's on-disk transcript — that is the only reliable channel.
 - Prefer the **gemini** engine (`--output-format json`) when you need clean, pipeable structured output.
 
-Explanation: `agy --print` does not deliver its response over a pipe in non-interactive use (upstream google-gemini/gemini-cli#27466). No prompt instruction changes that; the plugin diffs the transcript dirs to recover the answer, and this path is verified on Windows/Linux only (macOS unverified).
+Explanation: `agy --print` does not deliver its response over a pipe in non-interactive use (upstream google-gemini/gemini-cli#27466). No prompt instruction changes that; the plugin diffs the transcript dirs to recover the answer; this path is verified on Windows and macOS (same brain root), with Linux reported working.
 
 ## Assuming Gemini/AGY behaves like Codex (parity-specific)
 


### PR DESCRIPTION
## Summary

The README asks macOS AGY users to report the actual brain directory ("If you run AGY on macOS, please open an issue with the actual brain directory so the path can be added"). This PR reports it — with end-to-end verification — and updates the docs and platform notes accordingly.

**Finding: macOS needs no code change.** On macOS the AGY brain root is `~/.gemini/antigravity-cli/brain` — the same path already first in `agyBrainRoots()` (the Windows 1.0.3 entry) — so `--engine agy` works on macOS out of the box.

## Verification (macOS, Darwin 25.5.0, agy 1.0.7, 2026-06-12)

1. **Brain root + transcript layout match the code's expectations:**
   ```
   ~/.gemini/antigravity-cli/brain/<conversation-uuid>/.system_generated/logs/transcript.jsonl
   ~/.gemini/antigravity-cli/brain/<conversation-uuid>/.system_generated/logs/transcript_full.jsonl
   ```
2. **End-to-end run succeeds** — transcript recovery returns the response:
   ```
   $ node plugins/gemini/scripts/gemini-companion.mjs task --engine agy "Reply with exactly: MACOS-AGY-OK"
   [gemini] Detecting engine...
   [gemini] Starting agy turn...
   [gemini] Turn completed.
   MACOS-AGY-OK
   ```
3. **Upstream no-pipe bug (google-gemini/gemini-cli#27466) reproduced on macOS** — confirming transcript recovery is required there too, not just on Windows:
   ```
   $ agy --print "Reply with exactly: PIPE-TEST" | cat   # exit 0, stdout = 0 bytes
   ```

## Changes (docs/comments + one user-facing string; no behavior change)

- `agy-transcript.mjs` — platform notes updated: macOS 1.0.7 verified on the shared root; **TODO-3 (platform paths) resolved**; removed the speculative commented-out `Library/Application Support` macOS guess; the "no brain root" failure reason now tells the user to run `agy` once instead of pointing at an internal TODO.
- `README.md` / `README.zh-TW.md` — Engine Routing note rewritten (Windows + macOS verified, Linux reported), the macOS row in Troubleshooting generalized to a "no brain root" row, and the macOS bullet removed from Known limitations.
- `skills/gemini-prompting/references/gemini-prompt-antipatterns.md` — platform claim updated to match.
- `CHANGELOG.md` — `Unreleased` section documenting the verification.

`docs/PARITY_AUDIT*.md` were left untouched as historical audit snapshots.

## Test plan

- [x] `npm test` — 191/191 pass
- [x] `npm run check-version` — all metadata at 0.6.6 (no bump: docs/comments only; happy to bump if you prefer)
- [x] `npm run verify-contracts` — passes
- [x] Live macOS verification above