### PR TITLE
chore(release): prepare v0.8.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,13 +6,13 @@
   },
   "metadata": {
     "description": "Use Gemini CLI or Antigravity CLI (agy) inside Claude Code for task delegation, code review, and adversarial review.",
-    "version": "0.7.1"
+    "version": "0.8.0"
   },
   "plugins": [
     {
       "name": "gemini",
       "description": "Gemini CLI and Antigravity CLI bridge for Claude Code task delegation and adversarial review",
-      "version": "0.7.1",
+      "version": "0.8.0",
       "author": {
         "name": "arcobaleno64"
       },

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Compared with AGY-only, multi-host plugins, this project keeps the Gemini CLI pa
 | Need | Use this plugin when... |
 |---|---|
 | Gemini CLI still works for you | You want model selection, JSON output, and stdin prompt delivery. |
-| You are migrating to AGY | Use `--engine agy` for Antigravity CLI fallback. |
+| You are migrating to AGY | Use `--engine agy` as the fully supported Antigravity CLI backend. |
 | You want adversarial review | Use `/gemini:adversarial-review` with optional focus text. |
 | You need AGY-only multi-host support | Consider an AGY-only plugin instead. |
 
@@ -35,13 +35,13 @@ Compared with AGY-only, multi-host plugins, this project keeps the Gemini CLI pa
 
 ## Features
 
-- **`/gemini:rescue`** — Delegate investigation, debugging, or implementation tasks to Gemini. Runs in the foreground or detached in the background.
+- **`/gemini:rescue`** — Delegate investigation, debugging, or implementation tasks to the selected Gemini CLI or AGY engine. Runs in the foreground or detached in the background.
 - **`/gemini:review`** — Standard (pragmatic) code review over the current diff or branch. Finds real bugs, missing error handling, and incomplete code paths. Add `--deep` for an agentic pass that explores repo context beyond the diff.
 - **`/gemini:adversarial-review`** — Adversarial code review that challenges design decisions over the current diff or branch. Returns structured findings with severity ratings.
 - **`/gemini:setup`** — Check Gemini CLI / AGY availability and OAuth status.
 - **`/gemini:status`** — Inspect active and completed background jobs.
 - **`/gemini:result`** / **`/gemini:cancel`** — Retrieve or cancel a background job.
-- **Engine auto-detection** — Prefers `gemini` CLI (pipe-safe); falls back to `agy`.
+- **Engine auto-detection** — Both engines are first-class; `auto` checks `gemini` first for its JSON/model contract, then `agy`.
 - **Version-aware stdin prompt delivery** — Gemini always uses stdin; AGY 1.1.2 or newer uses its auto-print stdin path, while older or unknown versions retain the compatible positional path.
 - **Session lifecycle hooks** — Automatically injects `GEMINI_COMPANION_SESSION_ID`; cleans up stale jobs on session end.
 
@@ -52,13 +52,13 @@ Compared with AGY-only, multi-host plugins, this project keeps the Gemini CLI pa
 | Requirement | Version | Install |
 |---|---|---|
 | Node.js | ≥ 18 | [nodejs.org](https://nodejs.org) |
-| Gemini CLI | ≥ 0.40 | `npm install -g @google/gemini-cli` |
-| AGY _(optional)_ | ≥ 1.0.3; ≥ 1.1.2 recommended (Windows verified) | _(see install note below)_ |
+| Gemini CLI | ≥ 0.40; required for the `gemini` engine | `npm install -g @google/gemini-cli` |
+| AGY | ≥ 1.0.3; ≥ 1.1.2 recommended and live-verified on Windows/Ubuntu WSL2 | _(see install note below)_ |
 | Claude Code | any | [claude.ai/code](https://claude.ai/code) |
 
-**Install AGY** (optional fallback): `curl -fsSL https://antigravity.google/cli/install.sh | bash`
+**Install AGY** (required for `--engine agy`): `curl -fsSL https://antigravity.google/cli/install.sh | bash`
 
-**Authentication**: Run `gemini` once to complete OAuth. No API key is required.
+**Authentication**: Each engine authenticates independently. Run `gemini` once for the Gemini engine, or run `agy` once interactively for the AGY engine. AGY authentication cannot be verified reliably from a headless setup probe, so `/gemini:setup --engine agy` reports it as unknown until a real AGY command succeeds. No API key is required.
 
 > **Heads-up (reality check):**
 > - **2026-06-18 consumer transition**: Google announced that free/personal, Google AI Pro, and Google AI Ultra Gemini CLI requests stop being served after this date; Standard/Enterprise access remains. See Google's [Gemini CLI to Antigravity CLI announcement](https://developers.googleblog.com/an-important-update-transitioning-gemini-cli-to-antigravity-cli/).
@@ -83,17 +83,17 @@ Compared with AGY-only, multi-host plugins, this project keeps the Gemini CLI pa
 
 ### Pinned release (a specific published version)
 
-Pin the marketplace to a release tag — e.g. `v0.7.1`:
+Pin the marketplace to a release tag — e.g. `v0.8.0`:
 
 ```
-/plugin marketplace add arcobaleno64/gemini-plugin-cc@v0.7.1
+/plugin marketplace add arcobaleno64/gemini-plugin-cc@v0.8.0
 /plugin install gemini@gemini-plugin-cc
 /reload-plugins
 ```
 
-> Claude Code installs plugins from the git tree, not from GitHub Release tarballs — `@<tag>` selects the git tag behind a [Release](https://github.com/arcobaleno64/gemini-plugin-cc/releases). A pinned install does **not** auto-update; to move to a newer release, re-add the marketplace with the new tag (e.g. `…@v0.7.2`).
+> Claude Code installs plugins from the git tree, not from GitHub Release tarballs — `@<tag>` selects the git tag behind a [Release](https://github.com/arcobaleno64/gemini-plugin-cc/releases). A pinned install does **not** auto-update; to move to a newer release, re-add the marketplace with the new tag (e.g. `…@v0.8.1`).
 
-Then run `/gemini:setup` — it will check whether Gemini CLI is ready. If Gemini is missing and npm is available, it will offer to install it for you.
+Then run `/gemini:setup` for `auto`/Gemini, or `/gemini:setup --engine agy` for AGY. The selected engine is the only engine dependency that must be installed; setup offers the matching installer when it is missing.
 
 If Gemini is installed but not authenticated yet, run:
 
@@ -231,7 +231,7 @@ When enabled and the review returns `needs-attention`, Claude Code is blocked fr
 In `auto` mode the plugin selects the first available engine in this order:
 
 1. **`gemini` CLI** — outputs via stdout; supports stdin prompt delivery.
-2. **`agy`** — fallback; AGY 1.1.2 or newer receives the prompt on stdin with no `--print` flag, while older or unknown versions retain `agy --print <prompt>`.
+2. **`agy`** — first-class supported engine and second `auto` candidate; AGY 1.1.2 or newer receives the prompt on stdin with no `--print` flag, while older or unknown versions retain `agy --print <prompt>`.
 
 Override via `--engine` flag or the `GEMINI_ENGINE` environment variable.
 
@@ -245,6 +245,7 @@ Override via `--engine` flag or the `GEMINI_ENGINE` environment variable.
 
 - **Stdin delivery**: Gemini prompts and AGY 1.1.2-or-newer prompts use Node's `spawnSync` `input` option and never enter argv. AGY versions older than 1.1.2, plus unparseable versions, keep the positional compatibility path and its 24,000-character limit; prefer Gemini or AGY 1.1.2+ for untrusted prompt content.
 - **Windows process boundary**: Gemini's npm `.cmd` shim is launched through `shell:true`, but its prompt remains on stdin and only validated flags enter argv. AGY must resolve to an absolute `.exe` and is always launched with `shell:false`.
+- **Git process boundary**: Repository-derived refs are always passed to Git as literal argv with `shell:false`, including on Windows; Git helpers never inherit the `.cmd` wrapper fallback.
 - **DEP0190 warning is benign**: On Windows you may see `(node:NNN) [DEP0190] DeprecationWarning: Passing args to a child process with shell option true can lead to security vulnerabilities, as the arguments are not escaped, only concatenated.` This is **safe to ignore here** — the deprecation is about *prompt content* placed in argv under `shell: true`, but this plugin never does that for the gemini engine: the prompt travels on stdin, and only controlled flags reach argv (each validated, e.g. model ids must match `^[A-Za-z0-9][A-Za-z0-9._-]*$`). The warning is Node flagging the general pattern, not an actual injection vector in this code path.
 - **AGY transport fallback**: Only a stable parsed version of 1.1.2 or newer enables stdin. Unknown and prerelease version strings fail closed to the existing positional path, preserving compatibility rather than assuming an upstream capability.
 - **Credential handling**: OAuth credentials in `~/.gemini/oauth_creds.json` are read only to check token expiry via `getGeminiLoginStatus()`; they are never logged, copied elsewhere, or transmitted by this plugin.
@@ -260,11 +261,11 @@ Override via `--engine` flag or the `GEMINI_ENGINE` environment variable.
 | `npm: not found` | Node/npm missing from PATH | Install Node.js ≥ 18 from [nodejs.org](https://nodejs.org) |
 | setup shows `gemini auth: No credentials …` | OAuth not completed | Run `!gemini` once and complete the browser login |
 | setup shows `… token expired` | OAuth token lapsed | Run `!gemini` again to refresh credentials |
-| `Status: partial (AGY fallback only …)` | Gemini CLI unavailable but AGY present | Install Gemini CLI, or use `--engine agy` (its auth cannot be verified) |
+| `Status: partial (AGY available …)` | Gemini CLI unavailable but AGY present | Use `--engine agy` directly; setup keeps AGY auth `unknown` because it cannot verify the independent AGY OAuth flow non-interactively |
 | Windows: command resolves but fails | `.cmd` wrapper / PATH | Confirm `where gemini` resolves; the plugin spawns bare names through `shell: true` to find `.cmd` shims |
 | `--engine agy` reports no brain root | AGY has not created its brain directory yet, or it lives in an unknown location | Run `agy` once so it creates the brain dir. Known roots: `~/.gemini/antigravity-cli/brain` (verified on Windows, macOS AGY 1.0.7, and Linux AGY 1.1.2) and `~/.antigravity-cli/brain` (older Linux 1.0.2, reported); if yours differs, open an issue with its location |
 
-To authenticate, run **`!gemini`** once — the plugin completes OAuth by invoking `gemini` itself. There is **no** `gemini login` subcommand. `setup` reports `ready: true` only when Node **and** the Gemini CLI are present **and** OAuth is valid; an installed-but-unauthenticated Gemini is reported as *not ready*.
+For the Gemini engine, run **`!gemini`** once — the plugin completes OAuth by invoking `gemini` itself. There is **no** `gemini login` subcommand. For the AGY engine, run `agy` interactively once; its separate OAuth state is not inferred from Gemini's `~/.gemini/oauth_creds.json`. `setup` reports AGY as `partial` while the binary is present but auth remains unverifiable.
 
 ---
 
@@ -288,13 +289,13 @@ Background mode spawns a detached worker child process (`task-worker` for `/gemi
 
 ## Parity with codex-plugin-cc
 
-This plugin is a high-fidelity port of [openai/codex-plugin-cc](https://github.com/openai/codex-plugin-cc). The public slash-command surface, background job model, and state/result/status/cancel flow mirror the upstream; the execution backend is the Gemini CLI (with an AGY fallback) rather than the Codex app server.
+This plugin is a high-fidelity port of [openai/codex-plugin-cc](https://github.com/openai/codex-plugin-cc). The public slash-command surface, background job model, and state/result/status/cancel flow mirror the upstream; the execution backends are the first-class Gemini CLI and AGY engines rather than the Codex app server.
 
 ### Compatibility Matrix
 
 | Upstream (Codex) | This plugin (Gemini) | Parity |
 |---|---|---|
-| `/codex:setup` | `/gemini:setup` | **Gemini-specific divergence** — checks `gemini` OAuth + optional AGY fallback instead of Codex auth |
+| `/codex:setup` | `/gemini:setup` | **Gemini-specific divergence** — checks Gemini OAuth or AGY binary readiness for the selected first-class engine instead of Codex auth |
 | `/codex:review` | `/gemini:review` | **best-effort equivalent** — prompt / CLI-adapter review, not a native reviewer |
 | `/codex:adversarial-review` | `/gemini:adversarial-review` | **best-effort equivalent** — adversarial prompt over the same diff target |
 | `/codex:rescue` | `/gemini:rescue` | **1:1 parity** — same forwarder/subagent contract and flags |
@@ -304,7 +305,7 @@ This plugin is a high-fidelity port of [openai/codex-plugin-cc](https://github.c
 
 ### Codex app server vs Gemini CLI adapter
 
-- **Runtime**: Codex uses a persistent app-server with native review and persistent threads. This plugin invokes the Gemini CLI directly *per command* (no shared runtime); AGY is an optional fallback.
+- **Runtime**: Codex uses a persistent app-server with native review and persistent threads. This plugin invokes the selected first-class Gemini CLI or AGY engine directly *per command* (no shared runtime); `auto` uses capability-based Gemini→AGY ordering.
 - **Standard review**: In the Codex plugin, `/codex:review` is a *native* reviewer. Here, `/gemini:review` is a **prompt-based / CLI-adapter equivalent** — it sends the diff to Gemini with a pragmatic-review prompt and parses structured JSON back. It is not a native Gemini reviewer.
 - **Sandbox**: Codex exposes `read-only` / `workspace-write` sandboxes. Gemini has no equivalent; write access is gated by `--write` (`--yolo`), and otherwise the prompt enforces read-only discipline. (`--approval-mode plan` is intentionally not used: it requires a TTY and conflicts with stdin prompt delivery.)
 - **Thread/session resume**: Codex persists threads on the app server. Here, resume relies on the Gemini CLI **session id** captured from the JSON envelope; `/gemini:result` prints `gemini --resume <session-id>`, and `--resume-last` continues the latest thread *for the current Claude session*.
@@ -346,4 +347,4 @@ This project is a derivative work of [openai/codex-plugin-cc](https://github.com
 
 **Derived from upstream** (adapted, Apache-2.0): the slash-command structure, the background job model (enqueue / worker / status / result / cancel), the `.omc/state` persistence and job-control patterns, the stop-time review-gate pattern, the skill contract layout, and the version/manifest tooling (`bump-version`).
 
-**Original to this repository** (MIT): the Gemini/AGY engine detection and routing, stdin prompt delivery, the `model-map` alias/effort source, the AGY fallback handling, OAuth status checks, and the contract-verification script.
+**Original to this repository** (MIT): the Gemini/AGY engine detection and routing, stdin prompt delivery, the `model-map` alias/effort source, AGY engine handling, OAuth status checks, and the contract-verification script.

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -25,7 +25,7 @@
 | 需求 | 適合使用本外掛的情境 |
 |---|---|
 | Gemini CLI 仍可用 | 你需要 model selection、JSON output 與 stdin prompt delivery。 |
-| 正在遷移到 AGY | 使用 `--engine agy` 作為 Antigravity CLI fallback。 |
+| 正在遷移到 AGY | 使用 `--engine agy` 作為完整支援的 Antigravity CLI 後端。 |
 | 需要 adversarial review | 使用 `/gemini:adversarial-review`，可加 focus text。 |
 | 需要 AGY-only 多宿主支援 | 可考慮 AGY-only plugin。 |
 
@@ -33,13 +33,13 @@
 
 ## 功能特色
 
-- **`/gemini:rescue`** — 將調查、除錯或實作任務委派給 Gemini。可在前景執行或以背景工作方式分離執行。
+- **`/gemini:rescue`** — 將調查、除錯或實作任務委派給所選的 Gemini CLI 或 AGY 引擎。可在前景執行或以背景工作方式分離執行。
 - **`/gemini:review`** — 對當前 diff 或分支執行標準（務實）程式碼審查，找出真實 bug、缺漏之錯誤處理與未竟之程式路徑。加 `--deep` 可進行 agentic 探查、看 diff 以外的 repo 脈絡。
 - **`/gemini:adversarial-review`** — 對當前 diff 或分支執行對抗性程式碼審查，挑戰設計決策，回傳含嚴重程度評級的結構化發現。
 - **`/gemini:setup`** — 檢查 Gemini CLI / AGY 的可用性與 OAuth 狀態。
 - **`/gemini:status`** — 查看作用中與已完成的背景工作。
 - **`/gemini:result`** / **`/gemini:cancel`** — 取得或取消背景工作。
-- **引擎自動偵測** — 優先使用 `gemini` CLI（支援 pipe 輸出）；備援退回至 `agy`。
+- **引擎自動偵測** — 兩個引擎皆為第一級支援；`auto` 因 JSON／model 合約先檢查 `gemini`，再檢查 `agy`。
 - **版本感知的 stdin 提示傳遞** — Gemini 固定走 stdin；AGY 1.1.2 以上走自動 print 的 stdin 路徑，舊版或版本不明時保留 positional 相容路徑。
 - **會話生命週期掛鉤** — 自動注入 `GEMINI_COMPANION_SESSION_ID`；會話結束時清理殘留工作。
 
@@ -50,13 +50,13 @@
 | 項目 | 版本 | 安裝方式 |
 |---|---|---|
 | Node.js | ≥ 18 | [nodejs.org](https://nodejs.org) |
-| Gemini CLI | ≥ 0.40 | `npm install -g @google/gemini-cli` |
-| AGY _(選用)_ | ≥ 1.0.3；建議 ≥ 1.1.2（Windows 已驗證） | _(安裝指令見下)_ |
+| Gemini CLI | ≥ 0.40；使用 `gemini` 引擎時必須安裝 | `npm install -g @google/gemini-cli` |
+| AGY | ≥ 1.0.3；建議 ≥ 1.1.2，已於 Windows／Ubuntu WSL2 live 驗證 | _(安裝指令見下)_ |
 | Claude Code | 任意版本 | [claude.ai/code](https://claude.ai/code) |
 
-**安裝 AGY**（選用備援）：`curl -fsSL https://antigravity.google/cli/install.sh | bash`
+**安裝 AGY**（使用 `--engine agy` 時必須安裝）：`curl -fsSL https://antigravity.google/cli/install.sh | bash`
 
-**認證**：執行一次 `gemini` 完成 OAuth 登入。不需要 API 金鑰。
+**認證**：兩個引擎各自認證。Gemini 引擎請執行一次 `gemini`；AGY 引擎請互動式執行一次 `agy`。Headless setup probe 無法可靠驗證 AGY 認證，因此 `/gemini:setup --engine agy` 會將其標為 unknown，直到真實 AGY 命令成功。不需要 API 金鑰。
 
 > **重要提示（貼近現實）：**
 > - **2026-06-18 consumer transition**：Google 宣布免費／個人版、Google AI Pro、Google AI Ultra 的 Gemini CLI requests 於此日期後停止服務；Standard/Enterprise access 維持。詳見 Google 的 [Gemini CLI to Antigravity CLI announcement](https://developers.googleblog.com/an-important-update-transitioning-gemini-cli-to-antigravity-cli/)。
@@ -81,17 +81,17 @@
 
 ### 釘選發布版（指定某個已發布版本）
 
-將 marketplace 釘到某個 release 標籤——例如 `v0.7.1`：
+將 marketplace 釘到某個 release 標籤——例如 `v0.8.0`：
 
 ```
-/plugin marketplace add arcobaleno64/gemini-plugin-cc@v0.7.1
+/plugin marketplace add arcobaleno64/gemini-plugin-cc@v0.8.0
 /plugin install gemini@gemini-plugin-cc
 /reload-plugins
 ```
 
-> Claude Code 從 git tree 安裝外掛，**並非**從 GitHub Releases 的 tarball——`@<tag>` 選的是 [Release](https://github.com/arcobaleno64/gemini-plugin-cc/releases) 背後的 git 標籤。釘版安裝**不會**自動更新；欲升至新版，請以新標籤重新加入 marketplace（例如 `…@v0.7.2`）。
+> Claude Code 從 git tree 安裝外掛，**並非**從 GitHub Releases 的 tarball——`@<tag>` 選的是 [Release](https://github.com/arcobaleno64/gemini-plugin-cc/releases) 背後的 git 標籤。釘版安裝**不會**自動更新；欲升至新版，請以新標籤重新加入 marketplace（例如 `…@v0.8.1`）。
 
-接著執行 `/gemini:setup`——若 Gemini CLI 尚未安裝且 npm 可用，指令會提供自動安裝選項。
+接著對 `auto`／Gemini 執行 `/gemini:setup`，或對 AGY 執行 `/gemini:setup --engine agy`。只需安裝所選引擎的 dependency；若缺少，setup 會提供對應安裝選項。
 
 若 Gemini 已安裝但尚未完成認證，請執行：
 
@@ -229,7 +229,7 @@
 在 `auto` 模式下，外掛依以下優先順序選擇可用引擎：
 
 1. **`gemini` CLI** — 透過 stdout 輸出；支援 stdin 提示傳遞。
-2. **`agy`** — 備援引擎；AGY 1.1.2 以上以 stdin 接收 prompt 且不帶 `--print`，舊版或版本不明時保留 `agy --print <prompt>`。
+2. **`agy`** — 第一級支援引擎及 `auto` 的第二候選；AGY 1.1.2 以上以 stdin 接收 prompt 且不帶 `--print`，舊版或版本不明時保留 `agy --print <prompt>`。
 
 可透過 `--engine` 旗標或 `GEMINI_ENGINE` 環境變數覆蓋。
 
@@ -243,6 +243,7 @@
 
 - **Stdin 傳遞**：Gemini prompt 與 AGY 1.1.2 以上 prompt 透過 Node.js `spawnSync` 的 `input` 傳遞，不進入 argv。AGY 1.1.2 以下或版本無法解析時保留 positional 相容路徑與 24,000 字元上限；處理不可信內容時請使用 Gemini 或 AGY 1.1.2 以上。
 - **Windows process 邊界**：Gemini 的 npm `.cmd` shim 以 `shell:true` 啟動，但 prompt 留在 stdin，argv 只有已驗證旗標。AGY 必須解析成絕對 `.exe`，並固定以 `shell:false` 啟動。
+- **Git process 邊界**：repository-derived ref 一律以 literal argv 與 `shell:false` 傳給 Git（Windows 亦同）；Git helper 不繼承 `.cmd` wrapper fallback。
 - **DEP0190 警告屬無害**：於 Windows 上可能見到 `(node:NNN) [DEP0190] DeprecationWarning: Passing args to a child process with shell option true can lead to security vulnerabilities, as the arguments are not escaped, only concatenated.`。此處**可安心忽略**——該 deprecation 針對的是在 `shell: true` 下把*提示內容*放入 argv，但本外掛的 gemini 引擎從不如此：提示走 stdin，僅受控旗標進入 argv（且各自驗證，如 model id 須符合 `^[A-Za-z0-9][A-Za-z0-9._-]*$`）。此警告是 Node 對該通用模式的提醒，並非本程式路徑中的實際注入點。
 - **AGY transport 回退**：只有可穩定解析為 1.1.2 以上的版本才啟用 stdin；未知版與 prerelease 字串一律 fail closed 至既有 positional 路徑，不假設上游能力。
 - **憑證處理**：`~/.gemini/oauth_creds.json` 之 OAuth 憑證僅用於 `getGeminiLoginStatus()` 檢查 token 是否過期；本外掛從不記錄、複製或傳輸之。
@@ -258,11 +259,11 @@
 | `npm: not found` | PATH 中缺 Node/npm | 自 [nodejs.org](https://nodejs.org) 安裝 Node.js ≥ 18 |
 | setup 顯示 `gemini auth: No credentials …` | 未完成 OAuth | 執行一次 `!gemini` 並完成瀏覽器登入 |
 | setup 顯示 `… token expired` | OAuth token 已過期 | 再次執行 `!gemini` 以更新憑證 |
-| `Status: partial (AGY fallback only …)` | Gemini CLI 不可用但 AGY 存在 | 安裝 Gemini CLI，或使用 `--engine agy`（其認證無法驗證） |
+| `Status: partial (AGY available …)` | Gemini CLI 不可用但 AGY 存在 | 直接使用 `--engine agy`；setup 因無法非互動驗證 AGY 的獨立 OAuth flow，會維持 auth `unknown` |
 | Windows：命令可解析但執行失敗 | `.cmd` wrapper／PATH | 確認 `where gemini` 可解析；外掛以 `shell: true` 啟動裸命令名以尋得 `.cmd` shim |
 | `--engine agy` 回報找不到 brain 根目錄 | AGY 尚未建立 brain 目錄，或其位於未知位置 | 先執行一次 `agy` 讓其建立 brain 目錄。已知路徑：`~/.gemini/antigravity-cli/brain`（已於 Windows、macOS AGY 1.0.7 與 Linux AGY 1.1.2 驗證）與 `~/.antigravity-cli/brain`（較舊的 Linux 1.0.2，回報）；若不同請開 issue 回報其位置 |
 
-如需認證，執行一次 **`!gemini`**——外掛即以呼叫 `gemini` 自身完成 OAuth。**並無** `gemini login` 子命令。唯有 Node **且** Gemini CLI 皆存在**且** OAuth 有效時，`setup` 方回報 `ready: true`；已安裝但未認證之 Gemini 將回報為 *not ready*。
+Gemini 引擎請執行一次 **`!gemini`**——外掛即以呼叫 `gemini` 自身完成 OAuth，**並無** `gemini login` 子命令。AGY 引擎請互動式執行一次 `agy`；其獨立 OAuth 狀態不由 Gemini 的 `~/.gemini/oauth_creds.json` 推定。AGY binary 存在但 auth 無法驗證時，setup 會回報 `partial`。
 
 ---
 
@@ -286,13 +287,13 @@ Claude Code
 
 ## 與 codex-plugin-cc 的對應
 
-本外掛為 [openai/codex-plugin-cc](https://github.com/openai/codex-plugin-cc) 的高保真移植版。公開的斜線命令介面、背景工作模型，以及 state/result/status/cancel 流程皆鏡像上游；執行後端則改用 Gemini CLI（並以 AGY 為備援），而非 Codex app server。
+本外掛為 [openai/codex-plugin-cc](https://github.com/openai/codex-plugin-cc) 的高保真移植版。公開的斜線命令介面、背景工作模型，以及 state/result/status/cancel 流程皆鏡像上游；執行後端則為第一級支援的 Gemini CLI 與 AGY 引擎，而非 Codex app server。
 
 ### 相容性對照表
 
 | 上游（Codex） | 本外掛（Gemini） | 對應程度 |
 |---|---|---|
-| `/codex:setup` | `/gemini:setup` | **Gemini 專屬差異** — 檢查 `gemini` OAuth 與選用之 AGY 備援，而非 Codex 認證 |
+| `/codex:setup` | `/gemini:setup` | **Gemini 專屬差異** — 依所選第一級引擎檢查 Gemini OAuth 或 AGY binary readiness，而非 Codex 認證 |
 | `/codex:review` | `/gemini:review` | **最佳等效** — prompt／CLI adapter 審查，非原生審查器 |
 | `/codex:adversarial-review` | `/gemini:adversarial-review` | **最佳等效** — 對同一 diff target 施以對抗性 prompt |
 | `/codex:rescue` | `/gemini:rescue` | **1:1 對等** — 相同的 forwarder／subagent 合約與旗標 |
@@ -302,7 +303,7 @@ Claude Code
 
 ### Codex app server 與 Gemini CLI adapter
 
-- **執行時**：Codex 使用常駐 app-server，具原生審查與持久 thread。本外掛則於*每次命令*直接呼叫 Gemini CLI（無共享執行時）；AGY 為選用備援。
+- **執行時**：Codex 使用常駐 app-server，具原生審查與持久 thread。本外掛則於*每次命令*直接呼叫所選的第一級 Gemini CLI 或 AGY 引擎（無共享執行時）；`auto` 採 Gemini→AGY 的 capability-based 順序。
 - **標準審查**：Codex 外掛之 `/codex:review` 為*原生*審查器；本外掛之 `/gemini:review` 為 **prompt／CLI adapter 等效實作**——將 diff 連同務實審查 prompt 送交 Gemini 並解析回傳之結構化 JSON，並非原生 Gemini 審查器。
 - **沙箱**：Codex 提供 `read-only`／`workspace-write` 沙箱。Gemini 無對應沙箱；寫入權由 `--write`（`--yolo`）把關，否則以 prompt 強制唯讀紀律。（不採 `--approval-mode plan`：其需 TTY，與 stdin 提示傳遞衝突。）
 - **Thread／session 接續**：Codex 於 app-server 持久化 thread。本外掛之接續依賴自 JSON 信封擷取之 Gemini CLI **session id**；`/gemini:result` 會印出 `gemini --resume <session-id>`，而 `--resume-last` 接續*當前 Claude session* 之最新 thread。
@@ -344,4 +345,4 @@ MIT © 2026 arcobaleno64。
 
 **衍生自上游**（沿用，Apache-2.0）：斜線命令結構、背景工作模型（enqueue／worker／status／result／cancel）、`.omc/state` 持久化與 job-control 模式、停止時 review-gate 模式、skill 合約佈局，以及 version／manifest 工具（`bump-version`）。
 
-**本倉儲原創**（MIT）：Gemini/AGY 引擎偵測與路由、stdin 提示傳遞、`model-map` 別名／努力來源、AGY 備援處理、OAuth 狀態檢查，以及 contract 驗證腳本。
+**本倉儲原創**（MIT）：Gemini/AGY 引擎偵測與路由、stdin 提示傳遞、`model-map` 別名／努力來源、AGY 引擎處理、OAuth 狀態檢查，以及 contract 驗證腳本。

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@arcobaleno64/gemini-plugin-cc",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@arcobaleno64/gemini-plugin-cc",
-      "version": "0.7.1",
+      "version": "0.8.0",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arcobaleno64/gemini-plugin-cc",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "private": true,
   "type": "module",
   "description": "Use Gemini CLI or Antigravity CLI (agy) inside Claude Code for task delegation, code review, and adversarial review.",

--- a/plugins/gemini/.claude-plugin/plugin.json
+++ b/plugins/gemini/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gemini",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "Use Gemini/AGY from Claude Code to review code or delegate tasks.",
   "author": {
     "name": "arcobaleno64",

--- a/plugins/gemini/CHANGELOG.md
+++ b/plugins/gemini/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 0.8.0 — 2026-07-15 — First-class AGY and Git hardening
+
+### Security
+- **Git helpers no longer route repository-derived arguments through a Windows shell.** Every call in `lib/git.mjs` now forces `shell:false` after caller options, so auto-detected refs are passed as literal argv and cannot be reinterpreted by `cmd.exe`. A cross-platform regression creates a valid default ref containing `&`, places an adjacent command probe on `PATH`, and verifies branch target detection and diff collection complete without executing the probe. The test helper now honors an explicit `shell` override. ([#18](https://github.com/arcobaleno64/gemini-plugin-cc/issues/18))
+
+### Changed
+- **AGY is documented and reported as a first-class supported engine.** Gemini CLI and AGY are conditional dependencies: users install the CLI for the engine they select, while `auto` keeps capability-based Gemini→AGY ordering because Gemini exposes the plugin's JSON/model contract. Setup now permits the official `curl` installer without incorrectly requiring npm; runtime labels, skills, failure guidance, attribution, and the English/Traditional Chinese READMEs no longer describe AGY as an optional or lower-tier fallback.
+- **AGY authentication status is now honest.** AGY 1.1.x uses an independent `consumerOAuth` flow whose state cannot be inferred from Gemini's `~/.gemini/oauth_creds.json`. `getAgyLoginStatus()` now returns `state:"unknown"` and `verifiable:false` for an installed AGY binary, instructs users to run `agy` interactively, and never claims the shared Gemini credential proves AGY login. The existing `loggedIn` and `agyFallbackAvailable` fields remain for JSON compatibility; consumers should use `agyAuth.state`, and the additive `agyAvailable` field carries the support-neutral availability signal.
+
+### Documentation
+- Added the AGY 1.1.2 macOS/Linux validation checklist and Ubuntu 24.04 WSL2 live evidence for stdin/stdout, foreground task, background task, structured review, invalid-model failure, OAuth TTY/headless behavior, transcript pairing, and the complete Linux test suite. Real macOS 1.1.2 remains explicitly `OPTIONAL / NOT RUN` as a platform-validation gate, not an indication that the AGY engine itself is optional.
+- Updated the AGY prompting anti-patterns to distinguish older positional `--print` behavior from the 1.1.2 stdin auto-print path while retaining transcript-authoritative recovery.
+
+### Tests
+- The complete Windows suite passes: 238 tests, 235 passed, 0 failed, with 3 POSIX-only AGY fixtures skipped as expected. A real local AGY 1.1.2 `setup --engine agy` smoke reports `agyAvailable:true`, `authState:"unknown"`, and `authVerifiable:false` without reading or exposing credentials.
+
+### Compatibility
+- No slash-command flags, engine names, permission policy, transcript recovery, timeout, or task/review result structure changed. Gemini-only and AGY-only installations remain valid; installing both CLIs is not required.
+
 ## 0.7.1 — 2026-07-14 — AGY stdin transport
 
 ### Changed

--- a/plugins/gemini/NOTICE
+++ b/plugins/gemini/NOTICE
@@ -19,6 +19,6 @@ adapted architecture includes, in particular:
 
 Gemini/AGY-specific modifications and additions — including engine detection
 and routing, stdin prompt delivery, the model-map alias/effort source, AGY
-fallback handling, OAuth status checks, and the contract-verification script —
+engine handling, OAuth status checks, and the contract-verification script —
 are Copyright (c) 2026 arcobaleno64 and are distributed under the MIT License
 (see LICENSE). They are original work and are not part of the upstream project.

--- a/plugins/gemini/commands/setup.md
+++ b/plugins/gemini/commands/setup.md
@@ -1,7 +1,7 @@
 ---
 description: Check whether Gemini CLI / AGY is ready and optionally toggle the stop-time review gate
 argument-hint: '[--engine <agy|gemini>] [--enable-review-gate|--disable-review-gate]'
-allowed-tools: Bash(node:*), Bash(npm:*), AskUserQuestion
+allowed-tools: Bash(node:*), Bash(npm:*), Bash(curl:*), AskUserQuestion
 ---
 
 Run:
@@ -10,11 +10,14 @@ Run:
 node "${CLAUDE_PLUGIN_ROOT}/scripts/gemini-companion.mjs" setup --json "$ARGUMENTS"
 ```
 
-Gemini CLI is the primary engine. AGY is an optional fallback that is only
-relevant when the user routes to it with `--engine agy` (or `GEMINI_ENGINE=agy`).
-Drive the install decisions below off the setup JSON's `requestedEngine` field,
-which already resolves both the `--engine` flag and the `GEMINI_ENGINE`
-environment variable — do **not** branch on the raw `$ARGUMENTS` text.
+Gemini CLI and AGY are first-class supported engines. Each is a conditional
+dependency: the user only needs the binary for the engine they select. In
+`auto` mode Gemini is checked first because it exposes the plugin's JSON/model
+contract, then AGY is checked; that order does not make AGY an optional or
+lower-tier integration. Drive the install decisions below off the setup JSON's
+`requestedEngine` field, which already resolves both the `--engine` flag and
+the `GEMINI_ENGINE` environment variable — do **not** branch on the raw
+`$ARGUMENTS` text.
 
 If the result says Gemini CLI is unavailable (`gemini.available` is false), npm
 is available, and `requestedEngine` is **not** `agy`:
@@ -35,8 +38,8 @@ npm install -g @google/gemini-cli
 node "${CLAUDE_PLUGIN_ROOT}/scripts/gemini-companion.mjs" setup --json "$ARGUMENTS"
 ```
 
-Only if `requestedEngine` is `agy`, AGY is unavailable
-(`agy.available` is false), and npm is available:
+When `requestedEngine` is `agy` and AGY is unavailable
+(`agy.available` is false):
 - Use `AskUserQuestion` exactly once to ask whether Claude should install AGY now.
 - Put the install option first and suffix it with `(Recommended)`.
 - Use these two options:
@@ -55,12 +58,12 @@ node "${CLAUDE_PLUGIN_ROOT}/scripts/gemini-companion.mjs" setup --json "$ARGUMEN
 ```
 
 Do not ask about installation when:
-- Gemini CLI is already available (even if it still needs authentication) **and
-  `requestedEngine` is not `agy`**, or
-- npm is unavailable, or
+- the selected engine is already available (even if it still needs
+  authentication), or
+- Gemini CLI is the missing selected/auto candidate and npm is unavailable, or
 - the only missing engine is AGY and `requestedEngine` is not `agy`. In that
-  case Gemini is the default engine; mention AGY only as an optional fallback,
-  do not push its installation.
+  case AGY is not the selected conditional dependency, so do not push its
+  installation.
 
 When `requestedEngine` is `agy` and AGY is unavailable, the AGY install prompt
 above takes precedence even if Gemini CLI is already present — the user routed

--- a/plugins/gemini/scripts/gemini-companion.mjs
+++ b/plugins/gemini/scripts/gemini-companion.mjs
@@ -179,7 +179,7 @@ function buildSetupReport(cwd, actionsTaken = [], options = {}) {
 
   // Readiness is computed for the engine the user actually selected (via
   // `--engine` or GEMINI_ENGINE). The default/gemini path mirrors upstream: the
-  // primary engine must be installed AND authenticated. Explicit `--engine agy`
+  // auto-preferred engine must be installed AND authenticated. Explicit `--engine agy`
   // must NOT inherit Gemini's ready state — it depends on the AGY binary (whose
   // auth cannot be verified non-interactively), so AGY-present is "partial" and
   // AGY-missing is "not-ready".
@@ -191,7 +191,10 @@ function buildSetupReport(cwd, actionsTaken = [], options = {}) {
     requestedEngine === "" || requestedEngine === "auto" || requestedEngine === "gemini" || requestedEngine === "agy";
   const agySelected = requestedEngine === "agy";
   const geminiReady = geminiStatus.available && geminiAuth.loggedIn;
-  const agyFallbackAvailable = agyStatus.available;
+  const agyAvailable = agyStatus.available;
+  // Backward-compatible alias retained for existing JSON consumers. AGY is a
+  // first-class supported engine; "fallback" describes only auto-routing order.
+  const agyFallbackAvailable = agyAvailable;
   // AGY auth cannot be verified non-interactively, so `--engine agy` is never
   // reported as fully `ready` — the most it reaches is `readyState: "partial"`
   // (binary present, auth unknown). `ready:true` is reserved for a verified
@@ -208,7 +211,7 @@ function buildSetupReport(cwd, actionsTaken = [], options = {}) {
           : "not-ready"
         : geminiReady
           ? "ready"
-          : agyFallbackAvailable
+          : agyAvailable
             ? "partial"
             : "not-ready";
 
@@ -229,14 +232,16 @@ function buildSetupReport(cwd, actionsTaken = [], options = {}) {
     );
   }
   if (!geminiStatus.available && !agyStatus.available) {
-    nextSteps.push("Install Gemini CLI with `npm install -g @google/gemini-cli`.");
+    nextSteps.push(
+      "Install at least one supported engine: Gemini CLI with `npm install -g @google/gemini-cli`, or AGY with `curl -fsSL https://antigravity.google/cli/install.sh | bash`."
+    );
   }
   if (!agySelected && geminiStatus.available && !geminiAuth.loggedIn) {
     nextSteps.push("Run `gemini` once to authenticate via OAuth.");
   }
-  if (!agySelected && !geminiStatus.available && agyFallbackAvailable) {
+  if (!agySelected && !geminiStatus.available && agyAvailable) {
     nextSteps.push(
-      "Gemini CLI is unavailable; AGY is present as a fallback. Use `--engine agy` to route through it (its auth state cannot be verified), or install Gemini CLI with `npm install -g @google/gemini-cli` for the default engine."
+      "Gemini CLI is unavailable; AGY is installed as a supported engine and auto routing can select it. Use `--engine agy` explicitly to confirm its authentication state, or install Gemini CLI to restore the preferred auto-routing candidate."
     );
   }
 
@@ -261,6 +266,7 @@ function buildSetupReport(cwd, actionsTaken = [], options = {}) {
     readyState,
     requestedEngine: requestedEngine || "auto",
     geminiReady,
+    agyAvailable,
     agyFallbackAvailable,
     geminiPlanTier,
     node: nodeStatus,

--- a/plugins/gemini/scripts/lib/engine.mjs
+++ b/plugins/gemini/scripts/lib/engine.mjs
@@ -93,9 +93,10 @@ export function detectEngine(requestedEngine = null, options = {}) {
     return { engine: "gemini", binary: "gemini", version: status.detail ?? "unknown" };
   }
 
-  // auto: prefer gemini because it has the plugin's JSON/model contract. AGY
-  // remains a fallback even though 1.1.2 adds stdin prompt delivery; its response
-  // and conversation id still depend on transcript recovery in this adapter.
+  // auto: choose gemini first because it has the plugin's JSON/model contract,
+  // then choose the equally supported AGY engine. This is capability-based
+  // routing order, not a lower support tier; AGY responses and conversation ids
+  // still depend on transcript recovery in this adapter.
   const geminiStatus = binaryAvailable("gemini", ["--version"]);
   if (geminiStatus.available) {
     return { engine: "gemini", binary: "gemini", version: geminiStatus.detail ?? "unknown" };
@@ -107,7 +108,7 @@ export function detectEngine(requestedEngine = null, options = {}) {
     return { engine: "agy", binary: agyBinary, version: agyStatus.detail ?? "unknown" };
   }
 
-  throw new Error("No Gemini or AGY engine found. Install agy or gemini CLI and retry.");
+  throw new Error("No Gemini or AGY engine found. Install either supported engine and retry.");
 }
 
 function formatAgyTimeout(timeoutMs) {

--- a/plugins/gemini/scripts/lib/failures.mjs
+++ b/plugins/gemini/scripts/lib/failures.mjs
@@ -19,7 +19,7 @@ const DEFAULTS = {
   "binary-missing": {
     retryable: false,
     summary: "Required CLI binary is not available.",
-    nextStep: "Install Gemini CLI, or use `--engine agy` only after AGY is installed and initialized."
+    nextStep: "Install and initialize either supported engine, then select it with `--engine gemini` or `--engine agy`."
   },
   auth: {
     retryable: false,

--- a/plugins/gemini/scripts/lib/gemini.mjs
+++ b/plugins/gemini/scripts/lib/gemini.mjs
@@ -562,22 +562,18 @@ export function getGeminiPlanTier() {
 export function getAgyLoginStatus() {
   const status = binaryAvailable("agy", ["--version"]);
   if (!status.available) {
-    return { loggedIn: false, detail: "AGY binary not found." };
+    return { loggedIn: false, state: "unavailable", verifiable: false, detail: "AGY binary not found." };
   }
-  // AGY (Antigravity) stores no credential of its own — verified: no oauth/token
-  // file exists under any ~/.antigravity* or ~/.gemini/antigravity-cli dir; it
-  // runs off the SAME Google OAuth as the gemini CLI (~/.gemini/oauth_creds.json,
-  // with per-machine state under ~/.gemini/antigravity-cli/). So gauge agy auth
-  // from that shared credential — the only signal available without an
-  // interactive run.
-  const shared = getGeminiLoginStatus();
-  const pipeNote = "Note: agy --print does not return output over a pipe (#27466); the plugin recovers responses from the transcript.";
-  if (shared.loggedIn) {
-    return { loggedIn: true, detail: `AGY ${status.detail ?? ""} present; shared Google OAuth valid. ${pipeNote}`.trim() };
-  }
+  // AGY 1.1.x uses its own consumerOAuth flow and may store credentials in an
+  // OS credential service. Gemini's ~/.gemini/oauth_creds.json is therefore not
+  // evidence of AGY authentication. Keep `loggedIn` for JSON compatibility, but
+  // pair it with an explicit unknown state so callers do not interpret it as a
+  // verified logout.
   return {
     loggedIn: false,
-    detail: `AGY ${status.detail ?? ""} present, but the shared Google OAuth is missing/expired (${shared.detail}). Run \`gemini\` once to authenticate. ${pipeNote}`.trim(),
+    state: "unknown",
+    verifiable: false,
+    detail: `AGY ${status.detail ?? ""} present; authentication cannot be verified non-interactively. Run \`agy\` once interactively to authenticate or refresh credentials.`.trim(),
   };
 }
 
@@ -591,7 +587,7 @@ export function getSessionRuntimeStatus() {
   const label = gemini.available
     ? "gemini CLI (per-command)"
     : agy.available
-      ? "agy fallback (per-command)"
+      ? "agy (per-command)"
       : "no engine available";
   return { mode: "direct", gemini, agy, available, label };
 }

--- a/plugins/gemini/scripts/lib/git.mjs
+++ b/plugins/gemini/scripts/lib/git.mjs
@@ -7,11 +7,11 @@ import { runCommand, runCommandChecked } from "./process.mjs";
 const MAX_UNTRACKED_BYTES = 24 * 1024;
 
 function git(cwd, args, options = {}) {
-  return runCommand("git", args, { cwd, ...options });
+  return runCommand("git", args, { cwd, ...options, shell: false });
 }
 
 function gitChecked(cwd, args, options = {}) {
-  return runCommandChecked("git", args, { cwd, ...options });
+  return runCommandChecked("git", args, { cwd, ...options, shell: false });
 }
 
 export function ensureGitRepository(cwd) {

--- a/plugins/gemini/scripts/lib/process.mjs
+++ b/plugins/gemini/scripts/lib/process.mjs
@@ -4,8 +4,8 @@ import process from "node:process";
 
 // This is not a reliable cmd.exe escaper: embedded quotes toggle cmd's parse
 // state, and backslashes escape quotes for MSVCRT children, not for cmd.exe.
-// Keep it only as a belt-and-suspenders safety net for the fixed-constant argv
-// used by remaining bare-name command paths (git/where/gemini/taskkill), never
+// Keep it only as a belt-and-suspenders safety net for fixed or validated argv
+// used by remaining bare-name command paths (where/gemini/taskkill), never
 // as protection for free text. Gemini and AGY >=1.1.2 prompts use stdin; older
 // AGY positional prompts are protected by absolute-path resolution and
 // therefore shell:false instead.

--- a/plugins/gemini/scripts/lib/render.mjs
+++ b/plugins/gemini/scripts/lib/render.mjs
@@ -200,7 +200,7 @@ export function renderSetupReport(report) {
     report.readyState === "partial"
       ? report.requestedEngine === "agy"
         ? "partial (AGY selected — binary present, auth not verifiable non-interactively)"
-        : "partial (AGY fallback only — Gemini CLI not ready)"
+        : "partial (AGY available — Gemini CLI not ready)"
       : report.ready
         ? "ready"
         : "needs attention";

--- a/plugins/gemini/skills/gemini-cli-runtime/SKILL.md
+++ b/plugins/gemini/skills/gemini-cli-runtime/SKILL.md
@@ -34,10 +34,13 @@ Command selection:
 - `task --resume-last`: for "keep going", "resume", "apply the top fix", or "dig deeper".
 
 Engine routing:
-- Default engine: auto-detect (gemini preferred, agy fallback).
+- Gemini CLI and AGY are both first-class supported engines; only the selected
+  engine's CLI is required.
+- Default engine: auto-detect in capability order (gemini first for its
+  JSON/model contract, then agy).
 - Force AGY: add `--engine agy`.
 - Force Gemini CLI: add `--engine gemini`.
-- Note: `--model` and `--effort` are ignored when the AGY engine is active; AGY selects its model and tier interactively.
+- Note: `--model` and `--effort` are ignored when the AGY engine is active; AGY uses its configured/default model and tier.
 
 Safety rules:
 - Default to write-capable work in `gemini:gemini-rescue` unless the user explicitly asks for read-only behavior.

--- a/plugins/gemini/skills/gemini-prompting/references/gemini-prompt-antipatterns.md
+++ b/plugins/gemini/skills/gemini-prompting/references/gemini-prompt-antipatterns.md
@@ -123,10 +123,10 @@ Pipe `agy --print "..."` and read its stdout, or tell AGY to print only the fina
 ```
 
 Better:
-- Let the plugin recover the response from AGY's on-disk transcript — that is the only reliable channel.
+- Let the plugin treat AGY's on-disk transcript as authoritative, even when AGY 1.1.2 also emits stdout.
 - Prefer the **gemini** engine (`--output-format json`) when you need clean, pipeable structured output.
 
-Explanation: `agy --print` does not deliver its response over a pipe in non-interactive use (upstream google-gemini/gemini-cli#27466). No prompt instruction changes that; the plugin diffs the transcript dirs to recover the answer; this path is verified on Windows and macOS (same brain root), with Linux reported working.
+Explanation: older positional `agy --print` releases did not deliver responses over a pipe (upstream google-gemini/gemini-cli#27466). AGY 1.1.2's stdin auto-print path can emit stdout, but the plugin still diffs transcript dirs for the completed response, DONE status, thinking, and conversation id. The 1.1.2 path is live-verified on Windows and Ubuntu WSL2; real macOS 1.1.2 remains not run.
 
 ## Assuming Gemini/AGY behaves like Codex (parity-specific)
 

--- a/tests/commands.test.mjs
+++ b/tests/commands.test.mjs
@@ -96,12 +96,15 @@ test("review commands enforce verbatim output without a contradictory fix prompt
   }
 });
 
-// --- P0-4: AGY install is gated behind --engine agy; gemini is the primary engine ---
+// --- P0-4: engine dependencies follow the selected first-class engine ---
 
-test("setup prompts Gemini CLI install primarily and gates AGY behind --engine agy", () => {
+test("setup treats Gemini CLI and AGY as first-class conditional dependencies", () => {
   const source = readCommand("setup.md");
   assert.match(source, /Install Gemini CLI \(Recommended\)/);
   assert.match(source, /--engine agy/, "AGY install must be gated behind --engine agy");
+  assert.match(source, /Bash\(curl:\*\)/, "the first-class AGY installer must be allowed to invoke curl");
+  assert.match(source, /first-class supported engines/i);
+  assert.doesNotMatch(source, /AGY is an optional fallback/i);
 });
 
 test("setup authenticates by running gemini, not a nonexistent `gemini login`", () => {

--- a/tests/fake-gemini-fixture.mjs
+++ b/tests/fake-gemini-fixture.mjs
@@ -155,7 +155,7 @@ export function buildFailingAgyEnv(binDir) {
 }
 
 // Shadow only gemini with a wrapper that fails its --version probe, leaving any
-// installed agy untouched. Pair with installFakeAgy for AGY-fallback assertions.
+// installed agy untouched. Pair with installFakeAgy for AGY-availability assertions.
 export function installUnavailableGemini(binDir) {
   if (process.platform === "win32") {
     fs.writeFileSync(path.join(binDir, "gemini.cmd"), `@echo off\r\nexit /b 1\r\n`, "utf8");

--- a/tests/git.test.mjs
+++ b/tests/git.test.mjs
@@ -4,7 +4,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import { collectReviewContext, formatUntrackedFile, getWorkingTreeState, resolveReviewTarget } from "../plugins/gemini/scripts/lib/git.mjs";
-import { initGitRepo, makeTempDir, run } from "./helpers.mjs";
+import { initGitRepo, makeTempDir, run, writeExecutable } from "./helpers.mjs";
 
 function commitInitial(cwd) {
   fs.writeFileSync(path.join(cwd, "app.js"), "console.log('v1');\n");
@@ -96,6 +96,62 @@ test("resolveReviewTarget rejects an unsafe --base ref", () => {
   commitInitial(cwd);
   assert.throws(() => resolveReviewTarget(cwd, { base: "--upload-pack=evil" }), /Invalid --base ref/);
   assert.throws(() => resolveReviewTarget(cwd, { base: "x; rm -rf /" }), /Invalid --base ref/);
+});
+
+test("auto-detected default refs with shell metacharacters stay literal", () => {
+  const cwd = makeTempDir();
+  const binDir = makeTempDir("gemini-git-ref-probe-");
+  const sentinel = path.join(cwd, "shell-injection-sentinel.txt");
+  const originalPath = process.env.PATH;
+  const originalSentinel = process.env.AGY_REF_SENTINEL;
+  const probeName = process.platform === "win32" ? "agyrefprobe.cmd" : "agyrefprobe";
+  const probeSource = process.platform === "win32"
+    ? "@echo off\r\n> \"%AGY_REF_SENTINEL%\" echo injected\r\n"
+    : "#!/bin/sh\nprintf injected > \"$AGY_REF_SENTINEL\"\n";
+
+  writeExecutable(path.join(binDir, probeName), probeSource);
+  process.env.PATH = `${binDir}${path.delimiter}${originalPath ?? ""}`;
+  process.env.AGY_REF_SENTINEL = sentinel;
+
+  try {
+    initGitRepo(cwd);
+    commitInitial(cwd);
+    const mainCommit = run("git", ["rev-parse", "HEAD"], { cwd, shell: false }).stdout.trim();
+    assert.ok(mainCommit);
+    assert.equal(
+      run("git", ["update-ref", "refs/heads/main&agyrefprobe", mainCommit], { cwd, shell: false }).status,
+      0
+    );
+    assert.equal(
+      run("git", ["update-ref", "refs/remotes/origin/main&agyrefprobe", mainCommit], { cwd, shell: false }).status,
+      0
+    );
+    assert.equal(
+      run(
+        "git",
+        ["symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/main&agyrefprobe"],
+        { cwd, shell: false }
+      ).status,
+      0
+    );
+
+    run("git", ["checkout", "-b", "feature/literal-ref"], { cwd, shell: false });
+    fs.writeFileSync(path.join(cwd, "app.js"), "console.log('literal ref');\n");
+    run("git", ["add", "app.js"], { cwd, shell: false });
+    run("git", ["commit", "-m", "literal ref change"], { cwd, shell: false });
+
+    const target = resolveReviewTarget(cwd, { scope: "branch" });
+    const context = collectReviewContext(cwd, target);
+
+    assert.equal(target.baseRef, "main&agyrefprobe");
+    assert.match(context.content, /literal ref/);
+    assert.equal(fs.existsSync(sentinel), false, "a repository-derived ref must never execute an adjacent command");
+  } finally {
+    if (originalPath == null) delete process.env.PATH;
+    else process.env.PATH = originalPath;
+    if (originalSentinel == null) delete process.env.AGY_REF_SENTINEL;
+    else process.env.AGY_REF_SENTINEL = originalSentinel;
+  }
 });
 
 test("formatUntrackedFile skips a directory instead of crashing", () => {

--- a/tests/helpers.mjs
+++ b/tests/helpers.mjs
@@ -14,7 +14,7 @@ export function run(command, args, options = {}) {
     env: options.env,
     encoding: "utf8",
     input: options.input,
-    shell: process.platform === "win32" && !path.isAbsolute(command),
+    shell: options.shell ?? (process.platform === "win32" && !path.isAbsolute(command)),
     windowsHide: true
   });
 }

--- a/tests/render.test.mjs
+++ b/tests/render.test.mjs
@@ -19,7 +19,7 @@ function setupReport(overrides = {}) {
     gemini: { detail: "0.44.1" },
     geminiAuth: { detail: "logged in" },
     agy: { detail: "1.0.2" },
-    agyAuth: { detail: "logged in" },
+    agyAuth: { loggedIn: false, state: "unknown", verifiable: false, detail: "authentication unknown" },
     sessionRuntime: { label: "gemini 0.44.1" },
     reviewGateEnabled: false,
     actionsTaken: [],
@@ -35,6 +35,7 @@ test("renderSetupReport lists every check and the review-gate state", () => {
   assert.match(out, /- node: v24\.0\.0/);
   assert.match(out, /- gemini: 0\.44\.1/);
   assert.match(out, /- agy: 1\.0\.2/);
+  assert.match(out, /- agy auth: authentication unknown/);
   assert.match(out, /- review gate: enabled/);
   assert.match(out, /Next steps:/);
 });

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -98,8 +98,8 @@ test("setup is not ready when gemini is installed but unauthenticated", () => {
   assert.equal(result.status, 0, result.stderr);
   const payload = JSON.parse(result.stdout);
   // Core P0-3 contract: an unauthenticated gemini is never "ready". (readyState
-  // may be "partial" when a real AGY fallback happens to be on PATH, so it is
-  // asserted deterministically in the AGY-fallback test instead.)
+  // may be "partial" when a real AGY engine happens to be on PATH, so it is
+  // asserted deterministically in the AGY-available test instead.)
   assert.equal(payload.ready, false);
   assert.equal(payload.gemini.available, true);
   assert.equal(payload.geminiAuth.loggedIn, false);
@@ -120,7 +120,7 @@ test("setup is not ready when the gemini OAuth token is expired", () => {
   assert.match(payload.geminiAuth.detail, /expired/i);
 });
 
-test("setup reports a partial AGY fallback when gemini is unavailable but agy is present", () => {
+test("setup reports a partial supported AGY engine when gemini is unavailable but agy is present", () => {
   const binDir = makeTempDir();
   installUnavailableGemini(binDir);
   installFakeAgy(binDir);
@@ -133,7 +133,13 @@ test("setup reports a partial AGY fallback when gemini is unavailable but agy is
   assert.equal(payload.agy.available, true);
   assert.equal(payload.ready, false);
   assert.equal(payload.readyState, "partial");
+  assert.equal(payload.agyAvailable, true);
   assert.equal(payload.agyFallbackAvailable, true);
+  assert.equal(payload.agyAuth.loggedIn, false);
+  assert.equal(payload.agyAuth.state, "unknown");
+  assert.equal(payload.agyAuth.verifiable, false);
+  assert.match(payload.agyAuth.detail, /cannot be verified non-interactively/i);
+  assert.doesNotMatch(payload.agyAuth.detail, /shared Google OAuth|Run `gemini`/i);
   assert.ok(payload.nextSteps.some((step) => /--engine agy/.test(step)));
 });
 
@@ -217,6 +223,9 @@ test("setup --engine agy is partial, never fully ready, when agy is present but 
   assert.equal(payload.agy.available, true);
   assert.equal(payload.ready, false);
   assert.equal(payload.readyState, "partial");
+  assert.equal(payload.agyAvailable, true);
+  assert.equal(payload.agyAuth.state, "unknown");
+  assert.equal(payload.agyAuth.verifiable, false);
   assert.ok(payload.nextSteps.some((step) => /cannot be verified|authentication/i.test(step)));
 });
 
@@ -236,8 +245,8 @@ test("non-JSON setup --engine agy does not claim Gemini is not ready when it is"
 });
 
 // The default-engine partial (Gemini genuinely unavailable, AGY present) must
-// still render the AGY-fallback label.
-test("non-JSON setup keeps the AGY-fallback partial label when gemini is unavailable", () => {
+// render AGY as an available supported engine.
+test("non-JSON setup renders AGY as available when gemini is unavailable", () => {
   const binDir = makeTempDir();
   installUnavailableGemini(binDir);
   installFakeAgy(binDir);
@@ -245,7 +254,7 @@ test("non-JSON setup keeps the AGY-fallback partial label when gemini is unavail
   const result = run("node", [SCRIPT, "setup"], { cwd: makeTempDir(), env: buildEnvUnavailable(binDir) });
 
   assert.equal(result.status, 0, result.stderr);
-  assert.match(result.stdout, /AGY fallback only — Gemini CLI not ready/);
+  assert.match(result.stdout, /AGY available — Gemini CLI not ready/);
 });
 
 // Setup readiness must use the same engine allow-set as the runtime resolver


### PR DESCRIPTION
## Summary
- force every Git helper call through `shell:false` so repository-derived refs stay literal on Windows
- report installed AGY authentication as `unknown`/unverifiable instead of inferring Gemini OAuth
- position Gemini CLI and AGY as first-class conditional engines while preserving Gemini→AGY auto-routing order
- prepare all version sources, install examples, changelog, skills, setup guidance, and attribution for v0.8.0

## Compatibility
- Gemini-only and AGY-only installations remain supported; users do not need both CLIs
- `agyFallbackAvailable` remains as a compatibility alias and `agyAvailable` is additive
- no slash-command flags, permission policy, transcript recovery, timeout, or task/review result structure changed
- real macOS AGY 1.1.2 validation remains not run and is not claimed

## Validation
- `npm test`: 238 tests, 235 passed, 0 failed, 3 expected POSIX-only skips on Windows
- `npm run check-version`: pass for 0.8.0
- `npm run verify-contracts`: pass
- `git diff --check`: pass
- real local AGY 1.1.2 setup smoke: `agyAvailable:true`, `authState:"unknown"`, `authVerifiable:false`

Closes #18