### PR TITLE
ci: validate plugin and marketplace structure in CI

### DIFF
--- a/.github/workflows/pull-request-ci.yml
+++ b/.github/workflows/pull-request-ci.yml
@@ -17,3 +17,10 @@ jobs:
       - run: npm test
       - run: npm run check-version
       - run: npm run verify-contracts
+      # verify-contracts checks version lockstep and the command surface; it does
+      # not schema-check the manifests themselves. `claude plugin validate` does,
+      # and it needs no credentials — verified against an empty CLAUDE_CONFIG_DIR.
+      # Pinned so a Claude Code release cannot change this gate without a commit.
+      - run: npm install -g @anthropic-ai/claude-code@2.1.222
+      - run: claude plugin validate ./plugins/gemini --strict
+      - run: claude plugin validate . --strict

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,12 @@ jobs:
       - run: npm test
       - run: npm run check-version
       - run: npm run verify-contracts
+      # Same structural gate as pull-request-ci.yml, placed before the release is
+      # cut so a malformed manifest cannot reach a published tag. Keep the pinned
+      # version in both workflows in step.
+      - run: npm install -g @anthropic-ai/claude-code@2.1.222
+      - run: claude plugin validate ./plugins/gemini --strict
+      - run: claude plugin validate . --strict
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}

--- a/tests/contract.test.mjs
+++ b/tests/contract.test.mjs
@@ -84,6 +84,30 @@ test("verify-contracts fails when the README install command is missing", () => 
   assert.match(result.stderr, /install command/);
 });
 
+// --- CI workflow gates ---
+
+// Both workflows run `claude plugin validate` against a pinned Claude Code. If
+// the pins drift apart the PR gate and the release gate stop validating against
+// the same schema, and nothing else would report it.
+test("both workflows pin the same claude-code version for plugin validation", () => {
+  const workflows = ["pull-request-ci.yml", "release.yml"].map((name) => ({
+    name,
+    text: fs.readFileSync(path.join(ROOT, ".github", "workflows", name), "utf8")
+  }));
+
+  const pins = workflows.map(({ name, text }) => {
+    const match = text.match(/@anthropic-ai\/claude-code@(\S+)/);
+    assert.ok(match, `${name} does not install a pinned @anthropic-ai/claude-code`);
+    return match[1];
+  });
+  assert.equal(pins[0], pins[1], "workflow pins disagree");
+
+  for (const { name, text } of workflows) {
+    assert.match(text, /claude plugin validate \.\/plugins\/gemini --strict/, `${name} misses the plugin validate step`);
+    assert.match(text, /claude plugin validate \. --strict/, `${name} misses the marketplace validate step`);
+  }
+});
+
 // --- bump-version (ported from upstream, adapted for the gemini layout) ---
 
 test("bump-version updates every manifest and --check detects drift", () => {


### PR DESCRIPTION
Summary:
Both CI workflows now run `claude plugin validate` against `./plugins/gemini` and the marketplace root, closing HANDOFF §14 P0 "Add `claude plugin validate --strict` to PR CI" and "Add marketplace-root validation to PR CI", and completing the release workflow's "confirms version, contracts, and plugin structure" clause.

Why:
`npm run verify-contracts` checks version lockstep, marketplace identity, the plugin source path, the README install command, and the presence of each command file. It never schema-checks the manifests themselves. A `plugin.json` with a name containing spaces, a malformed `author`, or an unparseable `hooks.json` passed every existing gate and would only fail at user install time.

Security impact:
None to plugin behavior. Adds one global npm install to CI, pinned to `@anthropic-ai/claude-code@2.1.222` so a Claude Code release cannot silently change what the gate accepts. The existing SHA-pinned actions are untouched.

Data/privacy impact:
None. `claude plugin validate` is offline manifest validation; no credentials are used or needed.

Compatibility:
No runtime, engine, platform, or command-surface change.

Validation:
- `npm test` — 294 tests, 289 pass, 0 fail, 5 skipped (was 293/288/0/5; +1 new test)
- `npm run check-version` — matches 0.14.1
- `npm run verify-contracts` — passed
- `claude plugin validate ./plugins/gemini --strict` — passed
- `claude plugin validate . --strict` — passed
- `git diff --check` — clean

Fixture tests:
- New: `tests/contract.test.mjs` asserts both workflows pin the same `@anthropic-ai/claude-code` version and both carry the two validate steps. Without it the PR gate and the release gate could drift into validating against different schemas with nothing reporting it.

Live tests:
- Credential-free operation confirmed locally: `claude plugin validate . --strict` with `CLAUDE_CONFIG_DIR` pointed at an empty directory and API-key env vars unset exits 0.
- Gate is not a no-op: the same command against a fixture `plugin.json` named `"Bad Name With Spaces"` exits 1 with `name: Plugin name cannot contain spaces`.

Not tested:
- The steps have not yet run on a GitHub Actions runner. This PR's own CI run is that test — if the install or validate step fails there, the fallback is an offline `scripts/validate-manifests.mjs` covering the same manifest fields.
- Windows/macOS runners: CI is `ubuntu-latest` only, unchanged.

Known limitations:
- The pinned Claude Code version must be bumped deliberately; it will not track new plugin-schema requirements on its own. The pin test keeps the two workflows in step but cannot tell you the pin is stale.

Version:
No bump in this PR. Batched into a single `0.14.2` PATCH at the end of the backlog series (HANDOFF §6: CI and test changes with no interface change).

Rollback:
Revert this commit. It touches only CI configuration and one test; no plugin file changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)