### PR TITLE
feat(agy): route 1.1.2 prompts through stdin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,13 +6,13 @@
   },
   "metadata": {
     "description": "Use Gemini CLI or Antigravity CLI (agy) inside Claude Code for task delegation, code review, and adversarial review.",
-    "version": "0.7.0"
+    "version": "0.7.1"
   },
   "plugins": [
     {
       "name": "gemini",
       "description": "Gemini CLI and Antigravity CLI bridge for Claude Code task delegation and adversarial review",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "author": {
         "name": "arcobaleno64"
       },

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ Compared with AGY-only, multi-host plugins, this project keeps the Gemini CLI pa
 - Pragmatic and adversarial code review over the current diff or branch.
 - Background task delegation for longer-running companion-agent work.
 - Gemini model aliases, graceful model fallback, and transient review retry.
-- AGY transcript recovery for `agy --print` non-pipe behavior.
-- Safer stdin prompt delivery on the Gemini engine.
+- Version-gated AGY prompt transport with transcript-authoritative recovery.
+- Safer stdin prompt delivery on Gemini and AGY 1.1.2 or newer.
 
 | Need | Use this plugin when... |
 |---|---|
@@ -42,7 +42,7 @@ Compared with AGY-only, multi-host plugins, this project keeps the Gemini CLI pa
 - **`/gemini:status`** — Inspect active and completed background jobs.
 - **`/gemini:result`** / **`/gemini:cancel`** — Retrieve or cancel a background job.
 - **Engine auto-detection** — Prefers `gemini` CLI (pipe-safe); falls back to `agy`.
-- **Stdin prompt delivery** — Prompts are passed via stdin on all platforms, eliminating shell injection and Windows `.cmd` wrapper issues.
+- **Version-aware stdin prompt delivery** — Gemini always uses stdin; AGY 1.1.2 or newer uses its auto-print stdin path, while older or unknown versions retain the compatible positional path.
 - **Session lifecycle hooks** — Automatically injects `GEMINI_COMPANION_SESSION_ID`; cleans up stale jobs on session end.
 
 ---
@@ -53,7 +53,7 @@ Compared with AGY-only, multi-host plugins, this project keeps the Gemini CLI pa
 |---|---|---|
 | Node.js | ≥ 18 | [nodejs.org](https://nodejs.org) |
 | Gemini CLI | ≥ 0.40 | `npm install -g @google/gemini-cli` |
-| AGY _(optional)_ | ≥ 1.0.3 (1.1.0 verified) | _(see install note below)_ |
+| AGY _(optional)_ | ≥ 1.0.3; ≥ 1.1.2 recommended (Windows verified) | _(see install note below)_ |
 | Claude Code | any | [claude.ai/code](https://claude.ai/code) |
 
 **Install AGY** (optional fallback): `curl -fsSL https://antigravity.google/cli/install.sh | bash`
@@ -83,15 +83,15 @@ Compared with AGY-only, multi-host plugins, this project keeps the Gemini CLI pa
 
 ### Pinned release (a specific published version)
 
-Pin the marketplace to a release tag — e.g. `v0.7.0`:
+Pin the marketplace to a release tag — e.g. `v0.7.1`:
 
 ```
-/plugin marketplace add arcobaleno64/gemini-plugin-cc@v0.7.0
+/plugin marketplace add arcobaleno64/gemini-plugin-cc@v0.7.1
 /plugin install gemini@gemini-plugin-cc
 /reload-plugins
 ```
 
-> Claude Code installs plugins from the git tree, not from GitHub Release tarballs — `@<tag>` selects the git tag behind a [Release](https://github.com/arcobaleno64/gemini-plugin-cc/releases). A pinned install does **not** auto-update; to move to a newer release, re-add the marketplace with the new tag (e.g. `…@v0.7.1`).
+> Claude Code installs plugins from the git tree, not from GitHub Release tarballs — `@<tag>` selects the git tag behind a [Release](https://github.com/arcobaleno64/gemini-plugin-cc/releases). A pinned install does **not** auto-update; to move to a newer release, re-add the marketplace with the new tag (e.g. `…@v0.7.2`).
 
 Then run `/gemini:setup` — it will check whether Gemini CLI is ready. If Gemini is missing and npm is available, it will offer to install it for you.
 
@@ -231,22 +231,22 @@ When enabled and the review returns `needs-attention`, Claude Code is blocked fr
 In `auto` mode the plugin selects the first available engine in this order:
 
 1. **`gemini` CLI** — outputs via stdout; supports stdin prompt delivery.
-2. **`agy`** — fallback; through plugin v0.7.0 the adapter still uses `agy --print <prompt>` and recovers the response from the on-disk transcript, so explicit `--engine agy` is required to use it.
+2. **`agy`** — fallback; AGY 1.1.2 or newer receives the prompt on stdin with no `--print` flag, while older or unknown versions retain `agy --print <prompt>`.
 
 Override via `--engine` flag or the `GEMINI_ENGINE` environment variable.
 
 > `--model` and `--effort` are managed by the **gemini** engine only. `--engine agy` currently leaves model choice to AGY's configured/default behavior; the plugin does not translate Gemini aliases or effort tiers to AGY arguments.
 
-> **AGY transcript recovery is platform-verified on Windows and macOS; Linux is reported working.** Positional `agy --print` produced no piped response on the older versions the adapter targets (upstream [google-gemini/gemini-cli#27466](https://github.com/google-gemini/gemini-cli/issues/27466); reproduced on macOS agy 1.0.7), so the plugin recovers AGY responses from the on-disk "brain" transcript under `~/.gemini/antigravity-cli/brain` (Windows 1.0.3/1.1.0/1.1.2 and macOS 1.0.7, same root) or `~/.antigravity-cli/brain` (Linux 1.0.2, reported). AGY 1.1.2 separately supports an auto-print stdin prompt path and returned stdout in a Windows probe, but plugin v0.7.0 has not switched to that path and cross-platform behavior is not yet verified. If `--engine agy` reports no brain root, run `agy` once so it creates the directory, or open an issue with its actual location.
+> **AGY transcript recovery remains authoritative.** Positional `agy --print` produced no piped response on older releases (upstream [google-gemini/gemini-cli#27466](https://github.com/google-gemini/gemini-cli/issues/27466); reproduced on macOS AGY 1.0.7). Plugin v0.7.1 uses the auto-print stdin path on AGY 1.1.2 or newer, but still takes the completed response, DONE status, thinking, and conversation ID from the on-disk transcript. Known brain roots are `~/.gemini/antigravity-cli/brain` (Windows/macOS) and `~/.antigravity-cli/brain` (Linux, reported). The 1.1.2 stdin path is live-verified on Windows and covered by a POSIX integration fixture; real macOS/Linux 1.1.2 verification remains pending. If no brain root is found, run `agy` once or open an issue with its actual location.
 
 ---
 
 ## Security
 
-- **Stdin delivery (gemini engine)**: For the `gemini` engine, prompts are passed via `stdin` (Node's `spawnSync` `input` option) and never interpolated into a shell string, eliminating shell-injection risk regardless of prompt content. Plugin v0.7.0 has not yet adopted AGY 1.1.2's stdin path, so prefer the default `gemini` engine for untrusted input.
-- **Windows `.cmd` wrappers**: npm installs `gemini`/`agy` as `.cmd` shims, which require `shell: true` to launch. Because the gemini prompt travels on stdin (never in argv), `shell: true` never exposes it to `cmd.exe` parsing — only controlled flags (model id, `--yolo`, …) are ever placed in argv.
+- **Stdin delivery**: Gemini prompts and AGY 1.1.2-or-newer prompts use Node's `spawnSync` `input` option and never enter argv. AGY versions older than 1.1.2, plus unparseable versions, keep the positional compatibility path and its 24,000-character limit; prefer Gemini or AGY 1.1.2+ for untrusted prompt content.
+- **Windows process boundary**: Gemini's npm `.cmd` shim is launched through `shell:true`, but its prompt remains on stdin and only validated flags enter argv. AGY must resolve to an absolute `.exe` and is always launched with `shell:false`.
 - **DEP0190 warning is benign**: On Windows you may see `(node:NNN) [DEP0190] DeprecationWarning: Passing args to a child process with shell option true can lead to security vulnerabilities, as the arguments are not escaped, only concatenated.` This is **safe to ignore here** — the deprecation is about *prompt content* placed in argv under `shell: true`, but this plugin never does that for the gemini engine: the prompt travels on stdin, and only controlled flags reach argv (each validated, e.g. model ids must match `^[A-Za-z0-9][A-Za-z0-9._-]*$`). The warning is Node flagging the general pattern, not an actual injection vector in this code path.
-- **AGY positional prompt in plugin v0.7.0**: Although AGY 1.1.2 supports an auto-print stdin prompt path, this adapter still passes the prompt as a positional CLI argument and therefore keeps its 24,000-character safety limit. **Do not route untrusted prompt content through `--engine agy`** in this version — prefer the default `gemini` engine. On Windows the plugin still resolves an absolute `.exe` and uses `shell:false`; the remaining concern is prompt exposure in argv and platform quoting, not shell invocation through an npm shim.
+- **AGY transport fallback**: Only a stable parsed version of 1.1.2 or newer enables stdin. Unknown and prerelease version strings fail closed to the existing positional path, preserving compatibility rather than assuming an upstream capability.
 - **Credential handling**: OAuth credentials in `~/.gemini/oauth_creds.json` are read only to check token expiry via `getGeminiLoginStatus()`; they are never logged, copied elsewhere, or transmitted by this plugin.
 - **`.gitignore`**: The `.omc/` state directory (job logs, session state) is excluded from version control.
 
@@ -275,10 +275,10 @@ Claude Code
   └─ /gemini:rescue "prompt"
        └─ gemini-companion.mjs task
             ├─ detectEngine()        → gemini | agy
-            ├─ buildCliArgs()        → args (no prompt in args for gemini)
-            ├─ runCommand()          → spawnSync, prompt via stdin
-            │    shell: true (Win)   ← fixes Windows .cmd wrapper
-            │    input: prompt       ← gemini engine: prompt via stdin (no shell parsing)
+            ├─ buildCliArgs()        → version-gated args
+            ├─ runCommand()          → spawnSync
+            │    input: prompt       ← gemini + AGY ≥1.1.2
+            │    argv: prompt        ← older/unknown AGY only (24K cap)
             └─ renderTaskResult()   → Markdown output to Claude
 ```
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -19,8 +19,8 @@
 - 對目前 diff 或 branch 執行 pragmatic code review 與 adversarial review。
 - 用 background task delegation 處理較長時間的 companion-agent 工作。
 - Gemini model aliases、graceful model fallback 與 transient review retry。
-- 針對 `agy --print` non-pipe behavior 的 AGY transcript recovery。
-- Gemini engine 採用較安全的 stdin prompt delivery。
+- 具版本分流的 AGY prompt transport，並以 transcript recovery 為權威來源。
+- Gemini 與 AGY 1.1.2 以上採用較安全的 stdin prompt delivery。
 
 | 需求 | 適合使用本外掛的情境 |
 |---|---|
@@ -40,7 +40,7 @@
 - **`/gemini:status`** — 查看作用中與已完成的背景工作。
 - **`/gemini:result`** / **`/gemini:cancel`** — 取得或取消背景工作。
 - **引擎自動偵測** — 優先使用 `gemini` CLI（支援 pipe 輸出）；備援退回至 `agy`。
-- **Gemini stdin 提示傳遞** — gemini 引擎的提示透過 stdin 傳入，消除 Windows `.cmd` wrapper 問題與 shell injection 風險。
+- **版本感知的 stdin 提示傳遞** — Gemini 固定走 stdin；AGY 1.1.2 以上走自動 print 的 stdin 路徑，舊版或版本不明時保留 positional 相容路徑。
 - **會話生命週期掛鉤** — 自動注入 `GEMINI_COMPANION_SESSION_ID`；會話結束時清理殘留工作。
 
 ---
@@ -51,7 +51,7 @@
 |---|---|---|
 | Node.js | ≥ 18 | [nodejs.org](https://nodejs.org) |
 | Gemini CLI | ≥ 0.40 | `npm install -g @google/gemini-cli` |
-| AGY _(選用)_ | ≥ 1.0.3（1.1.0 已驗證） | _(安裝指令見下)_ |
+| AGY _(選用)_ | ≥ 1.0.3；建議 ≥ 1.1.2（Windows 已驗證） | _(安裝指令見下)_ |
 | Claude Code | 任意版本 | [claude.ai/code](https://claude.ai/code) |
 
 **安裝 AGY**（選用備援）：`curl -fsSL https://antigravity.google/cli/install.sh | bash`
@@ -81,15 +81,15 @@
 
 ### 釘選發布版（指定某個已發布版本）
 
-將 marketplace 釘到某個 release 標籤——例如 `v0.7.0`：
+將 marketplace 釘到某個 release 標籤——例如 `v0.7.1`：
 
 ```
-/plugin marketplace add arcobaleno64/gemini-plugin-cc@v0.7.0
+/plugin marketplace add arcobaleno64/gemini-plugin-cc@v0.7.1
 /plugin install gemini@gemini-plugin-cc
 /reload-plugins
 ```
 
-> Claude Code 從 git tree 安裝外掛，**並非**從 GitHub Releases 的 tarball——`@<tag>` 選的是 [Release](https://github.com/arcobaleno64/gemini-plugin-cc/releases) 背後的 git 標籤。釘版安裝**不會**自動更新；欲升至新版，請以新標籤重新加入 marketplace（例如 `…@v0.7.1`）。
+> Claude Code 從 git tree 安裝外掛，**並非**從 GitHub Releases 的 tarball——`@<tag>` 選的是 [Release](https://github.com/arcobaleno64/gemini-plugin-cc/releases) 背後的 git 標籤。釘版安裝**不會**自動更新；欲升至新版，請以新標籤重新加入 marketplace（例如 `…@v0.7.2`）。
 
 接著執行 `/gemini:setup`——若 Gemini CLI 尚未安裝且 npm 可用，指令會提供自動安裝選項。
 
@@ -229,22 +229,22 @@
 在 `auto` 模式下，外掛依以下優先順序選擇可用引擎：
 
 1. **`gemini` CLI** — 透過 stdout 輸出；支援 stdin 提示傳遞。
-2. **`agy`** — 備援引擎；截至外掛 v0.7.0，adapter 仍使用 `agy --print <prompt>` 並從磁碟 transcript 恢復回應，需明確使用 `--engine agy` 才能強制啟用。
+2. **`agy`** — 備援引擎；AGY 1.1.2 以上以 stdin 接收 prompt 且不帶 `--print`，舊版或版本不明時保留 `agy --print <prompt>`。
 
 可透過 `--engine` 旗標或 `GEMINI_ENGINE` 環境變數覆蓋。
 
 > `--model` 與 `--effort` 只由 **gemini** 引擎管理。`--engine agy` 目前讓 AGY 使用其 configured/default model；本外掛不會把 Gemini aliases 或 effort tiers 翻譯成 AGY 參數。
 
-> **AGY transcript recovery 已於 Windows 與 macOS 驗證通過；Linux 為回報可用。** Adapter 所支援的舊版 AGY 以 positional `agy --print` 執行時無 piped response（上游 [google-gemini/gemini-cli#27466](https://github.com/google-gemini/gemini-cli/issues/27466)，已於 macOS agy 1.0.7 重現），所以外掛從磁碟上的「brain」transcript 恢復回應——`~/.gemini/antigravity-cli/brain`（Windows 1.0.3／1.1.0／1.1.2 與 macOS 1.0.7，同一路徑）或 `~/.antigravity-cli/brain`（Linux 1.0.2，回報）。AGY 1.1.2 另已支援自動 print 的 stdin prompt 路徑，Windows 實測亦有 stdout，但外掛 v0.7.0 尚未切換，跨平台行為也尚未驗證。若找不到 brain 根目錄，請先執行一次 `agy` 建立目錄，或開 issue 回報實際位置。
+> **AGY transcript recovery 仍是權威來源。** 舊版 positional `agy --print` 沒有 piped response（上游 [google-gemini/gemini-cli#27466](https://github.com/google-gemini/gemini-cli/issues/27466)，已於 macOS AGY 1.0.7 重現）。外掛 v0.7.1 對 AGY 1.1.2 以上改走自動 print 的 stdin 路徑，但完成回應、DONE 狀態、thinking 與 conversation ID 仍取自磁碟 transcript。已知 brain root 為 `~/.gemini/antigravity-cli/brain`（Windows／macOS）及 `~/.antigravity-cli/brain`（Linux，回報）。1.1.2 stdin 路徑已於 Windows live 驗證並有 POSIX integration fixture；macOS／Linux 真實 1.1.2 尚待驗證。若找不到 brain root，請先執行一次 `agy` 或開 issue 回報實際位置。
 
 ---
 
 ## 安全性
 
-- **Stdin 傳遞（gemini 引擎）**：`gemini` 引擎之提示透過 stdin（Node.js `spawnSync` 的 `input` 選項）傳遞、從不插入 shell 命令字串，故無論內容為何皆無 shell injection 風險。外掛 v0.7.0 尚未採用 AGY 1.1.2 的 stdin 路徑；處理不可信輸入時請優先使用預設的 gemini 引擎。
-- **Windows `.cmd` wrapper**：npm 將 `gemini`／`agy` 安裝為 `.cmd` shim，需 `shell: true` 方能啟動。因 gemini 提示走 stdin（從不進 argv），`shell: true` 永不將其暴露給 `cmd.exe` 解析——argv 中僅有受控旗標（model id、`--yolo` 等）。
+- **Stdin 傳遞**：Gemini prompt 與 AGY 1.1.2 以上 prompt 透過 Node.js `spawnSync` 的 `input` 傳遞，不進入 argv。AGY 1.1.2 以下或版本無法解析時保留 positional 相容路徑與 24,000 字元上限；處理不可信內容時請使用 Gemini 或 AGY 1.1.2 以上。
+- **Windows process 邊界**：Gemini 的 npm `.cmd` shim 以 `shell:true` 啟動，但 prompt 留在 stdin，argv 只有已驗證旗標。AGY 必須解析成絕對 `.exe`，並固定以 `shell:false` 啟動。
 - **DEP0190 警告屬無害**：於 Windows 上可能見到 `(node:NNN) [DEP0190] DeprecationWarning: Passing args to a child process with shell option true can lead to security vulnerabilities, as the arguments are not escaped, only concatenated.`。此處**可安心忽略**——該 deprecation 針對的是在 `shell: true` 下把*提示內容*放入 argv，但本外掛的 gemini 引擎從不如此：提示走 stdin，僅受控旗標進入 argv（且各自驗證，如 model id 須符合 `^[A-Za-z0-9][A-Za-z0-9._-]*$`）。此警告是 Node 對該通用模式的提醒，並非本程式路徑中的實際注入點。
-- **外掛 v0.7.0 的 AGY positional 提示**：雖然 AGY 1.1.2 已支援自動 print 的 stdin prompt 路徑，本版 adapter 仍以 positional CLI 引數傳入提示，並保留 24,000 字元安全上限。**本版請勿將不可信提示內容經 `--engine agy` 傳遞**——應優先使用預設的 gemini 引擎。Windows 路徑仍解析絕對 `.exe` 並使用 `shell:false`；剩餘風險是 prompt 暴露於 argv 與平台引號規則，而非經 npm shim 啟動 shell。
+- **AGY transport 回退**：只有可穩定解析為 1.1.2 以上的版本才啟用 stdin；未知版與 prerelease 字串一律 fail closed 至既有 positional 路徑，不假設上游能力。
 - **憑證處理**：`~/.gemini/oauth_creds.json` 之 OAuth 憑證僅用於 `getGeminiLoginStatus()` 檢查 token 是否過期；本外掛從不記錄、複製或傳輸之。
 - **`.gitignore`**：`.omc/` 狀態目錄（工作日誌、會話狀態）已排除於版本控制之外。
 
@@ -273,10 +273,10 @@ Claude Code
   └─ /gemini:rescue "提示"
        └─ gemini-companion.mjs task
             ├─ detectEngine()        → gemini | agy
-            ├─ buildCliArgs()        → 引數（gemini 模式不含提示）
-            ├─ runCommand()          → spawnSync，提示透過 stdin 傳入
-            │    shell: true (Win)   ← 修復 Windows .cmd wrapper 問題
-            │    input: prompt       ← gemini 引擎：提示經 stdin（不經 shell 解析）
+            ├─ buildCliArgs()        → 依版本組合引數
+            ├─ runCommand()          → spawnSync
+            │    input: prompt       ← Gemini + AGY ≥1.1.2
+            │    argv: prompt        ← 舊版／未知版 AGY（24K 上限）
             └─ renderTaskResult()   → Markdown 輸出至 Claude
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@arcobaleno64/gemini-plugin-cc",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@arcobaleno64/gemini-plugin-cc",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arcobaleno64/gemini-plugin-cc",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "private": true,
   "type": "module",
   "description": "Use Gemini CLI or Antigravity CLI (agy) inside Claude Code for task delegation, code review, and adversarial review.",

--- a/plugins/gemini/.claude-plugin/plugin.json
+++ b/plugins/gemini/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gemini",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Use Gemini/AGY from Claude Code to review code or delegate tasks.",
   "author": {
     "name": "arcobaleno64",

--- a/plugins/gemini/CHANGELOG.md
+++ b/plugins/gemini/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.7.1 — 2026-07-14 — AGY stdin transport
+
+### Changed
+- **AGY 1.1.2 and newer now receive prompts on stdin.** The adapter parses `agy --version` and, only for a stable version at or above 1.1.2, omits both `--print` and the prompt from argv so AGY auto-enters print mode from piped input. Older, prerelease, and unparseable versions fail closed to the existing `agy --print <prompt>` path. The 24,000-character and NUL preflight checks now apply only to that positional fallback. Windows still requires an absolute `.exe` and `shell:false`; `--print-timeout`, `--continue`, `--new-project`, and `--dangerously-skip-permissions` behavior is unchanged. (`lib/engine.mjs`, `lib/gemini.mjs`)
+- **Transcript recovery remains authoritative.** Both task and review still snapshot the AGY brain directory and use the completed transcript for response text, DONE status, thinking, and conversation ID. Stdout is retained for diagnostics but does not replace the transcript contract, and the 105-second print / 120-second hard timeout strategy remains unchanged. (`lib/agy-transcript.mjs`)
+
+### Tests
+- Added version-boundary and argv tests for AGY 1.1.1 versus 1.1.2, including a prompt above the old 24,000-character positional limit. A POSIX fake AGY executable records argv/stdin, emits a conflicting stdout decoy, and writes a DONE transcript to cover task, review, legacy fallback, and transcript precedence. Existing task/review stderr-without-transcript regressions remain in place; Windows is covered by the AGY 1.1.2 live smoke described below.
+
+### Validation
+- **AGY 1.1.2 on Windows:** a foreground read-only task completed in 14 seconds and a background task in 13 seconds; both returned their unique marker, no touched files, and a conversation ID that matched a completed on-disk transcript. A one-line synthetic working-tree review completed in 26 seconds, returned structured JSON, and identified the planted wrong-operator defect. A direct invalid-model invocation used stdin with no `--print`, exited 1 in 1.7 seconds, wrote no stdout, and returned a non-empty stderr error plus the available-model list. A larger 53 KB review prompt reached a new transcript but produced no planner response before the existing 105-second print / 120-second hard timeout, which surfaced as `transcript-missing`; this confirms the transport while retaining the documented review-size/time boundary. Real credentials were not revoked, so the upstream OAuth fail-fast path remains documentation-backed rather than live-tested.
+
 ## 0.7.0 — 2026-07-14 — MCP bridge and AGY resilience
 
 ### Added

--- a/plugins/gemini/scripts/lib/agy-transcript.mjs
+++ b/plugins/gemini/scripts/lib/agy-transcript.mjs
@@ -1,13 +1,13 @@
-// agy-transcript.mjs — P0-E: recover agy --print responses from disk.
+// agy-transcript.mjs — recover authoritative AGY responses from disk.
 //
 // WHY THIS EXISTS
 // ---------------
-// `agy --print` does NOT deliver its response over stdout in non-TTY use
-// (upstream bug google-gemini/gemini-cli#27466; locally verified empty/hang on
-// agy 1.0.3 Windows and reproduced on 1.0.7 macOS — 0 bytes piped to stdout).
-// The response IS persisted to disk under the agy "brain" dir. We
-// recover it by diffing the set of conversation dirs before/after the spawn and
-// reading the new one's transcript.
+// Older positional `agy --print` releases did not deliver their response over
+// stdout in non-TTY use (google-gemini/gemini-cli#27466; verified on AGY 1.0.3
+// Windows and 1.0.7 macOS). AGY 1.1.2 can accept the prompt on stdin and return
+// stdout, but the transcript still supplies the cross-version response, DONE
+// status, thinking, and conversation id. The adapter therefore keeps transcript
+// recovery authoritative on both transport paths.
 //
 // SYNCHRONOUS MODEL (important)
 // -----------------------------
@@ -207,47 +207,7 @@ export function recoverAgyResponse(brainRoot, beforeSnapshot) {
   };
 }
 
-/* ============================================================================
- * INTEGRATION INTO runGeminiTurn (gemini.mjs) — NOW INTEGRATED (see gemini.mjs).
- * Kept below as a reference for the wiring; the live code is the source of truth.
- * ============================================================================
- * The agy branch currently reads result.stdout (always empty). Replace the
- * RESULT-EXTRACTION step for agy only; buildCliArgs stays as-is (we still spawn
- * `agy --print` to make agy run and write the transcript).
- *
- * import { resolveAgyBrainRoot, listConvDirs, recoverAgyResponse } from "./agy-transcript.mjs";
- *
- * // --- before spawn (agy only) ---
- * let agyBrainRoot = null, agyBefore = null;
- * if (engineInfo.engine === "agy") {
- *   agyBrainRoot = resolveAgyBrainRoot();
- *   agyBefore = listConvDirs(agyBrainRoot);
- * }
- *
- * // --- TODO-3: timeout grace ---
- * // Give agy's own --print-timeout LESS time than the spawn timeout so agy
- * // self-terminates and flushes the transcript before spawnSync SIGKILLs it.
- * // Currently both are AGY_SPAWN_TIMEOUT_MS (same value) => they race and the
- * // final PLANNER_RESPONSE may be truncated. Suggested:
- * //   const printTimeoutMs = Math.max(30_000, AGY_SPAWN_TIMEOUT_MS - 15_000);
- * //   buildCliArgs(..., { timeoutMs: printTimeoutMs })   // feeds --print-timeout
- * //   runCommand(..., { timeout: AGY_SPAWN_TIMEOUT_MS }) // hard kill is the grace-later one
- *
- * const result = runCommand(engineInfo.binary, args, { cwd, maxBuffer: MAX_BUFFER, timeout: spawnTimeoutMs });
- *
- * // --- after spawn: branch result extraction ---
- * let responseText;
- * if (engineInfo.engine === "agy") {
- *   const rec = recoverAgyResponse(agyBrainRoot, agyBefore);
- *   if (!rec.response) {
- *     throw new Error(`AGY produced no recoverable response (${rec.reason}). agy --print does not pipe output (#27466); transcript recovery failed.`);
- *   }
- *   if (!rec.confident) {
- *     process.stderr.write(`[gemini-companion] Warning: AGY transcript match not certain (${rec.reason}). Verify the response corresponds to this run.\n`);
- *   }
- *   responseText = rec.response;
- * } else {
- *   const rawStdout = stripAnsi(result.stdout ?? "");
- *   // ... existing gemini JSON-envelope path ...
- * }
- * ============================================================================ */
+// Integration invariant: gemini.mjs snapshots the brain directory before every
+// AGY spawn and calls recoverAgyResponse afterwards. Missing recovery is passed
+// to the failure classifier together with exit status and stderr; a completed
+// transcript remains authoritative even when AGY also returned stdout.

--- a/plugins/gemini/scripts/lib/engine.mjs
+++ b/plugins/gemini/scripts/lib/engine.mjs
@@ -54,6 +54,15 @@ function resolveAgyExecutablePath({ resolveBinaryPathImpl = resolveBinaryPath } 
   return resolved;
 }
 
+export function supportsAgyStdinPrompt(version) {
+  const match = String(version ?? "").trim().match(/(\d+)\.(\d+)\.(\d+)(-[0-9A-Za-z.-]+)?/);
+  if (!match || match[4]) return false;
+  const major = Number(match[1]);
+  const minor = Number(match[2]);
+  const patch = Number(match[3]);
+  return major > 1 || (major === 1 && (minor > 1 || (minor === 1 && patch >= 2)));
+}
+
 export function detectEngine(requestedEngine = null, options = {}) {
   const envEngine = process.env[ENGINE_ENV];
   const target = requestedEngine ?? envEngine ?? "auto";
@@ -67,14 +76,12 @@ export function detectEngine(requestedEngine = null, options = {}) {
     const binary = resolveAgyExecutablePath(options);
     const status = binaryAvailable(binary, ["--version"]);
     if (!status.available) throw new Error("AGY engine requested but agy binary is not available.");
-    // `agy --print` does not emit its response over a pipe in non-TTY use
-    // (upstream bug google-gemini/gemini-cli#27466); the plugin recovers the
-    // response from agy's on-disk transcript instead (see agy-transcript.mjs and
-    // runGeminiTurn). If no transcript brain dir exists on this platform there is
-    // nothing to recover from, so fail loud rather than spawn empty-handed.
+    // AGY 1.1.2 can accept a piped prompt and return stdout, but transcript
+    // recovery remains authoritative for the response, DONE status, and
+    // conversation id. Fail loud when that required recovery source is absent.
     if (!resolveAgyBrainRoot()) {
       throw new Error(
-        "AGY engine requested but `agy --print` cannot return output over a pipe (upstream bug google-gemini/gemini-cli#27466) and no transcript brain dir was found to recover from on this platform. Run `agy` once interactively to initialize it, or use `--engine gemini`."
+        "AGY engine requested but no transcript brain dir was found. The plugin requires AGY's on-disk transcript for the completed response and conversation id, including on AGY 1.1.2's stdin prompt path. Run `agy` once interactively to initialize it, or use `--engine gemini`."
       );
     }
     return { engine: "agy", binary, version: status.detail ?? "unknown" };
@@ -86,13 +93,9 @@ export function detectEngine(requestedEngine = null, options = {}) {
     return { engine: "gemini", binary: "gemini", version: status.detail ?? "unknown" };
   }
 
-  // auto: prefer gemini. AGY exposes a `--print` flag, but its response does not
-  // come through a pipe in non-interactive (non-TTY) use — local verification on
-  // agy 1.0.3 (2026-06) had `agy --print` return empty stdout or hang to its
-  // print-timeout under the exact piped spawn this plugin uses, while
-  // `gemini -p --output-format json` piped a clean JSON envelope every time.
-  // gemini is therefore the only engine reliable for this spawn model; AGY stays
-  // a last resort when gemini is entirely absent.
+  // auto: prefer gemini because it has the plugin's JSON/model contract. AGY
+  // remains a fallback even though 1.1.2 adds stdin prompt delivery; its response
+  // and conversation id still depend on transcript recovery in this adapter.
   const geminiStatus = binaryAvailable("gemini", ["--version"]);
   if (geminiStatus.available) {
     return { engine: "gemini", binary: "gemini", version: geminiStatus.detail ?? "unknown" };
@@ -137,9 +140,14 @@ export function buildCliArgs(engine, options = {}) {
   const { prompt = "", model, write = false, resumeLast = false, outputJson = false, approvalModePlan = false, timeoutMs, useStdin = false } = options;
 
   if (engine === "agy") {
-    // AGY does not support stdin; prompt must be passed as a positional argument
-    assertAgyPromptSafe(prompt);
-    const args = ["--print", prompt];
+    // AGY >=1.1.2 auto-enters print mode when a prompt is piped on stdin; adding
+    // --print would consume the following flag as its own prompt argument. Older
+    // versions retain the positional form and its Windows argv safety checks.
+    const args = [];
+    if (!useStdin) {
+      assertAgyPromptSafe(prompt);
+      args.push("--print", prompt);
+    }
     if (write) args.push("--dangerously-skip-permissions");
     if (resumeLast) {
       args.push("--continue");

--- a/plugins/gemini/scripts/lib/gemini.mjs
+++ b/plugins/gemini/scripts/lib/gemini.mjs
@@ -3,7 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import process from "node:process";
 
-import { buildCliArgs, detectEngine, mapEffortToModel, normalizeRequestedModel } from "./engine.mjs";
+import { buildCliArgs, detectEngine, mapEffortToModel, normalizeRequestedModel, supportsAgyStdinPrompt } from "./engine.mjs";
 import { classifyCliFailure } from "./failures.mjs";
 import { binaryAvailable, runCommand } from "./process.mjs";
 import { resolveAgyBrainRoot, listConvDirs, recoverAgyResponse } from "./agy-transcript.mjs";
@@ -149,15 +149,17 @@ export async function runGeminiTurn(cwd, options = {}) {
     model = normalizeRequestedModel(model) ?? model;
   }
 
-  // Gemini CLI reads from stdin to avoid shell injection on Windows (shell:true + args array)
-  const useStdin = engineInfo.engine === "gemini";
+  // Gemini always uses stdin. AGY auto-enters print mode from stdin starting at
+  // 1.1.2; unknown/older versions keep the positional compatibility path.
+  const useStdin = engineInfo.engine === "gemini"
+    || (engineInfo.engine === "agy" && supportsAgyStdinPrompt(engineInfo.version));
   const useJson = engineInfo.engine === "gemini";
   const spawnTimeoutMs = engineInfo.engine === "agy" ? AGY_SPAWN_TIMEOUT_MS : DEFAULT_SPAWN_TIMEOUT_MS;
 
-  // agy only (#27466): the response never reaches stdout — we recover it from the
-  // transcript agy writes on disk. Snapshot the conversation dirs BEFORE the spawn
-  // so we can identify the new one afterwards (agy does not surface the conversation
-  // id on stdout — antigravity-cli#7). TODO-3 timeout grace: give agy's own
+  // AGY recovery remains transcript-authoritative across both transport paths.
+  // Snapshot conversation dirs BEFORE the spawn so we can identify the new one
+  // afterwards (agy does not surface the conversation id reliably on stdout).
+  // Give agy's own
   // --print-timeout a shorter window than the hard spawn kill so agy self-terminates
   // and flushes a final status="DONE" transcript row before spawnSync SIGKILLs it.
   let agyBrainRoot = null;
@@ -221,8 +223,8 @@ export async function runGeminiTurn(cwd, options = {}) {
   let recoveryFailure = null;
 
   if (engineInfo.engine === "agy") {
-    // agy wrote the response to its transcript, not stdout (#27466). Recover it
-    // by diffing the conversation dirs captured before/after the spawn.
+    // Recover the authoritative response and conversation id by diffing the
+    // transcript directories captured before/after the spawn.
     const rec = recoverAgyResponse(agyBrainRoot, agyBefore);
     if (!rec.response) {
       if (exitCode === 0) exitCode = 1;
@@ -311,11 +313,12 @@ export async function runGeminiReview(cwd, options = {}) {
 
   const model = normalizeRequestedModel(requestedModel) ?? (engineInfo.engine === "gemini" ? "gemini-2.5-flash" : null);
 
-  const useStdin = engineInfo.engine === "gemini";
+  const useStdin = engineInfo.engine === "gemini"
+    || (engineInfo.engine === "agy" && supportsAgyStdinPrompt(engineInfo.version));
   const spawnTimeoutMs = engineInfo.engine === "agy" ? AGY_SPAWN_TIMEOUT_MS : DEFAULT_SPAWN_TIMEOUT_MS;
 
-  // agy only (#27466): recover the review from the transcript, not stdout (see
-  // runGeminiTurn for the rationale). Snapshot the conversation dirs before the
+  // Recover AGY review output from the authoritative transcript on both the old
+  // positional and 1.1.2+ stdin paths. Snapshot conversation dirs before the
   // spawn, and give agy's --print-timeout a grace window shorter than the hard
   // spawn kill so it flushes a final status="DONE" row before SIGKILL.
   let agyBrainRoot = null;
@@ -379,8 +382,7 @@ export async function runGeminiReview(cwd, options = {}) {
   let recoveryFailure = null;
 
   if (engineInfo.engine === "agy") {
-    // agy wrote the review to its transcript, not stdout (#27466). Recover it and
-    // parse the JSON findings out of the recovered text.
+    // Recover the authoritative review and parse JSON findings from that text.
     const rec = recoverAgyResponse(agyBrainRoot, agyBefore);
     if (!rec.response) {
       if (exitCode === 0) exitCode = 1;

--- a/plugins/gemini/scripts/lib/process.mjs
+++ b/plugins/gemini/scripts/lib/process.mjs
@@ -6,8 +6,9 @@ import process from "node:process";
 // state, and backslashes escape quotes for MSVCRT children, not for cmd.exe.
 // Keep it only as a belt-and-suspenders safety net for the fixed-constant argv
 // used by remaining bare-name command paths (git/where/gemini/taskkill), never
-// as protection for free text. Gemini prompts use stdin; agy's free-text prompt
-// is protected by absolute-path resolution and therefore shell:false instead.
+// as protection for free text. Gemini and AGY >=1.1.2 prompts use stdin; older
+// AGY positional prompts are protected by absolute-path resolution and
+// therefore shell:false instead.
 const WINDOWS_SHELL_UNSAFE = /[\s|<>&()^"]/;
 function quoteForWindowsShell(arg) {
   if (typeof arg !== "string" || !WINDOWS_SHELL_UNSAFE.test(arg)) return arg;

--- a/tests/engine.test.mjs
+++ b/tests/engine.test.mjs
@@ -1,7 +1,14 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
-import { MODEL_ALIASES, normalizeRequestedModel, mapEffortToModel, buildCliArgs, detectEngine } from "../plugins/gemini/scripts/lib/engine.mjs";
+import {
+  MODEL_ALIASES,
+  normalizeRequestedModel,
+  mapEffortToModel,
+  buildCliArgs,
+  detectEngine,
+  supportsAgyStdinPrompt
+} from "../plugins/gemini/scripts/lib/engine.mjs";
 
 // These two IDs return 404 ModelNotFound on the gemini CLI (verified 0.44.1).
 // No alias or effort tier may resolve to them.
@@ -62,6 +69,16 @@ test("detectEngine fails closed when agy resolves only to an absolute .cmd shim 
   );
 });
 
+test("AGY stdin prompt capability begins at stable 1.1.2 and fails closed for unknown versions", () => {
+  assert.equal(supportsAgyStdinPrompt("1.1.1"), false);
+  assert.equal(supportsAgyStdinPrompt("agy 1.1.1"), false);
+  assert.equal(supportsAgyStdinPrompt("1.1.2-beta.1"), false);
+  assert.equal(supportsAgyStdinPrompt("unknown"), false);
+  assert.equal(supportsAgyStdinPrompt("1.1.2"), true);
+  assert.equal(supportsAgyStdinPrompt("agy version 1.2.0"), true);
+  assert.equal(supportsAgyStdinPrompt("2.0.0"), true);
+});
+
 test("agy positional prompt rejects NUL bytes before argv construction", () => {
   assert.throws(
     () => buildCliArgs("agy", { prompt: "hello\0world" }),
@@ -74,6 +91,22 @@ test("agy positional prompt rejects prompts above the safe Windows argv limit", 
     () => buildCliArgs("agy", { prompt: "x".repeat(24_001) }),
     (error) => error.failure?.category === "prompt-too-long" && /24,000|24000/.test(error.message)
   );
+});
+
+test("AGY stdin mode omits --print and prompt while preserving execution flags", () => {
+  const prompt = "x".repeat(24_001);
+  const args = buildCliArgs("agy", {
+    prompt,
+    useStdin: true,
+    write: true,
+    timeoutMs: 105_000
+  });
+
+  assert.ok(!args.includes("--print"));
+  assert.ok(!args.includes(prompt));
+  assert.ok(args.includes("--dangerously-skip-permissions"));
+  assert.ok(args.includes("--new-project"));
+  assert.deepEqual(args.slice(-2), ["--print-timeout", "2m"]);
 });
 
 test("agy write turn adds --new-project so files land in cwd, not agy's scratch dir", () => {

--- a/tests/fake-gemini-fixture.mjs
+++ b/tests/fake-gemini-fixture.mjs
@@ -91,14 +91,46 @@ export function installFakeAgy(binDir) {
   }
 }
 
+// POSIX integration fixture for AGY transport tests. It records argv/stdin,
+// emits a decoy stdout response, and writes a completed transcript so tests can
+// prove that transport changes do not weaken transcript-authoritative recovery.
+export function installCapturingAgyExecutable(binDir, { version = "1.1.2" } = {}) {
+  if (process.platform === "win32") {
+    throw new Error("The capturing AGY fixture uses a POSIX shebang; Windows is covered by live AGY smoke tests.");
+  }
+
+  const source = [
+    "#!/usr/bin/env node",
+    'const fs = require("node:fs");',
+    'const path = require("node:path");',
+    `const version = ${JSON.stringify(version)};`,
+    "const args = process.argv.slice(2);",
+    'if (args.length === 1 && args[0] === "--version") { process.stdout.write(version + "\\n"); process.exit(0); }',
+    'const stdin = fs.readFileSync(0, "utf8");',
+    "const capturePath = process.env.FAKE_AGY_CAPTURE;",
+    'if (!capturePath) { process.stderr.write("FAKE_AGY_CAPTURE is required\\n"); process.exit(2); }',
+    "fs.mkdirSync(path.dirname(capturePath), { recursive: true });",
+    'fs.writeFileSync(capturePath, JSON.stringify({ args, stdin }, null, 2) + "\\n", "utf8");',
+    'const home = process.env.HOME || process.env.USERPROFILE || ".";',
+    'const conv = "fake-" + Date.now() + "-" + process.pid;',
+    'const logDir = path.join(home, ".gemini", "antigravity-cli", "brain", conv, ".system_generated", "logs");',
+    "fs.mkdirSync(logDir, { recursive: true });",
+    'const row = { step_index: 1, source: "MODEL", type: "PLANNER_RESPONSE", status: "DONE", content: process.env.FAKE_AGY_RESPONSE || "FAKE_AGY_TRANSCRIPT_OK", thinking: "fixture reasoning" };',
+    'fs.writeFileSync(path.join(logDir, "transcript_full.jsonl"), JSON.stringify(row) + "\\n", "utf8");',
+    'process.stdout.write(process.env.FAKE_AGY_STDOUT || "FAKE_AGY_STDOUT_DECOY\\n");'
+  ].join("\n");
+
+  writeExecutable(path.join(binDir, "agy"), source);
+}
+
 // Install an executable AGY stand-in that passes the --version probe, then
 // fails the real print invocation without creating a transcript. Windows AGY
 // must resolve to an absolute .exe, so a copied Node executable provides a
-// safe, deterministic non-zero `bad option: --print` response there.
+// safe, deterministic non-zero unknown-option response there.
 export function installFailingAgyExecutable(binDir) {
   if (process.platform === "win32") {
     fs.copyFileSync(process.execPath, path.join(binDir, "agy.exe"));
-    return /bad option: --print/i;
+    return /bad option: --print-timeout/i;
   }
 
   writeExecutable(

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -9,6 +9,7 @@ import {
   buildEnv,
   buildFailingAgyEnv,
   buildEnvUnavailable,
+  installCapturingAgyExecutable,
   installFakeAgy,
   installFakeGemini,
   installFailingAgyExecutable,
@@ -659,6 +660,85 @@ test("task rejects an unknown engine", () => {
 
   assert.notEqual(result.status, 0);
   assert.match(result.stderr, /Unknown engine/i);
+});
+
+test("AGY 1.1.2 task sends a long prompt only on stdin and keeps transcript authoritative", { skip: process.platform === "win32" }, () => {
+  const repo = makeTempDir();
+  const binDir = makeTempDir();
+  const capturePath = path.join(binDir, "agy-capture.json");
+  const marker = `AGY112_STDIN_${"x".repeat(24_001)}`;
+  installCapturingAgyExecutable(binDir, { version: "1.1.2" });
+  initGitRepo(repo);
+  commit(repo, "README.md", "hello\n");
+
+  const result = run("node", [SCRIPT, "task", "--engine", "agy", marker], {
+    cwd: repo,
+    env: {
+      ...buildFailingAgyEnv(binDir),
+      FAKE_AGY_CAPTURE: capturePath,
+      FAKE_AGY_RESPONSE: "AGY112_TRANSCRIPT_OK",
+      FAKE_AGY_STDOUT: "AGY112_STDOUT_DECOY\n"
+    }
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /AGY112_TRANSCRIPT_OK/);
+  assert.doesNotMatch(result.stdout, /AGY112_STDOUT_DECOY/);
+  const capture = JSON.parse(fs.readFileSync(capturePath, "utf8"));
+  assert.equal(capture.stdin, marker);
+  assert.ok(!capture.args.includes("--print"));
+  assert.ok(!capture.args.includes(marker));
+  assert.deepEqual(capture.args.slice(-2), ["--print-timeout", "2m"]);
+});
+
+test("AGY 1.1.1 task retains positional prompt compatibility", { skip: process.platform === "win32" }, () => {
+  const repo = makeTempDir();
+  const binDir = makeTempDir();
+  const capturePath = path.join(binDir, "agy-capture.json");
+  const prompt = "AGY111_POSITIONAL_MARKER";
+  installCapturingAgyExecutable(binDir, { version: "1.1.1" });
+  initGitRepo(repo);
+  commit(repo, "README.md", "hello\n");
+
+  const result = run("node", [SCRIPT, "task", "--engine", "agy", prompt], {
+    cwd: repo,
+    env: {
+      ...buildFailingAgyEnv(binDir),
+      FAKE_AGY_CAPTURE: capturePath,
+      FAKE_AGY_RESPONSE: "AGY111_TRANSCRIPT_OK"
+    }
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /AGY111_TRANSCRIPT_OK/);
+  const capture = JSON.parse(fs.readFileSync(capturePath, "utf8"));
+  assert.equal(capture.stdin, "");
+  assert.deepEqual(capture.args.slice(0, 2), ["--print", prompt]);
+});
+
+test("AGY 1.1.2 review sends the generated review prompt on stdin", { skip: process.platform === "win32" }, () => {
+  const repo = makeTempDir();
+  const binDir = makeTempDir();
+  const capturePath = path.join(binDir, "agy-capture.json");
+  installCapturingAgyExecutable(binDir, { version: "1.1.2" });
+  initGitRepo(repo);
+  commit(repo, "src/app.js", "export const value = 1;\n");
+  fs.writeFileSync(path.join(repo, "src", "app.js"), "export const value = 2;\n", "utf8");
+
+  const result = run("node", [SCRIPT, "review", "--engine", "agy", "--scope", "working-tree"], {
+    cwd: repo,
+    env: {
+      ...buildFailingAgyEnv(binDir),
+      FAKE_AGY_CAPTURE: capturePath,
+      FAKE_AGY_RESPONSE: JSON.stringify({ verdict: "clean", summary: "AGY stdin review completed.", findings: [] })
+    }
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /AGY stdin review completed/);
+  const capture = JSON.parse(fs.readFileSync(capturePath, "utf8"));
+  assert.match(capture.stdin, /export const value = 2/);
+  assert.ok(!capture.args.includes("--print"));
 });
 
 test("task preserves AGY stderr when no transcript response is recoverable", () => {


### PR DESCRIPTION
AGY 1.1.2+ now receives prompts through its auto-print stdin path; older, prerelease, and unknown versions retain the positional fallback. Transcript recovery, timeout windows, model behavior, and write permissions remain unchanged. Validation: local 237 tests with 234 pass and 3 POSIX-only skips, version and contract checks pass; Windows AGY 1.1.2 foreground/background tasks and a synthetic structured review passed; invalid model failed non-zero with stderr. A 53 KB live review reached the transcript but exceeded the existing 105/120-second timeout, which remains documented and unchanged. Ubuntu CI is the release gate for the three POSIX fake-AGY transport cases.