### PR TITLE
docs: refresh README install snippets to current release (v0.6.6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Ported from [openai/codex-plugin-cc](https://github.com/openai/codex-plugin-cc) 
 |---|---|---|
 | Node.js | ≥ 18 | [nodejs.org](https://nodejs.org) |
 | Gemini CLI | ≥ 0.40 | `npm install -g @google/gemini-cli` |
-| AGY _(optional)_ | 1.0.3 | _(see install note below)_ |
+| AGY _(optional)_ | ≥ 1.0.3 | _(see install note below)_ |
 | Claude Code | any | [claude.ai/code](https://claude.ai/code) |
 
 **Install AGY** (optional fallback): `curl -fsSL https://antigravity.google/cli/install.sh | bash`
@@ -58,15 +58,15 @@ Ported from [openai/codex-plugin-cc](https://github.com/openai/codex-plugin-cc) 
 
 ### Pinned release (a specific published version)
 
-Pin the marketplace to a release tag — e.g. the latest, `v0.6.0`:
+Pin the marketplace to a release tag — e.g. the latest, `v0.6.6`:
 
 ```
-/plugin marketplace add arcobaleno64/gemini-plugin-cc@v0.6.0
+/plugin marketplace add arcobaleno64/gemini-plugin-cc@v0.6.6
 /plugin install gemini@gemini-plugin-cc
 /reload-plugins
 ```
 
-> Claude Code installs plugins from the git tree, not from GitHub Release tarballs — `@<tag>` selects the git tag behind a [Release](https://github.com/arcobaleno64/gemini-plugin-cc/releases). A pinned install does **not** auto-update; to move to a newer release, re-add the marketplace with the new tag (e.g. `…@v0.6.1`).
+> Claude Code installs plugins from the git tree, not from GitHub Release tarballs — `@<tag>` selects the git tag behind a [Release](https://github.com/arcobaleno64/gemini-plugin-cc/releases). A pinned install does **not** auto-update; to move to a newer release, re-add the marketplace with the new tag (e.g. `…@v0.6.7`).
 
 Then run `/gemini:setup` — it will check whether Gemini CLI is ready. If Gemini is missing and npm is available, it will offer to install it for you.
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -26,7 +26,7 @@
 |---|---|---|
 | Node.js | ≥ 18 | [nodejs.org](https://nodejs.org) |
 | Gemini CLI | ≥ 0.40 | `npm install -g @google/gemini-cli` |
-| AGY _(選用)_ | 1.0.3 | _(安裝指令見下)_ |
+| AGY _(選用)_ | ≥ 1.0.3 | _(安裝指令見下)_ |
 | Claude Code | 任意版本 | [claude.ai/code](https://claude.ai/code) |
 
 **安裝 AGY**（選用備援）：`curl -fsSL https://antigravity.google/cli/install.sh | bash`
@@ -56,15 +56,15 @@
 
 ### 釘選發布版（指定某個已發布版本）
 
-將 marketplace 釘到某個 release 標籤——例如最新的 `v0.6.0`：
+將 marketplace 釘到某個 release 標籤——例如最新的 `v0.6.6`：
 
 ```
-/plugin marketplace add arcobaleno64/gemini-plugin-cc@v0.6.0
+/plugin marketplace add arcobaleno64/gemini-plugin-cc@v0.6.6
 /plugin install gemini@gemini-plugin-cc
 /reload-plugins
 ```
 
-> Claude Code 從 git tree 安裝外掛，**並非**從 GitHub Releases 的 tarball——`@<tag>` 選的是 [Release](https://github.com/arcobaleno64/gemini-plugin-cc/releases) 背後的 git 標籤。釘版安裝**不會**自動更新；欲升至新版，請以新標籤重新加入 marketplace（例如 `…@v0.6.1`）。
+> Claude Code 從 git tree 安裝外掛，**並非**從 GitHub Releases 的 tarball——`@<tag>` 選的是 [Release](https://github.com/arcobaleno64/gemini-plugin-cc/releases) 背後的 git 標籤。釘版安裝**不會**自動更新；欲升至新版，請以新標籤重新加入 marketplace（例如 `…@v0.6.7`）。
 
 接著執行 `/gemini:setup`——若 Gemini CLI 尚未安裝且 npm 可用，指令會提供自動安裝選項。
 

--- a/plugins/gemini/CHANGELOG.md
+++ b/plugins/gemini/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Documentation
 - **macOS AGY is now platform-verified.** On macOS (agy 1.0.7) the AGY brain root is `~/.gemini/antigravity-cli/brain` — the same path already first in `agyBrainRoots()` — so `--engine agy` works out of the box: `gemini-companion.mjs task --engine agy` was run end-to-end on macOS and recovered the response from the transcript (`<conv>/.system_generated/logs/transcript{,_full}.jsonl`, matching the expected layout), and the upstream no-pipe behavior of `agy --print` ([google-gemini/gemini-cli#27466](https://github.com/google-gemini/gemini-cli/issues/27466)) was reproduced on macOS (0 bytes reach stdout through a pipe), confirming transcript recovery is required there too. Updated README (EN + zh-TW) Engine Routing / Troubleshooting / Known limitations, the `gemini-prompting` antipatterns reference, and the `agy-transcript.mjs` platform notes; TODO-3 (platform paths) is resolved, and the "no brain root" reason string now tells the user to run `agy` once instead of pointing at an internal TODO. No behavior change — comments, docs, and one user-facing message only.
+- **README install snippets and dependency table refreshed to the current release.** Pinned-install examples now reference the latest tag `v0.6.6` (was the stale `v0.6.0`), the "newer tag" example bumped to `v0.6.7`, and the AGY dependency row reads `≥ 1.0.3` (1.0.7 verified on macOS). Docs only, no behavior change.
 
 ## 0.6.6 — 2026-06-09 — review retry resilience
 


### PR DESCRIPTION
## Summary

Refreshes the README install instructions and dependency table to the current release, fixing stale version references found while confirming the docs are up to date (post #16).

## Changes (docs only, no behavior change)

- **Pinned-install examples: `v0.6.0` → `v0.6.6`** — `v0.6.0` was labelled "the latest" but the actual Latest release is `v0.6.6`.
- "Newer tag" upgrade example: `…@v0.6.1` → `…@v0.6.7`.
- AGY dependency row: `1.0.3` → `≥ 1.0.3` — macOS verified `1.0.7` in #16; now consistent with the `Node ≥ 18` / `Gemini CLI ≥ 0.40` style.
- EN + zh-TW kept in sync; `CHANGELOG` `Unreleased` note added.

## Verification

- `npm run verify-contracts` → pass
- `npm run check-version` → all metadata at 0.6.6 (docs-only, no bump)

Time-sensitive notes (2026-06-18 free-CLI sunset, CLI 0.44.1, `-preview` model IDs) were reviewed and are accurate — left unchanged.