### PR TITLE
fix(security): stop the review path from sending secret file contents (v0.13.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,13 +6,13 @@
   },
   "metadata": {
     "description": "Use Gemini CLI or Antigravity CLI (agy) inside Claude Code for task delegation, code review, and adversarial review.",
-    "version": "0.12.0"
+    "version": "0.13.0"
   },
   "plugins": [
     {
       "name": "gemini",
       "description": "Gemini CLI and Antigravity CLI bridge for Claude Code task delegation and adversarial review",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "author": {
         "name": "arcobaleno64"
       },

--- a/docs/THREAT-MODEL.md
+++ b/docs/THREAT-MODEL.md
@@ -53,10 +53,10 @@ The plugin's function is to take content it did not author and hand it to an age
 
 | # | Flow | Write-capable | Bound |
 |---|---|---|---|
-| A | repo diff → review prompt → model → rendered output → **Claude Code's context** | no (`write: false`, `lib/gemini.mjs`) | none on the output |
+| A | repo diff → review prompt → model → rendered output → **Claude Code's context** | no (`write: false`, `lib/gemini.mjs`) | filename redaction + size cap on the input (7.4); none on the output |
 | B | repo content → rescue agent → **filesystem and shell** | **yes by default** (7.2) | none |
 | C | repo diff → `.omc/transfers/*.json` → an interactive AGY session started with `--add-dir .` | inherits that session's mode | filename redaction + size caps |
-| D | repo diff → stop-review-gate hook → model, with no explicit user action | no | none |
+| D | repo diff → stop-review-gate hook → model, with no explicit user action | no | same as A |
 
 ### 7.2 PI-1 — Write-capable delegation without a sandbox (High)
 
@@ -84,15 +84,17 @@ Calibrate that result honestly: it shows one model refusing one obvious payload.
 
 **Mitigation candidate**: render delegated output inside a delimited block labelled as untrusted data. That preserves verbatim reproduction while removing the ambiguity about whether it is addressed to the parent.
 
-### 7.4 PI-3 — No redaction or size bound on the review path (Medium)
+### 7.4 PI-3 — No redaction or size bound on the review path — **fixed in v0.13.0**
 
 `LLM02 Sensitive Information Disclosure`, `LLM10 Unbounded Consumption`
 
-`transfer-context.mjs` redacts secret-looking **filenames** and caps output at 5,000 characters per file and 25,000 overall. The review path has neither: `collectWorkingTreeContext` (`lib/git.mjs:182-183`) collects `git diff` output whole, with no filter and no cap.
+**The defect.** `transfer-context.mjs` redacted secret-looking filenames and capped its output, while the review path collected `git diff` whole with no filter and no cap. `/gemini:review` on a diff touching `.env` sent its contents to the model; `/gemini:transfer` on the same diff redacted them. Untracked files were worse — `formatUntrackedFile` read them in full, so a new untracked `.env` was sent whole.
 
-So `/gemini:review` on a diff that touches `.env`, a private key, or a credentials file sends its contents to the model, while `/gemini:transfer` on the same diff would redact it. Two paths, same repository, different policies.
+**The fix.** Detection moved to `lib/secrets.mjs`, shared by both paths. `redactSecretsFromDiff` splits a unified diff on its `diff --git` boundaries and withholds the body of any secret-looking file, keeping the header so the review still knows the file changed. `formatUntrackedFile` applies the same check before reading. A 400,000-character cap bounds the payload, and truncation is announced inside the content so the model reports it — a silently truncated review that returns "looks good" about code it never saw is a worse failure than an expensive one.
 
-Note the transfer filter is filename-based only: a secret pasted into `config.js` is not redacted on either path.
+**Widened while fixing.** The inherited pattern was anchored at `^\.env`, so it matched `.env` and `.env.production` but not `prod.env` or `staging.env`. Both paths now catch those.
+
+**Still true**: detection is filename-based. A credential pasted into `config.js` is not redacted on either path, and nothing here should be relied on as a secret scanner.
 
 ### 7.5 PI-4 — Automatic exposure via the stop-review gate (Low)
 
@@ -118,6 +120,6 @@ Note the transfer filter is filename-based only: a secret pasted into `config.js
 ### 7.7 Priority
 
 1. **7.2** — the only item where a successful injection reaches the filesystem. Make `--write` opt-in, and adopt an AGY path boundary when one exists.
-2. **7.4** — cheap to fix by reusing `isSecretFile` and the caps that already exist in `transfer-context.mjs`.
+2. ~~**7.4**~~ — **fixed in v0.13.0**; detection is shared between both paths and the review payload is bounded.
 3. **7.3** — output framing; low cost, and it does not weaken the verbatim rule.
 4. **7.5** — accept, or make the gate opt-in per repository.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@arcobaleno64/gemini-plugin-cc",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@arcobaleno64/gemini-plugin-cc",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arcobaleno64/gemini-plugin-cc",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "private": true,
   "type": "module",
   "description": "Use Gemini CLI or Antigravity CLI (agy) inside Claude Code for task delegation, code review, and adversarial review.",

--- a/plugins/gemini/.claude-plugin/plugin.json
+++ b/plugins/gemini/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gemini",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Use Gemini/AGY from Claude Code to review code or delegate tasks.",
   "author": {
     "name": "arcobaleno64",

--- a/plugins/gemini/CHANGELOG.md
+++ b/plugins/gemini/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.13.0 — 2026-08-04 — Secret redaction on the review path
+
+### Security
+- **`/gemini:review` and `/gemini:adversarial-review` no longer send secret file contents to the model.** `transfer-context.mjs` had redacted secret-looking filenames since 0.10.0, but the review path collected `git diff` whole, with no filter — so the same `.env` change was redacted by `/gemini:transfer` and disclosed by `/gemini:review`. Untracked files were worse: `formatUntrackedFile` read them in full, so a new untracked `.env` was sent whole. See [`docs/THREAT-MODEL.md` §7.4](../../docs/THREAT-MODEL.md).
+- **The secret pattern now catches stage-named stores.** It was anchored at `^\.env`, matching `.env` and `.env.production` but not `prod.env` or `staging.env`. Both the review and transfer paths now catch those.
+
+### Added
+- `lib/secrets.mjs` is the single definition of secret detection. `redactSecretsFromDiff` splits a unified diff on its `diff --git` boundaries and withholds the body of a secret file while keeping the header, so a review still knows the file changed without seeing its contents. `isSecretFile` is re-exported from `transfer-context.mjs` under its existing name.
+- A 400,000-character cap on the review payload. Truncation is announced **inside the content**, so the model reports it rather than silently reviewing half a diff — the failure mode fixed for empty reviews in 0.6.4 applied to oversized ones too.
+
+### Known limits
+- Detection is filename-based. A credential pasted into an ordinary source file is not redacted on any path, and this is not a secret scanner.
+
 ## 0.12.0 — 2026-08-04 — Auto-routing checks credentials, not just presence
 
 ### Fixed

--- a/plugins/gemini/scripts/lib/git.mjs
+++ b/plugins/gemini/scripts/lib/git.mjs
@@ -3,8 +3,18 @@ import path from "node:path";
 
 import { isProbablyText } from "./fs.mjs";
 import { runCommand, runCommandChecked } from "./process.mjs";
+import { isSecretFile, redactSecretsFromDiff, SECRET_DIFF_PLACEHOLDER } from "./secrets.mjs";
 
 const MAX_UNTRACKED_BYTES = 24 * 1024;
+
+// Total review payload sent to the model. Far larger than transfer's 25,000,
+// because a truncated review is a worse failure than an expensive one: a review
+// that silently loses half its diff can return "looks good" about code it never
+// saw. Truncation is therefore marked in the content itself so the model reports
+// it and the user sees it. (docs/THREAT-MODEL.md 7.4)
+const MAX_REVIEW_CONTENT_CHARS = 400_000;
+const REVIEW_TRUNCATION_NOTICE =
+  "\n\n[TRUNCATED: the diff exceeded the review size limit and was cut here. Say so in your summary — the remainder was NOT reviewed.]\n";
 
 function git(cwd, args, options = {}) {
   return runCommand("git", args, { cwd, ...options, shell: false });
@@ -141,8 +151,19 @@ function formatSection(title, body) {
   return [`## ${title}`, "", body.trim() ? body.trim() : "(none)", ""].join("\n");
 }
 
+function capReviewContent(content) {
+  if (content.length <= MAX_REVIEW_CONTENT_CHARS) return content;
+  return content.slice(0, MAX_REVIEW_CONTENT_CHARS) + REVIEW_TRUNCATION_NOTICE;
+}
+
 export function formatUntrackedFile(cwd, relativePath) {
   const absolutePath = path.join(cwd, relativePath);
+
+  // An untracked secret file would otherwise be sent whole — worse than the diff
+  // case, which at least only carries the changed lines.
+  if (isSecretFile(relativePath)) {
+    return `### ${relativePath}\n${SECRET_DIFF_PLACEHOLDER}`;
+  }
 
   let stat;
   try {
@@ -179,14 +200,14 @@ export function formatUntrackedFile(cwd, relativePath) {
 
 function collectWorkingTreeContext(cwd, state) {
   const status = gitChecked(cwd, ["status", "--short", "--untracked-files=all"]).stdout.trim();
-  const stagedDiff = gitChecked(cwd, ["diff", "--cached", "--binary", "--no-ext-diff", "--submodule=diff"]).stdout;
-  const unstagedDiff = gitChecked(cwd, ["diff", "--binary", "--no-ext-diff", "--submodule=diff"]).stdout;
+  const staged = redactSecretsFromDiff(gitChecked(cwd, ["diff", "--cached", "--binary", "--no-ext-diff", "--submodule=diff"]).stdout);
+  const unstaged = redactSecretsFromDiff(gitChecked(cwd, ["diff", "--binary", "--no-ext-diff", "--submodule=diff"]).stdout);
   const untrackedBody = state.untracked.map((file) => formatUntrackedFile(cwd, file)).join("\n\n");
 
   const parts = [
     formatSection("Git Status", status),
-    formatSection("Staged Diff", stagedDiff),
-    formatSection("Unstaged Diff", unstagedDiff),
+    formatSection("Staged Diff", staged.text),
+    formatSection("Unstaged Diff", unstaged.text),
     formatSection("Untracked Files", untrackedBody)
   ];
 
@@ -195,7 +216,8 @@ function collectWorkingTreeContext(cwd, state) {
     isEmpty:
       state.staged.length === 0 && state.unstaged.length === 0 && state.untracked.length === 0,
     summary: `Reviewing ${state.staged.length} staged, ${state.unstaged.length} unstaged, and ${state.untracked.length} untracked file(s).`,
-    content: parts.join("\n")
+    redactedFiles: [...staged.redactedFiles, ...unstaged.redactedFiles],
+    content: capReviewContent(parts.join("\n"))
   };
 }
 
@@ -205,17 +227,18 @@ function collectBranchContext(cwd, baseRef) {
   const currentBranch = getCurrentBranch(cwd);
   const logOutput = gitChecked(cwd, ["log", "--oneline", "--decorate", commitRange]).stdout.trim();
   const diffStat = gitChecked(cwd, ["diff", "--stat", commitRange]).stdout.trim();
-  const diff = gitChecked(cwd, ["diff", "--binary", "--no-ext-diff", "--submodule=diff", commitRange]).stdout;
+  const branch = redactSecretsFromDiff(gitChecked(cwd, ["diff", "--binary", "--no-ext-diff", "--submodule=diff", commitRange]).stdout);
 
   return {
     mode: "branch",
-    isEmpty: diff.trim() === "" && logOutput === "",
+    isEmpty: branch.text.trim() === "" && logOutput === "",
     summary: `Reviewing branch ${currentBranch} against ${baseRef} from merge-base ${mergeBase}.`,
-    content: [
+    redactedFiles: branch.redactedFiles,
+    content: capReviewContent([
       formatSection("Commit Log", logOutput),
       formatSection("Diff Stat", diffStat),
-      formatSection("Branch Diff", diff)
-    ].join("\n")
+      formatSection("Branch Diff", branch.text)
+    ].join("\n"))
   };
 }
 

--- a/plugins/gemini/scripts/lib/secrets.mjs
+++ b/plugins/gemini/scripts/lib/secrets.mjs
@@ -1,0 +1,56 @@
+// Secret-file detection, shared by every path that sends repository content to a
+// model. transfer-context.mjs re-exports isSecretFile under its existing name.
+//
+// Filename-based only: a credential pasted into an ordinary source file is not
+// detected here and never has been. This catches the files that exist to hold
+// secrets, which is where they usually are.
+
+const SECRET_PATTERNS = [
+  /^\.env(\..+)?$/i,
+  // The anchored pattern above only covers `.env` and `.env.production`. A file
+  // named `prod.env` or `staging.env` is the same kind of store and was missed.
+  /\.env$/i,
+  /\.pem$/i,
+  /\.key$/i,
+  /\.(p12|pfx|crt|keystore)$/i,
+  /^\.npmrc$/i,
+  /credentials\.json$/i,
+  /_creds\.json$/i,
+  /secrets?\.(json|yml|yaml|env)$/i,
+  /id_rsa/i,
+];
+
+export function isSecretFile(filepath) {
+  const filename = String(filepath ?? "").split(/[\\/]/).pop() ?? "";
+  return SECRET_PATTERNS.some((pattern) => pattern.test(filename));
+}
+
+export const SECRET_DIFF_PLACEHOLDER = "[REDACTED: secret file content withheld from the model]";
+
+// Split a unified diff on its `diff --git a/x b/y` boundaries and withhold the
+// body of any file that looks like a secret store, keeping the header so the
+// review still knows the file changed.
+//
+// git quotes whole paths containing special characters — `"a/we ird.env"
+// "b/we ird.env"` — so the opening quote sits *before* the `b/`. Match the b/
+// side with optional quotes on either end rather than parsing the whole header
+// grammar.
+export function redactSecretsFromDiff(diff) {
+  const text = String(diff ?? "");
+  if (!text.trim()) return { text, redactedFiles: [] };
+
+  const parts = text.split(/(?=^diff --git )/m);
+  const redactedFiles = [];
+
+  const out = parts.map((part) => {
+    if (!part.startsWith("diff --git ")) return part;
+    const header = part.slice(0, part.indexOf("\n") === -1 ? part.length : part.indexOf("\n"));
+    const match = header.match(/ "?b\/(.+?)"?$/);
+    const filePath = match ? match[1] : null;
+    if (!filePath || !isSecretFile(filePath)) return part;
+    redactedFiles.push(filePath);
+    return `${header}\n${SECRET_DIFF_PLACEHOLDER}\n`;
+  });
+
+  return { text: out.join(""), redactedFiles };
+}

--- a/plugins/gemini/scripts/lib/transfer-context.mjs
+++ b/plugins/gemini/scripts/lib/transfer-context.mjs
@@ -3,22 +3,11 @@ import path from 'node:path';
 import { execFileSync } from 'node:child_process';
 import crypto from 'node:crypto';
 
-const SECRET_PATTERNS = [
-  /^\.env(\..+)?$/i,
-  /\.pem$/i,
-  /\.key$/i,
-  /\.(p12|pfx|crt|keystore)$/i,
-  /^\.npmrc$/i,
-  /credentials\.json$/i,
-  /_creds\.json$/i,
-  /secrets?\.(json|yml|yaml|env)$/i,
-  /id_rsa/i,
-];
-
-export function isSecretFile(filepath) {
-  const filename = path.basename(filepath);
-  return SECRET_PATTERNS.some((pattern) => pattern.test(filename));
-}
+// Moved to lib/secrets.mjs so the review path shares one definition. Imported
+// (not just re-exported) because this module calls it too, and re-exported
+// because this is the existing public name.
+import { isSecretFile } from "./secrets.mjs";
+export { isSecretFile };
 
 export function checkGitConflict(cwd = process.cwd()) {
   const gitDir = path.join(cwd, '.git');

--- a/tests/git.test.mjs
+++ b/tests/git.test.mjs
@@ -167,3 +167,27 @@ test("formatUntrackedFile inlines a small text file", () => {
   assert.match(out, /### note\.txt/);
   assert.match(out, /hello content/);
 });
+
+// docs/THREAT-MODEL.md 7.4 — the review path used to send secret files whole
+// while /gemini:transfer redacted them from the same diff.
+test("collectReviewContext withholds secret file content from a working-tree review", () => {
+  const cwd = makeTempDir();
+  initGitRepo(cwd);
+  fs.writeFileSync(path.join(cwd, ".env"), "API_KEY=old\n");
+  fs.writeFileSync(path.join(cwd, "app.js"), "const a = 1;\n");
+  run("git", ["add", "-A"], { cwd });
+  run("git", ["commit", "-m", "init"], { cwd });
+
+  fs.writeFileSync(path.join(cwd, ".env"), "API_KEY=TRACKED_LEAK\n");
+  fs.writeFileSync(path.join(cwd, "app.js"), "const a = 2;\n");
+  fs.writeFileSync(path.join(cwd, ".env.production"), "TOKEN=UNTRACKED_LEAK\n");
+
+  const context = collectReviewContext(cwd, { mode: "working-tree" });
+  const payload = JSON.stringify(context);
+
+  assert.ok(!payload.includes("TRACKED_LEAK"), "a modified secret file must not reach the model");
+  assert.ok(!payload.includes("UNTRACKED_LEAK"), "an untracked secret file must not be sent whole");
+  assert.ok(payload.includes("const a = 2"), "ordinary code must still be reviewed");
+  // The filename survives so the review can still flag that the file changed.
+  assert.ok(payload.includes(".env"));
+});

--- a/tests/secrets.test.mjs
+++ b/tests/secrets.test.mjs
@@ -1,0 +1,77 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { isSecretFile, redactSecretsFromDiff, SECRET_DIFF_PLACEHOLDER } from "../plugins/gemini/scripts/lib/secrets.mjs";
+
+test("isSecretFile matches on the basename, including nested paths", () => {
+  assert.equal(isSecretFile(".env"), true);
+  assert.equal(isSecretFile("config/.env.production"), true);
+  assert.equal(isSecretFile("deep/nested/dir/id_rsa"), true);
+  assert.equal(isSecretFile("certs\\server.key"), true, "Windows separators must resolve too");
+  // The original pattern was anchored at `^\.env`, so a store named for its
+  // stage was missed entirely.
+  assert.equal(isSecretFile("prod.env"), true);
+  assert.equal(isSecretFile("config/staging.env"), true);
+  assert.equal(isSecretFile("src/index.js"), false);
+  assert.equal(isSecretFile("docs/environment.md"), false, "'environment' must not match the .env pattern");
+  assert.equal(isSecretFile(""), false);
+  assert.equal(isSecretFile(null), false);
+});
+
+test("redactSecretsFromDiff withholds secret file bodies and keeps the rest", () => {
+  const diff = [
+    "diff --git a/src/app.js b/src/app.js",
+    "index 111..222 100644",
+    "--- a/src/app.js",
+    "+++ b/src/app.js",
+    "@@ -1 +1 @@",
+    "-const a = 1;",
+    "+const a = 2;",
+    "diff --git a/.env b/.env",
+    "index 333..444 100644",
+    "--- a/.env",
+    "+++ b/.env",
+    "@@ -1 +1 @@",
+    "-API_KEY=old",
+    "+API_KEY=LEAKED_VALUE",
+    ""
+  ].join("\n");
+
+  const { text, redactedFiles } = redactSecretsFromDiff(diff);
+
+  assert.ok(!text.includes("LEAKED_VALUE"), "secret content must not survive");
+  assert.ok(text.includes(SECRET_DIFF_PLACEHOLDER));
+  assert.ok(text.includes("const a = 2;"), "ordinary code must survive");
+  // The header stays so the review still knows the file changed.
+  assert.ok(text.includes("diff --git a/.env b/.env"));
+  assert.deepEqual(redactedFiles, [".env"]);
+});
+
+test("redactSecretsFromDiff handles git's quoted paths", () => {
+  const diff = [
+    'diff --git "a/we ird.env" "b/we ird.env"',
+    "--- a/we ird.env",
+    "+++ b/we ird.env",
+    "@@ -1 +1 @@",
+    "+SECRET=QUOTED_LEAK",
+    ""
+  ].join("\n");
+
+  const { text, redactedFiles } = redactSecretsFromDiff(diff);
+  assert.ok(!text.includes("QUOTED_LEAK"));
+  assert.deepEqual(redactedFiles, ["we ird.env"]);
+});
+
+test("redactSecretsFromDiff passes through a diff with nothing to redact", () => {
+  const diff = "diff --git a/a.js b/a.js\n+const a = 1;\n";
+  const { text, redactedFiles } = redactSecretsFromDiff(diff);
+  assert.equal(text, diff);
+  assert.deepEqual(redactedFiles, []);
+});
+
+test("redactSecretsFromDiff tolerates empty and nullish input", () => {
+  for (const input of ["", "   ", null, undefined]) {
+    const { redactedFiles } = redactSecretsFromDiff(input);
+    assert.deepEqual(redactedFiles, []);
+  }
+});


### PR DESCRIPTION
Fixes [`docs/THREAT-MODEL.md` §7.4](../blob/main/docs/THREAT-MODEL.md), the finding ranked as the cheapest of the four from #35 because the helpers already existed.

## The defect

`transfer-context.mjs` has redacted secret-looking filenames since 0.10.0. The review path collected `git diff` whole, with no filter — so the **same `.env` change** was redacted by `/gemini:transfer` and disclosed by `/gemini:review`. Two paths, one repository, opposite policies.

Untracked files were worse. `formatUntrackedFile` reads the whole file, so a new untracked `.env` was sent in full rather than as a diff.

## The fix

`lib/secrets.mjs` becomes the single definition. `redactSecretsFromDiff` splits a unified diff on its `diff --git` boundaries and withholds the body of a secret file **while keeping the header**, so a review still knows the file changed without seeing its contents. `formatUntrackedFile` applies the same check before reading. `isSecretFile` is re-exported from `transfer-context.mjs` under its existing name, so no caller changes.

### Verified end to end

A repo with a modified tracked `.env`, an untracked `.env.production`, and an ordinary source change:

```
SUPER_SECRET_LEAKED_VALUE    withheld ✓
hunter2                      withheld ✓
UNTRACKED_SECRET_VALUE       withheld ✓
const y = 1                  preserved ✓
.env (filename)              still visible ✓
```

## Widened while fixing

The inherited pattern was anchored at `^\.env`, so it matched `.env` and `.env.production` but **not `prod.env` or `staging.env`**. Both paths catch those now.

Found sideways: a test I wrote asserted that a quoted path `we ird.env` would be redacted. It was not — correctly, since the pattern requires the name to *start* with `.env`. The failing test was wrong and the code was right, which is what exposed the real gap.

## Size cap

400,000 characters on the review payload, with truncation announced **inside the content** so the model reports it. A silently truncated review that approves code it never saw is a worse failure than an expensive one — the same reasoning behind the empty-review short circuit in 0.6.4. Deliberately far larger than transfer's 25,000, because a review legitimately needs the whole diff.

## Known limits, stated in the doc

Detection is filename-based. A credential pasted into `config.js` is not redacted on any path. This is not a secret scanner and should not be relied on as one.

## Verification

- `npm test` — 287 tests, **282 pass / 5 skipped / 0 fail**
- 5 new unit tests in `tests/secrets.test.mjs` (basename matching across nested and Windows paths, quoted git paths, pass-through, nullish input) and 1 integration test in `tests/git.test.mjs`
- `npm run check-version`, `npm run verify-contracts` — pass at v0.13.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H3Qwqu1oihfC2s48Hzj9Wm
