### PR TITLE
fix(security): stop a review reading through a symlink out of the workspace

### DIFF
--- a/docs/THREAT-MODEL.md
+++ b/docs/THREAT-MODEL.md
@@ -102,6 +102,10 @@ Calibrate that result honestly: it shows one model refusing one obvious payload.
 
 **Still true**: detection is filename-based. A credential pasted into `config.js` is not redacted on either path, and nothing here should be relied on as a secret scanner.
 
+**Reopened and closed again for symlinks.** The 0.13.0 fix routed `formatUntrackedFile` through the same filename check, but the name it checks is the *link* name, which whoever plants the link chooses. An untracked symlink called `notes.txt` pointing at `~/.ssh/id_rsa` passed the check, and `readFileSync` followed it — the review then carried key material from outside the repository. The reachable route is 7.2's own output: a write-capable delegated task creates the link, a later review or the 7.5 gate reads through it. `formatUntrackedFile` now resolves any symlink with `fs.realpathSync.native` and skips it when the target falls outside the workspace, so a review only ever carries content from the tree being reviewed. In-repo aliases still inline normally, and broken links still report as broken.
+
+**Also filename-based, but only for reporting.** `redactSecretsFromDiff` used to read the redacted file's name off the `diff --git a/P b/P` header, which is ambiguous once `P` contains a space — for `a b/c.env` it reported `c.env b/a b/c.env`. Redaction was never affected (the check runs on the final path segment, which survives either misparse), but the list shown to the user was wrong. The b-side path now comes from the unambiguous `+++ b/<path>` line, with the header kept as a fallback for diffs that have none.
+
 ### 7.5 PI-4 — Automatic exposure via the stop-review gate (Low)
 
 `LLM01 Prompt Injection`

--- a/plugins/gemini/CHANGELOG.md
+++ b/plugins/gemini/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Security
+- **A review no longer reads through an untracked symlink that leaves the workspace.** `formatUntrackedFile` checked `isSecretFile` against the *link* name — which whoever plants the link chooses — and then followed it with `readFileSync`. An untracked symlink called `notes.txt` pointing at `~/.ssh/id_rsa` passed every check and its target's contents were sent to the model. The link is now resolved with `fs.realpathSync.native` and skipped when the target falls outside the workspace; both sides are canonicalized first, because a `cwd` that is itself a symlinked path (macOS `/tmp`) would otherwise mark every file as an escape. In-repo aliases still inline normally and broken links still report as broken. The reachable route is a write-capable delegated task creating the link and a later review reading through it — see [`docs/THREAT-MODEL.md` §7.4](../../docs/THREAT-MODEL.md).
+
+### Fixed
+- **The redacted-file list named the wrong path when a directory contained a space.** `redactSecretsFromDiff` read the b-side path off the `diff --git a/P b/P` header, which is ambiguous once `P` holds a space: for `a b/c.env` the first ` b/` gives `c.env b/a b/c.env` and the last gives `c.env`. It now takes the path from the unambiguous `+++ b/<path>` line, stopping at the first `@@` so an added line beginning `++ ` cannot be misread as the header, and falls back to the old header match for diffs with no `+++` line. Redaction itself was never wrong — the check runs on the final path segment, which survives either misparse — so this is the accuracy of what the user is told was withheld.
+
 ### Documentation
 - **`PRIVACY.md` states what the plugin sends, keeps, and reads**, with a source file cited beside each claim. It was the one directory-compliance document the repository did not have; nothing in `README.md`, `README.zh-TW.md`, `SECURITY.md`, or `docs/THREAT-MODEL.md` contained the word *privacy*. Both READMEs and `SECURITY.md` link to it.
   - The document says the uncomfortable parts out loud: secret detection is by filename only; the size caps and redaction bound what the *plugin* assembles, not what the agentic CLI may read on its own once running in your workspace ([`docs/THREAT-MODEL.md` §7.2](../../docs/THREAT-MODEL.md)); and the opt-in Stop review gate is the one path that transmits a diff without a fresh command.
@@ -9,6 +15,13 @@
 
 ### Tests
 - `tests/privacy-doc.test.mjs` pins `PRIVACY.md`'s presence, the four questions it must answer, and the link from every entry document — a policy doc rots when a README rewrite silently drops the link, not when the file is deleted. It also derives the expected supported-version line from `package.json`, so the table cannot go stale again without failing CI.
+
+Coverage for the paths that had none, per HANDOFF §14 P1. Verified against real git output, not only hand-written diffs:
+- Untracked symlinks: escaping (skipped), in-workspace (still inlined), broken (still reported). Skipped with a reported reason on Windows hosts without symlink privilege rather than passing silently.
+- `resolveStateDir` canonicalizes the workspace before hashing, so one checkout reached through a symlink shares a state dir, while two workspaces sharing a basename stay separate.
+- Concurrent writers never expose a partially written `state.json` and leave no `.tmp` files. Pinned as the guarantee `atomicWriteJson` actually makes — a load/mutate/save cycle cannot also promise that concurrent writers keep each other's jobs.
+- Hostile filenames through redaction: a directory containing a space, a rename whose destination is the secret store, and a git C-quoted non-ASCII path.
+- Envelope truncation: an envelope cut mid-value is rejected, and so is one whose cut leaves a balanced inner object behind — the case where the balanced-block scan could otherwise report a successful run with no response. A large well-formed envelope is pinned as delivered intact, so any future size limit lands as a deliberate diff.
 
 ## 0.14.1 — 2026-08-05 — Correct argument quoting on the Windows shell path
 

--- a/plugins/gemini/scripts/lib/git.mjs
+++ b/plugins/gemini/scripts/lib/git.mjs
@@ -156,6 +156,23 @@ function capReviewContent(content) {
   return content.slice(0, MAX_REVIEW_CONTENT_CHARS) + REVIEW_TRUNCATION_NOTICE;
 }
 
+// Whether following `absolutePath` stays inside `cwd`. Both sides are resolved
+// first: `cwd` itself is routinely a symlinked path (macOS /tmp -> /private/tmp,
+// and every test that runs under one), so comparing an unresolved cwd against a
+// resolved target reports every file as an escape.
+function resolvesInsideWorkspace(cwd, absolutePath) {
+  let workspace;
+  let target;
+  try {
+    workspace = fs.realpathSync.native(cwd);
+    target = fs.realpathSync.native(absolutePath);
+  } catch {
+    return false;
+  }
+  const relative = path.relative(workspace, target);
+  return relative !== "" && !relative.startsWith("..") && !path.isAbsolute(relative);
+}
+
 export function formatUntrackedFile(cwd, relativePath) {
   const absolutePath = path.join(cwd, relativePath);
 
@@ -168,8 +185,17 @@ export function formatUntrackedFile(cwd, relativePath) {
   let stat;
   try {
     const linkStat = fs.lstatSync(absolutePath);
-    if (linkStat.isSymbolicLink() && !fs.existsSync(absolutePath)) {
-      return `### ${relativePath}\n(skipped: broken symlink or unreadable file)`;
+    if (linkStat.isSymbolicLink()) {
+      if (!fs.existsSync(absolutePath)) {
+        return `### ${relativePath}\n(skipped: broken symlink or unreadable file)`;
+      }
+      // isSecretFile matched the link name, which the planter chooses. A symlink
+      // called `notes.txt` pointing at ~/.ssh/id_rsa passed that check and was
+      // then read through with readFileSync, sending the target's contents to
+      // the model. Content only ever leaves the workspace being reviewed.
+      if (!resolvesInsideWorkspace(cwd, absolutePath)) {
+        return `### ${relativePath}\n(skipped: symlink resolves outside the workspace)`;
+      }
     }
     stat = fs.statSync(absolutePath);
   } catch {

--- a/plugins/gemini/scripts/lib/secrets.mjs
+++ b/plugins/gemini/scripts/lib/secrets.mjs
@@ -31,10 +31,40 @@ export const SECRET_DIFF_PLACEHOLDER = "[REDACTED: secret file content withheld 
 // body of any file that looks like a secret store, keeping the header so the
 // review still knows the file changed.
 //
-// git quotes whole paths containing special characters — `"a/we ird.env"
-// "b/we ird.env"` — so the opening quote sits *before* the `b/`. Match the b/
-// side with optional quotes on either end rather than parsing the whole header
-// grammar.
+// The `diff --git a/<P> b/<P>` header is genuinely ambiguous once a path holds a
+// space: for `a b/c.env` git emits `diff --git a/a b/c.env b/a b/c.env`, and no
+// regex over that line alone can say where the a-side ends — the first ` b/`
+// yields `c.env b/a b/c.env`, the last yields `c.env`, and both are wrong. git's
+// own tooling resolves it from the `+++ b/<path>` line, which runs to end of
+// line and cannot be misread. Use that, and keep the header regex for the cases
+// that have no `+++` line at all (pure renames, mode changes).
+//
+// git quotes whole paths containing special characters — `"b/we ird.env"` — so
+// the opening quote sits *before* the `b/` on every form. Strip optional quotes
+// on both ends rather than parsing git's C-quoting grammar; the escaped name is
+// reported as git wrote it.
+function bSidePath(part, header) {
+  for (const line of part.split("\n")) {
+    // Stop at the first hunk: an added line whose content begins with `++ `
+    // renders as `+++ ...` and would otherwise be read as the file header.
+    if (line.startsWith("@@")) break;
+    if (!line.startsWith("+++ ")) continue;
+    const target = line.slice(4).trim();
+    if (target === "/dev/null") break; // deletion: fall back to the header
+    const unquoted = target.replace(/^"(.*)"$/, "$1");
+    return unquoted.startsWith("b/") ? unquoted.slice(2) : unquoted;
+  }
+
+  const renamed = part.match(/^rename to (.+)$/m);
+  if (renamed) return renamed[1].trim().replace(/^"(.*)"$/, "$1");
+
+  // Last resort. The capture runs to end of line, so its final path segment is
+  // still the real basename even when the prefix is wrong — which is what
+  // isSecretFile tests.
+  const match = header.match(/ "?b\/(.+?)"?$/);
+  return match ? match[1] : null;
+}
+
 export function redactSecretsFromDiff(diff) {
   const text = String(diff ?? "");
   if (!text.trim()) return { text, redactedFiles: [] };
@@ -45,8 +75,7 @@ export function redactSecretsFromDiff(diff) {
   const out = parts.map((part) => {
     if (!part.startsWith("diff --git ")) return part;
     const header = part.slice(0, part.indexOf("\n") === -1 ? part.length : part.indexOf("\n"));
-    const match = header.match(/ "?b\/(.+?)"?$/);
-    const filePath = match ? match[1] : null;
+    const filePath = bSidePath(part, header);
     if (!filePath || !isSecretFile(filePath)) return part;
     redactedFiles.push(filePath);
     return `${header}\n${SECRET_DIFF_PLACEHOLDER}\n`;

--- a/tests/agy-envelope.test.mjs
+++ b/tests/agy-envelope.test.mjs
@@ -122,6 +122,57 @@ test("AGY 1.1.10 turn reports invalid-json when stdout is not an envelope", asyn
   assert.equal(result.failure.category, "invalid-json");
 });
 
+// The spawn caps stdout at MAX_BUFFER (50 MB); past that Node kills the child
+// and hands back whatever it had, so an oversized envelope arrives cut mid-token
+// rather than as a clean object. tryParseJsonFromText scans for balanced {...}
+// blocks, so the question is whether a truncated payload can still yield an
+// object the plugin would act on. It must not.
+test("AGY 1.1.10 turn rejects an envelope truncated mid-value", async () => {
+  const full = JSON.stringify({ ...SUCCESS_ENVELOPE, response: "x".repeat(4096) });
+  const runCommandFn = stubRun({ stdout: full.slice(0, full.length - 200), status: 0 });
+
+  const result = await runGeminiTurn("/repo", { prompt: "hi", write: false }, {
+    runCommandFn,
+    detectEngineFn: agyEngine()
+  });
+
+  assert.notEqual(result.status, 0);
+  assert.equal(result.failure.category, "invalid-json");
+});
+
+// A truncated envelope whose `usage` object closed before the cut leaves a
+// balanced {...} block behind. The scan must not mistake that fragment for the
+// envelope and report a successful run with no response.
+test("AGY 1.1.10 turn rejects a truncation that leaves a balanced inner object", async () => {
+  const stdout = '{"conversation_id":"abc","status":"SUCCESS","usage":{"total_tokens":42},"response":"partia';
+  const runCommandFn = stubRun({ stdout, status: 0 });
+
+  const result = await runGeminiTurn("/repo", { prompt: "hi", write: false }, {
+    runCommandFn,
+    detectEngineFn: agyEngine()
+  });
+
+  assert.notEqual(result.status, 0, "an inner fragment must not read as a completed run");
+  assert.equal(result.failure.category, "invalid-json");
+});
+
+// A very large but well-formed envelope is a cost problem, not a correctness
+// one: it is under the spawn cap, so it parses and the response is delivered
+// whole. Pinned so a future size limit is a deliberate change with a visible
+// diff rather than a silent truncation of someone's result.
+test("AGY 1.1.10 turn delivers a large well-formed envelope intact", async () => {
+  const response = "y".repeat(2 * 1024 * 1024);
+  const runCommandFn = stubRun({ stdout: JSON.stringify({ ...SUCCESS_ENVELOPE, response }), status: 0 });
+
+  const result = await runGeminiTurn("/repo", { prompt: "hi", write: false }, {
+    runCommandFn,
+    detectEngineFn: agyEngine()
+  });
+
+  assert.equal(result.status, 0);
+  assert.equal(result.finalMessage.length, response.length);
+});
+
 test("AGY 1.1.7 never requests the envelope", async () => {
   const runCommandFn = stubRun({ stdout: "ignored\n" });
 

--- a/tests/git.test.mjs
+++ b/tests/git.test.mjs
@@ -168,6 +168,61 @@ test("formatUntrackedFile inlines a small text file", () => {
   assert.match(out, /hello content/);
 });
 
+// Symlink creation needs SeCreateSymbolicLinkPrivilege on Windows (Developer
+// Mode or an elevated shell). Report the skip rather than passing silently on a
+// machine that never ran the assertion.
+function trySymlink(target, linkPath) {
+  try {
+    fs.symlinkSync(target, linkPath, "file");
+    return true;
+  } catch (error) {
+    if (process.platform === "win32" && (error.code === "EPERM" || error.code === "EACCES")) {
+      return false;
+    }
+    throw error;
+  }
+}
+
+test("formatUntrackedFile does not read through a symlink that leaves the workspace", (t) => {
+  const outside = makeTempDir("gemini-plugin-outside-");
+  fs.writeFileSync(path.join(outside, "id_rsa"), "OUTSIDE_KEY_MATERIAL\n");
+
+  const cwd = makeTempDir();
+  // The link name is what isSecretFile sees, and an attacker picks it. An
+  // innocuous name pointing at key material passed every earlier check.
+  if (!trySymlink(path.join(outside, "id_rsa"), path.join(cwd, "notes.txt"))) {
+    t.skip("symlink creation not permitted on this Windows host");
+    return;
+  }
+
+  const out = formatUntrackedFile(cwd, "notes.txt");
+  assert.ok(!out.includes("OUTSIDE_KEY_MATERIAL"), "content outside the workspace must not be sent");
+  assert.match(out, /\(skipped: symlink resolves outside the workspace\)/);
+});
+
+test("formatUntrackedFile still inlines a symlink that stays inside the workspace", (t) => {
+  const cwd = makeTempDir();
+  fs.writeFileSync(path.join(cwd, "real.txt"), "in-repo content\n");
+  if (!trySymlink(path.join(cwd, "real.txt"), path.join(cwd, "alias.txt"))) {
+    t.skip("symlink creation not permitted on this Windows host");
+    return;
+  }
+
+  // The containment check must not turn every symlink into a skip: an in-repo
+  // alias is ordinary reviewable content.
+  const out = formatUntrackedFile(cwd, "alias.txt");
+  assert.match(out, /in-repo content/);
+});
+
+test("formatUntrackedFile still reports a broken symlink as broken", (t) => {
+  const cwd = makeTempDir();
+  if (!trySymlink(path.join(cwd, "missing-target.txt"), path.join(cwd, "dangling.txt"))) {
+    t.skip("symlink creation not permitted on this Windows host");
+    return;
+  }
+  assert.match(formatUntrackedFile(cwd, "dangling.txt"), /\(skipped: broken symlink or unreadable file\)/);
+});
+
 // docs/THREAT-MODEL.md 7.4 — the review path used to send secret files whole
 // while /gemini:transfer redacted them from the same diff.
 test("collectReviewContext withholds secret file content from a working-tree review", () => {

--- a/tests/secrets.test.mjs
+++ b/tests/secrets.test.mjs
@@ -62,6 +62,48 @@ test("redactSecretsFromDiff handles git's quoted paths", () => {
   assert.deepEqual(redactedFiles, ["we ird.env"]);
 });
 
+// Real headers produced by git for these names, captured from a repository
+// built with each file in it. A directory containing a space puts a second
+// ` b/` inside the header.
+test("redactSecretsFromDiff names the right file when the path contains ' b/'", () => {
+  const diff = [
+    "diff --git a/a b/c.env b/a b/c.env",
+    "--- a/a b/c.env",
+    "+++ b/a b/c.env",
+    "@@ -1 +1 @@",
+    "+SECRET=SPACED_DIR_LEAK",
+    ""
+  ].join("\n");
+
+  const { text, redactedFiles } = redactSecretsFromDiff(diff);
+  assert.ok(!text.includes("SPACED_DIR_LEAK"));
+  assert.deepEqual(redactedFiles, ["a b/c.env"]);
+});
+
+test("redactSecretsFromDiff reports the b-side path of a rename", () => {
+  const diff = ["diff --git a/settings.js b/config/prod.env", "+API_KEY=RENAMED_LEAK", ""].join("\n");
+
+  const { text, redactedFiles } = redactSecretsFromDiff(diff);
+  assert.ok(!text.includes("RENAMED_LEAK"), "the destination decides, and it is a secret store");
+  assert.deepEqual(redactedFiles, ["config/prod.env"]);
+});
+
+// git applies C-style quoting to non-ASCII paths under the default
+// core.quotepath. Redaction still fires because the escaped form keeps the
+// extension; the reported name stays in git's escaped form rather than being
+// unquoted, which is a display limit and not a leak.
+test("redactSecretsFromDiff still redacts a git-escaped non-ASCII path", () => {
+  const diff = [
+    'diff --git "a/uni\\303\\247ode.env" "b/uni\\303\\247ode.env"',
+    "+SECRET=UNICODE_LEAK",
+    ""
+  ].join("\n");
+
+  const { text, redactedFiles } = redactSecretsFromDiff(diff);
+  assert.ok(!text.includes("UNICODE_LEAK"));
+  assert.deepEqual(redactedFiles, ["uni\\303\\247ode.env"]);
+});
+
 test("redactSecretsFromDiff passes through a diff with nothing to redact", () => {
   const diff = "diff --git a/a.js b/a.js\n+const a = 1;\n";
   const { text, redactedFiles } = redactSecretsFromDiff(diff);

--- a/tests/state.test.mjs
+++ b/tests/state.test.mjs
@@ -1,3 +1,4 @@
+import { spawn } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -41,6 +42,40 @@ test("resolveStateDir honors GEMINI_COMPANION_DATA when provided", () => {
       process.env.GEMINI_COMPANION_DATA = previous;
     }
   }
+});
+
+// resolveStateDir hashes the *canonicalized* workspace path (fs.realpathSync.native)
+// so the same checkout reached through a symlink shares one state dir. Nothing
+// covered that before, and it is the reason a job started under one path is
+// visible from the other.
+test("resolveStateDir canonicalizes the workspace before hashing", (t) => {
+  const realParent = makeTempDir();
+  const linkParent = makeTempDir();
+  const workspace = path.join(realParent, "ws");
+  const linked = path.join(linkParent, "ws");
+  fs.mkdirSync(workspace);
+
+  try {
+    fs.symlinkSync(workspace, linked, "dir");
+  } catch (error) {
+    if (process.platform === "win32" && (error.code === "EPERM" || error.code === "EACCES")) {
+      t.skip("symlink creation not permitted on this Windows host");
+      return;
+    }
+    throw error;
+  }
+
+  assert.equal(resolveStateDir(linked), resolveStateDir(workspace));
+});
+
+test("resolveStateDir separates two workspaces that share a basename", () => {
+  const first = path.join(makeTempDir(), "ws");
+  const second = path.join(makeTempDir(), "ws");
+  fs.mkdirSync(first);
+  fs.mkdirSync(second);
+
+  // The slug is identical; only the path hash keeps their jobs apart.
+  assert.notEqual(resolveStateDir(first), resolveStateDir(second));
 });
 
 test("saveState prunes dropped job artifacts when indexed jobs exceed the cap", () => {
@@ -100,6 +135,72 @@ test("state and job writes leave parseable JSON", () => {
 
   assert.equal(JSON.parse(fs.readFileSync(stateFile, "utf8")).jobs[0].id, "task-1");
   assert.equal(JSON.parse(fs.readFileSync(jobFile, "utf8")).status, "completed");
+});
+
+// saveState writes to a pid-and-random temp file and renames it into place. The
+// guarantee that buys is that a concurrent reader never sees a half-written
+// state.json — not that concurrent writers keep each other's jobs, which a
+// load/mutate/save cycle cannot promise. Assert the guarantee that exists.
+test("concurrent writers never expose a partially written state.json", async () => {
+  const workspace = makeTempDir();
+  const stateFile = resolveStateFile(workspace);
+  // Node 18 has no import.meta.dirname; the repo's other tests resolve paths
+  // through the module URL for the same reason.
+  const stateModule = new URL("../plugins/gemini/scripts/lib/state.mjs", import.meta.url).href;
+
+  const worker = path.join(workspace, "writer.mjs");
+  fs.writeFileSync(
+    worker,
+    [
+      `const { upsertJob } = await import(${JSON.stringify(stateModule)});`,
+      "const [workspace, tag] = process.argv.slice(2);",
+      "for (let i = 0; i < 12; i += 1) {",
+      "  upsertJob(workspace, { id: `${tag}-${i}`, status: 'completed', payload: 'x'.repeat(2048) });",
+      "}"
+    ].join("\n"),
+    "utf8"
+  );
+
+  let torn = 0;
+  let reads = 0;
+  const reading = setInterval(() => {
+    let raw;
+    try {
+      raw = fs.readFileSync(stateFile, "utf8");
+    } catch {
+      return; // not created yet, or mid-rename on Windows
+    }
+    reads += 1;
+    try {
+      JSON.parse(raw);
+    } catch {
+      torn += 1;
+    }
+  }, 1);
+
+  try {
+    await Promise.all(
+      ["a", "b", "c"].map(
+        (tag) =>
+          new Promise((resolve, reject) => {
+            const child = spawn(process.execPath, [worker, workspace, tag], { stdio: "ignore" });
+            child.on("error", reject);
+            child.on("exit", (code) => (code === 0 ? resolve() : reject(new Error(`writer ${tag} exited ${code}`))));
+          })
+      )
+    );
+  } finally {
+    // Without this on the failure path, the 1 ms interval keeps the event loop
+    // alive and the whole test run hangs instead of reporting the failure.
+    clearInterval(reading);
+  }
+
+  assert.ok(reads > 0, "the reader never observed the state file");
+  assert.equal(torn, 0, `observed ${torn} torn reads of state.json`);
+  assert.doesNotThrow(() => JSON.parse(fs.readFileSync(stateFile, "utf8")));
+
+  const leftovers = fs.readdirSync(path.dirname(stateFile)).filter((name) => name.endsWith(".tmp"));
+  assert.deepEqual(leftovers, [], "temp files were left behind");
 });
 
 test("readJobFile fails closed for corrupted job JSON", () => {


### PR DESCRIPTION
Summary:
Closes HANDOFF §14 P1 "Security hardening". Adding the requested symlink and path-escape coverage found a real disclosure path, so this PR carries a fix as well as the tests.

Why:
`formatUntrackedFile` checked `isSecretFile` against the **link** name — which whoever plants the link chooses — and then followed it with `readFileSync`. An untracked symlink called `notes.txt` pointing at `~/.ssh/id_rsa` passed every check and its target's contents were sent to the model. Confirmed by construction before the fix: the probe printed the outside file's contents inside the review payload.

The reachable route is the write-capable delegated task already documented in `docs/THREAT-MODEL.md` §7.2 — the task creates the link, and a later `/gemini:review` or the §7.5 stop gate reads through it. Symlinks are now resolved with `fs.realpathSync.native` and skipped when the target lands outside the workspace. Both sides are canonicalized first: a `cwd` that is itself a symlinked path (macOS `/tmp` → `/private/tmp`, and any test running under one) would otherwise mark every file as an escape.

Second, smaller correction: `redactSecretsFromDiff` reported the wrong filename when a directory contained a space. The `diff --git a/P b/P` header is genuinely ambiguous there — for `a b/c.env` the first ` b/` yields `c.env b/a b/c.env` and the last yields `c.env`. The path now comes from the unambiguous `+++ b/<path>` line, read only before the first `@@` so an added line beginning `++ ` cannot be mistaken for the header, with the old header match kept as a fallback. **Redaction itself was never wrong** — the check runs on the final path segment, which survives either misparse — so this is the accuracy of what the user is told was withheld, not a leak.

Security impact:
Fixes an information-disclosure path from outside the workspace to the model. No permission, write-scope, or engine-selection semantics change. Read-only default is untouched.

Data/privacy impact:
Strictly reduces what can be sent: review content is now confined to the tree being reviewed.

Compatibility:
Behavior change is limited to untracked symlinks resolving outside the workspace, which now render as `(skipped: symlink resolves outside the workspace)` instead of being inlined. In-repo symlink aliases still inline; broken symlinks still report as broken. Both are asserted.

Validation:
- `npm test` — 305 tests, 300 pass, 0 fail, 5 skipped (was 293/288/0/5 on main; +12 new tests)
- `npm run check-version` — matches 0.14.1
- `npm run verify-contracts` — passed
- `claude plugin validate ./plugins/gemini --strict` — passed
- `claude plugin validate . --strict` — passed
- `git diff --check` — clean

Fixture tests:
- Untracked symlinks: escaping is skipped, in-workspace still inlines, broken still reports as broken.
- `resolveStateDir` canonicalizes the workspace before hashing, so one checkout reached through a symlink shares a state dir; two workspaces sharing a basename stay separate.
- Concurrent writers never expose a partially written `state.json` and leave no `.tmp` files. Written as the guarantee `atomicWriteJson` actually makes — a load/mutate/save cycle cannot also promise concurrent writers keep each other's jobs, and the test says so rather than implying otherwise.
- Hostile filenames through redaction: a directory containing a space, a rename whose destination is the secret store, and a git C-quoted non-ASCII path.
- Envelope truncation: cut mid-value is rejected; cut leaving a balanced inner object is also rejected — that is the case where the balanced-block scan could otherwise report a successful run with an empty response. A large well-formed envelope is pinned as delivered intact so any future size limit lands as a deliberate diff.

Live tests:
- The hostile-filename cases were first run against **real git output** from a repository containing each name, not only against hand-written diff strings. That is what showed the reported name was `c.env b/a b/c.env`; after the fix the same probe reports `a b/c.env`.
- The symlink disclosure was reproduced before the fix and confirmed gone after.

Not tested:
- Windows CI. The repository's CI is `ubuntu-latest` only. The three symlink tests call `t.skip()` with a stated reason on a Windows host lacking `SeCreateSymbolicLinkPrivilege` rather than passing silently; they were run and passed on this Windows machine with Developer Mode enabled.
- macOS. The `/tmp` symlink case that motivated canonicalizing both sides is reasoned from the platform's layout, not executed there.
- No engine was contacted; the envelope cases use the existing `runCommandFn` injection seam.

Known limitations:
- The containment check applies to untracked files, which is the path that reads through a link. Tracked symlinks are stored by git as their target string and appear in a diff as that string, so they were never followed.
- Secret detection remains filename-based everywhere. Unchanged by this PR and still stated as a limit in `PRIVACY.md` and `docs/THREAT-MODEL.md` §7.4.
- The git C-quoted non-ASCII path is reported in git's escaped form (`uni\303\247ode.env`). Unquoting it means implementing C-string unescaping; the test pins the current form rather than leaving it unstated.

Version:
No bump in this PR. Batched into a single `0.14.2` PATCH at the end of the backlog series — HANDOFF §6 places security hardening that does not alter intended interfaces in PATCH. If you would rather ship the symlink fix on its own, it is the first commit's `git.mjs` hunk plus its three tests.

Rollback:
Revert this commit. The two source changes are self-contained in `lib/git.mjs` and `lib/secrets.mjs`; no state format, manifest, or command surface is involved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)