### PR TITLE
fix(agy): align model/effort gate and slash expansion with AGY 1.1.10 (v0.10.2)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,13 +6,13 @@
   },
   "metadata": {
     "description": "Use Gemini CLI or Antigravity CLI (agy) inside Claude Code for task delegation, code review, and adversarial review.",
-    "version": "0.10.1"
+    "version": "0.10.2"
   },
   "plugins": [
     {
       "name": "gemini",
       "description": "Gemini CLI and Antigravity CLI bridge for Claude Code task delegation and adversarial review",
-      "version": "0.10.1",
+      "version": "0.10.2",
       "author": {
         "name": "arcobaleno64"
       },

--- a/README.md
+++ b/README.md
@@ -150,8 +150,8 @@ Delegates a task to Gemini. Reads from stdin if no prompt is given.
 | `--resume-last` | Continue the most recent Gemini session |
 | `--fresh` | Force a new Gemini session, ignoring any resumable thread |
 | `--engine <gemini\|agy\|auto>` | Override engine selection |
-| `--model <alias\|id>` | Model override. Gemini resolves its aliases; AGY 1.1.5+ requires an exact model ID from `agy models`. AGY model selection cannot be combined with `--effort` or a dual-engine (`--engines gemini,agy`) review. |
-| `--effort <low\|medium\|high\|xhigh>` | Gemini maps effort to a model; AGY 1.1.5+ forwards `low`, `medium`, or `high` as native reasoning effort when no AGY model is selected. |
+| `--model <alias\|id>` | Model override. Gemini resolves its aliases; AGY 1.1.10+ requires an exact model ID from `agy models`. AGY model selection cannot be combined with `--effort` or a dual-engine (`--engines gemini,agy`) review. |
+| `--effort <low\|medium\|high\|xhigh>` | Gemini maps effort to a model; AGY 1.1.10+ forwards `low`, `medium`, or `high` as native reasoning effort when no AGY model is selected. |
 
 ### `/gemini:transfer [instructions...]`
 
@@ -175,7 +175,7 @@ Runs a standard, pragmatic review over the current working tree or branch diff �
 | `--scope <auto\|working-tree\|branch>` | Diff scope |
 | `--engine <gemini\|agy\|auto>` | Override engine |
 | `--model <alias\|id>` | Model override |
-| `--effort <level>` | Model selection on Gemini; native reasoning effort on AGY 1.1.5+ (`low`, `medium`, `high`) when no AGY model is selected |
+| `--effort <level>` | Model selection on Gemini; native reasoning effort on AGY 1.1.10+ (`low`, `medium`, `high`) when no AGY model is selected |
 
 ### `/gemini:adversarial-review [focus]`
 
@@ -188,7 +188,7 @@ Runs an adversarial review over the current working tree or branch diff.
 | `--scope <auto\|working-tree\|branch>` | Diff scope |
 | `--engine <gemini\|agy\|auto>` | Override engine |
 | `--model <alias\|id>` | Model override |
-| `--effort <level>` | Model selection on Gemini; native reasoning effort on AGY 1.1.5+ (`low`, `medium`, `high`) when no AGY model is selected |
+| `--effort <level>` | Model selection on Gemini; native reasoning effort on AGY 1.1.10+ (`low`, `medium`, `high`) when no AGY model is selected |
 
 ### `/gemini:setup`
 
@@ -249,7 +249,7 @@ When enabled and the review returns `needs-attention`, Claude Code is blocked fr
 - **CLI probe snapshot.** The alias table reflects the model-map probe from 2026-06-02 against gemini CLI 0.44.1. Newer Gemini CLI releases may serve different model IDs. If an alias stops resolving, override it with `--model <exact-id>` — any value that is not a known alias is passed through to the CLI unchanged.
 - **Gemini 3.5 availability can drift.** The 2026-06-02 gemini CLI 0.44.1 probe returned `404 ModelNotFound` for `gemini-3.5-flash` and `gemini-3.5-pro`; newer CLI releases may differ. Unknown or unavailable model IDs degrade gracefully to the GA fallback.
 - **Graceful model fallback.** If a requested model id is not found on your gemini CLI (preview/retired id, or a CLI-version mismatch), the plugin retries the run **once on the GA fallback `gemini-2.5-flash`** and prints a clear note — so a stale id degrades gracefully instead of hard-failing.
-- **AGY 1.1.5+ model and reasoning selection.** Use either `--model <exact-id>` from `agy models` or native `--effort <low|medium|high>`; the options are mutually exclusive. AGY model IDs are not Gemini aliases, and `--model` is unavailable for a dual-engine review because model IDs are engine-specific.
+- **AGY 1.1.10+ model and reasoning selection.** Use either `--model <exact-id>` from `agy models` or native `--effort <low|medium|high>`; the options are mutually exclusive. AGY model IDs are not Gemini aliases, and `--model` is unavailable for a dual-engine review because model IDs are engine-specific.
 
 ---
 
@@ -262,7 +262,7 @@ In `auto` mode the plugin selects the first available engine in this order:
 
 Override via `--engine` flag or the `GEMINI_ENGINE` environment variable.
 
-> **AGY 1.1.5+ selection:** use either `--model <exact-id>` from `agy models` or `--effort <low|medium|high>`. Gemini aliases are not valid AGY model IDs, model and effort cannot be combined, and `--model` is unavailable for a dual-engine review because IDs are engine-specific. Gemini retains its separate alias and effort-to-model mapping.
+> **AGY 1.1.10+ selection:** use either `--model <exact-id>` from `agy models` or `--effort <low|medium|high>`. Gemini aliases are not valid AGY model IDs, model and effort cannot be combined, and `--model` is unavailable for a dual-engine review because IDs are engine-specific. Gemini retains its separate alias and effort-to-model mapping.
 
 > **AGY transcript recovery remains authoritative.** Positional `agy --print` produced no piped response on older releases (upstream [google-gemini/gemini-cli#27466](https://github.com/google-gemini/gemini-cli/issues/27466); reproduced on macOS AGY 1.0.7). Plugin v0.7.1 uses the auto-print stdin path on AGY 1.1.2 or newer, but still takes the completed response, DONE status, thinking, and conversation ID from the on-disk transcript. Known brain roots are `~/.gemini/antigravity-cli/brain` (verified on Windows, macOS AGY 1.0.7, and Linux AGY 1.1.2) and `~/.antigravity-cli/brain` (older Linux 1.0.2, reported). The 1.1.2 stdin path is live-verified on Windows and Ubuntu 24.04 WSL2, and covered by a POSIX integration fixture; real macOS 1.1.2 verification is intentionally optional and has not been run. If no brain root is found, run `agy` once or open an issue with its actual location.
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -148,8 +148,8 @@
 | `--resume-last` | 繼續最近一次的 Gemini 工作階段 |
 | `--fresh` | 強制開啟全新 Gemini 工作階段，忽略可接續的執行緒 |
 | `--engine <gemini\|agy\|auto>` | 覆蓋引擎選擇 |
-| `--model <別名\|ID>` | 指定模型。Gemini 解析其別名；AGY 1.1.5+ 要求使用 `agy models` 列出的精確 model ID。AGY 的模型選擇不可與 `--effort` 或雙引擎（`--engines gemini,agy`）審查合併。 |
-| `--effort <low\|medium\|high\|xhigh>` | Gemini 將 effort 映射為模型；AGY 1.1.5+ 在未指定 AGY model 時，原生傳遞 `low`、`medium` 或 `high` 推理強度。 |
+| `--model <別名\|ID>` | 指定模型。Gemini 解析其別名；AGY 1.1.10+ 要求使用 `agy models` 列出的精確 model ID。AGY 的模型選擇不可與 `--effort` 或雙引擎（`--engines gemini,agy`）審查合併。 |
+| `--effort <low\|medium\|high\|xhigh>` | Gemini 將 effort 映射為模型；AGY 1.1.10+ 在未指定 AGY model 時，原生傳遞 `low`、`medium` 或 `high` 推理強度。 |
 
 ### `/gemini:transfer [instructions...]`
 
@@ -173,7 +173,7 @@
 | `--scope <auto\|working-tree\|branch>` | Diff 範圍 |
 | `--engine <gemini\|agy\|auto>` | 覆蓋引擎 |
 | `--model <別名\|ID>` | 指定模型 |
-| `--effort <level>` | Gemini 的模型選擇；未指定 AGY model 時的 AGY 1.1.5+ 原生推理強度（`low`、`medium`、`high`） |
+| `--effort <level>` | Gemini 的模型選擇；未指定 AGY model 時的 AGY 1.1.10+ 原生推理強度（`low`、`medium`、`high`） |
 
 ### `/gemini:adversarial-review [焦點]`
 
@@ -186,7 +186,7 @@
 | `--scope <auto\|working-tree\|branch>` | Diff 範圍 |
 | `--engine <gemini\|agy\|auto>` | 覆蓋引擎 |
 | `--model <別名\|ID>` | 指定模型 |
-| `--effort <level>` | Gemini 的模型選擇；未指定 AGY model 時的 AGY 1.1.5+ 原生推理強度（`low`、`medium`、`high`） |
+| `--effort <level>` | Gemini 的模型選擇；未指定 AGY model 時的 AGY 1.1.10+ 原生推理強度（`low`、`medium`、`high`） |
 
 ### `/gemini:setup`
 
@@ -260,7 +260,7 @@
 
 可透過 `--engine` 旗標或 `GEMINI_ENGINE` 環境變數覆蓋。
 
-> **AGY 1.1.5+ 選擇機制：** 使用 `agy models` 所列的 `--model <精確 ID>`，或使用 `--effort <low|medium|high>` 二者之一。Gemini alias 不是有效的 AGY model ID，model 與 effort 不可合併；雙引擎審查不可使用 `--model`，因為 model ID 具引擎特性。Gemini 仍維持其獨立的 alias 與 effort-to-model 映射。
+> **AGY 1.1.10+ 選擇機制：** 使用 `agy models` 所列的 `--model <精確 ID>`，或使用 `--effort <low|medium|high>` 二者之一。Gemini alias 不是有效的 AGY model ID，model 與 effort 不可合併；雙引擎審查不可使用 `--model`，因為 model ID 具引擎特性。Gemini 仍維持其獨立的 alias 與 effort-to-model 映射。
 
 > **AGY transcript recovery 仍是權威來源。** 舊版 positional `agy --print` 沒有 piped response（上游 [google-gemini/gemini-cli#27466](https://github.com/google-gemini/gemini-cli/issues/27466)，已於 macOS AGY 1.0.7 重現）。外掛 v0.7.1 對 AGY 1.1.2 以上改走自動 print 的 stdin 路徑，但完成回應、DONE 狀態、thinking 與 conversation ID 仍取自磁碟 transcript。已知 brain root 為 `~/.gemini/antigravity-cli/brain`（已於 Windows、macOS AGY 1.0.7 與 Linux AGY 1.1.2 驗證）及 `~/.antigravity-cli/brain`（較舊的 Linux 1.0.2，回報）。1.1.2 stdin 路徑已於 Windows 與 Ubuntu 24.04 WSL2 live 驗證，並有 POSIX integration fixture；真實 macOS 1.1.2 驗證刻意列為 optional，尚未執行。若找不到 brain root，請先執行一次 `agy` 或開 issue 回報實際位置。
 

--- a/docs/adapter-contract.md
+++ b/docs/adapter-contract.md
@@ -14,5 +14,5 @@ cancel(pid) → { signaled, confirmedTerminated?, reason? }
 
 - `binaryAvailable`／`resolveBinaryPath`（`process.mjs`）對應契約 `detect()` 的組成件。
 - `terminateProcessTree` 對應契約 `cancel(pid)`：語意等價為樹殺與結果物件。
-- Prompt 遞送：gemini 與 AGY >=1.1.2 使用 stdin；舊版、prerelease 或無法解析版本的 AGY 才使用 argv。AGY 的 positional fallback 會預先拒絕 NUL 與超過 24,000 字元的 prompt，並以絕對 `.exe` 路徑及 `shell:false` 啟動；model id 字元集白名單適用於兩個引擎。AGY >=1.1.5 的 `--model` 使用 `agy models` 列出的引擎別 ID，`--effort` 值域為 `low|medium|high`，兩者不可合併。
+- Prompt 遞送：gemini 與 AGY >=1.1.2 使用 stdin；舊版、prerelease 或無法解析版本的 AGY 才使用 argv。AGY 的 positional fallback 會預先拒絕 NUL 與超過 24,000 字元的 prompt，並以絕對 `.exe` 路徑及 `shell:false` 啟動；model id 字元集白名單適用於兩個引擎。AGY >=1.1.10 的 `--model` 使用 `agy models` 列出的引擎別 ID，`--effort` 值域為 `low|medium|high`，兩者不可合併；1.1.5–1.1.9 雖接受這兩個旗標，卻在 headless 執行時忽略它們而靜默落回預設模型，故一律拒絕並要求升級。AGY >=1.1.9 一律加上 `--disable-slash-commands`，避免 print mode 把位於 prompt 開頭的使用者文字當成 slash command 或 skill 展開。
 - 不改動 CC 既有函式命名（已發布 v0.6.6，Hyrum 面）；本檔為對照文件，宣告 CC 以語意等價符合契約。

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@arcobaleno64/gemini-plugin-cc",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@arcobaleno64/gemini-plugin-cc",
-      "version": "0.10.1",
+      "version": "0.10.2",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arcobaleno64/gemini-plugin-cc",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "private": true,
   "type": "module",
   "description": "Use Gemini CLI or Antigravity CLI (agy) inside Claude Code for task delegation, code review, and adversarial review.",

--- a/plugins/gemini/.claude-plugin/plugin.json
+++ b/plugins/gemini/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gemini",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Use Gemini/AGY from Claude Code to review code or delegate tasks.",
   "author": {
     "name": "arcobaleno64",

--- a/plugins/gemini/CHANGELOG.md
+++ b/plugins/gemini/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.10.2 — 2026-08-04 — AGY 1.1.9/1.1.10 behavior alignment
+
+### Fixed
+- **AGY `--model` / `--effort` are now gated at 1.1.10, not 1.1.5.** AGY's 1.1.10 release notes record that both flags were applied after model configuration had already been initialized, so headless `-p` runs through 1.1.9 silently fell back to the persisted or default model. The plugin previously advertised support from 1.1.5 and forwarded a selection those versions ignored. Requests on 1.1.5–1.1.9 are now refused with an upgrade message instead of reporting a selection the run will not honor.
+- **AGY invocations pass `--disable-slash-commands` on 1.1.9 and newer.** AGY 1.1.9 added slash-command and skill expansion to print mode. Task prompts are raw user text at position 0, so a request such as `/gemini:rescue /clear the cache logic` would have executed AGY's `/clear` instead of being read as instructions. The flag is omitted on older AGY, where it does not exist.
+
+### Changed
+- The three AGY version predicates share one `agyVersionAtLeast` comparison instead of repeating the parse; prerelease builds still fail closed.
+- Version-specific wording removed from two errors that are not version-specific: the `--model` + `--effort` combination refusal, and the same refusal in `transfer`.
+- `docs/adapter-contract.md` records both the 1.1.10 selection gate and the 1.1.9 slash opt-out.
+
 ## 0.10.1 — 2026-08-04 — `/gemini:transfer` command registration fix
 
 ### Fixed

--- a/plugins/gemini/scripts/gemini-companion.mjs
+++ b/plugins/gemini/scripts/gemini-companion.mjs
@@ -693,12 +693,12 @@ function prepareEngineSelection(engineInfo, model, effort) {
 
   if (engineInfo.engine === "agy") {
     if (!supportsAgyModelSelection(engineInfo.version)) {
-      throw new Error(`AGY ${engineInfo.version} does not support --model/--effort. Upgrade to AGY 1.1.5 or newer, or select --engine gemini.`);
+      throw new Error(`AGY ${engineInfo.version} does not support --model/--effort. AGY 1.1.5 through 1.1.9 accept the flags but ignore them in headless runs. Upgrade to AGY 1.1.10 or newer, or select --engine gemini.`);
     }
     const agyModel = normalizeAgyRequestedModel(requestedModel);
     const agyEffort = normalizeAgyEffort(requestedEffort);
     if (agyModel && agyEffort) {
-      throw new Error("AGY 1.1.5 cannot combine --model with --effort for its available model IDs. Select a model or an effort level, not both.");
+      throw new Error("AGY cannot combine --model with --effort for its available model IDs. Select a model or an effort level, not both.");
     }
     return { model: agyModel, effort: agyEffort };
   }

--- a/plugins/gemini/scripts/lib/engine.mjs
+++ b/plugins/gemini/scripts/lib/engine.mjs
@@ -84,22 +84,34 @@ export function normalizeAgyEffort(effort) {
   return normalized;
 }
 
-export function supportsAgyStdinPrompt(version) {
+// A prerelease build (1.1.10-rc.1) never counts as the released feature.
+function agyVersionAtLeast(version, minMinor, minPatch) {
   const match = String(version ?? "").trim().match(/(\d+)\.(\d+)\.(\d+)(-[0-9A-Za-z.-]+)?/);
   if (!match || match[4]) return false;
   const major = Number(match[1]);
   const minor = Number(match[2]);
   const patch = Number(match[3]);
-  return major > 1 || (major === 1 && (minor > 1 || (minor === 1 && patch >= 2)));
+  return major > 1 || (major === 1 && (minor > minMinor || (minor === minMinor && patch >= minPatch)));
 }
 
+export function supportsAgyStdinPrompt(version) {
+  return agyVersionAtLeast(version, 1, 2);
+}
+
+// AGY 1.1.5 accepts --model and --effort, but through 1.1.9 it applied them
+// after model configuration had already been initialized, so a headless `-p`
+// run silently fell back to the persisted or default model. AGY 1.1.10 fixed
+// that; anything older is treated as not supporting selection at all rather
+// than reporting a selection the run will not honor.
 export function supportsAgyModelSelection(version) {
-  const match = String(version ?? "").trim().match(/(\d+)\.(\d+)\.(\d+)(-[0-9A-Za-z.-]+)?/);
-  if (!match || match[4]) return false;
-  const major = Number(match[1]);
-  const minor = Number(match[2]);
-  const patch = Number(match[3]);
-  return major > 1 || (major === 1 && (minor > 1 || (minor === 1 && patch >= 5)));
+  return agyVersionAtLeast(version, 1, 10);
+}
+
+// AGY 1.1.9 expands slash commands and skills in print mode. Plugin prompts
+// carry raw user text at position 0, so a task beginning with "/" would be
+// executed as an AGY command instead of read as instructions.
+export function supportsAgySlashCommandOptOut(version) {
+  return agyVersionAtLeast(version, 1, 9);
 }
 
 export function detectEngine(requestedEngine = null, options = {}) {
@@ -177,7 +189,7 @@ function assertAgyPromptSafe(prompt) {
 }
 
 export function buildCliArgs(engine, options = {}) {
-  const { prompt = "", model, effort, write = false, resumeLast = false, outputJson = false, approvalModePlan = false, timeoutMs, useStdin = false } = options;
+  const { prompt = "", model, effort, write = false, resumeLast = false, outputJson = false, approvalModePlan = false, timeoutMs, useStdin = false, agyVersion = null } = options;
 
   if (engine === "agy") {
     // AGY >=1.1.2 auto-enters print mode when a prompt is piped on stdin; adding
@@ -188,13 +200,18 @@ export function buildCliArgs(engine, options = {}) {
       assertAgyPromptSafe(prompt);
       args.push("--print", prompt);
     }
+    // The prompt is raw user text at position 0, so opt out of AGY's print-mode
+    // slash-command and skill expansion wherever the flag exists (1.1.9+).
+    if (supportsAgySlashCommandOptOut(agyVersion)) {
+      args.push("--disable-slash-commands");
+    }
     const agyModel = normalizeAgyRequestedModel(model);
     const agyEffort = normalizeAgyEffort(effort);
-    // AGY 1.1.5 accepts each flag, but the locally reported model IDs reject
-    // the combination. Refuse it before spawn rather than replacing a useful
-    // AGY diagnostic with a transcript-missing failure.
+    // AGY accepts each flag, but the locally reported model IDs reject the
+    // combination (machine-verified on 1.1.5). Refuse it before spawn rather
+    // than replacing a useful AGY diagnostic with a transcript-missing failure.
     if (agyModel && agyEffort) {
-      throw new Error("AGY 1.1.5 cannot combine --model with --effort for its available model IDs. Select a model or an effort level, not both.");
+      throw new Error("AGY cannot combine --model with --effort for its available model IDs. Select a model or an effort level, not both.");
     }
     if (agyModel) args.push("--model", agyModel);
     if (agyEffort) args.push("--effort", agyEffort);

--- a/plugins/gemini/scripts/lib/gemini.mjs
+++ b/plugins/gemini/scripts/lib/gemini.mjs
@@ -138,7 +138,7 @@ export async function runGeminiTurn(cwd, options = {}) {
   if (engineInfo.engine === "agy") {
     if (model || effort) {
       if (!supportsAgyModelSelection(engineInfo.version)) {
-        throw new Error(`AGY ${engineInfo.version} does not support --model/--effort. Upgrade to AGY 1.1.5 or newer, or select --engine gemini.`);
+        throw new Error(`AGY ${engineInfo.version} does not support --model/--effort. AGY 1.1.5 through 1.1.9 accept the flags but ignore them in headless runs. Upgrade to AGY 1.1.10 or newer, or select --engine gemini.`);
       }
       model = normalizeAgyRequestedModel(model);
       effort = normalizeAgyEffort(effort);
@@ -179,6 +179,7 @@ export async function runGeminiTurn(cwd, options = {}) {
     write,
     resumeLast,
     timeoutMs: engineInfo.engine === "agy" ? agyPrintTimeoutMs : spawnTimeoutMs,
+    agyVersion: engineInfo.version,
     useStdin,
     outputJson: useJson,
   });
@@ -318,7 +319,7 @@ export async function runGeminiReview(cwd, options = {}) {
   if (engineInfo.engine === "agy") {
     if (requestedModel || requestedEffort) {
       if (!supportsAgyModelSelection(engineInfo.version)) {
-        throw new Error(`AGY ${engineInfo.version} does not support --model/--effort. Upgrade to AGY 1.1.5 or newer, or select --engine gemini.`);
+        throw new Error(`AGY ${engineInfo.version} does not support --model/--effort. AGY 1.1.5 through 1.1.9 accept the flags but ignore them in headless runs. Upgrade to AGY 1.1.10 or newer, or select --engine gemini.`);
       }
       model = normalizeAgyRequestedModel(requestedModel);
       effort = normalizeAgyEffort(requestedEffort);
@@ -356,6 +357,7 @@ export async function runGeminiReview(cwd, options = {}) {
     // approvalModePlan requires TTY input and conflicts with stdin prompt delivery
     approvalModePlan: false,
     timeoutMs: engineInfo.engine === "agy" ? agyPrintTimeoutMs : spawnTimeoutMs,
+    agyVersion: engineInfo.version,
     useStdin,
   });
 

--- a/plugins/gemini/scripts/lib/transfer-context.mjs
+++ b/plugins/gemini/scripts/lib/transfer-context.mjs
@@ -134,7 +134,7 @@ export function collectGitContext(cwd = process.cwd()) {
 
 export function buildTransferSnapshot({ engine = 'auto', model = null, effort = null, instructions = '', cwd = process.cwd() }) {
   if (model && effort) {
-    throw new Error('AGY 1.1.5+ model selection and reasoning effort are mutually exclusive; specify either --model or --effort, not both.');
+    throw new Error('AGY model selection and reasoning effort are mutually exclusive; specify either --model or --effort, not both.');
   }
 
   const gitContext = collectGitContext(cwd);

--- a/plugins/gemini/scripts/lib/transfer-context.mjs
+++ b/plugins/gemini/scripts/lib/transfer-context.mjs
@@ -134,7 +134,7 @@ export function collectGitContext(cwd = process.cwd()) {
 
 export function buildTransferSnapshot({ engine = 'auto', model = null, effort = null, instructions = '', cwd = process.cwd() }) {
   if (model && effort) {
-    throw new Error('AGY model selection and reasoning effort are mutually exclusive; specify either --model or --effort, not both.');
+    throw new Error('Model selection and reasoning effort are mutually exclusive; specify either --model or --effort, not both.');
   }
 
   const gitContext = collectGitContext(cwd);

--- a/tests/engine.test.mjs
+++ b/tests/engine.test.mjs
@@ -11,6 +11,7 @@ import {
   buildCliArgs,
   detectEngine,
   supportsAgyModelSelection,
+  supportsAgySlashCommandOptOut,
   supportsAgyStdinPrompt
 } from "../plugins/gemini/scripts/lib/engine.mjs";
 
@@ -83,12 +84,27 @@ test("AGY stdin prompt capability begins at stable 1.1.2 and fails closed for un
   assert.equal(supportsAgyStdinPrompt("2.0.0"), true);
 });
 
-test("AGY model and effort selection begins at stable 1.1.5", () => {
+// 1.1.5 through 1.1.9 accept --model/--effort but drop them in headless runs
+// (fixed in AGY 1.1.10), so those versions must not be reported as supported.
+test("AGY model and effort selection begins at stable 1.1.10", () => {
   assert.equal(supportsAgyModelSelection("1.1.4"), false);
-  assert.equal(supportsAgyModelSelection("1.1.5-beta.1"), false);
+  assert.equal(supportsAgyModelSelection("agy 1.1.5"), false);
+  assert.equal(supportsAgyModelSelection("1.1.9"), false);
+  assert.equal(supportsAgyModelSelection("1.1.10-beta.1"), false);
   assert.equal(supportsAgyModelSelection("unknown"), false);
-  assert.equal(supportsAgyModelSelection("agy 1.1.5"), true);
+  assert.equal(supportsAgyModelSelection("agy 1.1.10"), true);
   assert.equal(supportsAgyModelSelection("1.2.0"), true);
+  assert.equal(supportsAgyModelSelection("2.0.0"), true);
+});
+
+test("AGY slash-command opt-out begins at stable 1.1.9", () => {
+  assert.equal(supportsAgySlashCommandOptOut("1.1.8"), false);
+  assert.equal(supportsAgySlashCommandOptOut("1.1.9-rc.1"), false);
+  assert.equal(supportsAgySlashCommandOptOut("unknown"), false);
+  assert.equal(supportsAgySlashCommandOptOut(null), false);
+  assert.equal(supportsAgySlashCommandOptOut("agy 1.1.9"), true);
+  assert.equal(supportsAgySlashCommandOptOut("1.1.10"), true);
+  assert.equal(supportsAgySlashCommandOptOut("2.0.0"), true);
 });
 
 test("AGY requires an exact model ID and preserves safe explicit IDs", () => {
@@ -143,6 +159,24 @@ test("AGY forwards an explicit model ID or effort as literal argv", () => {
     () => buildCliArgs("agy", { prompt: "hello", useStdin: true, model: "gemini-3.6-flash-high", effort: "high" }),
     /cannot combine --model with --effort/
   );
+});
+
+// AGY 1.1.9+ expands slash commands and skills in print mode. Task prompts are
+// raw user text at position 0, so "/clear the cache logic" would run AGY's
+// /clear instead of being read as instructions.
+test("agy opts out of print-mode slash expansion on 1.1.9 and newer", () => {
+  const modern = buildCliArgs("agy", { prompt: "/clear the cache logic", useStdin: true, agyVersion: "1.1.10" });
+  assert.ok(modern.includes("--disable-slash-commands"));
+});
+
+test("agy omits the slash opt-out where the flag does not exist", () => {
+  for (const agyVersion of ["1.1.8", null, "unknown"]) {
+    const args = buildCliArgs("agy", { prompt: "hello", useStdin: true, agyVersion });
+    assert.ok(
+      !args.includes("--disable-slash-commands"),
+      `AGY ${agyVersion} predates --disable-slash-commands and must not receive it`
+    );
+  }
 });
 
 test("agy write turn adds --new-project so files land in cwd, not agy's scratch dir", () => {

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -920,7 +920,7 @@ test("dispatchAdversarialReview validates every engine before spawning a group w
   assert.throws(
     () => dispatchAdversarialReview({ cwd: repo, scope: "working-tree", engines: ["gemini", "agy"], effort: "xhigh" }, {
       spawnFn() { spawnCount += 1; return { pid: spawnCount, unref() {} }; },
-      detectEngineFn(engine) { return { engine, version: "1.1.5" }; }
+      detectEngineFn(engine) { return { engine, version: "1.1.10" }; }
     }),
     /AGY supports --effort values/
   );
@@ -935,9 +935,27 @@ test("background AGY task validates model and effort before spawning", () => {
   assert.throws(
     () => dispatchBackgroundTask({ cwd: repo, engine: "agy", model: "gemini-3.6-flash-low", effort: "high", prompt: "diagnose" }, {
       spawnFn() { spawned = true; return { pid: 1, unref() {} }; },
-      detectEngineFn() { return { engine: "agy", version: "1.1.5" }; }
+      detectEngineFn() { return { engine: "agy", version: "1.1.10" }; }
     }),
     /cannot combine --model with --effort/
+  );
+  assert.equal(spawned, false);
+  fs.rmSync(repo, { recursive: true, force: true });
+});
+
+// AGY 1.1.5 through 1.1.9 accept --model/--effort and then ignore them in
+// headless runs, silently falling back to the persisted or default model.
+// Refuse the request instead of reporting a selection the run will not honor.
+test("background AGY task refuses model selection on AGY older than 1.1.10", () => {
+  const { repo } = setupRepo("task");
+  let spawned = false;
+
+  assert.throws(
+    () => dispatchBackgroundTask({ cwd: repo, engine: "agy", effort: "high", prompt: "diagnose" }, {
+      spawnFn() { spawned = true; return { pid: 1, unref() {} }; },
+      detectEngineFn() { return { engine: "agy", version: "1.1.9" }; }
+    }),
+    /does not support --model\/--effort.*Upgrade to AGY 1\.1\.10 or newer/s
   );
   assert.equal(spawned, false);
   fs.rmSync(repo, { recursive: true, force: true });


### PR DESCRIPTION
Found by an upstream sweep of AGY releases 1.1.3 → 1.1.10. Two shipped behaviors no longer match what AGY actually does.

## 1. `--model` / `--effort` were gated at 1.1.5, but AGY ignored them until 1.1.10

AGY's [1.1.10 release notes](https://github.com/google-antigravity/antigravity-cli/releases/tag/1.1.10):

> Fixed `--model` and `--effort` being ignored in interactive sessions and in headless `-p` runs, where the flags were applied after model configuration had already been initialized so the run silently fell back to the persisted or default model.

`supportsAgyModelSelection` gated at 1.1.5, so on AGY 1.1.5–1.1.9 the plugin accepted a selection, forwarded it, and reported it — while the run used the persisted or default model. README and the v0.9.0 changelog both asserted 1.1.5+ support.

Gate raised to 1.1.10. Older versions are refused with an upgrade message naming the reason, rather than reporting a selection the run will not honor.

## 2. AGY 1.1.9 expands slash commands in print mode; plugin prompts are raw user text

AGY 1.1.9 added slash-command and skill expansion to print mode, with `--disable-slash-commands` to opt out. Task prompts reach AGY as raw user text at position 0 (`gemini-companion.mjs:831` → `readTaskPrompt:610`, no wrapper), so `/gemini:rescue /clear the cache logic` would have executed AGY's `/clear` instead of being read as instructions.

`--disable-slash-commands` is now passed on 1.1.9+ and omitted on older AGY where the flag does not exist.

## Also

- The three AGY version predicates share one `agyVersionAtLeast` comparison instead of repeating the parse. Prerelease builds still fail closed.
- Version-specific wording removed from two errors that are not version-specific (the `--model` + `--effort` combination refusal, and the same refusal in `transfer`).
- README (EN + zh-TW) 11 occurrences of "AGY 1.1.5+" corrected; `docs/adapter-contract.md` records both changes.

## Not changed

The `--model` + `--effort` combination refusal stays. It was machine-verified against 1.1.5's model IDs and no 1.1.10 release note says the combination now works — removing it would need evidence, not inference.

## Verification

- `npm test` — 262 tests, 259 pass / 3 skipped / **0 fail**
- `npm run check-version`, `npm run verify-contracts` — pass at v0.10.2
- `buildCliArgs` against the locally detected AGY **1.1.10** emits `["--disable-slash-commands","--effort","high"]`
- Two existing runtime tests stubbed `version: "1.1.5"` to reach the validation paths; retargeted to 1.1.10, plus a new test asserting 1.1.9 is refused with the upgrade message

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H3Qwqu1oihfC2s48Hzj9Wm
