### PR TITLE
docs: give a reviewer a credential-free path and a place to report

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,90 @@
+name: Bug report
+description: Something the plugin does is wrong, and you can show it.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **Do not report a security vulnerability here.** Use
+        [private disclosure](https://github.com/arcobaleno64/gemini-plugin-cc/security/advisories/new)
+        instead — see `SECURITY.md`.
+
+        Paste no credentials, tokens, or `.env` contents. Redact repository paths
+        you would rather not publish.
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: What you ran, what you expected, and what you got instead.
+      placeholder: |
+        Ran: /gemini:review --engine agy
+        Expected: findings for the working-tree diff
+        Got: "AGY engine requested but no transcript brain dir was found"
+    validations:
+      required: true
+
+  - type: input
+    id: command
+    attributes:
+      label: The exact command
+      description: Including every flag. This is usually where the answer is.
+      placeholder: "/gemini:review --engine agy --scope working-tree"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: engine
+    attributes:
+      label: Engine
+      options:
+        - agy
+        - gemini
+        - auto (did not specify)
+        - not sure
+    validations:
+      required: true
+
+  - type: textarea
+    id: setup-output
+    attributes:
+      label: Output of /gemini:setup
+      description: >
+        This carries the plugin version, the engine versions, and the auth state
+        — the three things almost every diagnosis needs. Redact paths if you must,
+        but keep the version lines.
+      render: text
+    validations:
+      required: true
+
+  - type: input
+    id: os
+    attributes:
+      label: OS and Node version
+      placeholder: "Windows 11 26H1, Node 22.11.0"
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: How to reproduce it
+      description: >
+        A repository state that shows the problem. If you cannot share yours,
+        `node scripts/make-sample-repo.mjs` builds a disposable one that may
+        reproduce it — say so either way.
+      placeholder: |
+        1. Clone any repo with an untracked file
+        2. Run ...
+        3. Observe ...
+    validations:
+      required: false
+
+  - type: textarea
+    id: error-output
+    attributes:
+      label: Error output
+      description: The full message, not a summary of it.
+      render: text
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/compatibility_report.yml
+++ b/.github/ISSUE_TEMPLATE/compatibility_report.yml
@@ -1,0 +1,70 @@
+name: Compatibility report
+description: A CLI version, platform, or path the plugin has not been verified on.
+labels: ["compatibility"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        The README and `docs/known-diffs.md` state which engine versions and
+        platforms have actually been run, and which are inferred. This is how
+        that list gets corrected — in either direction. A report that something
+        **works** where the docs say "not run" is as useful as one that it breaks.
+
+  - type: dropdown
+    id: engine
+    attributes:
+      label: Engine
+      options:
+        - agy
+        - gemini
+    validations:
+      required: true
+
+  - type: input
+    id: engine-version
+    attributes:
+      label: Engine version
+      description: The exact output of `agy --version` or `gemini --version`.
+      placeholder: "1.1.11"
+    validations:
+      required: true
+
+  - type: input
+    id: platform
+    attributes:
+      label: Platform
+      placeholder: "macOS 15.4 arm64 / Ubuntu 24.04 under WSL2 / Windows 11"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: outcome
+    attributes:
+      label: Outcome
+      options:
+        - Works, and the docs say it is unverified
+        - Breaks, and the docs say it works
+        - Behaves differently from the documented behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: evidence
+    attributes:
+      label: What you ran and what happened
+      description: >
+        Commands and their output. For an AGY version report, the transport
+        matters — say whether the prompt went by stdin or positionally if you can
+        tell, and include `/gemini:setup` output.
+      render: text
+    validations:
+      required: true
+
+  - type: input
+    id: doc-claim
+    attributes:
+      label: Which documented claim this contradicts
+      description: File and the sentence, if you found it.
+      placeholder: "README.md — 'AGY 1.1.2+ uses stdin transport'"
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/arcobaleno64/gemini-plugin-cc/security/advisories/new
+    about: Report privately. Do not open a public issue for a vulnerability.
+  - name: Setup and authentication trouble
+    url: https://github.com/arcobaleno64/gemini-plugin-cc#setup--auth-troubleshooting
+    about: The symptom table covers most install and OAuth failures — check it first.
+  - name: Known differences from codex-plugin-cc
+    url: https://github.com/arcobaleno64/gemini-plugin-cc/blob/main/docs/known-diffs.md
+    about: Deliberate divergences, so you can tell a missing feature from a bug.

--- a/README.md
+++ b/README.md
@@ -368,6 +368,18 @@ Documented, non-blocking constraints — see the linked sections for detail:
 
 ---
 
+## Support
+
+- **Setup or auth failing** — check [Setup & Auth Troubleshooting](#setup--auth-troubleshooting) first; most install and OAuth symptoms are in that table.
+- **A feature behaves differently from `codex-plugin-cc`** — check [docs/known-diffs.md](docs/known-diffs.md) before filing. Several differences are deliberate and documented.
+- **A bug** — open a [bug report](https://github.com/arcobaleno64/gemini-plugin-cc/issues/new?template=bug_report.yml). Include the exact command and your `/gemini:setup` output; those two answer most questions on their own.
+- **An engine version or platform we have not verified** — open a [compatibility report](https://github.com/arcobaleno64/gemini-plugin-cc/issues/new?template=compatibility_report.yml). "It works on X" is as useful as "it breaks on X", because the docs only claim what has actually been run.
+- **A security vulnerability** — do not open an issue. Use [private disclosure](https://github.com/arcobaleno64/gemini-plugin-cc/security/advisories/new); see [`SECURITY.md`](SECURITY.md).
+
+Reviewing the plugin rather than using it? [`docs/verifying-without-credentials.md`](docs/verifying-without-credentials.md) is the complete offline path — no account, no API key.
+
+---
+
 ## Changelog
 
 See [CHANGELOG.md](plugins/gemini/CHANGELOG.md).

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -372,6 +372,18 @@ Claude Code
 
 ---
 
+## 支援管道
+
+- **安裝或認證失敗**——先查 [安裝與認證疑難排解](#安裝與認證疑難排解)，多數安裝與 OAuth 症狀都在該表內。
+- **行為與 `codex-plugin-cc` 不同**——回報前請先看 [docs/known-diffs.md](docs/known-diffs.md)；部分差異是刻意為之且已記錄。
+- **臭蟲**——開一則 [bug report](https://github.com/arcobaleno64/gemini-plugin-cc/issues/new?template=bug_report.yml)。請附完整命令與 `/gemini:setup` 輸出，這兩項通常就足以定位問題。
+- **尚未驗證的引擎版本或平台**——開一則 [compatibility report](https://github.com/arcobaleno64/gemini-plugin-cc/issues/new?template=compatibility_report.yml)。「在 X 上可用」與「在 X 上壞掉」同樣有價值，因為文件只聲稱實際跑過的部分。
+- **安全性漏洞**——請勿開 issue，改用 [私密回報](https://github.com/arcobaleno64/gemini-plugin-cc/security/advisories/new)；詳見 [`SECURITY.md`](SECURITY.md)。
+
+若你是要審查本外掛而非使用它：[`docs/verifying-without-credentials.md`](docs/verifying-without-credentials.md)（英文）記載完整的離線驗證路徑，不需帳號、不需 API key。
+
+---
+
 ## 更新日誌
 
 詳見 [CHANGELOG.md](plugins/gemini/CHANGELOG.md)。

--- a/docs/verifying-without-credentials.md
+++ b/docs/verifying-without-credentials.md
@@ -1,0 +1,94 @@
+# Verifying this plugin without credentials
+
+Everything in this document runs offline, with no Google account, no OAuth flow,
+and no API key. It exists so a reviewer can check the plugin's claims without
+being handed anyone's credentials — which will never happen, no matter who asks.
+
+Requirements: Node.js 18 or newer, `git` on `PATH`. Nothing else.
+
+---
+
+## 1. The full gate, offline
+
+```bash
+npm ci
+npm test
+npm run check-version
+npm run verify-contracts
+```
+
+`npm test` spawns no engine. Where a test needs the CLI to answer, it injects a
+stand-in through the `runCommandFn` / `detectEngineFn` seams, or spawns a copied
+`node` binary that plays the part. Tests that genuinely cannot run on the current
+platform call `t.skip()` with the reason printed, rather than passing silently.
+
+`npm run verify-contracts` is offline by construction — it reads the manifests,
+the README install command, and the command files from disk.
+
+Add the manifest schema check if you have the Claude Code CLI:
+
+```bash
+claude plugin validate ./plugins/gemini --strict
+claude plugin validate . --strict
+```
+
+Both work with no login. CI proves it: the `ci` job installs the CLI into a
+fresh runner with no credential of any kind and both commands exit 0.
+
+---
+
+## 2. The benchmark, replayed from cassettes
+
+```bash
+npm run bench
+```
+
+This replays recorded engine responses from `bench/cassettes/` and scores them
+against the planted defects in `bench/corpus/*/ground-truth.json`. No network,
+no auth.
+
+Read `bench/README.md` before quoting a number from it. The provenance of every
+cassette is stated there, including which cells are **seeded** rather than
+live-recorded, and why. A seeded cell is a fixture, not a measurement.
+
+---
+
+## 3. A disposable repository to point commands at
+
+```bash
+node scripts/make-sample-repo.mjs --list
+node scripts/make-sample-repo.mjs --case auth-basic
+```
+
+This builds a throwaway git repository in your system temp directory from a
+corpus case: the `base/` tree as a commit, the `head/` tree over it as
+working-tree changes. It prints the path, the defects planted in it, and the
+`rm -rf` to undo it. Nothing is written outside that directory.
+
+Use it when you want to exercise a command for real without pointing it at code
+you care about — in particular a `--write` run, which is write-capable and has no
+path sandbox (see [`THREAT-MODEL.md` §7.2](THREAT-MODEL.md)).
+
+Running a command against it does require an authenticated engine. The
+repository is the credential-free part; the engine call is not.
+
+---
+
+## 4. What needs credentials, and what that buys
+
+| Step | Needs auth | What it adds |
+|---|---|---|
+| `npm test`, `verify-contracts`, `check-version` | no | every contract and regression assertion |
+| `claude plugin validate` | no | manifest schema conformance |
+| `npm run bench` | no | scoring against planted defects, replayed |
+| `npm run bench:live` | **yes** | re-records cassettes from real engine runs |
+| `/gemini:review`, `/gemini:rescue`, `/gemini:transfer` end to end | **yes** | an actual delegated run |
+
+To authenticate for the live paths, use **your own** account: run `gemini` once
+for the Gemini engine, or `agy` once for AGY. Note that Google ended consumer
+Gemini CLI access on 2026-06-18, so a personal account authenticates but every
+request fails — AGY is the practical engine for a live check.
+
+`npm run bench:live` overwrites the committed cassettes. Run it on a branch, and
+follow the honesty rules in `bench/README.md`: never present a seeded cell as a
+measured one, and never merge live and replayed numbers into a single figure.

--- a/docs/version-sources.md
+++ b/docs/version-sources.md
@@ -1,0 +1,82 @@
+# Version sources: why there are six, and whether to cut one
+
+Status: **study, no change recommended for now.** Written to answer HANDOFF §14
+P1 "Version source simplification study" with something a future maintainer can
+act on rather than re-derive.
+
+## The six sources
+
+`npm run bump-version -- <version>` writes all of them; `npm run check-version`
+fails if any disagrees.
+
+| # | Source | Read by |
+|---|---|---|
+| 1 | `package.json` `version` | the bump script (as the expected value), the release workflow's tag assertion, npm tooling |
+| 2 | `package-lock.json` `version` | npm |
+| 3 | `package-lock.json` `packages[""].version` | npm |
+| 4 | `plugins/gemini/.claude-plugin/plugin.json` `version` | **Claude Code, first in its resolution order** |
+| 5 | `.claude-plugin/marketplace.json` `metadata.version` | the marketplace listing |
+| 6 | `.claude-plugin/marketplace.json` `plugins[gemini].version` | Claude Code, *only* when 4 is absent |
+
+Claude Code decides an installed plugin needs updating by, in order:
+`plugin.json` version → marketplace-entry version → git commit SHA.
+
+## The risk the docs warn about
+
+Anthropic's guidance is to avoid declaring the version in more than one place,
+because `plugin.json` wins and can silently mask a stale marketplace entry. That
+failure is real: bump 4 and forget 6, and the directory listing shows an old
+number while clients update correctly. Users comparing the two see a
+contradiction and cannot tell which is authoritative.
+
+This repository does not carry that risk in practice, for three reasons that all
+have to hold:
+
+1. one script writes every source, so partial updates are not the normal path;
+2. `npm run check-version` fails on any disagreement;
+3. that check runs in PR CI and in the release workflow, and the release workflow
+   additionally asserts the git tag matches `package.json`.
+
+The duplication is therefore **mechanically enforced consistency**, not six
+independent claims. That is a different situation from the one the guidance
+describes.
+
+## What removing #6 would cost
+
+Source 6 is the only genuinely redundant one — 2 and 3 are npm's own format, and
+5 describes the marketplace rather than the plugin.
+
+Dropping it means Claude Code falls through to `plugin.json` for every install
+path. That is fine for a plugin installed from this marketplace, because the
+plugin source is `./plugins/gemini` in the same repository, so the manifest is
+always present alongside the entry.
+
+It is not obviously fine for the two paths that matter after directory approval:
+
+- **The Anthropic directory pipeline.** Whether the directory reads the entry's
+  `version` for its own display or pinning is not documented in a way this
+  repository can rely on. Testing it means publishing a change and watching what
+  the directory shows — which is not a test, it is an experiment on live users.
+- **Tag-pinned installs.** A user who added the marketplace at `@v0.9.1` stays on
+  that tag. Removing a field from a future `marketplace.json` cannot retroactively
+  affect them, but it does mean two shapes of manifest exist in the wild, and the
+  older one is what a bisect or a bug report will show.
+
+## Recommendation
+
+**Keep all six until there is a reason beyond tidiness.** The cost of the current
+arrangement is one script and one CI check that already exist and already pass.
+The cost of changing it is an unverifiable interaction with a directory pipeline
+this repository does not control.
+
+Revisit if either of these becomes true:
+
+- Anthropic documents that the marketplace entry's `version` is ignored when
+  `plugin.json` is present, in which case removing 6 is safe and mechanical;
+- `check-version` or the bump script is removed or bypassed, in which case the
+  enforcement that makes six sources safe is gone and the duplication becomes the
+  liability the guidance describes.
+
+If it is ever done, treat it as release engineering, not cleanup: a dedicated PR,
+tested against both the independent repository marketplace and the approved
+Anthropic directory entry, with the migration written down before it ships.

--- a/plugins/gemini/CHANGELOG.md
+++ b/plugins/gemini/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Added
+- **`node scripts/make-sample-repo.mjs`** materializes a benchmark corpus case into a disposable git repository and prints the defects planted in it. It is the safe target for a `--write` run, which is write-capable with no path sandbox ([`docs/THREAT-MODEL.md` §7.2](../../docs/THREAT-MODEL.md)). No new fixture content: `bench/lib/corpus.mjs` already built exactly this repo for the benchmark, so the script is that call minus the cleanup.
+
 ### Security
 - **A review no longer reads through an untracked symlink that leaves the workspace.** `formatUntrackedFile` checked `isSecretFile` against the *link* name — which whoever plants the link chooses — and then followed it with `readFileSync`. An untracked symlink called `notes.txt` pointing at `~/.ssh/id_rsa` passed every check and its target's contents were sent to the model. The link is now resolved with `fs.realpathSync.native` and skipped when the target falls outside the workspace; both sides are canonicalized first, because a `cwd` that is itself a symlinked path (macOS `/tmp`) would otherwise mark every file as an escape. In-repo aliases still inline normally and broken links still report as broken. The reachable route is a write-capable delegated task creating the link and a later review reading through it — see [`docs/THREAT-MODEL.md` §7.4](../../docs/THREAT-MODEL.md).
 
@@ -12,9 +15,14 @@
 - **`PRIVACY.md` states what the plugin sends, keeps, and reads**, with a source file cited beside each claim. It was the one directory-compliance document the repository did not have; nothing in `README.md`, `README.zh-TW.md`, `SECURITY.md`, or `docs/THREAT-MODEL.md` contained the word *privacy*. Both READMEs and `SECURITY.md` link to it.
   - The document says the uncomfortable parts out loud: secret detection is by filename only; the size caps and redaction bound what the *plugin* assembles, not what the agentic CLI may read on its own once running in your workspace ([`docs/THREAT-MODEL.md` §7.2](../../docs/THREAT-MODEL.md)); and the opt-in Stop review gate is the one path that transmits a diff without a fresh command.
 - **`SECURITY.md` supported-versions table said `0.12.x`** while 0.14.1 shipped — a security policy claiming the current release is unsupported. Corrected, with the rule ("only the current MINOR line") written down so the next bump does not re-stale it. The in-scope-components list also still pointed `isSecretFile()` at `transfer-context.mjs`; the definition moved to `lib/secrets.mjs` in 0.13.0.
+- **`docs/verifying-without-credentials.md`** — the complete path for reviewing this plugin with no Google account, no OAuth, and no API key, and an explicit table of what the credentialed steps add. Maintainer credentials are never distributed, so the offline path has to be written down.
+- **`docs/version-sources.md`** — the HANDOFF §14 P1 study, answered rather than left open. Recommendation: **keep all six version sources.** The duplication Anthropic's guidance warns about is mechanically enforced here by one bump script and a `check-version` gate that runs in both workflows, and the only redundant field interacts with a directory pipeline this repository cannot test against without experimenting on live users. Two named conditions would change the answer.
+- **Support sections** in both READMEs, routing setup trouble, deliberate divergences, bugs, compatibility reports, and vulnerabilities to different places — a vulnerability in a public issue is the failure worth preventing.
+- Issue templates for bug reports and compatibility reports. The bug template requires the exact command and `/gemini:setup` output, because those two answer most questions unaided. The compatibility template accepts "works on X" as readily as "breaks on X", since the docs only claim what has actually been run.
 
 ### Tests
 - `tests/privacy-doc.test.mjs` pins `PRIVACY.md`'s presence, the four questions it must answer, and the link from every entry document — a policy doc rots when a README rewrite silently drops the link, not when the file is deleted. It also derives the expected supported-version line from `package.json`, so the table cannot go stale again without failing CI.
+- `tests/sample-repo.test.mjs` covers the script a credential-free reviewer starts from: cases list, a materialized repo that is a real git repo with a non-empty diff and named defects, and an unknown case rejected rather than silently substituted.
 
 Coverage for the paths that had none, per HANDOFF §14 P1. Verified against real git output, not only hand-written diffs:
 - Untracked symlinks: escaping (skipped), in-workspace (still inlined), broken (still reported). Skipped with a reported reason on Windows hosts without symlink privilege rather than passing silently.

--- a/scripts/make-sample-repo.mjs
+++ b/scripts/make-sample-repo.mjs
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+// Materialize one benchmark corpus case into a disposable git repository, so a
+// reviewer has something safe to point `/gemini:review` or a `--write` run at.
+//
+// The corpus already contains cases with planted defects and a ground-truth file
+// naming each one, and bench/lib/corpus.mjs already knows how to lay base/ down
+// as a commit and head/ over it as working-tree changes. This is that, minus the
+// cleanup, plus a path printed for you to cd into.
+//
+// Never touches the network, needs no credentials, and writes only inside a new
+// temp directory.
+import fs from "node:fs";
+import process from "node:process";
+
+import { listCases, loadCase, materializeCase } from "../bench/lib/corpus.mjs";
+
+function parseArgs(argv) {
+  let caseId = null;
+  let json = false;
+  for (let i = 0; i < argv.length; i += 1) {
+    if (argv[i] === "--case") {
+      caseId = argv[i + 1];
+      if (!caseId) throw new Error("--case requires a case id.");
+      i += 1;
+    } else if (argv[i] === "--json") {
+      json = true;
+    } else if (argv[i] === "--list") {
+      console.log(listCases().join("\n"));
+      process.exit(0);
+    } else if (argv[i] === "--help" || argv[i] === "-h") {
+      console.log(
+        [
+          "Usage: node scripts/make-sample-repo.mjs [--case <id>] [--json]",
+          "       node scripts/make-sample-repo.mjs --list",
+          "",
+          `Cases: ${listCases().join(", ") || "(none)"}`
+        ].join("\n")
+      );
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown option: ${argv[i]}`);
+    }
+  }
+  return { caseId, json };
+}
+
+function main() {
+  const { caseId: requested, json } = parseArgs(process.argv.slice(2));
+  const cases = listCases();
+  if (cases.length === 0) {
+    throw new Error("No corpus cases found under bench/corpus/.");
+  }
+
+  const caseId = requested ?? cases[0];
+  if (!cases.includes(caseId)) {
+    throw new Error(`Unknown case "${caseId}". Available: ${cases.join(", ")}`);
+  }
+
+  const { truth } = loadCase(caseId);
+  const { repoDir, diffText } = materializeCase(caseId);
+  const planted = (truth.planted ?? []).map((defect) => ({
+    id: defect.id,
+    file: defect.file,
+    severity: defect.severity ?? null
+  }));
+
+  if (json) {
+    console.log(JSON.stringify({ caseId, repoDir, plantedDefects: planted, diffChars: diffText.length }, null, 2));
+    return;
+  }
+
+  console.log(`Sample repository for "${caseId}": ${repoDir}`);
+  console.log(`Working-tree diff: ${diffText.length} characters across ${fs.readdirSync(repoDir).length} top-level entries.`);
+  console.log("");
+  console.log(`Planted defects (${planted.length}) — a good review should find these:`);
+  for (const defect of planted) {
+    console.log(`  - ${defect.id} (${defect.severity ?? "unrated"}) in ${defect.file}`);
+  }
+  console.log("");
+  console.log("Next:");
+  console.log(`  cd ${repoDir}`);
+  console.log("  claude --plugin-dir <repo>/plugins/gemini   # then run /gemini:review");
+  console.log("");
+  console.log(`Delete it when you are done: rm -rf ${repoDir}`);
+  console.log(`Full expectations: bench/corpus/${caseId}/ground-truth.json`);
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+}

--- a/tests/sample-repo.test.mjs
+++ b/tests/sample-repo.test.mjs
@@ -1,0 +1,46 @@
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import assert from "node:assert/strict";
+import { fileURLToPath } from "node:url";
+
+import { run } from "./helpers.mjs";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const SCRIPT = path.join(ROOT, "scripts", "make-sample-repo.mjs");
+
+// The script is a reviewer's entry point: it is what someone with no credentials
+// runs to get something safe to point a command at. If it breaks, the offline
+// verification path in docs/verifying-without-credentials.md breaks with it.
+
+test("make-sample-repo lists the corpus cases", () => {
+  const result = run("node", [SCRIPT, "--list"], { cwd: ROOT });
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /auth-basic/);
+});
+
+test("make-sample-repo builds a git repo with a diff and the planted defects", () => {
+  const result = run("node", [SCRIPT, "--case", "auth-basic", "--json"], { cwd: ROOT });
+  assert.equal(result.status, 0, result.stderr);
+
+  const report = JSON.parse(result.stdout);
+  try {
+    assert.equal(report.caseId, "auth-basic");
+    assert.ok(fs.existsSync(path.join(report.repoDir, ".git")), "not a git repository");
+    assert.ok(report.diffChars > 0, "a review target with no diff is useless");
+    assert.ok(report.plantedDefects.length > 0, "the reviewer needs to know what to expect");
+    for (const defect of report.plantedDefects) {
+      assert.ok(defect.id, "every planted defect needs an id to report against");
+    }
+  } finally {
+    // The script deliberately leaves the repo behind for the human; the test
+    // that created one has to clean up after itself.
+    fs.rmSync(report.repoDir, { recursive: true, force: true });
+  }
+});
+
+test("make-sample-repo rejects an unknown case instead of inventing one", () => {
+  const result = run("node", [SCRIPT, "--case", "no-such-case"], { cwd: ROOT });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /Unknown case/);
+});


### PR DESCRIPTION
Summary:
Closes the remaining HANDOFF §14 items: P1 "Reviewer reproducibility", P1 "Version source simplification study", and P2 "Adoption evidence".

Why:
Three backlog items shared one reader — someone evaluating this plugin who has no Google account and no reason to be handed one. `docs/verifying-without-credentials.md` is the offline path end to end, with an explicit table of what the credentialed steps add so nobody has to guess whether they are missing coverage. Maintainer OAuth credentials are never distributed, which is exactly why the credential-free path has to be written down rather than assumed.

`scripts/make-sample-repo.mjs` gives that reader a disposable repository to point commands at, including a `--write` run, which is write-capable with no path sandbox (`docs/THREAT-MODEL.md` §7.2). It adds **no new fixture content**: `bench/lib/corpus.mjs` already materialized exactly this repo for the benchmark, so the script is that call minus the cleanup, plus the planted defects printed so the reviewer knows what a good review should find.

`docs/version-sources.md` answers the study rather than leaving it open. **Recommendation: keep all six version sources.** The duplication Anthropic's guidance warns about is mechanically enforced here — one bump script writes every source, `check-version` fails on disagreement, and that gate runs in both workflows. The only genuinely redundant field (`marketplace.json` → `plugins[gemini].version`) interacts with a directory pipeline this repository cannot test against without experimenting on live users. Two named conditions would change the answer; both are written down.

The support sections and issue templates exist mainly to route a vulnerability somewhere other than a public issue, and to make "works on X" as reportable as "breaks on X" — the compatibility docs only claim what has actually been run, so a confirmation is evidence too.

Security impact:
None to plugin behavior. The new script writes only inside a fresh temp directory and makes no network call. Issue templates and `config.yml` add a prominent private-disclosure route.

Data/privacy impact:
None. No collection, no telemetry, nothing transmitted. The P2 item explicitly asks for adoption evidence *without* telemetry, and none was added.

Compatibility:
No runtime, engine, platform, or command-surface change. One new dev script under `scripts/`, alongside the existing `bump-version.mjs` and `verify-contracts.mjs`. Nothing under `plugins/gemini` changed except its changelog.

Validation:
- `npm test` — 296 tests, 291 pass, 0 fail, 5 skipped (was 293/288/0/5 on main; +3 new tests)
- `npm run check-version` — matches 0.14.1
- `npm run verify-contracts` — passed
- `claude plugin validate ./plugins/gemini --strict` — passed
- `claude plugin validate . --strict` — passed
- `git diff --check` — clean

Fixture tests:
- `tests/sample-repo.test.mjs` covers the script a credential-free reviewer starts from: the case list, a materialized repo that is a real git repo with a non-empty diff and named defects, and an unknown case rejected rather than silently substituted. Deliberately in its own file — `contract.test.mjs` is touched by another PR in this series and this had no reason to collide with it.

Live tests:
- `node scripts/make-sample-repo.mjs --case auth-basic` was run on Windows and produced a repo with all five planted defects listed.
- The instructions in `docs/verifying-without-credentials.md` mirror commands actually run during this series; the credential-free claim for `claude plugin validate` is the one CI already demonstrates on a runner with no credentials.

Not tested:
- Issue templates cannot be validated locally — GitHub parses them on push. Worth opening one draft issue from each after merge to confirm the forms render.
- The offline path was not re-executed from a genuinely clean machine (no Node, no git, empty npm cache); it is written from commands run in this working environment.

Known limitations:
- The sample repository is useful without credentials, but *running a command against it* still needs an authenticated engine. The document says so in place rather than implying the whole loop is offline.
- Both new documents are English-only. `README.zh-TW.md` links to them and marks them as such, rather than carrying translations that would drift.
- `docs/version-sources.md` is a study, not a change. It recommends no code change and makes none.

Version:
No bump in this PR, and a deviation from the original plan worth flagging: the changelog entries for this backlog series live on **three separate branches** (this one, the PRIVACY.md PR, and the security-hardening PR). Bumping here would produce a release note describing a quarter of the release. Recommend merging all four, then a small dedicated PR running `npm run bump-version -- 0.14.2` that consolidates the three `## Unreleased` blocks into one dated entry.

Rollback:
Revert this commit. Additive only — new docs, one dev script, one test file, and two README sections; no existing behavior depends on any of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)