### PR TITLE
fix: read the plugin-data variable Claude Code actually sets

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ Override via `--engine` flag or the `GEMINI_ENGINE` environment variable.
 - **AGY transport fallback**: Only a stable parsed version of 1.1.2 or newer enables stdin. Unknown and prerelease version strings fail closed to the existing positional path, preserving compatibility rather than assuming an upstream capability.
 - **AGY 1.1.10+ `.git` sandbox rule**: AGY 1.1.10 implements read-only `.git` sandbox rules during sandboxed execution, protecting git repository metadata and commit history against accidental modification during review and subagent tasks.
 - **Credential handling**: OAuth credentials in `~/.gemini/oauth_creds.json` are read only to check token expiry via `getGeminiLoginStatus()`; they are never logged, copied elsewhere, or transmitted by this plugin.
-- **`.gitignore`**: The `.omc/` state directory (job logs, session state) is excluded from version control.
+- **`.gitignore`**: The workspace-local `.omc/` directory, which holds `/gemini:transfer` snapshots, is excluded from version control. Job state and logs live outside the repository entirely — see [How It Works](#how-it-works).
 
 **What is sent, kept, and read** — including the one path that transmits without an explicit command — is documented in [`PRIVACY.md`](PRIVACY.md).
 
@@ -317,7 +317,11 @@ Claude Code
             └─ renderTaskResult()   → Markdown output to Claude
 ```
 
-Background mode spawns a detached worker child process (`task-worker` for `/gemini:rescue`, `review-worker` for `/gemini:review` and `/gemini:adversarial-review`) and returns a job ID immediately. State is persisted in `.omc/state/` and polled via `/gemini:status`, so a background result survives even if the Claude session is interrupted.
+Background mode spawns a detached worker child process (`task-worker` for `/gemini:rescue`, `review-worker` for `/gemini:review` and `/gemini:adversarial-review`) and returns a job ID immediately. State is polled via `/gemini:status`, so a background result survives even if the Claude session is interrupted.
+
+Job state is written to Claude Code's per-plugin data directory — `$CLAUDE_PLUGIN_DATA/state/<workspace>-<hash>/`, holding `state.json` and one `.json` plus `.log` per job, most recent 50 kept. Outside Claude Code, where that variable is unset, it falls back to `<system temp>/gemini-companion/<workspace>-<hash>/`; the OS eventually cleans that, so a job left running across a temp sweep can disappear. Set `GEMINI_COMPANION_DATA` to pin the location yourself.
+
+The workspace-local `.omc/` directory is a separate thing: it holds `/gemini:transfer` snapshots only, not job state.
 
 ---
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -279,7 +279,7 @@
 - **AGY transport 回退**：只有可穩定解析為 1.1.2 以上的版本才啟用 stdin；未知版與 prerelease 字串一律 fail closed 至既有 positional 路徑，不假設上游能力。
 - **AGY 1.1.10+ `.git` 沙箱規則**：AGY 1.1.10 在沙箱模式下實作 `.git` 目錄唯讀防護規則，保護版本庫 metadata 與 commit 歷史在審查及子代理人任務期間不被意外修改。
 - **憑證處理**：`~/.gemini/oauth_creds.json` 之 OAuth 憑證僅用於 `getGeminiLoginStatus()` 檢查 token 是否過期；本外掛從不記錄、複製或傳輸之。
-- **`.gitignore`**：`.omc/` 狀態目錄（工作日誌、會話狀態）已排除於版本控制之外。
+- **`.gitignore`**：工作區內的 `.omc/` 目錄（存放 `/gemini:transfer` 快照）已排除於版本控制之外。工作狀態與日誌則完全不在版本庫內——詳見 [運作原理](#運作原理)。
 
 **送出哪些資料、保留在何處、讀取了什麼**——包含唯一一條不需明確命令即會傳輸的路徑——記載於 [`PRIVACY.md`](PRIVACY.md)（英文）。
 
@@ -315,13 +315,11 @@ Claude Code
             └─ renderTaskResult()   → Markdown 輸出至 Claude
 ```
 
-背景模式會產生一個分離的 `task-worker` 子程序並立即回傳工作 ID。狀態持久化於 `.omc/state/`，可透過 `/gemini:status` 查詢。
+背景模式會產生一個分離的 `task-worker` 子程序並立即回傳工作 ID，可透過 `/gemini:status` 查詢；即使 Claude 會話中斷，背景結果仍然存在。
 
----
-            └─ renderTaskResult()   → Markdown 輸出至 Claude
-```
+工作狀態寫入 Claude Code 的每外掛資料目錄——`$CLAUDE_PLUGIN_DATA/state/<workspace>-<hash>/`，內含 `state.json` 以及每個工作各一份 `.json` 與 `.log`，最多保留最近 50 筆。在 Claude Code 之外、該變數未設定時，改用 `<系統暫存目錄>/gemini-companion/<workspace>-<hash>/`；該處會被作業系統定期清理，故跨越清理週期仍在執行的工作可能消失。可設定 `GEMINI_COMPANION_DATA` 自行指定位置。
 
-背景模式會產生一個分離的 `task-worker` 子程序並立即回傳工作 ID。狀態持久化於 `.omc/state/`，可透過 `/gemini:status` 查詢。
+工作區內的 `.omc/` 是另一回事：它只存放 `/gemini:transfer` 快照，不存工作狀態。
 
 ---
 

--- a/docs/known-diffs.md
+++ b/docs/known-diffs.md
@@ -8,10 +8,14 @@ campaign matrix for the full three-way comparison.
 
 ## Deliberate design differences
 
-- **Job state lives in the project-local `.omc/state/` dir**, not a user-home
-  dir like the siblings' `~/.companion-*/jobs`. This survives session
-  interruption in-tree. Converging the two would be a breaking change to where
-  existing jobs are found; kept as-is.
+- ~~**Job state lives in the project-local `.omc/state/` dir**~~ — **this was
+  never true and is withdrawn.** `resolveStateDir` has resolved to
+  `$CLAUDE_PLUGIN_DATA/state/<workspace>-<hash>/`, or a system-temp fallback,
+  since the first commit in this repository; only `/gemini:transfer` snapshots
+  are project-local. The entry also justified itself with a compatibility
+  argument for a location the code never used. What is actually true: job state
+  goes to Claude Code's per-plugin data directory, which is where upstream puts
+  it too, so this is not a divergence at all.
 - **Bench harness is retained.** The Codex-vs-Gemini benchmark suite (`bench/`,
   cassettes, scoring) lives only here; the siblings deliberately omit it (owner
   decision), so it is a one-way difference, not a gap.

--- a/plugins/gemini/CHANGELOG.md
+++ b/plugins/gemini/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Breaking
+- **Job state moves from `<system temp>/gemini-companion/<workspace>-<hash>/` to `$CLAUDE_PLUGIN_DATA/state/<workspace>-<hash>/`.** Jobs recorded before the upgrade are not migrated: they stay in the temp directory, unreferenced. Nothing is deleted, but `/gemini:status`, `/gemini:result` and `/gemini:cancel` will not see them, and a background job still running across the upgrade is orphaned — its PID lives in the old state file, so the session-end hook cannot reap it.
+  - **Before upgrading**, run `/gemini:status` and let anything in flight finish. Afterwards, the old directory can be deleted.
+  - To keep the previous location instead, set `GEMINI_COMPANION_DATA` to a directory of your choosing before upgrading. Do not point it at the system temp path — that is what this release exists to stop.
+
 ### Added
 - **`node scripts/make-sample-repo.mjs`** materializes a benchmark corpus case into a disposable git repository and prints the defects planted in it. It is the safe target for a `--write` run, which is write-capable with no path sandbox ([`docs/THREAT-MODEL.md` §7.2](../../docs/THREAT-MODEL.md)). No new fixture content: `bench/lib/corpus.mjs` already built exactly this repo for the benchmark, so the script is that call minus the cleanup.
 
@@ -10,6 +15,9 @@
 
 ### Fixed
 - **The redacted-file list named the wrong path when a directory contained a space.** `redactSecretsFromDiff` read the b-side path off the `diff --git a/P b/P` header, which is ambiguous once `P` holds a space: for `a b/c.env` the first ` b/` gives `c.env b/a b/c.env` and the last gives `c.env`. It now takes the path from the unambiguous `+++ b/<path>` line, stopping at the first `@@` so an added line beginning `++ ` cannot be misread as the header, and falls back to the old header match for diffs with no `+++` line. Redaction itself was never wrong — the check runs on the final path segment, which survives either misparse — so this is the accuracy of what the user is told was withheld.
+- **Background job state was landing in the system temp directory on every install, where the OS eventually deletes it.** `lib/state.mjs` read `GEMINI_COMPANION_DATA` to find Claude Code's per-plugin data directory. Nothing sets that name. `session-lifecycle-hook.mjs` forwards `CLAUDE_PLUGIN_DATA` — the variable Claude Code actually sets — so the forwarding was dead code and `resolveStateDir` always took its `<system temp>/gemini-companion/` fallback. Upstream `codex-plugin-cc` reads `CLAUDE_PLUGIN_DATA` in both files; the port renamed it in one. Present since the first commit in this repository, and invisible to the tests because they set `GEMINI_COMPANION_DATA` directly.
+  - `GEMINI_COMPANION_DATA` still works and still wins when both are set. It was readable in shipped source, so anyone who set it keeps their location instead of being moved by an upgrade. Deprecated; drop it at 1.0.
+  - A blank or whitespace-only value now falls through rather than rooting state at `""`.
 
 ### Documentation
 - **`PRIVACY.md` states what the plugin sends, keeps, and reads**, with a source file cited beside each claim. It was the one directory-compliance document the repository did not have; nothing in `README.md`, `README.zh-TW.md`, `SECURITY.md`, or `docs/THREAT-MODEL.md` contained the word *privacy*. Both READMEs and `SECURITY.md` link to it.
@@ -19,6 +27,8 @@
 - **`docs/version-sources.md`** — the HANDOFF §14 P1 study, answered rather than left open. Recommendation: **keep all six version sources.** The duplication Anthropic's guidance warns about is mechanically enforced here by one bump script and a `check-version` gate that runs in both workflows, and the only redundant field interacts with a directory pipeline this repository cannot test against without experimenting on live users. Two named conditions would change the answer.
 - **Support sections** in both READMEs, routing setup trouble, deliberate divergences, bugs, compatibility reports, and vulnerabilities to different places — a vulnerability in a public issue is the failure worth preventing.
 - Issue templates for bug reports and compatibility reports. The bug template requires the exact command and `/gemini:setup` output, because those two answer most questions unaided. The compatibility template accepts "works on X" as readily as "breaks on X", since the docs only claim what has actually been run.
+- **Both READMEs and `docs/known-diffs.md` described job state as living in the project-local `.omc/state/` directory. It never has** — `resolveStateDir` has resolved outside the workspace since the first commit, and `.omc/` holds `/gemini:transfer` snapshots only. `known-diffs.md` additionally listed this as a *deliberate* divergence kept for compatibility, defending a location the code never used; the entry is withdrawn rather than reworded, and what is actually true is stated in its place. The real state location, its 50-job cap, the temp fallback and its cleanup risk are now documented in both READMEs.
+- Repaired a duplicated block in `README.zh-TW.md`, where the tail of a code fence and the paragraph after it were repeated between two horizontal rules.
 
 ### Tests
 - `tests/privacy-doc.test.mjs` pins `PRIVACY.md`'s presence, the four questions it must answer, and the link from every entry document — a policy doc rots when a README rewrite silently drops the link, not when the file is deleted. It also derives the expected supported-version line from `package.json`, so the table cannot go stale again without failing CI.
@@ -30,6 +40,11 @@ Coverage for the paths that had none, per HANDOFF §14 P1. Verified against real
 - Concurrent writers never expose a partially written `state.json` and leave no `.tmp` files. Pinned as the guarantee `atomicWriteJson` actually makes — a load/mutate/save cycle cannot also promise that concurrent writers keep each other's jobs.
 - Hostile filenames through redaction: a directory containing a space, a rename whose destination is the secret store, and a git C-quoted non-ASCII path.
 - Envelope truncation: an envelope cut mid-value is rejected, and so is one whose cut leaves a balanced inner object behind — the case where the balanced-block scan could otherwise report a successful run with no response. A large well-formed envelope is pinned as delivered intact, so any future size limit lands as a deliberate diff.
+- Five cases pin the resolution order: neither variable set (temp fallback), `CLAUDE_PLUGIN_DATA` alone, `GEMINI_COMPANION_DATA` alone, both set (the deprecated name wins), and a blank value falling through. They set **both** variables explicitly on every case — the suite usually runs inside a Claude Code session, which sets `CLAUDE_PLUGIN_DATA`, so a test that only sets one silently depends on who is running it. Two existing cases had that flaw and are fixed.
+- The concurrent-writer case failed reliably on Windows and passed in Linux CI, so it shipped green and was only caught when the suite was next run locally. Cause: Windows refuses `rename` onto a path another process has open, and the test's reader reopens `state.json` every millisecond, so the writers' renames raised `EPERM`. The writer now retries on a sharing error and still fails on a persistent one; the torn-read assertion is unchanged. Verified by three consecutive Windows runs.
+
+### Known limitations
+- **On Windows, a `saveState` write can fail while another process holds `state.json` open** — the platform does not allow `rename` onto an open path, and `atomicWriteJson` lets the error propagate. In practice this needs a reader polling far harder than `/gemini:status` does, which is why it surfaced only under a test written to provoke it. No retry was added to the product in this release: that is a behavior change to the write path and belongs in its own change, not in a release already carrying a state relocation.
 
 ## 0.14.1 — 2026-08-05 — Correct argument quoting on the Windows shell path
 

--- a/plugins/gemini/scripts/lib/state.mjs
+++ b/plugins/gemini/scripts/lib/state.mjs
@@ -7,8 +7,28 @@ import { classifyCliFailure } from "./failures.mjs";
 import { resolveWorkspaceRoot } from "./workspace.mjs";
 
 const STATE_VERSION = 1;
-const PLUGIN_DATA_ENV = "GEMINI_COMPANION_DATA";
+
+// CLAUDE_PLUGIN_DATA is what Claude Code actually sets, and what
+// session-lifecycle-hook.mjs forwards into the session env file so later
+// commands see it. This module read GEMINI_COMPANION_DATA instead — a name
+// nothing sets — so the forwarding was dead and every install fell through to
+// the temp directory, where the OS eventually deletes background job state.
+// Upstream codex-plugin-cc reads CLAUDE_PLUGIN_DATA in both files; the port
+// renamed it here and not there.
+//
+// GEMINI_COMPANION_DATA is kept, and kept first, as a deliberate override: it
+// was readable in shipped source and someone may have set it. Deprecated —
+// drop it at 1.0.
+const PLUGIN_DATA_ENVS = ["GEMINI_COMPANION_DATA", "CLAUDE_PLUGIN_DATA"];
 const FALLBACK_STATE_ROOT_DIR = path.join(os.tmpdir(), "gemini-companion");
+
+function resolvePluginDataDir() {
+  for (const name of PLUGIN_DATA_ENVS) {
+    const value = String(process.env[name] ?? "").trim();
+    if (value) return value;
+  }
+  return null;
+}
 const STATE_FILE_NAME = "state.json";
 const JOBS_DIR_NAME = "jobs";
 const MAX_JOBS = 50;
@@ -37,7 +57,7 @@ export function resolveStateDir(cwd) {
   const slugSource = path.basename(workspaceRoot) || "workspace";
   const slug = slugSource.replace(/[^a-zA-Z0-9._-]+/g, "-").replace(/^-+|-+$/g, "") || "workspace";
   const hash = createHash("sha256").update(canonicalWorkspaceRoot).digest("hex").slice(0, 16);
-  const pluginDataDir = process.env[PLUGIN_DATA_ENV];
+  const pluginDataDir = resolvePluginDataDir();
   const stateRoot = pluginDataDir ? path.join(pluginDataDir, "state") : FALLBACK_STATE_ROOT_DIR;
   return path.join(stateRoot, `${slug}-${hash}`);
 }

--- a/tests/state.test.mjs
+++ b/tests/state.test.mjs
@@ -17,31 +17,86 @@ import {
   readJobFile
 } from "../plugins/gemini/scripts/lib/state.mjs";
 
-test("resolveStateDir uses a temp-backed per-workspace directory", () => {
-  const workspace = makeTempDir();
-  const stateDir = resolveStateDir(workspace);
+// These run inside a Claude Code session more often than not, and that session
+// sets CLAUDE_PLUGIN_DATA. Set both variables explicitly on every case, or the
+// result depends on who is running the suite.
+function withPluginDataEnv(values, body) {
+  const names = ["GEMINI_COMPANION_DATA", "CLAUDE_PLUGIN_DATA"];
+  const previous = Object.fromEntries(names.map((name) => [name, process.env[name]]));
+  try {
+    for (const name of names) {
+      const next = values[name];
+      if (next == null) delete process.env[name];
+      else process.env[name] = next;
+    }
+    body();
+  } finally {
+    for (const name of names) {
+      if (previous[name] == null) delete process.env[name];
+      else process.env[name] = previous[name];
+    }
+  }
+}
 
-  assert.equal(stateDir.startsWith(os.tmpdir()), true);
-  assert.match(path.basename(stateDir), /.+-[a-f0-9]{16}$/);
+test("resolveStateDir falls back to a temp-backed directory when neither variable is set", () => {
+  const workspace = makeTempDir();
+  withPluginDataEnv({}, () => {
+    const stateDir = resolveStateDir(workspace);
+    assert.equal(stateDir.startsWith(os.tmpdir()), true);
+    assert.match(path.basename(stateDir), /.+-[a-f0-9]{16}$/);
+  });
+});
+
+// The defect this pins: CLAUDE_PLUGIN_DATA is the variable Claude Code sets and
+// session-lifecycle-hook.mjs forwards, but this module used to read only
+// GEMINI_COMPANION_DATA — which nothing sets — so every real install landed in
+// the temp directory and lost background job state to OS cleanup.
+test("resolveStateDir honors CLAUDE_PLUGIN_DATA, which is the variable Claude Code sets", () => {
+  const workspace = makeTempDir();
+  const pluginDataDir = makeTempDir();
+
+  withPluginDataEnv({ CLAUDE_PLUGIN_DATA: pluginDataDir }, () => {
+    const stateDir = resolveStateDir(workspace);
+    assert.equal(stateDir.startsWith(path.join(pluginDataDir, "state")), true);
+    // The fallback root, not os.tmpdir() itself — makeTempDir builds the plugin
+    // data dir under the temp directory too.
+    assert.ok(
+      !stateDir.startsWith(path.join(os.tmpdir(), "gemini-companion")),
+      "state must not land in the OS-cleaned fallback root"
+    );
+  });
 });
 
 test("resolveStateDir honors GEMINI_COMPANION_DATA when provided", () => {
   const workspace = makeTempDir();
   const pluginDataDir = makeTempDir();
-  const previous = process.env.GEMINI_COMPANION_DATA;
-  process.env.GEMINI_COMPANION_DATA = pluginDataDir;
 
-  try {
+  withPluginDataEnv({ GEMINI_COMPANION_DATA: pluginDataDir }, () => {
     const stateDir = resolveStateDir(workspace);
     assert.equal(stateDir.startsWith(path.join(pluginDataDir, "state")), true);
     assert.match(path.basename(stateDir), /.+-[a-f0-9]{16}$/);
-  } finally {
-    if (previous == null) {
-      delete process.env.GEMINI_COMPANION_DATA;
-    } else {
-      process.env.GEMINI_COMPANION_DATA = previous;
-    }
-  }
+  });
+});
+
+// Deprecated, but it was readable in shipped source, so anyone who set it keeps
+// their location rather than being silently moved by an upgrade.
+test("GEMINI_COMPANION_DATA overrides CLAUDE_PLUGIN_DATA when both are set", () => {
+  const workspace = makeTempDir();
+  const explicit = makeTempDir();
+  const host = makeTempDir();
+
+  withPluginDataEnv({ GEMINI_COMPANION_DATA: explicit, CLAUDE_PLUGIN_DATA: host }, () => {
+    assert.equal(resolveStateDir(workspace).startsWith(path.join(explicit, "state")), true);
+  });
+});
+
+test("a blank plugin-data variable falls through instead of rooting state at ''", () => {
+  const workspace = makeTempDir();
+  const host = makeTempDir();
+
+  withPluginDataEnv({ GEMINI_COMPANION_DATA: "   ", CLAUDE_PLUGIN_DATA: host }, () => {
+    assert.equal(resolveStateDir(workspace).startsWith(path.join(host, "state")), true);
+  });
 });
 
 // resolveStateDir hashes the *canonicalized* workspace path (fs.realpathSync.native)
@@ -141,6 +196,10 @@ test("state and job writes leave parseable JSON", () => {
 // guarantee that buys is that a concurrent reader never sees a half-written
 // state.json — not that concurrent writers keep each other's jobs, which a
 // load/mutate/save cycle cannot promise. Assert the guarantee that exists.
+//
+// The rename is atomic on both platforms, but only POSIX lets it succeed while a
+// reader holds the file open; on Windows it raises EPERM instead, so the writer
+// retries. See the note in the worker.
 test("concurrent writers never expose a partially written state.json", async () => {
   const workspace = makeTempDir();
   const stateFile = resolveStateFile(workspace);
@@ -154,8 +213,28 @@ test("concurrent writers never expose a partially written state.json", async () 
     [
       `const { upsertJob } = await import(${JSON.stringify(stateModule)});`,
       "const [workspace, tag] = process.argv.slice(2);",
+      "",
+      "// Windows refuses to rename onto a path another process currently has",
+      "// open, so the reader loop below — which reopens state.json every",
+      "// millisecond, far harder than any real caller — makes saveState's",
+      "// rename throw EPERM. That is a property of the platform, not a torn",
+      "// write, and asserting it away would test the wrong thing. Retry, and",
+      "// let a persistent failure still fail the test.",
+      "function writeWithRetry(job) {",
+      "  for (let attempt = 0; ; attempt += 1) {",
+      "    try {",
+      "      upsertJob(workspace, job);",
+      "      return;",
+      "    } catch (error) {",
+      "      const sharing = error && (error.code === 'EPERM' || error.code === 'EBUSY' || error.code === 'EACCES');",
+      "      if (!sharing || attempt >= 50) throw error;",
+      "      Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 5);",
+      "    }",
+      "  }",
+      "}",
+      "",
       "for (let i = 0; i < 12; i += 1) {",
-      "  upsertJob(workspace, { id: `${tag}-${i}`, status: 'completed', payload: 'x'.repeat(2048) });",
+      "  writeWithRetry({ id: `${tag}-${i}`, status: 'completed', payload: 'x'.repeat(2048) });",
       "}"
     ].join("\n"),
     "utf8"


### PR DESCRIPTION
Summary:
`lib/state.mjs` read `GEMINI_COMPANION_DATA` to locate Claude Code's per-plugin data directory. Nothing sets that name, so `resolveStateDir` always took its `<system temp>/gemini-companion/` fallback — where the OS eventually deletes background job state.

Why:
`session-lifecycle-hook.mjs:11` forwards `CLAUDE_PLUGIN_DATA` into the session env file so later commands can see it. `state.mjs:10` read a different name. Nothing bridged them, so the forwarding was dead code.

Three pieces of evidence, not inference:
- `CLAUDE_PLUGIN_DATA` is present in the environment of a running Claude Code session; `GEMINI_COMPANION_DATA` is not.
- Upstream `codex-plugin-cc` 1.0.6 reads `CLAUDE_PLUGIN_DATA` in **both** `lib/state.mjs` and `session-lifecycle-hook.mjs`. This repository's port renamed it in one file only.
- `git log -S` puts the mismatch in the first commit in this repository, so it has never worked.

The tests never caught it because they set `GEMINI_COMPANION_DATA` directly and then assert the variable they just set is honored.

Security impact:
None directly. Job state and logs move from a world-writable-adjacent shared temp root to Claude Code's per-plugin directory, which is the narrower location. No permission, write-scope, or engine semantics change.

Data/privacy impact:
Changes **where** local job state is stored, not what is stored or what is transmitted. Nothing new is collected or sent. `PRIVACY.md` (in PR #41) documents both locations and needs its variable name corrected — see the ordering note below.

Compatibility:
**Breaking, and deliberately so.** Job state moves from `<system temp>/gemini-companion/<workspace>-<hash>/` to `$CLAUDE_PLUGIN_DATA/state/<workspace>-<hash>/`.
- Jobs recorded before the upgrade are not migrated. Nothing is deleted; they become unreferenced, and `/gemini:status`, `/gemini:result` and `/gemini:cancel` will not see them.
- A background job still running across the upgrade is orphaned: its PID lives in the old state file, so the session-end hook cannot reap it.
- Migration: run `/gemini:status` and let in-flight work finish before upgrading. To keep the old location, set `GEMINI_COMPANION_DATA` yourself first — that name still works and still wins when both are set, precisely so an upgrade does not move anyone silently.

No automatic migration was written. The jobs affected are, by construction, ones living in a directory the OS was already free to delete; copying them would be more code guarding a window measured in one session.

Validation:
- `npm test` — 296 tests, 291 pass, 0 fail, 5 skipped (was 293/288/0/5 on main; +3 net new tests)
- `npm run check-version` — matches 0.14.1
- `npm run verify-contracts` — passed
- `claude plugin validate ./plugins/gemini --strict` — passed
- `claude plugin validate . --strict` — passed
- `git diff --check` — clean

Fixture tests:
Five cases pin the whole resolution order: neither variable set (temp fallback), `CLAUDE_PLUGIN_DATA` alone, `GEMINI_COMPANION_DATA` alone, both set (the deprecated name wins), and a whitespace-only value falling through instead of rooting state at `""`.

They set **both** variables explicitly on every case. The suite usually runs inside a Claude Code session, which sets `CLAUDE_PLUGIN_DATA`, so a case that sets only one silently depends on who is running it — two existing cases had that flaw and are fixed here. Verified by running the suite locally *with* `CLAUDE_PLUGIN_DATA` set; CI runs it without.

Live tests:
- The environment claim was checked directly in a live Claude Code session, not read from documentation.
- The upstream comparison was made against the installed `openai-codex/codex/1.0.6` plugin on disk.

Not tested:
- No end-to-end background job was run before and after the change to observe the orphaning first-hand; the consequence is read off the state-file layout.
- macOS and Linux. The variable is set by Claude Code rather than the platform, so no platform-specific behavior is expected, but it was exercised on Windows only.

Documentation corrections in the same PR:
Both READMEs and `docs/known-diffs.md` stated that job state lives in the project-local `.omc/state/` directory. **It never has** — `resolveStateDir` has resolved outside the workspace since the first commit, and `.omc/` holds `/gemini:transfer` snapshots only. `known-diffs.md` went further and listed it as a *deliberate* divergence kept for compatibility, defending a location the code never used; that entry is withdrawn rather than reworded, per the honesty rule in HANDOFF §2.1. The real location, the 50-job cap, the temp fallback and its cleanup risk are now documented. Also repairs a duplicated block in `README.zh-TW.md` where a code-fence tail and the paragraph after it appeared twice.

Version:
**This raises the batch from `0.14.2` PATCH to `0.15.0` MINOR**, and a judgment call is worth your attention: HANDOFF §6 lists "changed job-state location" under **MAJOR**. I am proposing MINOR because §6 also allows a labeled breaking change during `0.x` with migration instructions, and because the old location was a defect rather than a contract — it was never documented, and the documentation that existed described a third location entirely. If you would rather honor §6 literally, this is `1.0.0`. Your call; nothing here is published yet.

Ordering with the other open PRs:
This is the fifth PR in the backlog series and depends on none of them. One follow-up is needed after **both** this and #41 land: `PRIVACY.md` names `$GEMINI_COMPANION_DATA` as the job-state root and should name `$CLAUDE_PLUGIN_DATA`, with `GEMINI_COMPANION_DATA` described as the override. I can push that to #41's branch on request, or fold it into the release PR.

Rollback:
Revert this commit. State returns to the temp directory; anything written under `$CLAUDE_PLUGIN_DATA/state/` becomes unreferenced in the same way described above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)