### PR TITLE
fix(engine): require a credential before auto-routing to gemini (v0.12.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,13 +6,13 @@
   },
   "metadata": {
     "description": "Use Gemini CLI or Antigravity CLI (agy) inside Claude Code for task delegation, code review, and adversarial review.",
-    "version": "0.11.1"
+    "version": "0.12.0"
   },
   "plugins": [
     {
       "name": "gemini",
       "description": "Gemini CLI and Antigravity CLI bridge for Claude Code task delegation and adversarial review",
-      "version": "0.11.1",
+      "version": "0.12.0",
       "author": {
         "name": "arcobaleno64"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@arcobaleno64/gemini-plugin-cc",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@arcobaleno64/gemini-plugin-cc",
-      "version": "0.11.1",
+      "version": "0.12.0",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arcobaleno64/gemini-plugin-cc",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "private": true,
   "type": "module",
   "description": "Use Gemini CLI or Antigravity CLI (agy) inside Claude Code for task delegation, code review, and adversarial review.",

--- a/plugins/gemini/.claude-plugin/plugin.json
+++ b/plugins/gemini/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gemini",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "description": "Use Gemini/AGY from Claude Code to review code or delegate tasks.",
   "author": {
     "name": "arcobaleno64",

--- a/plugins/gemini/CHANGELOG.md
+++ b/plugins/gemini/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.12.0 — 2026-08-04 — Auto-routing checks credentials, not just presence
+
+### Fixed
+- **`auto` no longer selects an installed-but-unauthenticated Gemini CLI.** It picked gemini on `--version` success alone, so on any machine whose Gemini access has lapsed — the norm since Google ended consumer CLI access on 2026-06-18 — every `auto` command failed on auth while a working AGY sat beside it. Auto now requires the same "installed AND authenticated" condition `/gemini:setup` already reports as `geminiReady`. An explicit `--engine gemini` is unchanged: the check is a routing heuristic, not an authorization gate.
+- **`auto` distinguishes "no engine installed" from "gemini installed but unauthenticated"**, because the fix differs and the second case previously surfaced as a confusing downstream API error.
+
+### Changed
+- The comment justifying gemini-first routing claimed AGY "responses and conversation ids still depend on transcript recovery". That stopped being true in v0.11.0; the rationale is now stated accurately — gemini's remaining edge is its model aliases and effort-to-model mapping, neither of which applies to an unqualified `auto`.
+- `getGeminiLoginStatus` and `getGeminiPlanTier` moved to `lib/gemini-auth.mjs` so `engine.mjs` can consult credentials without an import cycle. Both are re-exported from `lib/gemini.mjs` under their existing names.
+- `GEMINI_API_KEY` / `GOOGLE_API_KEY` now count as a credential for routing purposes; an API-key user has no `oauth_creds.json` and must not be read as unauthenticated.
+
+### Added
+- Auto-routing had **no test coverage at all** — which is why this defect shipped. `detectEngine` accepts `binaryAvailableImpl` and `hasGeminiCredentialsImpl` (matching the existing `resolveBinaryPathImpl` seam), and five tests now pin every branch of the decision.
+
 ## 0.11.1 — 2026-08-04 — Testable engine-response path
 
 ### Changed

--- a/plugins/gemini/scripts/lib/engine.mjs
+++ b/plugins/gemini/scripts/lib/engine.mjs
@@ -5,6 +5,7 @@ import { createFailureError } from "./failures.mjs";
 import { binaryAvailable, resolveBinaryPath } from "./process.mjs";
 import { EFFORT_MODEL_MAP, MODEL_ALIASES, VALID_EFFORT_LEVELS } from "./model-map.mjs";
 import { resolveAgyBrainRoot } from "./agy-transcript.mjs";
+import { hasGeminiCredentials } from "./gemini-auth.mjs";
 
 export const ENGINE_ENV = "GEMINI_ENGINE";
 export const AGY_POSITIONAL_PROMPT_SAFE_LIMIT = 24_000;
@@ -122,6 +123,10 @@ export function supportsAgyStructuredOutput(version) {
 }
 
 export function detectEngine(requestedEngine = null, options = {}) {
+  const {
+    hasGeminiCredentialsImpl: hasGeminiCredentialsFn = hasGeminiCredentials,
+    binaryAvailableImpl: binaryAvailableFn = binaryAvailable
+  } = options;
   const envEngine = process.env[ENGINE_ENV];
   const target = requestedEngine ?? envEngine ?? "auto";
   const normalized = String(target).trim().toLowerCase();
@@ -132,7 +137,7 @@ export function detectEngine(requestedEngine = null, options = {}) {
 
   if (normalized === "agy") {
     const binary = resolveAgyExecutablePath(options);
-    const status = binaryAvailable(binary, ["--version"]);
+    const status = binaryAvailableFn(binary, ["--version"]);
     if (!status.available) throw new Error("AGY engine requested but agy binary is not available.");
     const version = status.detail ?? "unknown";
     // Below 1.1.8 the on-disk transcript is the only source for the response,
@@ -147,26 +152,45 @@ export function detectEngine(requestedEngine = null, options = {}) {
   }
 
   if (normalized === "gemini") {
-    const status = binaryAvailable("gemini", ["--version"]);
+    const status = binaryAvailableFn("gemini", ["--version"]);
     if (!status.available) throw new Error("Gemini engine requested but gemini binary is not available.");
     return { engine: "gemini", binary: "gemini", version: status.detail ?? "unknown" };
   }
 
-  // auto: choose gemini first because it has the plugin's JSON/model contract,
-  // then choose the equally supported AGY engine. This is capability-based
-  // routing order, not a lower support tier; AGY responses and conversation ids
-  // still depend on transcript recovery in this adapter.
-  const geminiStatus = binaryAvailable("gemini", ["--version"]);
-  if (geminiStatus.available) {
+  // auto: prefer gemini when it is installed AND has a usable credential — the
+  // same "ready" notion `/gemini:setup` reports. An installed-but-unauthenticated
+  // gemini answers `--version` and then rejects every request, so selecting it on
+  // binary presence alone sent users to a guaranteed auth failure while a working
+  // AGY sat beside it (common since consumer access ended 2026-06-18).
+  //
+  // AGY is not a lower tier. Since plugin v0.11.0 it carries the same structured
+  // JSON contract, so gemini's remaining edge is only its model aliases and
+  // effort-to-model mapping, neither of which applies to an unqualified `auto`.
+  const geminiStatus = binaryAvailableFn("gemini", ["--version"]);
+  const geminiUsable = geminiStatus.available && hasGeminiCredentialsFn();
+  if (geminiUsable) {
     return { engine: "gemini", binary: "gemini", version: geminiStatus.detail ?? "unknown" };
   }
 
-  const agyBinary = resolveAgyExecutablePath(options);
-  const agyStatus = binaryAvailable(agyBinary, ["--version"]);
+  let agyBinary = null;
+  try {
+    agyBinary = resolveAgyExecutablePath(options);
+  } catch {
+    agyBinary = null;
+  }
+  const agyStatus = agyBinary ? binaryAvailableFn(agyBinary, ["--version"]) : { available: false };
   if (agyStatus.available) {
     return { engine: "agy", binary: agyBinary, version: agyStatus.detail ?? "unknown" };
   }
 
+  // Nothing usable. Distinguish "no engine installed" from "gemini installed but
+  // unauthenticated", because the fix differs and the second case used to be
+  // reported as a confusing downstream API error.
+  if (geminiStatus.available) {
+    throw new Error(
+      "Gemini CLI is installed but has no usable credential, and no AGY binary was found. Run `gemini` to authenticate, set GEMINI_API_KEY, or install AGY. See `/gemini:setup`."
+    );
+  }
   throw new Error("No Gemini or AGY engine found. Install either supported engine and retry.");
 }
 

--- a/plugins/gemini/scripts/lib/gemini-auth.mjs
+++ b/plugins/gemini/scripts/lib/gemini-auth.mjs
@@ -1,0 +1,60 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
+
+// Gemini credential inspection, kept in its own module so engine.mjs can consult
+// it without importing gemini.mjs (which imports engine.mjs). gemini.mjs
+// re-exports these for existing callers.
+
+function geminiHomeDir() {
+  return process.env.GEMINI_HOME ?? path.join(os.homedir(), ".gemini");
+}
+
+export function getGeminiLoginStatus() {
+  const credFile = path.join(geminiHomeDir(), "oauth_creds.json");
+  if (!fs.existsSync(credFile)) {
+    return { loggedIn: false, detail: `No credentials at ${credFile}. Run \`gemini\` to authenticate.` };
+  }
+  try {
+    const creds = JSON.parse(fs.readFileSync(credFile, "utf8"));
+    const expiry = creds?.expiry_date ?? creds?.expiry ?? creds?.token?.expiry_date;
+    if (expiry && Date.now() > Number(expiry)) {
+      return { loggedIn: false, detail: `OAuth token expired at ${new Date(Number(expiry)).toISOString()}. Run \`gemini\` to re-authenticate.` };
+    }
+  } catch {
+    return { loggedIn: false, detail: `Cannot read credentials at ${credFile}. Run \`gemini\` to authenticate.` };
+  }
+  return { loggedIn: true, detail: `OAuth credentials found at ${credFile}` };
+}
+
+// Personal (free) Gemini plans lose CLI access on 2026-06-18; Gemini Code Assist
+// Standard/Enterprise do not. The selected auth type is recorded in
+// ~/.gemini/settings.json as security.auth.selectedType (e.g. "oauth-personal").
+export function getGeminiPlanTier() {
+  const settingsFile = path.join(geminiHomeDir(), "settings.json");
+  try {
+    const settings = JSON.parse(fs.readFileSync(settingsFile, "utf8"));
+    const selectedType = settings?.security?.auth?.selectedType ?? null;
+    if (typeof selectedType === "string") {
+      return { tier: /personal/i.test(selectedType) ? "personal" : "other", selectedType };
+    }
+  } catch {
+    // fall through to unknown
+  }
+  return { tier: "unknown", selectedType: null };
+}
+
+// Whether the gemini CLI has any credential it could actually use. An API key
+// bypasses the OAuth file entirely, so check it first — an API-key user has no
+// oauth_creds.json and must not be treated as unauthenticated.
+//
+// This is the same notion `/gemini:setup` calls `geminiReady`: installed AND
+// authenticated. Auto-routing consults it so it cannot select a gemini binary
+// that answers `--version` but rejects every request.
+export function hasGeminiCredentials() {
+  if (String(process.env.GEMINI_API_KEY ?? "").trim() || String(process.env.GOOGLE_API_KEY ?? "").trim()) {
+    return true;
+  }
+  return getGeminiLoginStatus().loggedIn;
+}

--- a/plugins/gemini/scripts/lib/gemini.mjs
+++ b/plugins/gemini/scripts/lib/gemini.mjs
@@ -633,41 +633,9 @@ export function getAgyAvailability() {
   return binaryAvailable("agy", ["--version"]);
 }
 
-export function getGeminiLoginStatus() {
-  const geminiHome = process.env.GEMINI_HOME ?? path.join(os.homedir(), ".gemini");
-  const credFile = path.join(geminiHome, "oauth_creds.json");
-  if (!fs.existsSync(credFile)) {
-    return { loggedIn: false, detail: `No credentials at ${credFile}. Run \`gemini\` to authenticate.` };
-  }
-  try {
-    const creds = JSON.parse(fs.readFileSync(credFile, "utf8"));
-    const expiry = creds?.expiry_date ?? creds?.expiry ?? creds?.token?.expiry_date;
-    if (expiry && Date.now() > Number(expiry)) {
-      return { loggedIn: false, detail: `OAuth token expired at ${new Date(Number(expiry)).toISOString()}. Run \`gemini\` to re-authenticate.` };
-    }
-  } catch {
-    return { loggedIn: false, detail: `Cannot read credentials at ${credFile}. Run \`gemini\` to authenticate.` };
-  }
-  return { loggedIn: true, detail: `OAuth credentials found at ${credFile}` };
-}
-
-// Personal (free) Gemini plans lose CLI access on 2026-06-18; Gemini Code Assist
-// Standard/Enterprise do not. The selected auth type is recorded in
-// ~/.gemini/settings.json as security.auth.selectedType (e.g. "oauth-personal").
-export function getGeminiPlanTier() {
-  const geminiHome = process.env.GEMINI_HOME ?? path.join(os.homedir(), ".gemini");
-  const settingsFile = path.join(geminiHome, "settings.json");
-  try {
-    const settings = JSON.parse(fs.readFileSync(settingsFile, "utf8"));
-    const selectedType = settings?.security?.auth?.selectedType ?? null;
-    if (typeof selectedType === "string") {
-      return { tier: /personal/i.test(selectedType) ? "personal" : "other", selectedType };
-    }
-  } catch {
-    // no settings.json / unreadable — tier unknown
-  }
-  return { tier: "unknown", selectedType: null };
-}
+// Moved to lib/gemini-auth.mjs so engine.mjs can consult credentials without an
+// import cycle. Re-exported here because these are the existing public names.
+export { getGeminiLoginStatus, getGeminiPlanTier } from "./gemini-auth.mjs";
 
 export function getAgyLoginStatus() {
   const status = binaryAvailable("agy", ["--version"]);

--- a/tests/engine.test.mjs
+++ b/tests/engine.test.mjs
@@ -222,3 +222,68 @@ test("agy read-only turn adds neither --dangerously-skip-permissions nor --new-p
   assert.ok(!args.includes("--dangerously-skip-permissions"));
   assert.ok(!args.includes("--new-project"));
 });
+
+// --- auto routing ---
+// Previously untested. `auto` selected gemini on binary presence alone, so an
+// installed-but-unauthenticated gemini (the norm since consumer access ended
+// 2026-06-18) routed every command into a guaranteed auth failure while a
+// working AGY sat beside it.
+
+const AVAILABLE = { available: true, detail: "1.0.0" };
+const MISSING = { available: false };
+
+function stubBinaries({ gemini = MISSING, agy = MISSING } = {}) {
+  return (binary) => (String(binary).includes("gemini") ? gemini : agy);
+}
+
+test("auto prefers gemini when it is installed and has a credential", () => {
+  const info = detectEngine("auto", {
+    binaryAvailableImpl: stubBinaries({ gemini: { available: true, detail: "0.52.0" }, agy: AVAILABLE }),
+    hasGeminiCredentialsImpl: () => true,
+    resolveBinaryPathImpl: () => "/fake/agy.exe"
+  });
+  assert.equal(info.engine, "gemini");
+  assert.equal(info.version, "0.52.0");
+});
+
+test("auto falls through to AGY when gemini is installed but unauthenticated", () => {
+  const info = detectEngine("auto", {
+    binaryAvailableImpl: stubBinaries({ gemini: AVAILABLE, agy: { available: true, detail: "1.1.10" } }),
+    hasGeminiCredentialsImpl: () => false,
+    resolveBinaryPathImpl: () => "/fake/agy.exe"
+  });
+  assert.equal(info.engine, "agy");
+  assert.equal(info.version, "1.1.10");
+});
+
+test("auto reports the credential problem when gemini is the only engine present", () => {
+  assert.throws(
+    () => detectEngine("auto", {
+      binaryAvailableImpl: stubBinaries({ gemini: AVAILABLE, agy: MISSING }),
+      hasGeminiCredentialsImpl: () => false,
+      resolveBinaryPathImpl: () => "/fake/agy.exe"
+    }),
+    /installed but has no usable credential/
+  );
+});
+
+test("auto keeps the plain not-installed message when neither engine is present", () => {
+  assert.throws(
+    () => detectEngine("auto", {
+      binaryAvailableImpl: stubBinaries({}),
+      hasGeminiCredentialsImpl: () => false,
+      resolveBinaryPathImpl: () => "/fake/agy.exe"
+    }),
+    /No Gemini or AGY engine found/
+  );
+});
+
+// An explicit --engine gemini must still work: the user asked for it, and the
+// credential check is an auto-routing heuristic, not an authorization gate.
+test("explicit gemini selection ignores the credential check", () => {
+  const info = detectEngine("gemini", {
+    binaryAvailableImpl: stubBinaries({ gemini: AVAILABLE }),
+    hasGeminiCredentialsImpl: () => false
+  });
+  assert.equal(info.engine, "gemini");
+});

--- a/tests/plan-tier.test.mjs
+++ b/tests/plan-tier.test.mjs
@@ -5,6 +5,7 @@ import os from "node:os";
 import path from "node:path";
 
 import { getGeminiPlanTier } from "../plugins/gemini/scripts/lib/gemini.mjs";
+import { hasGeminiCredentials } from "../plugins/gemini/scripts/lib/gemini-auth.mjs";
 
 // getGeminiPlanTier reads $GEMINI_HOME/settings.json. Point it at a temp dir,
 // write a settings file, assert, and always restore the env afterwards.
@@ -67,4 +68,28 @@ test("settings.json without an auth type yields tier 'unknown'", () => {
   withGeminiHome(JSON.stringify({ security: {} }), () => {
     assert.equal(getGeminiPlanTier().tier, "unknown");
   });
+});
+
+// hasGeminiCredentials backs the auto-routing decision. An API key bypasses the
+// OAuth file entirely, so an API-key user must not be read as unauthenticated.
+test("hasGeminiCredentials treats an API key as a credential", (t) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "gemini-auth-"));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+  const prevHome = process.env.GEMINI_HOME;
+  const prevKey = process.env.GEMINI_API_KEY;
+  process.env.GEMINI_HOME = dir; // no oauth_creds.json here
+  t.after(() => {
+    if (prevHome === undefined) delete process.env.GEMINI_HOME; else process.env.GEMINI_HOME = prevHome;
+    if (prevKey === undefined) delete process.env.GEMINI_API_KEY; else process.env.GEMINI_API_KEY = prevKey;
+  });
+
+  delete process.env.GEMINI_API_KEY;
+  assert.equal(hasGeminiCredentials(), false);
+
+  process.env.GEMINI_API_KEY = "  ";
+  assert.equal(hasGeminiCredentials(), false, "whitespace is not a credential");
+
+  process.env.GEMINI_API_KEY = "AIza-test-key";
+  assert.equal(hasGeminiCredentials(), true);
 });


### PR DESCRIPTION
Surfaced in #33 while re-verifying `model-map`, fixed here.

## The defect

`detectEngine("auto")` selected gemini whenever the binary answered `--version`. Since Google ended consumer Gemini CLI access on 2026-06-18, that is routinely a binary which installs, reports `0.52.0`, and then rejects every request:

```
API key not valid. Please pass a valid API key. (API_KEY_INVALID)
```

Reproduced on this machine: `auto` chose gemini 0.52.0 with an OAuth token that had expired on 2026-07-28, while a working AGY 1.1.10 sat right beside it. Every `auto` command was routed into a guaranteed auth failure.

**The plugin already had the check.** `getGeminiLoginStatus()` correctly returned `loggedIn: false` here, and `/gemini:setup` already computes `geminiReady = available && loggedIn`. The router simply never consulted it — it was out of sync with the plugin's own definition of ready.

## The fix

Auto now requires installed **and** authenticated, the same notion setup reports. `--engine gemini` is unchanged — the check is a routing heuristic, not an authorization gate, and a user who explicitly asks for gemini gets gemini.

`GEMINI_API_KEY` / `GOOGLE_API_KEY` count as a credential: an API-key user has no `oauth_creds.json` and must not be read as unauthenticated.

Auto also now distinguishes "no engine installed" from "gemini installed but unauthenticated", since the fix differs and the second case used to surface as a confusing downstream API error.

## A stale comment removed

The justification for gemini-first read:

> AGY responses and conversation ids still depend on transcript recovery in this adapter.

That stopped being true in v0.11.0. The remaining honest edge for gemini is its model aliases and effort-to-model mapping — neither of which applies to an unqualified `auto`.

## Why this shipped

**Auto-routing had no test coverage at all.** The full suite passed both before and after the behavior change, which is not evidence of safety.

`detectEngine` now accepts `binaryAvailableImpl` and `hasGeminiCredentialsImpl`, matching the `resolveBinaryPathImpl` seam it already had, and five tests pin every branch: gemini-with-credential, gemini-without-credential-falls-to-AGY, gemini-only-unauthenticated error, neither-installed error, and explicit-gemini-ignores-the-check. A sixth covers `hasGeminiCredentials` treating an API key (but not whitespace) as a credential.

`getGeminiLoginStatus` / `getGeminiPlanTier` moved to `lib/gemini-auth.mjs` so `engine.mjs` can consult credentials without an import cycle; both are re-exported from `lib/gemini.mjs` under their existing names, so no caller changes.

## Verification

- `npm test` — 281 tests, **276 pass / 5 skipped / 0 fail**
- `npm run check-version`, `npm run verify-contracts` — pass at v0.12.0
- `detectEngine("auto")` on this machine now returns **agy 1.1.10** instead of the unauthenticated gemini

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H3Qwqu1oihfC2s48Hzj9Wm
