### PR TITLE
fix(commands): register /gemini:transfer as a Markdown command (v0.10.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,13 +6,13 @@
   },
   "metadata": {
     "description": "Use Gemini CLI or Antigravity CLI (agy) inside Claude Code for task delegation, code review, and adversarial review.",
-    "version": "0.10.0"
+    "version": "0.10.1"
   },
   "plugins": [
     {
       "name": "gemini",
       "description": "Gemini CLI and Antigravity CLI bridge for Claude Code task delegation and adversarial review",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "author": {
         "name": "arcobaleno64"
       },

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Compared with AGY-only, multi-host plugins, this project keeps the Gemini CLI pa
 ## Features
 
 - **`/gemini:rescue`** — Delegate investigation, debugging, or implementation tasks to the selected Gemini CLI or AGY engine. Runs in the foreground or detached in the background.
-- **`/gemini:transfer`** — Export current session context (git status, diff, instructions) into a structured JSON snapshot and generate single-quoted POSIX Bash and Windows PowerShell launch commands for AGY or Gemini CLI.
+- **`/gemini:transfer`** — Export current session context (git status, diff, instructions) into a structured JSON snapshot and print a single-quoted launch command for AGY or Gemini CLI (POSIX Bash form everywhere, plus a PowerShell form on Windows).
 - **`/gemini:review`** — Standard (pragmatic) code review over the current diff or branch. Finds real bugs, missing error handling, and incomplete code paths. Add `--deep` for an agentic pass that explores repo context beyond the diff.
 - **`/gemini:adversarial-review`** — Adversarial code review that challenges design decisions over the current diff or branch. Returns structured findings with severity ratings.
 - **`/gemini:setup`** — Check Gemini CLI / AGY availability and OAuth status.
@@ -153,9 +153,15 @@ Delegates a task to Gemini. Reads from stdin if no prompt is given.
 | `--model <alias\|id>` | Model override. Gemini resolves its aliases; AGY 1.1.5+ requires an exact model ID from `agy models`. AGY model selection cannot be combined with `--effort` or a dual-engine (`--engines gemini,agy`) review. |
 | `--effort <low\|medium\|high\|xhigh>` | Gemini maps effort to a model; AGY 1.1.5+ forwards `low`, `medium`, or `high` as native reasoning effort when no AGY model is selected. |
 
-### `/gemini:transfer [--engine <gemini|agy|auto>] [instructions...]`
+### `/gemini:transfer [instructions...]`
 
-Exports current workspace context (git diff, status, instructions) and generates ready-to-run CLI commands (`agy`/`gemini`) to hand off work to an interactive terminal session. Includes automated secret redaction (`.env*`, credentials) and git conflict safeguards.
+Exports current workspace context (git diff, status, instructions) and generates ready-to-run CLI commands (`agy`/`gemini`) to hand off work to an interactive terminal session. Includes automated secret redaction (`.env*`, credentials) and git conflict safeguards. The generated commands are printed for you to paste into a terminal; the plugin never runs them.
+
+| Flag | Description |
+|---|---|
+| `--engine <gemini\|agy\|auto>` | Which handoff commands to print. `auto` (default) prints both |
+| `--model <id>` | Model override carried into the generated command. AGY requires an exact ID from `agy models` |
+| `--effort <low\|medium\|high\|xhigh>` | Reasoning effort carried into the generated AGY command. Cannot be combined with `--model` |
 
 ### `/gemini:review`
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -34,7 +34,7 @@
 ## 功能特色
 
 - **`/gemini:rescue`** — 將調查、除錯或實作任務委派給所選的 Gemini CLI 或 AGY 引擎。可在前景執行或以背景工作方式分離執行。
-- **`/gemini:transfer`** — 匯出當前工作區情境（git status、diff、接續指令）為結構化 JSON 快照，並產生 POSIX Bash 與 Windows PowerShell 之 AGY / Gemini CLI 接手命令。
+- **`/gemini:transfer`** — 匯出當前工作區情境（git status、diff、接續指令）為結構化 JSON 快照，並輸出單引號跳脫之 AGY / Gemini CLI 接手命令（各平台皆印 POSIX Bash 形式，Windows 另加印 PowerShell 形式）。
 - **`/gemini:review`** — 對當前 diff 或分支執行標準（務實）程式碼審查，找出真實 bug、缺漏之錯誤處理與未竟之程式路徑。加 `--deep` 可進行 agentic 探查、看 diff 以外的 repo 脈絡。
 - **`/gemini:adversarial-review`** — 對當前 diff 或分支執行對抗性程式碼審查，挑戰設計決策，回傳含嚴重程度評級的結構化發現。
 - **`/gemini:setup`** — 檢查 Gemini CLI / AGY 的可用性與 OAuth 狀態。
@@ -151,9 +151,15 @@
 | `--model <別名\|ID>` | 指定模型。Gemini 解析其別名；AGY 1.1.5+ 要求使用 `agy models` 列出的精確 model ID。AGY 的模型選擇不可與 `--effort` 或雙引擎（`--engines gemini,agy`）審查合併。 |
 | `--effort <low\|medium\|high\|xhigh>` | Gemini 將 effort 映射為模型；AGY 1.1.5+ 在未指定 AGY model 時，原生傳遞 `low`、`medium` 或 `high` 推理強度。 |
 
-### `/gemini:transfer [--engine <gemini|agy|auto>] [instructions...]`
+### `/gemini:transfer [instructions...]`
 
-匯出當前工作區情境（git diff、status、接續指令），並產生可直接複製執行的 CLI 接手命令（`agy`/`gemini`），移交給獨立終端機進行互動開發。包含自動化機密遮蔽（`.env*`、憑證）與 Git 衝突安全鎖定。
+匯出當前工作區情境（git diff、status、接續指令），並產生可直接複製執行的 CLI 接手命令（`agy`/`gemini`），移交給獨立終端機進行互動開發。包含自動化機密遮蔽（`.env*`、憑證）與 Git 衝突安全鎖定。產生的命令僅供使用者自行貼上執行，plugin 不會代為執行。
+
+| 旗標 | 說明 |
+|---|---|
+| `--engine <gemini\|agy\|auto>` | 決定輸出哪一種接手命令；`auto`（預設）兩種都印 |
+| `--model <ID>` | 帶入產生命令的模型指定。AGY 要求使用 `agy models` 列出的精確 ID |
+| `--effort <low\|medium\|high\|xhigh>` | 帶入產生之 AGY 命令的推理強度，不可與 `--model` 併用 |
 
 ### `/gemini:review`
 

--- a/docs/PARITY_AUDIT.md
+++ b/docs/PARITY_AUDIT.md
@@ -14,7 +14,7 @@
 
 | 原修正項 | 狀態 | 落實摘要 |
 |---|---|---|
-| **v0.10.0** `/gemini:transfer` 與 AGY 1.1.10 對齊 | ✅ 已補 | 實作 `/gemini:transfer` Session handoff 命令，對齊 upstream v1.0.5 功能；補強機密檔案過濾、Git conflict 鎖定、Per-file 截斷、LRU 快照清理與 Posix/PowerShell 引號安全轉義。 |
+| **v0.10.0** `/gemini:transfer` 與 AGY 1.1.10 對齊 | ✅ 已補（v0.10.1 補正註冊） | 實作 `/gemini:transfer` Session handoff 命令，對齊 upstream v1.0.5 功能；補強機密檔案過濾、Git conflict 鎖定、Per-file 截斷、LRU 快照清理與 Posix/PowerShell 引號安全轉義。**更正**：v0.10.0 之命令檔誤以 `commands/transfer.json` 形式交付，Claude Code 命令載入器僅辨識 `.md`，故該版之 `/gemini:transfer` 從未實際註冊，僅腳本存在；v0.10.1 改為 `commands/transfer.md` 並以「`commands/` 不得含非 `.md` 檔」之測試守則鎖定。 |
 | **P0** rescue `available`↔`found` | ✅ 已修 | companion 改回 `available`（棄 `found`），rescue 續接提示得以觸發;守則測試鎖定欄位名。 |
 | **P1** 背景 review 無持久化 | ✅ 已修 | 新增 `review-worker`（仿 task-worker），背景 review 結果可持久化並經 `/status`/`/result` 取回。 |
 | **P1** 死碼 `renderNativeReviewResult` | ✅ 已修 | 移除。 |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@arcobaleno64/gemini-plugin-cc",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@arcobaleno64/gemini-plugin-cc",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arcobaleno64/gemini-plugin-cc",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "private": true,
   "type": "module",
   "description": "Use Gemini CLI or Antigravity CLI (agy) inside Claude Code for task delegation, code review, and adversarial review.",

--- a/plugins/gemini/.claude-plugin/plugin.json
+++ b/plugins/gemini/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gemini",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Use Gemini/AGY from Claude Code to review code or delegate tasks.",
   "author": {
     "name": "arcobaleno64",

--- a/plugins/gemini/CHANGELOG.md
+++ b/plugins/gemini/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.10.1 — 2026-08-04 — `/gemini:transfer` command registration fix
+
+### Fixed
+- **`/gemini:transfer` is now actually registered as a slash command.** It shipped in 0.10.0 as `commands/transfer.json`, a format Claude Code's command loader ignores, so the command never appeared in `/plugin` and `scripts/transfer.mjs` had no entry point. Replaced it with `commands/transfer.md` following the same contract as every other command in this plugin: `disable-model-invocation: true`, `allowed-tools: Bash(node:*)`, a quoted `"$ARGUMENTS"` invocation, and explicit output-handling rules.
+- **`transfer` now parses the quoted `"$ARGUMENTS"` string the slash command passes it.** It previously assumed a pre-split `argv`, which would have left `--engine`, `--model`, and `--effort` unparsed inside the instructions text. It now shares `normalizeArgv` + `parseArgs` with `gemini-companion.mjs` and rejects an unknown `--engine` value with the same message as the engine detector.
+
+### Changed
+- `normalizeArgv` moved from `gemini-companion.mjs` into `scripts/lib/args.mjs` so both entry points use one definition.
+- `transfer.mjs` now guards its self-invocation with the `process.argv[1] === SELF_PATH` comparison already used by `gemini-companion.mjs` and `gemini-mcp.mjs`, instead of a loose filename suffix match.
+- Command-contract tests now fail on any non-Markdown file in `commands/`, which is the defect class that hid this bug, and `transfer` is a required command in `verify-contracts`.
+
 ## 0.10.0 — 2026-08-04 — Session transfer command & AGY 1.1.10 updates
 
 ### Added

--- a/plugins/gemini/commands/transfer.json
+++ b/plugins/gemini/commands/transfer.json
@@ -1,6 +1,0 @@
-{
-  "name": "gemini:transfer",
-  "description": "Export current session context and generate ready-to-run CLI launch commands to hand off work to an interactive Gemini CLI or AGY session.",
-  "argumentHint": "[--engine <gemini|agy|auto>] [instructions...]",
-  "script": "node ${PLUGIN_DIR}/scripts/transfer.mjs"
-}

--- a/plugins/gemini/commands/transfer.md
+++ b/plugins/gemini/commands/transfer.md
@@ -1,0 +1,17 @@
+---
+description: Export the current workspace context into a transfer snapshot and generate ready-to-run AGY / Gemini CLI handoff commands
+argument-hint: '[--engine <gemini|agy|auto>] [--model <id>] [--effort <low|medium|high|xhigh>] [instructions...]'
+disable-model-invocation: true
+allowed-tools: Bash(node:*)
+---
+
+!`node "${CLAUDE_PLUGIN_ROOT}/scripts/transfer.mjs" "$ARGUMENTS"`
+
+Present the command output to the user exactly as returned. Preserve:
+- The snapshot path under `.omc/transfers/`
+- Every generated launch command verbatim, including its quoting — the prompt is already shell-escaped for the target shell, and rewriting or reflowing it breaks the handoff
+- Both the Bash/Zsh and PowerShell variants whenever both are printed
+
+Do not run the generated commands. They are for the user to paste into an interactive terminal.
+
+If the command reports a failure, relay the error verbatim and stop. The expected failures are a clean working tree with no instructions, a git repository in conflict state (`MERGE_HEAD`, `REBASE_HEAD`, `CHERRY_PICK_HEAD`), an unknown `--engine` value, and `--model` combined with `--effort` (AGY 1.1.5+ treats them as mutually exclusive).

--- a/plugins/gemini/scripts/gemini-companion.mjs
+++ b/plugins/gemini/scripts/gemini-companion.mjs
@@ -6,7 +6,7 @@ import path from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
 
-import { parseArgs, splitRawArgumentString } from "./lib/args.mjs";
+import { parseArgs, normalizeArgv } from "./lib/args.mjs";
 import { detectEngine, ENGINE_ENV, normalizeAgyEffort, normalizeAgyRequestedModel, normalizeRequestedModel, supportsAgyModelSelection, VALID_EFFORT_LEVELS } from "./lib/engine.mjs";
 import { collectReviewContext, ensureGitRepository, resolveReviewTarget } from "./lib/git.mjs";
 import { readStdinIfPiped } from "./lib/fs.mjs";
@@ -112,17 +112,6 @@ function outputResult(value, asJson) {
 
 function outputCommandResult(payload, rendered, asJson) {
   outputResult(asJson ? payload : rendered, asJson);
-}
-
-function normalizeArgv(argv) {
-  if (argv.length === 1) {
-    const [raw] = argv;
-    if (!raw || !raw.trim()) {
-      return [];
-    }
-    return splitRawArgumentString(raw);
-  }
-  return argv;
 }
 
 function parseCommandInput(argv, config = {}) {

--- a/plugins/gemini/scripts/lib/args.mjs
+++ b/plugins/gemini/scripts/lib/args.mjs
@@ -73,6 +73,17 @@ export function parseArgs(argv, config = {}) {
   return { options, positionals };
 }
 
+export function normalizeArgv(argv) {
+  if (argv.length === 1) {
+    const [raw] = argv;
+    if (!raw || !raw.trim()) {
+      return [];
+    }
+    return splitRawArgumentString(raw);
+  }
+  return argv;
+}
+
 export function splitRawArgumentString(raw) {
   const tokens = [];
   let current = "";

--- a/plugins/gemini/scripts/transfer.mjs
+++ b/plugins/gemini/scripts/transfer.mjs
@@ -1,36 +1,53 @@
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parseArgs, normalizeArgv } from './lib/args.mjs';
 import { buildTransferSnapshot } from './lib/transfer-context.mjs';
 
-function parseArgs(args) {
-  let engine = 'auto';
-  let model = null;
-  let effort = null;
-  let isJson = false;
-  const positional = [];
+const SELF_PATH = fileURLToPath(import.meta.url);
+const VALID_ENGINES = new Set(['auto', 'gemini', 'agy']);
 
-  for (let i = 0; i < args.length; i++) {
-    const arg = args[i];
-    if (arg === '--engine' && i + 1 < args.length) {
-      engine = args[++i];
-    } else if (arg === '--model' && i + 1 < args.length) {
-      model = args[++i];
-    } else if (arg === '--effort' && i + 1 < args.length) {
-      effort = args[++i];
-    } else if (arg === '--json') {
-      isJson = true;
-    } else {
-      positional.push(arg);
-    }
+// The slash command hands the whole user tail over as one quoted "$ARGUMENTS"
+// token, so it has to go through the same normalize + parse path as every
+// gemini-companion subcommand.
+export function parseTransferArgs(argv) {
+  const { options, positionals } = parseArgs(normalizeArgv(argv), {
+    valueOptions: ['engine', 'model', 'effort'],
+    booleanOptions: ['json'],
+  });
+
+  const engine = String(options.engine ?? 'auto').trim().toLowerCase();
+  if (!VALID_ENGINES.has(engine)) {
+    throw new Error(`Unknown engine "${options.engine}". Valid values: auto, gemini, agy.`);
   }
 
-  return { engine, model, effort, isJson, instructions: positional.join(' ') };
+  // `json` stays in booleanOptions so it never leaks into the instructions text.
+  return {
+    engine,
+    model: options.model ?? null,
+    effort: options.effort ?? null,
+    instructions: positionals.join(' '),
+  };
+}
+
+// Resolved before parsing so an argument error is still reported in the shape
+// the caller asked for.
+// Mirrors how parseArgs resolves a boolean option, including `--json=false`
+// and last-occurrence-wins, so both paths read the same flag the same way.
+function wantsJson(tokens) {
+  let value = false;
+  for (const token of tokens) {
+    if (token === '--json') value = true;
+    else if (token.startsWith('--json=')) value = token.slice('--json='.length) !== 'false';
+  }
+  return value;
 }
 
 export function main() {
-  const args = process.argv.slice(2);
-  const { engine, model, effort, isJson, instructions } = parseArgs(args);
+  const tokens = normalizeArgv(process.argv.slice(2));
+  const isJson = wantsJson(tokens);
 
   try {
+    const { engine, model, effort, instructions } = parseTransferArgs(tokens);
     const { snapshot, snapshotPath } = buildTransferSnapshot({ engine, model, effort, instructions });
 
     if (isJson) {
@@ -91,6 +108,6 @@ export function main() {
   }
 }
 
-if (process.argv[1] && process.argv[1].endsWith('transfer.mjs')) {
+if (process.argv[1] === SELF_PATH) {
   main();
 }

--- a/scripts/verify-contracts.mjs
+++ b/scripts/verify-contracts.mjs
@@ -17,7 +17,8 @@ const REQUIRED_COMMANDS = [
   "rescue",
   "status",
   "result",
-  "cancel"
+  "cancel",
+  "transfer"
 ];
 
 function parseArgs(argv) {

--- a/tests/commands.test.mjs
+++ b/tests/commands.test.mjs
@@ -19,10 +19,19 @@ test("all expected command files are present", () => {
     "result.md",
     "review.md",
     "setup.md",
-    "status.md"
+    "status.md",
+    "transfer.md"
   ].sort();
   const actual = fs.readdirSync(COMMANDS_DIR).filter((f) => f.endsWith(".md")).sort();
   assert.deepEqual(actual, expected);
+});
+
+// Claude Code only discovers Markdown command files. A command shipped in any
+// other format (e.g. a JSON manifest) is silently skipped by the loader and
+// never appears in /plugin, so the directory must hold nothing else.
+test("commands directory contains only Markdown command files", () => {
+  const stray = fs.readdirSync(COMMANDS_DIR).filter((f) => !f.endsWith(".md"));
+  assert.deepEqual(stray, [], `non-Markdown files in commands/ are never loaded as slash commands: ${stray.join(", ")}`);
 });
 
 test("review command calls gemini-companion review subcommand", () => {
@@ -114,6 +123,15 @@ test("setup authenticates by running gemini, not a nonexistent `gemini login`", 
   assert.match(source, /OAuth/i);
 });
 
+test("transfer is a deterministic runner that calls scripts/transfer.mjs", () => {
+  const source = readCommand("transfer.md");
+  assert.match(source, /disable-model-invocation:\s*true/);
+  assert.match(source, /allowed-tools:\s*Bash\(node:\*\)/);
+  assert.match(source, /scripts\/transfer\.mjs"?\s+"\$ARGUMENTS"/);
+  // The generated launch commands are user-pasted, never executed by Claude.
+  assert.match(source, /Do not run the generated commands/i);
+});
+
 // --- Shell-safety: $ARGUMENTS must always be quoted when handed to the companion ---
 // Unquoted $ARGUMENTS lets the shell word-split, glob, or command-substitute the
 // user's raw slash-command text before the companion's parser/validation runs.
@@ -121,7 +139,7 @@ test("every command quotes $ARGUMENTS in its companion invocation", () => {
   const files = fs.readdirSync(COMMANDS_DIR).filter((f) => f.endsWith(".md"));
   for (const file of files) {
     for (const line of readCommand(file).split(/\r?\n/)) {
-      if (line.includes("gemini-companion.mjs") && line.includes("$ARGUMENTS")) {
+      if (line.includes(".mjs") && line.includes("$ARGUMENTS")) {
         assert.match(
           line,
           /"\$ARGUMENTS"/,

--- a/tests/contract.test.mjs
+++ b/tests/contract.test.mjs
@@ -9,7 +9,7 @@ import { makeTempDir, run } from "./helpers.mjs";
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const BUMP = path.join(ROOT, "scripts", "bump-version.mjs");
 const VERIFY = path.join(ROOT, "scripts", "verify-contracts.mjs");
-const COMMANDS = ["setup", "review", "adversarial-review", "rescue", "status", "result", "cancel"];
+const COMMANDS = ["setup", "review", "adversarial-review", "rescue", "status", "result", "cancel", "transfer"];
 
 function writeJson(filePath, json) {
   fs.mkdirSync(path.dirname(filePath), { recursive: true });

--- a/tests/transfer.test.mjs
+++ b/tests/transfer.test.mjs
@@ -4,6 +4,44 @@ import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 import { isSecretFile, checkGitConflict, pruneOldTransfers, buildTransferSnapshot } from '../plugins/gemini/scripts/lib/transfer-context.mjs';
+import { parseTransferArgs } from '../plugins/gemini/scripts/transfer.mjs';
+
+// The slash command passes the entire user tail as one quoted "$ARGUMENTS"
+// token, so flags only work if that single string is re-split first.
+test('parseTransferArgs splits a single quoted $ARGUMENTS string into flags and instructions', () => {
+  const parsed = parseTransferArgs(['--engine agy --effort high finish the login refactor']);
+
+  assert.equal(parsed.engine, 'agy');
+  assert.equal(parsed.effort, 'high');
+  assert.equal(parsed.model, null);
+  assert.equal(parsed.instructions, 'finish the login refactor');
+});
+
+test('parseTransferArgs handles a pre-split argv and --flag=value form', () => {
+  const parsed = parseTransferArgs(['--engine=gemini', '--model', 'gemini-3.5-pro', 'continue', 'here']);
+
+  assert.equal(parsed.engine, 'gemini');
+  assert.equal(parsed.model, 'gemini-3.5-pro');
+  assert.equal(parsed.instructions, 'continue here');
+});
+
+test('parseTransferArgs defaults to auto and keeps --json out of the instructions', () => {
+  const parsed = parseTransferArgs(['--json hand off the current state']);
+
+  assert.equal(parsed.engine, 'auto');
+  assert.equal(parsed.instructions, 'hand off the current state');
+});
+
+test('parseTransferArgs rejects an unknown engine', () => {
+  assert.throws(() => parseTransferArgs(['--engine copilot']), /Unknown engine "copilot"/);
+});
+
+test('parseTransferArgs treats an empty $ARGUMENTS as no arguments', () => {
+  const parsed = parseTransferArgs(['']);
+
+  assert.equal(parsed.engine, 'auto');
+  assert.equal(parsed.instructions, '');
+});
 
 test('isSecretFile correctly identifies sensitive credential file patterns', () => {
   assert.equal(isSecretFile('.env'), true);


### PR DESCRIPTION
## Problem

`/gemini:transfer` shipped in v0.10.0 as `plugins/gemini/commands/transfer.json`. Claude Code's command loader only discovers Markdown command files, so the command never registered — it was absent from `/plugin`, and `scripts/transfer.mjs` had no entry point at all.

Upstream `codex-plugin-cc` ships the equivalent as `commands/transfer.md`.

## Changes

**Registration**
- `commands/transfer.json` → `commands/transfer.md`, following the same contract as the other seven commands: `disable-model-invocation: true`, `allowed-tools: Bash(node:*)`, a quoted `"$ARGUMENTS"` invocation, and explicit output-handling rules (present verbatim; never execute the generated launch commands).

**Argument parsing**
- `transfer.mjs` assumed a pre-split `argv`. With the slash command handing it one quoted `"$ARGUMENTS"` string, `--engine`, `--model` and `--effort` would have been swallowed into the instructions text. It now shares `normalizeArgv` + `parseArgs` with `gemini-companion.mjs`.
- Rejects an unknown `--engine` with the same message as `lib/engine.mjs`.
- `normalizeArgv` moved from `gemini-companion.mjs` into `lib/args.mjs` so both entry points use one definition.
- Self-invocation guard switched from a loose `endsWith('transfer.mjs')` to the `process.argv[1] === SELF_PATH` comparison already used by `gemini-companion.mjs` and `gemini-mcp.mjs` — the file is now imported by tests, so the loose match was unsafe.

**Regression guards**
- Command-contract tests fail on any non-Markdown file in `commands/` — the defect class that hid this bug.
- `transfer` added to `REQUIRED_COMMANDS` in `verify-contracts` and to the contract-test fixture.
- Five new `parseTransferArgs` unit tests covering the single-string, pre-split, `--flag=value`, unknown-engine and empty-arguments cases.

**Docs**
- `docs/PARITY_AUDIT.md`: the v0.10.0 "✅ 已補" row now records that it held for the script only, not the registered command.
- README (EN + zh-TW): documents `--model` / `--effort`, notes the generated commands are user-pasted and never executed by the plugin, and corrects the claim that both a Bash and a PowerShell command are always printed — PowerShell is win32-only (`transfer.mjs:76,86`).

## Verification

- `npm test` — 258 tests, 255 pass / 3 skipped / **0 fail**
- `npm run check-version` — all version metadata matches 0.10.1
- `npm run verify-contracts` — passed for `gemini@gemini-plugin-cc v0.10.1`
- Direct runs of `transfer.mjs` in a scratch workspace, covering:
  - success: `--engine agy --effort high <instructions>` → correct AGY handoff command
  - unknown engine → `exit 1`, `Unknown engine "copilot". Valid values: auto, gemini, agy.`
  - missing flag value (`--json --engine`) → `exit 1`, JSON-shaped error
  - `--json=false` → plain-text error, matching how `parseArgs` resolves the flag
  - SELF_PATH guard still fires when invoked with a forward-slash path on Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H3Qwqu1oihfC2s48Hzj9Wm
