### PR TITLE
docs: state what the plugin sends, keeps, and reads (PRIVACY.md)

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,164 @@
+# Privacy and Data Handling
+
+This document states exactly what `gemini-plugin-cc` reads, what it sends, where it
+sends it, and what it keeps. Every claim here is checkable against the source
+files cited beside it. If you find a statement that the code does not support,
+that is a bug — report it as described in [`SECURITY.md`](SECURITY.md).
+
+Applies to plugin version 0.14.x.
+
+---
+
+## 1. The plugin operates no service
+
+- **No remote endpoint of its own.** The plugin makes no HTTP requests, opens no
+  sockets, and performs no DNS lookups. There is no `fetch`, `http`, `https`,
+  `net`, or `dns` call anywhere in `plugins/gemini/scripts/`. The only URLs in
+  the source are install instructions inside error messages
+  (`scripts/gemini-companion.mjs`).
+- **No telemetry, analytics, crash reporting, or update check.** None exists to
+  disable.
+- **No dependencies.** `package.json` declares neither `dependencies` nor
+  `devDependencies`; everything runs on the Node standard library. There is no
+  third-party package that could collect anything.
+- **Nothing is sent to the maintainer.** The maintainer receives only what you
+  choose to put in a GitHub issue or a security advisory.
+
+---
+
+## 2. What leaves your machine
+
+Data leaves your machine on exactly one path: the plugin spawns the **Gemini CLI
+or Antigravity CLI (`agy`) binary you installed**, and that binary sends your
+prompt to Google. The plugin is the thing that assembles the prompt; Google's CLI
+is the thing that transmits it.
+
+Transport is argv or stdin on a `shell: false` child process — never a shell
+command line. See [`SECURITY.md`](SECURITY.md) for the process-boundary details.
+
+What gets assembled depends on the command:
+
+| Command | Repository data included | Limits and redaction |
+|---|---|---|
+| `/gemini:rescue` | Your instruction text only | — |
+| `/gemini:review`, `/gemini:adversarial-review` | `git status`, staged and unstaged diffs or a branch diff, and the contents of untracked files (`scripts/lib/git.mjs`) | Secret-file contents withheld; 400,000-character total cap; untracked files skipped above 24 KB, and skipped entirely if binary, a directory, or a broken symlink |
+| `/gemini:transfer` | `git status -s` plus a per-file diff (`scripts/lib/transfer-context.mjs`) | Secret-file contents withheld; 5,000 characters per file; 25,000 characters total |
+
+Truncation is announced **inside** the content that is sent, so the model reports
+that it saw a partial diff rather than reviewing half a change silently.
+
+**The table describes what the plugin assembles, not the ceiling on what Google
+receives.** Gemini CLI and AGY are agentic: they run in your workspace directory
+and can read files on their own initiative while working on the prompt. For
+`/gemini:rescue` in particular, the plugin sends your instruction and nothing
+else, but the CLI may then read whatever it judges relevant — including files no
+redaction rule here ever saw. The limits and redaction above bound the plugin's
+contribution; they do not sandbox the engine, and neither AGY nor Gemini CLI
+offers a path-boundary mode the plugin could impose. This is documented as a
+known, unmitigated gap in
+[`docs/THREAT-MODEL.md` §7.2](docs/THREAT-MODEL.md). If a workspace contains
+material that must not reach Google, do not run a delegated task in it.
+
+### Secret-file redaction
+
+Files whose names look like credential stores — `.env` and `.env.*`, `*.env`,
+`*.pem`, `*.key`, `*.p12`/`*.pfx`/`*.crt`/`*.keystore`, `.npmrc`,
+`credentials.json`, `*_creds.json`, `secret(s).json|yml|yaml|env`, anything
+matching `id_rsa` — have their contents replaced with a placeholder before the
+prompt is built. The diff header is kept, so the review still knows the file
+changed. One definition covers both the review and transfer paths
+(`scripts/lib/secrets.mjs`).
+
+**Known limit, stated plainly:** detection is by filename only. A credential
+pasted into an ordinary source file, hardcoded in a config, or embedded in a
+test fixture is **not** redacted on any path. This is not a secret scanner, and
+it has never been one. Treat the diff you are about to review as the thing you
+are sending.
+
+### The one automated send, and how it is gated
+
+The optional Stop review gate (`scripts/stop-review-gate-hook.mjs`) can run an
+adversarial review of your working tree without a fresh command from you. It
+fires only when **both** conditions hold:
+
+1. you enabled it explicitly (`stopReviewGateEnabled`, set through
+   `/gemini:setup`; it defaults to off), **and**
+2. a `--write` task has completed in this workspace.
+
+Disable it the same way you enabled it. Nothing else in the plugin transmits
+anything without a command you typed.
+
+### Third parties
+
+Whatever the Gemini CLI or AGY sends is then governed by Google's terms and
+privacy policy for that product, including any retention or model-training
+practices they apply to your plan tier. This project has no control over, and no
+visibility into, what happens after the prompt reaches Google:
+
+- Gemini CLI: <https://github.com/google-gemini/gemini-cli>
+- Antigravity: <https://antigravity.google/>
+- Google Privacy Policy: <https://policies.google.com/privacy>
+
+Review those terms for your plan before sending proprietary code.
+
+---
+
+## 3. What is read from your machine
+
+Beyond the workspace you invoke a command in, the plugin reads three things
+outside it — all locally, none transmitted:
+
+| Path | What is read | Why |
+|---|---|---|
+| `~/.gemini/oauth_creds.json` (or `$GEMINI_HOME`) | The token **expiry timestamp** only | To report Gemini auth status and to keep `auto` routing from selecting an unauthenticated CLI (`scripts/lib/gemini-auth.mjs`) |
+| `~/.gemini/settings.json` | The `security.auth.selectedType` string only | To tell a personal plan from a Code Assist plan, which differ in CLI access (`scripts/lib/gemini-auth.mjs`) |
+| `~/.gemini/antigravity-cli/brain/` or `~/.antigravity-cli/brain/` | AGY's own conversation transcript for the run it just started | Only on AGY older than 1.1.8, which has no structured stdout; newer AGY returns a JSON envelope and the transcript is not read (`scripts/lib/agy-transcript.mjs`, `scripts/lib/engine.mjs`) |
+
+The token value itself is never logged, copied, or transmitted. `GEMINI_API_KEY`
+and `GOOGLE_API_KEY` are checked for presence only; their values are never read
+into a prompt.
+
+### What the plugin does not touch
+
+- Claude memory (`~/.claude/`, `CLAUDE.md`, `MEMORY.md`) — never read.
+- Claude Code conversation history, transcripts, or summaries — never read.
+- Files you uploaded to Claude — never read.
+- Your credentials as values — see above.
+- Any other home-directory content. The three paths in the table are the whole
+  list.
+
+---
+
+## 4. What is stored locally, and where
+
+Nothing is stored remotely. Two local locations, both prunable, both yours:
+
+### Transfer snapshots
+
+`<workspace>/.omc/transfers/transfer-*.json` — written by `/gemini:transfer`,
+containing the workspace path, your instructions, `git status`, and the redacted
+diff. The 20 most recent are kept; older ones are deleted on each new transfer
+(`scripts/lib/transfer-context.mjs`). `.omc/` is in `.gitignore`, so snapshots
+are not committed by accident.
+
+### Job state and logs
+
+`$GEMINI_COMPANION_DATA/state/<workspace-slug>-<hash>/`, or
+`<system temp>/gemini-companion/<workspace-slug>-<hash>/` when that variable is
+unset — containing `state.json`, `jobs/<id>.json`, and `jobs/<id>.log` for
+background jobs. The 50 most recent jobs are kept; older records and their log
+files are deleted together (`scripts/lib/state.mjs`). The directory name derives
+from your workspace path so separate projects do not share state; ending a
+Claude Code session removes that session's jobs
+(`scripts/session-lifecycle-hook.mjs`).
+
+Delete either directory at any time. The plugin recreates what it needs.
+
+---
+
+## 5. Changes to this document
+
+New data collection, new transmission, new retention, or a new remote service is
+a material change: it requires a threat-model review, a `SECURITY.md` update,
+this document updated in the same pull request, and at minimum a MINOR version
+bump. See [`docs/THREAT-MODEL.md`](docs/THREAT-MODEL.md).

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -143,14 +143,16 @@ are not committed by accident.
 
 ### Job state and logs
 
-`$GEMINI_COMPANION_DATA/state/<workspace-slug>-<hash>/`, or
-`<system temp>/gemini-companion/<workspace-slug>-<hash>/` when that variable is
-unset — containing `state.json`, `jobs/<id>.json`, and `jobs/<id>.log` for
-background jobs. The 50 most recent jobs are kept; older records and their log
-files are deleted together (`scripts/lib/state.mjs`). The directory name derives
-from your workspace path so separate projects do not share state; ending a
-Claude Code session removes that session's jobs
-(`scripts/session-lifecycle-hook.mjs`).
+`$CLAUDE_PLUGIN_DATA/state/<workspace-slug>-<hash>/` — Claude Code's per-plugin
+data directory — containing `state.json`, `jobs/<id>.json`, and `jobs/<id>.log`
+for background jobs. Outside Claude Code, where that variable is unset, it falls
+back to `<system temp>/gemini-companion/<workspace-slug>-<hash>/`. Setting
+`GEMINI_COMPANION_DATA` overrides both.
+
+The 50 most recent jobs are kept; older records and their log files are deleted
+together (`scripts/lib/state.mjs`). The directory name derives from your
+workspace path so separate projects do not share state; ending a Claude Code
+session removes that session's jobs (`scripts/session-lifecycle-hook.mjs`).
 
 Delete either directory at any time. The plugin recreates what it needs.
 

--- a/README.md
+++ b/README.md
@@ -283,6 +283,8 @@ Override via `--engine` flag or the `GEMINI_ENGINE` environment variable.
 - **Credential handling**: OAuth credentials in `~/.gemini/oauth_creds.json` are read only to check token expiry via `getGeminiLoginStatus()`; they are never logged, copied elsewhere, or transmitted by this plugin.
 - **`.gitignore`**: The `.omc/` state directory (job logs, session state) is excluded from version control.
 
+**What is sent, kept, and read** — including the one path that transmits without an explicit command — is documented in [`PRIVACY.md`](PRIVACY.md).
+
 ---
 
 ## Setup & Auth Troubleshooting

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -281,6 +281,8 @@
 - **憑證處理**：`~/.gemini/oauth_creds.json` 之 OAuth 憑證僅用於 `getGeminiLoginStatus()` 檢查 token 是否過期；本外掛從不記錄、複製或傳輸之。
 - **`.gitignore`**：`.omc/` 狀態目錄（工作日誌、會話狀態）已排除於版本控制之外。
 
+**送出哪些資料、保留在何處、讀取了什麼**——包含唯一一條不需明確命令即會傳輸的路徑——記載於 [`PRIVACY.md`](PRIVACY.md)（英文）。
+
 ---
 
 ## 安裝與認證疑難排解

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,10 +2,12 @@
 
 ## Supported Versions
 
+Only the current MINOR line is supported. Update this table with every MINOR bump.
+
 | Version | Supported |
 |---|---|
-| 0.12.x | :white_check_mark: |
-| < 0.12.0 | :x: |
+| 0.14.x | :white_check_mark: |
+| < 0.14.0 | :x: |
 
 ## Security Model & Trust Boundaries
 
@@ -15,7 +17,7 @@
 - Stdin transport and prompt escaping logic (`plugins/gemini/scripts/lib/gemini.mjs`, `plugins/gemini/scripts/transfer.mjs`).
 - Argument validation and flag parsing (preventing flag injection into CLI subprocesses).
 - Process boundary security (forcing `shell: false` on Git operations in `plugins/gemini/scripts/lib/git.mjs`).
-- Secret file redaction filters (`isSecretFile()` in `plugins/gemini/scripts/lib/transfer-context.mjs`).
+- Secret file redaction filters (`isSecretFile()` and `redactSecretsFromDiff()` in `plugins/gemini/scripts/lib/secrets.mjs`, shared by the review and transfer paths; `transfer-context.mjs` re-exports `isSecretFile` under its original name).
 - Background job state directory isolation (`.omc/`).
 - **Prompt injection and delegated agency** — the plugin hands repository content it did not author to an agent that can be write-capable. Modelled in [`docs/THREAT-MODEL.md` §7](docs/THREAT-MODEL.md), mapped against the OWASP Top 10 for LLM Applications. Read that section before reporting: the highest-rated item (`/gemini:rescue` defaulting to a write-capable run with no path sandbox) is **known and documented**, not an undisclosed flaw.
 
@@ -23,6 +25,10 @@
 - Third-party CLI binary vulnerabilities within Google's `gemini` or `agy` executables.
 - Claude Code runtime environment process sandbox boundaries.
 - User-managed OAuth token storage inside `~/.gemini/oauth_creds.json` or AGY system keyrings.
+
+### Data Handling
+
+What the plugin sends, keeps, and reads — and the single path that transmits without an explicit user command — is documented in [`PRIVACY.md`](PRIVACY.md). Report any statement there that the code does not support as a documentation defect.
 
 ## Reporting a Vulnerability
 

--- a/plugins/gemini/CHANGELOG.md
+++ b/plugins/gemini/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### Documentation
+- **`PRIVACY.md` states what the plugin sends, keeps, and reads**, with a source file cited beside each claim. It was the one directory-compliance document the repository did not have; nothing in `README.md`, `README.zh-TW.md`, `SECURITY.md`, or `docs/THREAT-MODEL.md` contained the word *privacy*. Both READMEs and `SECURITY.md` link to it.
+  - The document says the uncomfortable parts out loud: secret detection is by filename only; the size caps and redaction bound what the *plugin* assembles, not what the agentic CLI may read on its own once running in your workspace ([`docs/THREAT-MODEL.md` §7.2](../../docs/THREAT-MODEL.md)); and the opt-in Stop review gate is the one path that transmits a diff without a fresh command.
+- **`SECURITY.md` supported-versions table said `0.12.x`** while 0.14.1 shipped — a security policy claiming the current release is unsupported. Corrected, with the rule ("only the current MINOR line") written down so the next bump does not re-stale it. The in-scope-components list also still pointed `isSecretFile()` at `transfer-context.mjs`; the definition moved to `lib/secrets.mjs` in 0.13.0.
+
+### Tests
+- `tests/privacy-doc.test.mjs` pins `PRIVACY.md`'s presence, the four questions it must answer, and the link from every entry document — a policy doc rots when a README rewrite silently drops the link, not when the file is deleted. It also derives the expected supported-version line from `package.json`, so the table cannot go stale again without failing CI.
+
 ## 0.14.1 — 2026-08-05 — Correct argument quoting on the Windows shell path
 
 ### Fixed

--- a/tests/privacy-doc.test.mjs
+++ b/tests/privacy-doc.test.mjs
@@ -1,0 +1,44 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+// PRIVACY.md is a directory-compliance document: an approved plugin has to be
+// able to point at one. These assertions keep it present and reachable — the way
+// a policy doc actually rots is that a README rewrite drops the link and nobody
+// notices, not that the file is deleted.
+
+const ROOT = path.resolve(fileURLToPath(new URL("..", import.meta.url)));
+
+const read = (...segments) => fs.readFileSync(path.join(ROOT, ...segments), "utf8");
+
+test("PRIVACY.md exists and answers the four directory questions", () => {
+  const privacy = read("PRIVACY.md");
+
+  // What leaves the machine, and to whom.
+  assert.match(privacy, /Gemini CLI|Antigravity/);
+  // What is retained locally, and where.
+  assert.match(privacy, /\.omc[/\\]transfers/);
+  assert.match(privacy, /state\.json/);
+  // What is explicitly not accessed.
+  assert.match(privacy, /Claude memory/);
+  // The limits of the redaction claim, stated rather than glossed.
+  assert.match(privacy, /filename only/);
+});
+
+test("every entry document links to PRIVACY.md", () => {
+  for (const file of ["README.md", "README.zh-TW.md", "SECURITY.md"]) {
+    assert.match(read(file), /\(PRIVACY\.md\)/, `${file} does not link to PRIVACY.md`);
+  }
+});
+
+test("SECURITY.md declares support for the shipped minor line", () => {
+  const version = JSON.parse(read("package.json")).version;
+  const minorLine = `${version.split(".").slice(0, 2).join(".")}.x`;
+  assert.match(
+    read("SECURITY.md"),
+    new RegExp(`\\|\\s*${minorLine.replaceAll(".", "\\.")}\\s*\\|`),
+    `SECURITY.md does not list ${minorLine} as supported`
+  );
+});


### PR DESCRIPTION
Summary:
Adds `PRIVACY.md` and links it from `README.md`, `README.zh-TW.md`, and `SECURITY.md`. Closes HANDOFF §14 P0 "Privacy and directory compliance" in full: what repository data is sent to Gemini/AGY, that the plugin runs no remote collection service, what local job and transfer data is retained and where, that Claude memory and conversation history are not accessed, and links to the third-party policies without implying control over them.

Why:
The repository had no privacy document. `README.md`, `README.zh-TW.md`, `SECURITY.md` and `docs/THREAT-MODEL.md` contained no occurrence of the word "privacy". An approved directory entry needs somewhere to point, and a reviewer had no single place to check what a delegated review actually transmits.

Every claim in the document cites the file that supports it. The uncomfortable parts are stated rather than glossed:
- Secret detection is filename-only; a credential pasted into an ordinary source file is not redacted on any path.
- The size caps and redaction bound what the **plugin** assembles, not what an agentic CLI may read on its own once running in the workspace. Cross-referenced to `docs/THREAT-MODEL.md` §7.2, which already records this as a known unmitigated gap.
- The opt-in Stop review gate is the one path that transmits a diff without a fresh user command, with both of its preconditions named.

Two adjacent corrections found while verifying claims:
- `SECURITY.md` declared `0.12.x` supported and `< 0.12.0` unsupported — a security policy asserting that the shipped 0.14.1 is out of support. Corrected to `0.14.x`, with the rule ("only the current MINOR line") written down and now derived from `package.json` by a test.
- The in-scope-components list pointed `isSecretFile()` at `transfer-context.mjs`. That definition moved to `lib/secrets.mjs` in 0.13.0; `transfer-context.mjs` re-exports it.

Security impact:
None. Documentation and one test file; no plugin code touched.

Data/privacy impact:
No behavior change. This PR describes existing behavior; it does not add, remove, or alter any data flow.

Compatibility:
No runtime, engine, platform, or command-surface change.

Validation:
- `npm test` — 296 tests, 291 pass, 0 fail, 5 skipped (was 293/288/0/5 on main; +3 new tests)
- `npm run check-version` — matches 0.14.1
- `npm run verify-contracts` — passed
- `claude plugin validate ./plugins/gemini --strict` — passed
- `claude plugin validate . --strict` — passed
- `git diff --check` — clean

Fixture tests:
- New `tests/privacy-doc.test.mjs`: asserts `PRIVACY.md` exists and answers the four directory questions, that all three entry documents link to it, and that `SECURITY.md`'s supported-version row matches the minor line in `package.json`. The realistic rot for a policy doc is a README rewrite dropping the link, not the file being deleted.

Live tests:
- None required; no code path changed.
- Claims were verified by reading source, not by running the engines: no `fetch`/`http`/`net`/`dns` call exists under `plugins/gemini/scripts/`; `package.json` declares no dependencies; the three home-directory reads are `~/.gemini/oauth_creds.json` (expiry field only), `~/.gemini/settings.json` (auth type only), and the AGY brain directory (AGY < 1.1.8 only).

Not tested:
- The document's accuracy is asserted by reading, not by instrumenting a live run and capturing what the CLI transmits. A reviewer wanting stronger evidence would have to trace the Gemini/AGY process itself, which is outside this plugin's boundary.

Known limitations:
- Claims are pinned to plugin version 0.14.x, stated at the top of the document. A future change to any data flow must update it in the same PR — recorded as a requirement in §5 of the document.
- The document is English-only. `README.zh-TW.md` links to it and marks it as such rather than carrying a translation that could drift out of sync with the English original.

Version:
No bump in this PR. Batched into a single `0.14.2` PATCH at the end of the backlog series; the changelog entry sits under `## Unreleased`.

Rollback:
Revert this commit. Documentation and one test file only; nothing to migrate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)