### PR TITLE
fix: correct backslash handling in Windows argv quoting and Markdown cells (v0.14.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,13 +6,13 @@
   },
   "metadata": {
     "description": "Use Gemini CLI or Antigravity CLI (agy) inside Claude Code for task delegation, code review, and adversarial review.",
-    "version": "0.14.0"
+    "version": "0.14.1"
   },
   "plugins": [
     {
       "name": "gemini",
       "description": "Gemini CLI and Antigravity CLI bridge for Claude Code task delegation and adversarial review",
-      "version": "0.14.0",
+      "version": "0.14.1",
       "author": {
         "name": "arcobaleno64"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@arcobaleno64/gemini-plugin-cc",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@arcobaleno64/gemini-plugin-cc",
-      "version": "0.14.0",
+      "version": "0.14.1",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arcobaleno64/gemini-plugin-cc",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "private": true,
   "type": "module",
   "description": "Use Gemini CLI or Antigravity CLI (agy) inside Claude Code for task delegation, code review, and adversarial review.",

--- a/plugins/gemini/.claude-plugin/plugin.json
+++ b/plugins/gemini/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gemini",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Use Gemini/AGY from Claude Code to review code or delegate tasks.",
   "author": {
     "name": "arcobaleno64",

--- a/plugins/gemini/CHANGELOG.md
+++ b/plugins/gemini/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.14.1 — 2026-08-05 — Correct argument quoting on the Windows shell path
+
+### Fixed
+- **Arguments ending in a backslash were corrupted when `runCommand` used the Windows shell.** The escaper handled `"` but left backslashes alone, so MSVCRT read the doubled-up run as an escape: a value like `a b\` reached the child as `a b"`, `a b\\` as `a b\`, and `a\"b` as `a\b`. Backslashes are now doubled before a quote and at the end of the value, per the MSVCRT argv rules. Measured on Windows: all eight awkward values now round-trip through `node -p process.argv` unchanged, where three of them were mangled before. This path carries fixed or validated argv only (`where`/`gemini`/`taskkill`), so it was a latent defect rather than an exploitable one — the module comment explaining why this is not a general cmd.exe escaper still stands.
+- **Table cells containing a backslash could break the Markdown table.** `escapeMarkdownCell` escaped `|` without escaping `\` first, so an input containing `\|` rendered as a literal backslash followed by a live column separator. Backslashes are escaped first. Display correctness only; no security claim attaches to it.
+
+### Added
+- `quoteForWindowsShell` is exported for tests. Its rules are Windows-specific and are **not** equivalent under POSIX `sh`, so they are asserted on the returned string — which runs everywhere — with the argv round-trip kept as a Windows-only leg.
+
 ## 0.14.0 — 2026-08-04 — Delegated output is framed as data
 
 ### Security

--- a/plugins/gemini/scripts/lib/process.mjs
+++ b/plugins/gemini/scripts/lib/process.mjs
@@ -9,10 +9,23 @@ import process from "node:process";
 // as protection for free text. Gemini and AGY >=1.1.2 prompts use stdin; older
 // AGY positional prompts are protected by absolute-path resolution and
 // therefore shell:false instead.
+// Exported for tests only: the escaping rules below are Windows/MSVCRT specific
+// and are NOT equivalent under POSIX sh (`"a\\ "` loses a backslash there), so
+// they can only be asserted on the returned string, not by round-tripping argv
+// through a shell on Linux CI. Do not call this from other modules.
 const WINDOWS_SHELL_UNSAFE = /[\s|<>&()^"]/;
-function quoteForWindowsShell(arg) {
+export function quoteForWindowsShell(arg) {
   if (typeof arg !== "string" || !WINDOWS_SHELL_UNSAFE.test(arg)) return arg;
-  return `"${arg.replace(/"/g, '\\"')}"`;
+  // MSVCRT argv rules: a backslash is literal EXCEPT before a quote, where each
+  // one must be doubled, and a run at the end must be doubled so it does not
+  // escape the closing quote. Replacing only `"` left `a\` + `"` as `a\\"`,
+  // which the child reads as a literal backslash and a closing quote — the
+  // caller's value escapes its own quoting. This does not make the function a
+  // cmd.exe escaper; see the note above for why that is not attempted.
+  const escaped = arg
+    .replace(/(\\*)"/g, '$1$1\\"')
+    .replace(/(\\+)$/, "$1$1");
+  return `"${escaped}"`;
 }
 
 export function runCommand(command, args = [], options = {}) {

--- a/plugins/gemini/scripts/lib/render.mjs
+++ b/plugins/gemini/scripts/lib/render.mjs
@@ -108,6 +108,10 @@ function pushFailureDetails(lines, failure, indent = "") {
 
 function escapeMarkdownCell(value) {
   return String(value ?? "")
+    // Backslash first: escaping `|` without it means an input containing `\|`
+    // becomes `\\|`, which renders as a literal backslash followed by a live
+    // column separator and breaks the table. Display correctness, not security.
+    .replace(/\\/g, "\\\\")
     .replace(/\|/g, "\\|")
     .replace(/\r?\n/g, " ")
     .trim();

--- a/tests/process.test.mjs
+++ b/tests/process.test.mjs
@@ -7,7 +7,8 @@ import {
   binaryAvailable,
   formatCommandFailure,
   resolveBinaryPath,
-  runCommand
+  runCommand,
+  quoteForWindowsShell
 } from "../plugins/gemini/scripts/lib/process.mjs";
 
 test("terminateProcessTree uses taskkill on Windows", () => {
@@ -105,6 +106,41 @@ test("runCommand leaves argv unchanged when shell is disabled", () => {
 
   assert.equal(result.status, 0, result.stderr);
   assert.equal(result.stdout.trim(), '["argument with spaces"]');
+});
+
+// Values with no shell-unsafe character are passed through untouched, which is
+// why the trailing-backslash cases below all carry a space: a bare `a\` never
+// reaches the quoting branch at all.
+test("quoteForWindowsShell leaves values without shell-unsafe characters alone", () => {
+  assert.equal(quoteForWindowsShell("plain"), "plain");
+  assert.equal(quoteForWindowsShell("a\\b"), "a\\b");
+  assert.equal(quoteForWindowsShell("trailing\\"), "trailing\\");
+  assert.equal(quoteForWindowsShell(42), 42);
+});
+
+// MSVCRT rules: backslashes are literal except before a quote (double them) and
+// at the end of the value (double them so they do not escape the closing quote).
+// Escaping only `"` shipped `a b\` as `"a b\"`, which the child read as `a b"`.
+test("quoteForWindowsShell doubles backslashes before a quote and at the end", () => {
+  assert.equal(quoteForWindowsShell("a b\\"), '"a b\\\\"');
+  assert.equal(quoteForWindowsShell("a b\\\\"), '"a b\\\\\\\\"');
+  assert.equal(quoteForWindowsShell('b"c'), '"b\\"c"');
+  assert.equal(quoteForWindowsShell('a\\"b'), '"a\\\\\\"b"');
+  assert.equal(quoteForWindowsShell("x y"), '"x y"');
+  // Interior backslashes not adjacent to a quote stay literal and single.
+  assert.equal(quoteForWindowsShell("a\\b c"), '"a\\b c"');
+});
+
+// The string rules above only matter if they match what MSVCRT actually parses,
+// and that can only be observed on Windows — POSIX sh reads these escapes
+// differently, so this leg is skipped rather than asserted cross-platform.
+test("runCommand round-trips awkward argv through the Windows shell path", { skip: process.platform !== "win32" }, () => {
+  for (const value of ["a b\\", "a b\\\\", 'a\\"b', 'b"c', "x y", "p&q", "(x) y", "a|b"]) {
+    // Bare command name, so runCommand takes the shell:true branch on Windows.
+    const result = runCommand("node", ["-p", "JSON.stringify(process.argv.slice(1))", value]);
+    assert.equal(result.status, 0, `${JSON.stringify(value)}: ${result.stderr}`);
+    assert.deepEqual(JSON.parse(result.stdout.trim()), [value]);
+  }
 });
 
 test("formatCommandFailure formats exit-code and signal failures", () => {

--- a/tests/render.test.mjs
+++ b/tests/render.test.mjs
@@ -84,6 +84,39 @@ test("renderStatusReport announces the stop-time review gate when enabled", () =
   assert.match(out, /stop-time review gate is enabled/);
 });
 
+// A summary containing `|` must not open a new column, and a summary containing
+// `\|` must not degrade into a literal backslash plus a live separator — which
+// is what escaping `|` without escaping `\` first produced. Display correctness.
+test("renderStatusReport keeps the active-jobs table intact when cells contain pipes and backslashes", () => {
+  const out = renderStatusReport({
+    sessionRuntime: { label: "agy 1.1.10" },
+    running: [
+      {
+        id: "task-1",
+        kindLabel: "Task",
+        status: "running",
+        phase: "",
+        elapsed: "3s",
+        threadId: "conv-1",
+        summary: "grep 'a|b' then C:\\tmp\\out and a literal \\| pair\nsecond line"
+      }
+    ],
+    latestFinished: null,
+    recent: [],
+    needsReview: false
+  });
+
+  const row = out.split("\n").find((line) => line.startsWith("| task-1 "));
+  assert.ok(row, "expected the active-jobs row to be rendered");
+  // 8 columns, plus the leading and trailing separators => 9 splits, 10 fragments.
+  assert.equal(row.split(/(?<!\\)\|/).length, 10);
+  assert.ok(row.includes("grep 'a\\|b'"));
+  assert.ok(row.includes("C:\\\\tmp\\\\out"));
+  assert.ok(row.includes("a literal \\\\\\| pair"));
+  // Newlines are folded into the cell rather than breaking the table.
+  assert.ok(row.includes("pair second line"));
+});
+
 test("renderJobStatusReport renders a single job's id and status", () => {
   const out = renderJobStatusReport({ id: "task-1", status: "completed", title: "Investigate flake" });
   assert.match(out, /# Gemini Job Status/);


### PR DESCRIPTION
Clears the two open CodeQL alerts. Both are genuine defects, so both are fixed in code rather than dismissed with a justification.

## `quoteForWindowsShell` (`plugins/gemini/scripts/lib/process.mjs`)

It escaped `"` but left backslashes alone. MSVCRT treats a backslash as literal *except* before a quote, and a run at the end of a quoted value escapes the closing quote — so the value escaped its own quoting.

Measured on Windows before the fix:

| input | child received |
|---|---|
| `a b\` | `a b"` |
| `a b\` | `a b\` |
| `a\"b` | `a\b` |

After the fix all eight awkward values round-trip through `node -p process.argv` unchanged.

This path only ever carries fixed or validated argv (`where` / `gemini` / `taskkill`), so the defect was latent rather than exploitable. The module comment explaining why this is deliberately *not* a general cmd.exe escaper is unchanged.

## `escapeMarkdownCell` (`plugins/gemini/scripts/lib/render.mjs`)

It escaped `|` without escaping `\` first, so a cell containing `\|` rendered as a literal backslash followed by a live column separator and split the table. Display correctness — no security claim attaches to it.

## Testing notes

The quoting rules are Windows/MSVCRT specific and are **not** equivalent under POSIX `sh` (there, `"a\ "` loses a backslash), so a cross-platform shell round-trip would assert something false. Instead:

- `quoteForWindowsShell` is exported and its returned string is asserted directly — runs on Linux CI.
- The argv round-trip through `runCommand` is a Windows-only leg, skipped elsewhere.
- The Markdown fix is asserted through the public `renderStatusReport`, counting unescaped separators in the rendered row.

## Verification

- `npm test` — 293 tests, 288 pass, 5 skipped, 0 fail (Windows)
- `npm run check-version` — all manifests at 0.14.1
- `npm run verify-contracts` — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)