### PR TITLE
test(agy): make the engine-response path testable without a spawn (v0.11.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,13 +6,13 @@
   },
   "metadata": {
     "description": "Use Gemini CLI or Antigravity CLI (agy) inside Claude Code for task delegation, code review, and adversarial review.",
-    "version": "0.11.0"
+    "version": "0.11.1"
   },
   "plugins": [
     {
       "name": "gemini",
       "description": "Gemini CLI and Antigravity CLI bridge for Claude Code task delegation and adversarial review",
-      "version": "0.11.0",
+      "version": "0.11.1",
       "author": {
         "name": "arcobaleno64"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@arcobaleno64/gemini-plugin-cc",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@arcobaleno64/gemini-plugin-cc",
-      "version": "0.11.0",
+      "version": "0.11.1",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arcobaleno64/gemini-plugin-cc",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "private": true,
   "type": "module",
   "description": "Use Gemini CLI or Antigravity CLI (agy) inside Claude Code for task delegation, code review, and adversarial review.",

--- a/plugins/gemini/.claude-plugin/plugin.json
+++ b/plugins/gemini/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gemini",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Use Gemini/AGY from Claude Code to review code or delegate tasks.",
   "author": {
     "name": "arcobaleno64",

--- a/plugins/gemini/CHANGELOG.md
+++ b/plugins/gemini/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.11.1 — 2026-08-04 — Testable engine-response path
+
+### Changed
+- `runGeminiTurn` and `runGeminiReview` accept an optional third argument, `{ runCommandFn, detectEngineFn }`, mirroring the `{ spawnFn, detectEngineFn }` seam `dispatchBackgroundTask` already uses. No behavior change: both default to the real implementations.
+- Envelope handling moved from spawn-driven fixtures to `tests/agy-envelope.test.mjs`, which injects those dependencies. Those cases previously could not run on Windows at all — the AGY stand-in there must be an absolute `.exe` (CVE-2024-27980), so a copied `node.exe` is used and cannot report a chosen AGY version. Two spawn tests remain to cover what unit tests cannot see: real argv reaching a process, and the transcript genuinely being read on AGY 1.1.7.
+
+### Added
+- Envelope coverage that did not exist before: an unrecognized `status` is treated as failure rather than rejected as malformed, stdout that is not an envelope reports `invalid-json`, and the review path's findings-JSON-inside-the-envelope-response nesting is asserted directly.
+
 ## 0.11.0 — 2026-08-04 — AGY native JSON envelope replaces transcript scraping
 
 ### Changed

--- a/plugins/gemini/scripts/lib/gemini.mjs
+++ b/plugins/gemini/scripts/lib/gemini.mjs
@@ -193,14 +193,19 @@ function resolveAgyStructuredResult({ rawStdout, rawStderr, exitCode, result, en
   };
 }
 
-export async function runGeminiTurn(cwd, options = {}) {
+// The third parameter mirrors dispatchBackgroundTask's { spawnFn, detectEngineFn }
+// seam. It exists so the engine-response logic can be exercised without a real
+// binary: the Windows AGY stand-in must be an absolute .exe (CVE-2024-27980), so
+// a fixture there cannot report a chosen version, and spawn-driven tests cost
+// ~150s per suite against ~0.2s for direct calls.
+export async function runGeminiTurn(cwd, options = {}, { runCommandFn = runCommand, detectEngineFn = detectEngine } = {}) {
   const { prompt, effort: requestedEffort, write = true, resumeLast = false, engine: requestedEngine, onProgress } = options;
   let { model } = options;
   let effort = requestedEffort;
 
   onProgress?.({ message: "Detecting engine...", phase: "starting" });
 
-  const engineInfo = detectEngine(requestedEngine ?? null);
+  const engineInfo = detectEngineFn(requestedEngine ?? null);
 
   if (engineInfo.engine === "agy") {
     if (model || effort) {
@@ -255,7 +260,7 @@ export async function runGeminiTurn(cwd, options = {}) {
 
   onProgress?.({ message: `Starting ${engineInfo.engine} turn...`, phase: "running" });
 
-  const result = runCommand(engineInfo.binary, args, {
+  const result = runCommandFn(engineInfo.binary, args, {
     cwd,
     input: useStdin ? prompt : undefined,
     maxBuffer: MAX_BUFFER,
@@ -282,7 +287,7 @@ export async function runGeminiTurn(cwd, options = {}) {
       useStdin,
       outputJson: useJson,
     });
-    const fbResult = runCommand(engineInfo.binary, fbArgs, { cwd, input: useStdin ? prompt : undefined, maxBuffer: MAX_BUFFER, timeout: spawnTimeoutMs });
+    const fbResult = runCommandFn(engineInfo.binary, fbArgs, { cwd, input: useStdin ? prompt : undefined, maxBuffer: MAX_BUFFER, timeout: spawnTimeoutMs });
     rawStdout = stripAnsi(fbResult.stdout ?? "");
     rawStderr = stripAnsi(fbResult.stderr ?? "");
     exitCode = fbResult.status ?? (fbResult.error ? 1 : 0);
@@ -371,7 +376,8 @@ export async function runGeminiTurn(cwd, options = {}) {
   };
 }
 
-export async function runGeminiReview(cwd, options = {}) {
+// Same injection seam as runGeminiTurn; see the note there.
+export async function runGeminiReview(cwd, options = {}, { runCommandFn = runCommand, detectEngineFn = detectEngine } = {}) {
   const { prompt, model: requestedModel, effort: requestedEffort, engine: requestedEngine, isAdversarial = true, onProgress } = options;
 
   // Mode-aware label: the standard /review and adversarial /adversarial-review
@@ -381,9 +387,9 @@ export async function runGeminiReview(cwd, options = {}) {
   // prefer gemini for JSON output, unless forced to agy
   let engineInfo;
   try {
-    engineInfo = detectEngine(requestedEngine ?? "gemini");
+    engineInfo = detectEngineFn(requestedEngine ?? "gemini");
   } catch {
-    engineInfo = detectEngine(requestedEngine ?? null);
+    engineInfo = detectEngineFn(requestedEngine ?? null);
   }
   const agyStructured = engineInfo.engine === "agy" && supportsAgyStructuredOutput(engineInfo.version);
   const useJson = engineInfo.engine === "gemini" || agyStructured;
@@ -437,7 +443,7 @@ export async function runGeminiReview(cwd, options = {}) {
     useStdin,
   });
 
-  const result = runCommand(engineInfo.binary, args, {
+  const result = runCommandFn(engineInfo.binary, args, {
     cwd,
     input: useStdin ? prompt : undefined,
     maxBuffer: MAX_BUFFER,
@@ -464,7 +470,7 @@ export async function runGeminiReview(cwd, options = {}) {
       timeoutMs: spawnTimeoutMs,
       useStdin,
     });
-    const fbResult = runCommand(engineInfo.binary, fbArgs, { cwd, input: useStdin ? prompt : undefined, maxBuffer: MAX_BUFFER, timeout: spawnTimeoutMs });
+    const fbResult = runCommandFn(engineInfo.binary, fbArgs, { cwd, input: useStdin ? prompt : undefined, maxBuffer: MAX_BUFFER, timeout: spawnTimeoutMs });
     rawStdout = stripAnsi(fbResult.stdout ?? "");
     rawStderr = stripAnsi(fbResult.stderr ?? "");
     exitCode = fbResult.status ?? (fbResult.error ? 1 : 0);

--- a/tests/agy-envelope.test.mjs
+++ b/tests/agy-envelope.test.mjs
@@ -1,0 +1,170 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { runGeminiReview, runGeminiTurn } from "../plugins/gemini/scripts/lib/gemini.mjs";
+
+// AGY's stdout envelope, captured verbatim from a live `agy --output-format json`
+// run on 1.1.10. Keep these shapes tied to real output — an injected fake is only
+// as good as the sample it was built from.
+const SUCCESS_ENVELOPE = {
+  conversation_id: "8cd8584a-fd2a-4229-8dff-61aecdaaead1",
+  status: "SUCCESS",
+  response: "17 × 23 = 391\n",
+  duration_seconds: 3.3086563,
+  num_turns: 1,
+  usage: { input_tokens: 22872, output_tokens: 180, thinking_tokens: 165, cache_read_tokens: 0, total_tokens: 23052 }
+};
+
+const ERROR_ENVELOPE = {
+  conversation_id: "",
+  status: "ERROR",
+  response: "",
+  error: 'invalid model selection (--model "definitely-not-a-real-model" --effort ""): model definitely-not-a-real-model is not recognized as a known model or custom model in settings',
+  duration_seconds: 0,
+  num_turns: 0,
+  usage: { input_tokens: 0, output_tokens: 0, thinking_tokens: 0, cache_read_tokens: 0, total_tokens: 0 }
+};
+
+function agyEngine(version = "1.1.10") {
+  return () => ({ engine: "agy", binary: "/fake/agy.exe", version });
+}
+
+// Records the argv it was handed so a test can assert on the constructed command
+// without spawning anything.
+function stubRun({ stdout = "", stderr = "", status = 0 } = {}) {
+  const calls = [];
+  const fn = (binary, args, opts) => {
+    calls.push({ binary, args, opts });
+    return { stdout, stderr, status };
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+test("AGY 1.1.10 turn takes response and conversation id from the envelope", async () => {
+  const runCommandFn = stubRun({ stdout: `${JSON.stringify(SUCCESS_ENVELOPE)}\n` });
+
+  const result = await runGeminiTurn("/repo", { prompt: "hi", write: false }, {
+    runCommandFn,
+    detectEngineFn: agyEngine()
+  });
+
+  assert.equal(result.status, 0);
+  assert.equal(result.finalMessage, "17 × 23 = 391");
+  assert.equal(result.threadId, "8cd8584a-fd2a-4229-8dff-61aecdaaead1");
+  assert.equal(result.failure ?? null, null);
+
+  const [call] = runCommandFn.calls;
+  assert.deepEqual(
+    call.args.slice(call.args.indexOf("--output-format"), call.args.indexOf("--output-format") + 2),
+    ["--output-format", "json"]
+  );
+});
+
+test("AGY 1.1.10 turn classifies an ERROR envelope from its error string", async () => {
+  const runCommandFn = stubRun({ stdout: `${JSON.stringify(ERROR_ENVELOPE)}\n`, status: 1 });
+
+  const result = await runGeminiTurn("/repo", { prompt: "hi", write: false }, {
+    runCommandFn,
+    detectEngineFn: agyEngine()
+  });
+
+  assert.notEqual(result.status, 0);
+  // The envelope's `error` reaches the classifier; AGY leaves stderr empty here.
+  assert.equal(result.failure.category, "model-unavailable");
+  assert.equal(result.failure.retryable, false);
+});
+
+// Review finding on #30: conversation_id identifies the conversation, not the
+// envelope, and may be absent entirely.
+test("AGY 1.1.10 turn accepts an ERROR envelope that omits conversation_id", async () => {
+  const runCommandFn = stubRun({
+    stdout: JSON.stringify({ status: "ERROR", error: "model bogus is not recognized as a known model" }),
+    status: 1
+  });
+
+  const result = await runGeminiTurn("/repo", { prompt: "hi", write: false }, {
+    runCommandFn,
+    detectEngineFn: agyEngine()
+  });
+
+  assert.equal(result.failure.category, "model-unavailable");
+  assert.equal(result.threadId ?? null, null);
+});
+
+// Only SUCCESS and ERROR have been observed; whether that vocabulary is closed is
+// an open question upstream (antigravity-cli#546), so an unknown status must be
+// treated as a failure rather than rejected as a malformed envelope.
+test("AGY 1.1.10 turn treats an unrecognized status as failure, not malformed output", async () => {
+  const runCommandFn = stubRun({
+    stdout: JSON.stringify({ conversation_id: "abc", status: "CANCELLED", response: "" }),
+    status: 1
+  });
+
+  const result = await runGeminiTurn("/repo", { prompt: "hi", write: false }, {
+    runCommandFn,
+    detectEngineFn: agyEngine()
+  });
+
+  assert.notEqual(result.status, 0);
+  assert.notEqual(result.failure.category, "invalid-json");
+});
+
+test("AGY 1.1.10 turn reports invalid-json when stdout is not an envelope", async () => {
+  const runCommandFn = stubRun({ stdout: "AGY printed prose instead of JSON\n", status: 0 });
+
+  const result = await runGeminiTurn("/repo", { prompt: "hi", write: false }, {
+    runCommandFn,
+    detectEngineFn: agyEngine()
+  });
+
+  assert.notEqual(result.status, 0);
+  assert.equal(result.failure.category, "invalid-json");
+});
+
+test("AGY 1.1.7 never requests the envelope", async () => {
+  const runCommandFn = stubRun({ stdout: "ignored\n" });
+
+  // Transcript recovery finds nothing here and reports a failure rather than
+  // throwing, so the run completes and the argv is all this test needs.
+  await runGeminiTurn("/repo", { prompt: "hi", write: false }, {
+    runCommandFn,
+    detectEngineFn: agyEngine("1.1.7")
+  });
+
+  const [call] = runCommandFn.calls;
+  assert.ok(!call.args.includes("--output-format"), "1.1.7 predates the JSON envelope");
+});
+
+// The review path does something the task path does not: it parses findings JSON
+// out of the envelope's `response`. That nesting — JSON inside the envelope's
+// string field — is where a naive "just parse stdout" would go wrong.
+test("AGY 1.1.10 review parses findings JSON out of the envelope response", async () => {
+  const findings = { verdict: "changes-requested", findings: [{ file: "src/app.js", line: 2, summary: "off-by-one" }] };
+  const runCommandFn = stubRun({
+    stdout: JSON.stringify({ ...SUCCESS_ENVELOPE, response: JSON.stringify(findings) })
+  });
+
+  const result = await runGeminiReview("/repo", { prompt: "review this" }, {
+    runCommandFn,
+    detectEngineFn: agyEngine()
+  });
+
+  assert.equal(result.status, 0);
+  assert.deepEqual(result.reviewJson, findings);
+  assert.equal(result.failure ?? null, null);
+});
+
+test("AGY 1.1.10 review reports invalid-json when the response is not findings JSON", async () => {
+  const runCommandFn = stubRun({
+    stdout: JSON.stringify({ ...SUCCESS_ENVELOPE, response: "I reviewed it and it looks fine to me." })
+  });
+
+  const result = await runGeminiReview("/repo", { prompt: "review this" }, {
+    runCommandFn,
+    detectEngineFn: agyEngine()
+  });
+
+  // The envelope parsed; its payload did not. Those are different failures.
+  assert.equal(result.failure.category, "invalid-json");
+});

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -764,73 +764,10 @@ test("AGY 1.1.10 task takes the response and conversation id from the stdout env
   assert.equal(capture.args[capture.args.indexOf("--output-format") + 1], "json");
 });
 
-test("AGY 1.1.10 task classifies an ERROR envelope and surfaces its error text", { skip: process.platform === "win32" }, () => {
-  const repo = makeTempDir();
-  const binDir = makeTempDir();
-  const capturePath = path.join(binDir, "agy-capture.json");
-  installCapturingAgyExecutable(binDir, { version: "1.1.10" });
-  initGitRepo(repo);
-  commit(repo, "README.md", "hello\n");
-
-  const envelope = {
-    conversation_id: "",
-    status: "ERROR",
-    response: "",
-    error: "invalid model selection (--model \"nope\"): model nope is not recognized",
-    duration_seconds: 0,
-    num_turns: 0,
-    usage: { input_tokens: 0, output_tokens: 0, thinking_tokens: 0, cache_read_tokens: 0, total_tokens: 0 }
-  };
-
-  const result = run("node", [SCRIPT, "task", "--engine", "agy", "do something"], {
-    cwd: repo,
-    env: {
-      ...buildFailingAgyEnv(binDir),
-      FAKE_AGY_CAPTURE: capturePath,
-      FAKE_AGY_RESPONSE: "AGY_TRANSCRIPT_MUST_NOT_WIN",
-      FAKE_AGY_STDOUT: `${JSON.stringify(envelope)}\n`,
-      FAKE_AGY_EXIT: "1"
-    }
-  });
-
-  assert.notEqual(result.status, 0);
-  assert.match(`${result.stdout}${result.stderr}`, /model nope is not recognized/);
-  assert.doesNotMatch(result.stdout, /AGY_TRANSCRIPT_MUST_NOT_WIN/);
-
-  const state = JSON.parse(fs.readFileSync(path.join(resolveStateDir(repo), "state.json"), "utf8"));
-  assert.equal(state.jobs[0].status, "failed");
-  // The envelope's `error` reaches the classifier, which recognizes the wording.
-  assert.equal(state.jobs[0].failure.category, "model-unavailable");
-});
-
-// Review finding on #30: conversation_id identifies the conversation, not the
-// envelope. An ERROR envelope without it must still classify on its `error`
-// rather than degrading to invalid-json.
-test("AGY 1.1.10 accepts an ERROR envelope that omits conversation_id", { skip: process.platform === "win32" }, () => {
-  const repo = makeTempDir();
-  const binDir = makeTempDir();
-  installCapturingAgyExecutable(binDir, { version: "1.1.10" });
-  initGitRepo(repo);
-  commit(repo, "README.md", "hello\n");
-
-  const envelope = { status: "ERROR", error: "model bogus is not recognized as a known model" };
-
-  const result = run("node", [SCRIPT, "task", "--engine", "agy", "do something"], {
-    cwd: repo,
-    env: {
-      ...buildFailingAgyEnv(binDir),
-      FAKE_AGY_CAPTURE: path.join(binDir, "agy-capture.json"),
-      FAKE_AGY_RESPONSE: "AGY_TRANSCRIPT_MUST_NOT_WIN",
-      FAKE_AGY_STDOUT: `${JSON.stringify(envelope)}\n`,
-      FAKE_AGY_EXIT: "1"
-    }
-  });
-
-  assert.notEqual(result.status, 0);
-  const state = JSON.parse(fs.readFileSync(path.join(resolveStateDir(repo), "state.json"), "utf8"));
-  assert.equal(state.jobs[0].failure.category, "model-unavailable");
-  assert.equal(state.jobs[0].threadId ?? null, null);
-});
+// Envelope classification itself lives in tests/agy-envelope.test.mjs, which
+// injects runCommand instead of spawning and therefore runs on every platform.
+// What stays here is the wiring those unit tests cannot see: real argv reaching
+// a real process, and the transcript actually being read on older AGY.
 
 test("AGY 1.1.7 keeps transcript recovery and never asks for the envelope", { skip: process.platform === "win32" }, () => {
   const repo = makeTempDir();


### PR DESCRIPTION
Follow-up to #30. The envelope tests it added could only run on POSIX, and CI caught two mistakes in them that a local run would have caught in under a second.

## Why they could not run locally

`resolveAgyExecutablePath` requires an absolute `.exe` on Windows — that is the CVE-2024-27980 defense, and a `.cmd` shim is refused on purpose. So the AGY stand-in is a copied `node.exe`, which answers `--version` with Node's version and cannot report a chosen AGY version. Every option for fixing that is either impractical (Node SEA: postject plus a ~110MB binary per build; compiling a stub: no compiler guaranteed) or unsafe (relaxing the `.exe` rule behind a flag).

The binary was never the real problem. Envelope parsing, version gating, fallback selection and failure classification are pure logic; they only needed a spawned process because there was no seam.

| | |
|---|---|
| `runtime.test.mjs` (spawn-driven) | **152.8 s** |
| `engine.test.mjs` (pure logic) | **0.2 s** |
| new `agy-envelope.test.mjs`, 8 cases | **0.23 s**, every platform |

## Change

`runGeminiTurn` and `runGeminiReview` take an optional third argument `{ runCommandFn, detectEngineFn }` — the same shape `dispatchBackgroundTask(request, { spawnFn, detectEngineFn })` already uses, so this is the house pattern rather than a new one. Both default to the real implementations; nothing changes at runtime.

Envelope handling moves to `tests/agy-envelope.test.mjs`. Windows skips drop from 7 to 5.

**Two spawn tests stay** — deliberately. Injection cannot see real argv reaching a real process, nor prove the transcript is genuinely read on AGY 1.1.7. Those are the wiring and the compatibility promise, and they still cost a spawn.

Envelope samples in the unit tests are captured verbatim from live 1.1.10 output. An injected fake is only as good as the sample behind it, which is the one real risk this trade introduces.

## Coverage that did not exist before

- An unrecognized `status` must be treated as failure, **not** rejected as a malformed envelope. Only `SUCCESS` and `ERROR` have been observed and whether that vocabulary is closed is an open question upstream (antigravity-cli#546), so rejecting unknowns would turn a future AGY status into `invalid-json`.
- Non-envelope stdout reports `invalid-json` rather than silently falling back to the transcript.
- The review path parses findings JSON out of the envelope's `response` string — JSON nested inside a JSON field, which is exactly where a naive "parse stdout" would go wrong.

## Verification

- `npm test` — 275 tests, **270 pass / 5 skipped / 0 fail** on Windows (was 7 skipped)
- `npm run check-version`, `npm run verify-contracts` — pass at v0.11.1
- CI runs the full set with 0 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H3Qwqu1oihfC2s48Hzj9Wm
