### PR TITLE
docs: record what the model-map re-verification could and could not establish

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,9 @@ Compared with AGY-only, multi-host plugins, this project keeps the Gemini CLI pa
 
 **Install AGY** (required for `--engine agy`): `curl -fsSL https://antigravity.google/cli/install.sh | bash`
 
-**Authentication**: Each engine authenticates independently. Run `gemini` once for the Gemini engine, or run `agy` once interactively for the AGY engine. AGY 1.1.10+ also supports Application Default Credentials (ADC) and Gemini Enterprise / Workforce Identity Federation (WIF). AGY OAuth authentication cannot be verified reliably from a headless setup probe, so `/gemini:setup --engine agy` reports it as unknown until a real AGY command succeeds. No API key is required.
+**Authentication**: Each engine authenticates independently. Run `gemini` once for the Gemini engine, or run `agy` once interactively for the AGY engine. AGY 1.1.10+ also supports Application Default Credentials (ADC) and Gemini Enterprise / Workforce Identity Federation (WIF). AGY OAuth authentication cannot be verified reliably from a headless setup probe, so `/gemini:setup --engine agy` reports it as unknown until a real AGY command succeeds.
+
+> **The Gemini engine now needs a Standard/Enterprise account or an API key.** Google ended consumer Gemini CLI access on 2026-06-18. On a personal account, gemini CLI 0.52.0 still installs and answers `--version`, but every request returns `API key not valid` (`API_KEY_INVALID`) — verified 2026-08-04. The AGY engine is unaffected and is the practical default; pass `--engine agy`, or set `GEMINI_ENGINE=agy`, if `auto` selects an unauthenticated gemini binary.
 
 > **Heads-up (reality check):**
 > - **2026-06-18 consumer transition**: Google announced that free/personal, Google AI Pro, and Google AI Ultra Gemini CLI requests stop being served after this date; Standard/Enterprise access remains. See Google's [Gemini CLI to Antigravity CLI announcement](https://developers.googleblog.com/an-important-update-transitioning-gemini-cli-to-antigravity-cli/).

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -57,7 +57,9 @@
 
 **安裝 AGY**（使用 `--engine agy` 時必須安裝）：`curl -fsSL https://antigravity.google/cli/install.sh | bash`
 
-**認證**：兩個引擎各自認證。Gemini 引擎請執行一次 `gemini`；AGY 引擎請互動式執行一次 `agy`。AGY 1.1.10+ 亦支援 Application Default Credentials (ADC) 與 Gemini Enterprise / Workforce Identity Federation (WIF)。Headless setup probe 無法可靠驗證 AGY 認證，因此 `/gemini:setup --engine agy` 會將其標為 unknown，直到真實 AGY 命令成功。不需要 API 金鑰。
+**認證**：兩個引擎各自認證。Gemini 引擎請執行一次 `gemini`；AGY 引擎請互動式執行一次 `agy`。AGY 1.1.10+ 亦支援 Application Default Credentials (ADC) 與 Gemini Enterprise / Workforce Identity Federation (WIF)。Headless setup probe 無法可靠驗證 AGY 認證，因此 `/gemini:setup --engine agy` 會將其標為 unknown，直到真實 AGY 命令成功。
+
+> **Gemini 引擎現在需要 Standard／Enterprise 帳戶或 API 金鑰。** Google 已於 2026-06-18 終止消費級 Gemini CLI 存取。個人帳戶下 gemini CLI 0.52.0 仍可安裝、`--version` 也正常，但所有請求都回 `API key not valid`（`API_KEY_INVALID`）——2026-08-04 實測。AGY 引擎不受影響，實務上就是預設引擎；若 `auto` 選到未認證的 gemini binary，請改用 `--engine agy` 或設定 `GEMINI_ENGINE=agy`。
 
 > **重要提示（貼近現實）：**
 > - **2026-06-18 consumer transition**：Google 宣布免費／個人版、Google AI Pro、Google AI Ultra 的 Gemini CLI requests 於此日期後停止服務；Standard/Enterprise access 維持。詳見 Google 的 [Gemini CLI to Antigravity CLI announcement](https://developers.googleblog.com/an-important-update-transitioning-gemini-cli-to-antigravity-cli/)。

--- a/plugins/gemini/scripts/lib/model-map.mjs
+++ b/plugins/gemini/scripts/lib/model-map.mjs
@@ -8,10 +8,18 @@
 //
 //   lastVerified: model IDs last checked against gemini CLI 0.44.1 on 2026-06-02.
 //   source:       gemini CLI model listing / Google Gemini API model names.
+//
+// Re-verification attempted 2026-08-04 against gemini CLI 0.52.0 and could not
+// advance the date. Google ended consumer Gemini CLI access on 2026-06-18, so a
+// personal account now answers every model probe with `API key not valid`
+// (API_KEY_INVALID) rather than a model-validity signal. Re-verifying these ids
+// requires a Standard/Enterprise account or an API key; until then the 2026-06
+// date stands and preview ids should be assumed drifted.
 export const MODEL_MAP_METADATA = {
   lastVerified: "2026-06",
   source: "gemini CLI 0.44.1 live model probe on 2026-06-02 / Google Gemini API model names",
-  note: "Preview model IDs (…-preview) may change; override with --model <id>. The 2026-06-02 probe returned 404 for gemini-3.5-flash/-pro on gemini CLI 0.44.1, but newer CLI releases may differ. Unknown/unavailable model ids degrade gracefully to the GA fallback at runtime."
+  reverifyBlockedSince: "2026-06-18",
+  note: "Preview model IDs (…-preview) may change; override with --model <id>. The 2026-06-02 probe returned 404 for gemini-3.5-flash/-pro on gemini CLI 0.44.1. Re-verification on 2026-08-04 (gemini CLI 0.52.0) was blocked: consumer access ended 2026-06-18 and probes return API_KEY_INVALID, so these ids are unverified rather than confirmed. Unknown/unavailable model ids degrade gracefully to the GA fallback at runtime."
 };
 
 // Ordered alias entries. `preview: true` marks IDs that can change.
@@ -30,11 +38,15 @@ export const MODEL_ALIAS_ENTRIES = [
 export const MODEL_ALIASES = new Map(MODEL_ALIAS_ENTRIES.map((entry) => [entry.alias, entry.model]));
 
 // Reasoning-effort tier -> resolved model, used when --effort is supplied
-// without an explicit --model. These apply to the GEMINI engine only. The AGY
-// CLI has its own model surface in newer versions, but this plugin does not
-// translate Gemini aliases / effort tiers to AGY arguments yet, so plugin-managed
-// model selection remains a gemini-engine feature.
-// See lib/gemini.mjs (the agy branch nulls model and emits a note).
+// without an explicit --model. These apply to the GEMINI engine only.
+//
+// AGY has its own model surface and takes exact ids from `agy models`; the two
+// namespaces do not overlap, which is why normalizeAgyRequestedModel rejects
+// Gemini aliases outright. Verified live on AGY 1.1.10, 2026-08-04 — `agy models`
+// returned gemini-3.6-flash-{high,medium,low}, gemini-3.5-flash-{high,medium,low},
+// gemini-3.1-pro-{high,low}, claude-sonnet-4-6, claude-opus-4-6-thinking and
+// gpt-oss-120b-medium, none of which is a valid id here. AGY 1.1.10+ also accepts
+// native --effort low|medium|high; see supportsAgyModelSelection in engine.mjs.
 export const EFFORT_MODEL_MAP = new Map([
   ["none", "gemini-2.5-flash-lite"],
   ["minimal", "gemini-2.5-flash-lite"],


### PR DESCRIPTION
Follow-up to the v0.11.1 parity audit, which named `model-map`'s `lastVerified: "2026-06"` as the oldest unexamined claim in the codebase.

**The date could not be advanced, and that is the finding.** Google ended consumer Gemini CLI access on 2026-06-18. gemini CLI 0.52.0 still installs and answers `--version`, but every model probe returns:

```
API key not valid. Please pass a valid API key. (API_KEY_INVALID)
```

That is an auth signal, not a model-validity signal, so the preview ids are **unverified rather than confirmed**. Recorded as such — refreshing the date on an unsuccessful probe would have been worse than leaving it stale.

**The AGY half did verify.** `agy models` on 1.1.10 returns `gemini-3.6-flash-{high,medium,low}`, `gemini-3.5-flash-{high,medium,low}`, `gemini-3.1-pro-{high,low}`, `claude-sonnet-4-6`, `claude-opus-4-6-thinking`, `gpt-oss-120b-medium`. No overlap with the Gemini alias namespace, which is precisely why `normalizeAgyRequestedModel` rejects aliases outright. Captured in the comment so the next reader does not re-derive it.

README (EN + zh-TW): "No API key is required" no longer holds for the Gemini engine on a personal account, and now says so with the verification date.

## Surfaced, not fixed here

`detectEngine("auto")` on this machine selects **gemini 0.52.0** — the unauthenticated engine — while a working AGY sits next to it, so every `auto` command fails on auth. The comment justifying that order (`engine.mjs:155-158`) says AGY "responses and conversation ids still depend on transcript recovery", which stopped being true in v0.11.0.

Left out deliberately: changing default engine selection affects every user and deserves its own decision, not a ride-along in a docs PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H3Qwqu1oihfC2s48Hzj9Wm
