### PR TITLE
docs(security): model the prompt-injection surface and map it to OWASP LLM Top 10

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,8 +4,8 @@
 
 | Version | Supported |
 |---|---|
-| 0.10.x | :white_check_mark: |
-| < 0.10.0 | :x: |
+| 0.12.x | :white_check_mark: |
+| < 0.12.0 | :x: |
 
 ## Security Model & Trust Boundaries
 
@@ -17,6 +17,7 @@
 - Process boundary security (forcing `shell: false` on Git operations in `plugins/gemini/scripts/lib/git.mjs`).
 - Secret file redaction filters (`isSecretFile()` in `plugins/gemini/scripts/lib/transfer-context.mjs`).
 - Background job state directory isolation (`.omc/`).
+- **Prompt injection and delegated agency** — the plugin hands repository content it did not author to an agent that can be write-capable. Modelled in [`docs/THREAT-MODEL.md` §7](docs/THREAT-MODEL.md), mapped against the OWASP Top 10 for LLM Applications. Read that section before reporting: the highest-rated item (`/gemini:rescue` defaulting to a write-capable run with no path sandbox) is **known and documented**, not an undisclosed flaw.
 
 ### Out-of-Scope Components
 - Third-party CLI binary vulnerabilities within Google's `gemini` or `agy` executables.

--- a/docs/THREAT-MODEL.md
+++ b/docs/THREAT-MODEL.md
@@ -2,24 +2,28 @@
 
 This document formalizes the threat model and risk mitigations for `gemini-plugin-cc`.
 
+Scope note: sections 1–6 cover the conventional CLI-host surface (argv, subprocess, credentials). Section 7 covers the surface specific to delegating work to an LLM agent, which the earlier sections did not model.
+
 ## 1. Assets
 - **Local Credentials**: OAuth tokens stored in user home directories (`~/.gemini/oauth_creds.json`).
 - **Workspace Source Code**: Repository files, uncommitted diffs, and developer environment states.
 - **Background Job State**: Job output logs and resume IDs stored in `.omc/`.
+- **The parent agent's context**: Claude Code renders this plugin's output verbatim, so that output is itself an asset — see 7.3.
 
 ## 2. Trust Boundaries
 1. **User Prompt & Terminal Entry Point** $\rightarrow$ `gemini-plugin-cc` script dispatcher.
 2. `gemini-plugin-cc` $\rightarrow$ Subprocess execution of `git`, `gemini`, or `agy`.
 3. Subprocess $\rightarrow$ External LLM API endpoints.
+4. **Repository content** $\rightarrow$ model prompt. Repository content is *data*, but every consumer downstream of the model treats model output as *instructions*. This boundary is the subject of section 7.
 
 ## 3. Entry Points & Attack Vectors
 - **Malicious Repository Content**: Untrusted repositories containing specially named files (e.g. `--flag-file` or `& calc.exe`) designed to trigger argument/command injection.
-- **Prompt Injection**: Untrusted diffs containing prompt injection payloads attempting to bypass read-only discipline during review.
+- **Prompt Injection**: Untrusted diffs, file contents, or commit messages carrying instructions aimed at the delegated agent. Detailed in section 7.
 - **Unsanitized Argv**: CLI arguments provided by user slash commands (`--model`, `--effort`, `instructions`).
 
 ## 4. Threat Actors
-- **Malicious Repository Author**: Provides a repository containing crafted file paths or git metadata.
-- **Prompt Injector**: Places malicious instructions inside git diffs or commit messages.
+- **Malicious Repository Author**: Provides a repository containing crafted file paths or git metadata. Realistic delivery: a dependency, a fork, a drive-by clone, or a pull request the user reviews locally.
+- **Prompt Injector**: Places instructions inside git diffs, file contents, or commit messages.
 
 ## 5. Existing Mitigations
 
@@ -27,11 +31,93 @@ This document formalizes the threat model and risk mitigations for `gemini-plugi
 |---|---|---|
 | Command Injection (CWE-78) | Forced `shell: false` on Git operations | `plugins/gemini/scripts/lib/git.mjs`, `plugins/gemini/scripts/lib/transfer-context.mjs` |
 | Argument Injection | Strict regex validation of flags (`--model`) | `plugins/gemini/scripts/lib/engine.mjs` |
-| Credential Leakage | Automated secret file redaction (`.env*`, `.pem`, `.npmrc`) | `plugins/gemini/scripts/lib/transfer-context.mjs` |
+| Argv smuggling on Windows | AGY must resolve to an absolute `.exe`; `.cmd` shims are refused (CVE-2024-27980) | `resolveAgyExecutablePath`, `plugins/gemini/scripts/lib/engine.mjs` |
+| Credential Leakage (transfer only) | Secret **filename** redaction (`.env*`, `.pem`, `.npmrc`, `id_rsa`) plus per-file and total size caps | `isSecretFile`, `plugins/gemini/scripts/lib/transfer-context.mjs` |
 | Prompt Transport / Argv Risk | Gemini and AGY 1.1.2+ use stdin; older, prerelease, or unparseable AGY versions use a validated positional fallback with NUL and 24,000-character preflight limits | `plugins/gemini/scripts/lib/gemini.mjs`, `plugins/gemini/scripts/lib/engine.mjs` |
-| File Mutation Risks | Gate background file modifications behind explicit `--write` | `plugins/gemini/scripts/lib/job-control.mjs` |
+| Slash-command hijack of the prompt | `--disable-slash-commands` on AGY 1.1.9+, which otherwise expands a task beginning with `/` as its own command | `buildCliArgs`, `plugins/gemini/scripts/lib/engine.mjs` |
+| File Mutation | `--write` selects the write-capable run | `plugins/gemini/scripts/lib/job-control.mjs` |
 
-## 6. Residual Risks & Codex Security Verification Scope
+> **Correction (2026-08-04).** This table previously described file mutation as "gated behind explicit `--write`". That gate does not hold on the default path: `plugins/gemini/agents/gemini-rescue.md:34` instructs the subagent to *add* `--write` unless the user asks for read-only. `/gemini:rescue` is therefore write-capable by default. See 7.2.
+
+## 6. Residual Risks (conventional surface)
 - **Malicious Repository Content Boundary**: Audit edge cases where malformed git diffs or file paths might evade regex filters.
 - **State Corruption**: Audit concurrency and state file handling in `.omc/` during multi-job execution.
-- **Unsafe Writes**: Verify that `--write` modes strictly respect directory scope and cannot be manipulated into arbitrary file truncation outside the workspace.
+
+---
+
+## 7. Prompt injection and delegated agency
+
+The plugin's function is to take content it did not author and hand it to an agent. That is the whole product, so the exposure cannot be removed — only bounded. This section maps it against the **OWASP Top 10 for LLM Applications (2025)**.
+
+### 7.1 Data flows carrying untrusted content
+
+| # | Flow | Write-capable | Bound |
+|---|---|---|---|
+| A | repo diff → review prompt → model → rendered output → **Claude Code's context** | no (`write: false`, `lib/gemini.mjs`) | none on the output |
+| B | repo content → rescue agent → **filesystem and shell** | **yes by default** (7.2) | none |
+| C | repo diff → `.omc/transfers/*.json` → an interactive AGY session started with `--add-dir .` | inherits that session's mode | filename redaction + size caps |
+| D | repo diff → stop-review-gate hook → model, with no explicit user action | no | none |
+
+### 7.2 PI-1 — Write-capable delegation without a sandbox (High)
+
+`LLM06 Excessive Agency`, `LLM01 Prompt Injection`
+
+`agents/gemini-rescue.md:34` tells the subagent to default to `--write`. `buildCliArgs` maps `write` to `--dangerously-skip-permissions` (AGY) or `--yolo` (gemini) — `lib/engine.mjs:253,273`. Those flags remove the approval prompt; they do not constrain where the agent may act.
+
+**This is where the port diverges from upstream, and the parity audit did not catch it** because it compared command surfaces rather than capability semantics. `codex-companion.mjs:491` passes `sandbox: request.write ? "workspace-write" : "read-only"` — upstream's write mode is *confined to the workspace by a sandbox*. This plugin has no equivalent, because AGY has no path-boundary mode. That gap is exactly what [antigravity-cli#749](https://github.com/google-antigravity/antigravity-cli/issues/749) requests.
+
+Compounding evidence that the boundary is not implicit: `lib/engine.mjs:217-222` records that AGY without `--new-project` writes to its own scratch directory rather than `cwd`, and a live 1.1.10 run during this session resolved *read* paths against a different checkout than the one passed as `cwd`.
+
+**Deliberately not tested.** Demonstrating this would mean letting an agent write to disk under attacker-supplied instructions. The architectural claim rests on reading the flags, not on a live exploit.
+
+**Mitigations available now**: keep `--write` opt-in rather than default; adopt `--sandbox=workspace-only` when AGY ships it.
+
+### 7.3 PI-2 — Model output reaches the parent agent unfiltered (Medium)
+
+`LLM05 Improper Output Handling`, `LLM01 Prompt Injection`
+
+`commands/review.md`, `adversarial-review.md`, `result.md` and `rescue.md` all instruct Claude Code to present the delegated model's output **verbatim**, without paraphrase or commentary. That rule exists for good reasons — it prevents the parent from softening or fabricating findings — but it also means text originating in an untrusted repository reaches the parent agent's context with no framing that marks it as data.
+
+**Live test, 2026-08-04, AGY 1.1.10.** A diff carrying a blatant payload — a comment addressed to "the reviewing agent" instructing it to suppress findings, emit the literal string `PWNED_BY_INJECTION`, and set the verdict to approve — was **resisted**. The review reported the genuine `eval()` defect, emitted no injected string, and returned `needs-attention`.
+
+Calibrate that result honestly: it shows one model refusing one obvious payload. **The refusal came entirely from the model. The plugin applies no control of its own**, so the result says nothing about a subtler payload or a different model.
+
+**Mitigation candidate**: render delegated output inside a delimited block labelled as untrusted data. That preserves verbatim reproduction while removing the ambiguity about whether it is addressed to the parent.
+
+### 7.4 PI-3 — No redaction or size bound on the review path (Medium)
+
+`LLM02 Sensitive Information Disclosure`, `LLM10 Unbounded Consumption`
+
+`transfer-context.mjs` redacts secret-looking **filenames** and caps output at 5,000 characters per file and 25,000 overall. The review path has neither: `collectWorkingTreeContext` (`lib/git.mjs:182-183`) collects `git diff` output whole, with no filter and no cap.
+
+So `/gemini:review` on a diff that touches `.env`, a private key, or a credentials file sends its contents to the model, while `/gemini:transfer` on the same diff would redact it. Two paths, same repository, different policies.
+
+Note the transfer filter is filename-based only: a secret pasted into `config.js` is not redacted on either path.
+
+### 7.5 PI-4 — Automatic exposure via the stop-review gate (Low)
+
+`LLM01 Prompt Injection`
+
+`stop-review-gate-hook.mjs` runs a review when a Claude Code turn stops, so repository content reaches a model without any explicit user action. Impact is limited: the gate is read-only and fails open, so a manipulated verdict cannot block work — but it widens the window in which untrusted content is sent automatically.
+
+### 7.6 OWASP Top 10 for LLM Applications (2025) coverage
+
+| ID | Applies | Where |
+|---|---|---|
+| LLM01 Prompt Injection | **Yes** | 7.2, 7.3, 7.5 |
+| LLM02 Sensitive Information Disclosure | **Yes** | 7.4 |
+| LLM03 Supply Chain | Partial | Plugin installs by git clone from a marketplace; version pinning is documented in the README. No lockfile for the delegated CLIs themselves |
+| LLM04 Data and Model Poisoning | No | The plugin neither trains nor fine-tunes |
+| LLM05 Improper Output Handling | **Yes** | 7.3 |
+| LLM06 Excessive Agency | **Yes** | 7.2 |
+| LLM07 System Prompt Leakage | Low | Prompt templates ship in `prompts/` and are public by design |
+| LLM08 Vector and Embedding Weaknesses | No | No retrieval or embedding store |
+| LLM09 Misinformation | Accepted | A review may be wrong; output is advisory and always shown to a human |
+| LLM10 Unbounded Consumption | Partial | AGY spawn timeout and `--print-timeout` bound a run; the review diff itself is unbounded (7.4) |
+
+### 7.7 Priority
+
+1. **7.2** — the only item where a successful injection reaches the filesystem. Make `--write` opt-in, and adopt an AGY path boundary when one exists.
+2. **7.4** — cheap to fix by reusing `isSecretFile` and the caps that already exist in `transfer-context.mjs`.
+3. **7.3** — output framing; low cost, and it does not weaken the verbatim rule.
+4. **7.5** — accept, or make the gate opt-in per repository.


### PR DESCRIPTION
`THREAT-MODEL.md` modelled the conventional CLI-host surface — argv, subprocess, credentials — and nothing about what the plugin actually does, which is hand content it did not author to an agent. New **section 7** covers that, mapped against the OWASP Top 10 for LLM Applications (2025).

Docs-only. No code changes.

## Two existing claims did not survive checking

| Claim | Reality |
|---|---|
| §5: file mutation is "gated behind explicit `--write`" | `agents/gemini-rescue.md:34` tells the subagent to **add** `--write` unless the user asks for read-only. `/gemini:rescue` is write-capable by default |
| §6: "verify `--write` respects directory scope" (listed as a risk to check) | It does not. `buildCliArgs` maps `write` to `--dangerously-skip-permissions` / `--yolo`, which remove the approval prompt without constraining where the agent may act |

## The divergence the parity audit missed

`codex-companion.mjs:491` — upstream:

```js
sandbox: request.write ? "workspace-write" : "read-only"
```

Upstream's write mode is **confined by a sandbox**. This plugin has no equivalent, because AGY has no path-boundary mode — precisely what [antigravity-cli#749](https://github.com/google-antigravity/antigravity-cli/issues/749) asks for. Same user-facing default ("write-capable by default"), materially different blast radius.

The parity audit never caught this because it compared command surfaces, not capability semantics. Worth remembering for the next audit round.

Corroborating evidence that the boundary is not implicit: `engine.mjs:217-222` records AGY writing to its scratch directory rather than `cwd` without `--new-project`, and a live 1.1.10 run this session resolved *read* paths against a different checkout than the `cwd` it was given.

## Live-tested where testing is safe

A diff carrying a blatant payload — a comment addressed to "the reviewing agent" telling it to suppress findings, emit `PWNED_BY_INJECTION`, and approve — was **resisted** on AGY 1.1.10. The review reported the genuine `eval()` defect and emitted none of the injected output.

Recorded with its limits, because the result is easy to over-read: that is **one model refusing one obvious payload**, and the refusal came entirely from the model. The plugin applies no control of its own.

The write-capable path was **deliberately not tested**. Proving it would mean letting an agent write to disk under attacker-supplied instructions. The claim there rests on reading the flags.

## Also found

The review path has neither the secret-filename redaction nor the size caps that `transfer-context.mjs` already implements. `/gemini:review` on a diff touching `.env` sends its contents to the model; `/gemini:transfer` on the same diff would redact them. Two paths, one repository, different policies — and the cheapest of the four findings to fix, since the helpers already exist.

## Ranked in the document

1. **7.2** write-capable delegation without a sandbox — the only path where a successful injection reaches the filesystem
2. **7.4** no redaction or size bound on review — reuse `isSecretFile` and the existing caps
3. **7.3** delegated output reaches the parent agent unfiltered — output framing, does not weaken the verbatim rule
4. **7.5** stop-gate auto-exposure — accept, or make it opt-in per repository

`SECURITY.md` now points at section 7 and marks the top item as known-and-documented, so it is not reported as an undisclosed flaw. Supported-version table refreshed to 0.12.x.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H3Qwqu1oihfC2s48Hzj9Wm
