### PR TITLE
feat(mcp): annotate every tool so a client can gate it

### DIFF
--- a/plugins/gemini/CHANGELOG.md
+++ b/plugins/gemini/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Unreleased
+
+### Added
+- **Every MCP tool now carries the annotations a client uses to decide whether a call needs confirmation** — `title`, `readOnlyHint`, `openWorldHint`, and `destructiveHint`/`idempotentHint` on the two tools that can write. All five previously shipped with none, so a client had nothing to gate on and had to treat a write-capable delegation exactly like a status read. Required by the Anthropic software directory policy, which names those three by name.
+  - The hints describe the **worst** a call can do, because they are static per tool and cannot vary with arguments: `gemini_rescue` reports as destructive even though its `write` argument defaults to false, since `write: true` hands the delegated agent the filesystem with no path boundary ([`docs/THREAT-MODEL.md` §7.2](../../docs/THREAT-MODEL.md)).
+  - `gemini_job_cancel` is destructive but idempotent — cancelling a `--write` task can leave half-applied edits behind, while cancelling a finished job is a no-op.
+  - `readOnlyHint` here means "does not modify the workspace it was pointed at". Every tool writes plugin job state, which lives outside that workspace and is bookkeeping rather than user content; the reasoning is recorded beside the definitions rather than left for a reviewer to infer.
+  - `openWorldHint` marks the two tools that reach Google through the Gemini/AGY CLI. `gemini_review` is read-only **and** open-world: it never touches the reviewed workspace, but it does send the diff.
+
+### Tests
+- One test requires the annotations to exist and be well-formed on every tool, including the policy's 64-character name limit, and refuses a meaningless `destructiveHint` on a read-only tool. A second pins each tool's hints individually — a wrong hint is worse than a missing one, because a client acts on it.
+
 ## 0.15.0 — 2026-08-05 — Job state lands where Claude Code puts plugin data
 
 Maintenance release closing the post-approval handoff backlog. Two defects surfaced while writing the tests that backlog asked for, and both are fixed here rather than deferred.

--- a/plugins/gemini/scripts/gemini-mcp.mjs
+++ b/plugins/gemini/scripts/gemini-mcp.mjs
@@ -20,8 +20,23 @@ const { version: SERVER_VERSION } = JSON.parse(
   readFileSync(new URL("../.claude-plugin/plugin.json", import.meta.url), "utf8")
 );
 
-function tool(name, description, required, properties) {
-  return { name, description, inputSchema: { type: "object", additionalProperties: false, required, properties } };
+// Annotations are hints a client uses to decide whether a call needs
+// confirmation, so they describe the *worst* a call can do — they are static per
+// tool and cannot vary with arguments. `gemini_rescue` therefore reports as
+// destructive even though its `write` argument defaults to false.
+//
+// `readOnlyHint` here means "does not modify the workspace it was pointed at".
+// Every tool writes plugin job state (`state.json`, `jobs/*.json`, `jobs/*.log`),
+// which lives outside that workspace in Claude Code's plugin data directory and
+// is bookkeeping, not user content. `openWorldHint` marks the tools that reach
+// Google through the Gemini/AGY CLI.
+function tool(name, title, description, annotations, required, properties) {
+  return {
+    name,
+    description,
+    annotations: { title, ...annotations },
+    inputSchema: { type: "object", additionalProperties: false, required, properties }
+  };
 }
 
 function enumSchema(values, defaultValue) {
@@ -29,34 +44,77 @@ function enumSchema(values, defaultValue) {
 }
 
 export const TOOLS = [
-  tool("gemini_rescue", "Queue a Gemini/AGY rescue task through the existing companion runtime.", ["workspace", "prompt"], {
-    workspace: { type: "string", description: "Absolute path to the target workspace." },
-    prompt: { type: "string", minLength: 1 },
-    write: { type: "boolean", default: false },
-    model: { type: "string" },
-    effort: enumSchema(["none", "minimal", "low", "medium", "high", "xhigh"]),
-    engine: enumSchema(["auto", "gemini", "agy"])
-  }),
-  tool("gemini_review", "Queue a read-only code review through the existing companion runtime.", ["workspace"], {
-    workspace: { type: "string", description: "Absolute path to the target workspace." },
-    base: { type: "string" },
-    scope: enumSchema(["auto", "working-tree", "branch"], "auto"),
-    model: { type: "string" },
-    engine: enumSchema(["auto", "gemini", "agy"]),
-    deep: { type: "boolean", default: false }
-  }),
-  tool("gemini_job_status", "Return the current state of a Gemini companion job.", ["workspace", "jobId"], {
-    workspace: { type: "string", description: "Absolute path to the job workspace." },
-    jobId: { type: "string", minLength: 1 }
-  }),
-  tool("gemini_job_result", "Return the stored output of a finished Gemini companion job.", ["workspace", "jobId"], {
-    workspace: { type: "string", description: "Absolute path to the job workspace." },
-    jobId: { type: "string", minLength: 1 }
-  }),
-  tool("gemini_job_cancel", "Cancel a queued or running Gemini companion job.", ["workspace", "jobId"], {
-    workspace: { type: "string", description: "Absolute path to the job workspace." },
-    jobId: { type: "string", minLength: 1 }
-  })
+  tool(
+    "gemini_rescue",
+    "Delegate a task to Gemini or AGY",
+    "Queue a Gemini/AGY rescue task through the existing companion runtime. With `write: true` the delegated CLI may edit files anywhere it can reach; it is not confined to the workspace.",
+    // Not read-only, because `write: true` hands the delegated agent the
+    // filesystem with no path boundary (docs/THREAT-MODEL.md 7.2). Not
+    // idempotent: every call queues a new job.
+    { readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true },
+    ["workspace", "prompt"],
+    {
+      workspace: { type: "string", description: "Absolute path to the target workspace." },
+      prompt: { type: "string", minLength: 1 },
+      write: { type: "boolean", default: false },
+      model: { type: "string" },
+      effort: enumSchema(["none", "minimal", "low", "medium", "high", "xhigh"]),
+      engine: enumSchema(["auto", "gemini", "agy"])
+    }
+  ),
+  tool(
+    "gemini_review",
+    "Review the current diff with Gemini or AGY",
+    "Queue a read-only code review through the existing companion runtime. Sends the workspace diff to the configured Gemini/AGY engine; secret-looking files are withheld by filename.",
+    // The review path runs the engine with write disabled, so the reviewed
+    // workspace is never modified. It does send the diff to Google, which is
+    // what openWorldHint is for.
+    { readOnlyHint: true, openWorldHint: true },
+    ["workspace"],
+    {
+      workspace: { type: "string", description: "Absolute path to the target workspace." },
+      base: { type: "string" },
+      scope: enumSchema(["auto", "working-tree", "branch"], "auto"),
+      model: { type: "string" },
+      engine: enumSchema(["auto", "gemini", "agy"]),
+      deep: { type: "boolean", default: false }
+    }
+  ),
+  tool(
+    "gemini_job_status",
+    "Check a delegated job's status",
+    "Return the current state of a Gemini companion job.",
+    { readOnlyHint: true, openWorldHint: false },
+    ["workspace", "jobId"],
+    {
+      workspace: { type: "string", description: "Absolute path to the job workspace." },
+      jobId: { type: "string", minLength: 1 }
+    }
+  ),
+  tool(
+    "gemini_job_result",
+    "Read a finished job's output",
+    "Return the stored output of a finished Gemini companion job.",
+    { readOnlyHint: true, openWorldHint: false },
+    ["workspace", "jobId"],
+    {
+      workspace: { type: "string", description: "Absolute path to the job workspace." },
+      jobId: { type: "string", minLength: 1 }
+    }
+  ),
+  tool(
+    "gemini_job_cancel",
+    "Cancel a delegated job",
+    "Cancel a queued or running Gemini companion job, terminating its process tree.",
+    // Destructive because a cancelled `write` task can leave half-applied edits
+    // behind. Idempotent: cancelling an already-finished job is a no-op.
+    { readOnlyHint: false, destructiveHint: true, idempotentHint: true, openWorldHint: false },
+    ["workspace", "jobId"],
+    {
+      workspace: { type: "string", description: "Absolute path to the job workspace." },
+      jobId: { type: "string", minLength: 1 }
+    }
+  )
 ];
 
 const DEFAULT_RUNTIME = {

--- a/tests/gemini-mcp.test.mjs
+++ b/tests/gemini-mcp.test.mjs
@@ -30,6 +30,64 @@ test("gemini MCP advertises its identity and five tools", async () => {
   ]);
 });
 
+// The Anthropic software directory policy requires every applicable annotation,
+// naming readOnlyHint, destructiveHint and title. A client uses them to decide
+// whether a call needs confirmation, so a missing or flattering hint is a real
+// disclosure defect, not metadata tidiness.
+test("every MCP tool carries the annotations a client needs to gate it", async () => {
+  const { tools } = await handleRequest({ jsonrpc: "2.0", id: 1, method: "tools/list", params: {} });
+
+  for (const tool of tools) {
+    const a = tool.annotations;
+    assert.ok(a, `${tool.name} has no annotations`);
+    assert.equal(typeof a.title, "string", `${tool.name} has no title`);
+    assert.ok(a.title.length > 0 && a.title !== tool.name, `${tool.name} title must be human-readable`);
+    assert.equal(typeof a.readOnlyHint, "boolean", `${tool.name} has no readOnlyHint`);
+    assert.equal(typeof a.openWorldHint, "boolean", `${tool.name} has no openWorldHint`);
+
+    // destructiveHint and idempotentHint only carry meaning when a tool can
+    // write, and asserting them on a read-only tool would invite a meaningless
+    // `destructiveHint: false` on everything.
+    if (a.readOnlyHint) {
+      assert.ok(!("destructiveHint" in a), `${tool.name} is read-only; destructiveHint is meaningless`);
+    } else {
+      assert.equal(typeof a.destructiveHint, "boolean", `${tool.name} can write but has no destructiveHint`);
+      assert.equal(typeof a.idempotentHint, "boolean", `${tool.name} can write but has no idempotentHint`);
+    }
+
+    // Policy caps tool names at 64 characters.
+    assert.ok(tool.name.length <= 64, `${tool.name} exceeds the 64-character limit`);
+  }
+});
+
+// Pinned individually, because these are the claims a reviewer checks against
+// behavior. Getting one wrong is worse than omitting it.
+test("MCP annotations match what each tool can actually do", async () => {
+  const { tools } = await handleRequest({ jsonrpc: "2.0", id: 1, method: "tools/list", params: {} });
+  const byName = Object.fromEntries(tools.map((tool) => [tool.name, tool.annotations]));
+
+  // `write: true` hands the delegated agent the filesystem with no path
+  // boundary, and annotations cannot vary per call, so the worst case governs.
+  assert.equal(byName.gemini_rescue.readOnlyHint, false);
+  assert.equal(byName.gemini_rescue.destructiveHint, true);
+  assert.equal(byName.gemini_rescue.openWorldHint, true);
+
+  // The review path runs with write disabled but still sends the diff out.
+  assert.equal(byName.gemini_review.readOnlyHint, true);
+  assert.equal(byName.gemini_review.openWorldHint, true);
+
+  // Reading job state touches neither the workspace nor the network.
+  for (const name of ["gemini_job_status", "gemini_job_result"]) {
+    assert.equal(byName[name].readOnlyHint, true, `${name} must be read-only`);
+    assert.equal(byName[name].openWorldHint, false, `${name} must not reach the network`);
+  }
+
+  // Cancelling a write-capable task can leave half-applied edits behind.
+  assert.equal(byName.gemini_job_cancel.readOnlyHint, false);
+  assert.equal(byName.gemini_job_cancel.destructiveHint, true);
+  assert.equal(byName.gemini_job_cancel.idempotentHint, true);
+});
+
 test("handleRequest delegates rescue and review to injected runtime dispatchers", async () => {
   const workspace = makeTempDir();
   const calls = [];


### PR DESCRIPTION
Summary:
Adds `annotations` to all five MCP tools — `title`, `readOnlyHint`, `openWorldHint`, plus `destructiveHint`/`idempotentHint` on the two that can write. Closes item 29 of the Anthropic software directory policy ("Must provide all applicable annotations including readOnlyHint, destructiveHint, and title").

Why:
All five tools shipped with **no** annotations at all (`gemini-mcp.mjs:23-60` before this change). A client had nothing to gate on, so a write-capable delegation looked exactly like a status read and would be auto-approved on the same terms. That is a disclosure defect, not metadata tidiness.

The hints describe the **worst** a call can do, because annotations are static per tool and cannot vary with arguments:
- `gemini_rescue` — `readOnlyHint: false`, `destructiveHint: true`, `idempotentHint: false`, `openWorldHint: true`. It reports destructive even though its `write` argument defaults to `false`, because `write: true` hands the delegated agent the filesystem with no path boundary (`docs/THREAT-MODEL.md` §7.2).
- `gemini_review` — `readOnlyHint: true`, `openWorldHint: true`. Read-only and open-world at once: it never touches the reviewed workspace, but it does send the diff to Google.
- `gemini_job_status`, `gemini_job_result` — `readOnlyHint: true`, `openWorldHint: false`.
- `gemini_job_cancel` — `readOnlyHint: false`, `destructiveHint: true`, `idempotentHint: true`. Cancelling a `--write` task can leave half-applied edits behind; cancelling a finished job is a no-op.

One scoping decision worth reviewing: **`readOnlyHint` is scoped to the workspace the tool was pointed at.** Every tool writes plugin job state (`state.json`, `jobs/*.json`, `jobs/*.log`), which since v0.15.0 lives in Claude Code's plugin data directory — outside that workspace, and bookkeeping rather than user content. Annotating `gemini_review` as `readOnlyHint: false` on those grounds would make the hint useless for its actual purpose. The reasoning is recorded beside the definitions rather than left for a reviewer to infer.

Security impact:
Improves disclosure; changes no behavior. No permission, write-scope, engine-selection or transport semantics change. Nothing in the request-handling path was touched — only the `tools/list` payload.

Data/privacy impact:
None. `openWorldHint` makes an existing data flow visible to clients; it does not create one.

Compatibility:
`annotations` is an additive, optional field in the MCP `tools/list` response. Clients that ignore it are unaffected. Clients that read it will now gate `gemini_rescue` and `gemini_job_cancel` more strictly than before — that is the point, and it is the only user-visible effect.

Validation:
- `npm test` — 317 tests, 312 pass, 0 fail, 5 skipped (was 315/310/0/5 on main; +2 new tests)
- `npm run check-version` — matches 0.15.0
- `npm run verify-contracts` — passed
- `claude plugin validate ./plugins/gemini --strict` — passed
- `claude plugin validate . --strict` — passed
- `git diff --check` — clean

Fixture tests:
- One test requires annotations to exist and be well-formed on **every** tool — a human-readable `title` distinct from the tool name, boolean `readOnlyHint` and `openWorldHint`, `destructiveHint`/`idempotentHint` only where a tool can write, and the policy's 64-character name limit. It also refuses a meaningless `destructiveHint: false` on a read-only tool.
- A second pins each tool's hints individually. A wrong hint is worse than a missing one, because a client acts on it, so the values are asserted rather than merely required to exist.

Live tests:
None needed; the change is confined to the static tool descriptors. No engine was contacted.

Not tested:
- No MCP client was driven end to end to observe it gating a call differently. The assertion is on the advertised payload, which is the contract; how a given client uses it is outside this repository.
- The policy text was read from the published directory policy page on 2026-08-05. If the required annotation set changes, this needs revisiting — the test enumerates what is required today.

Known limitations:
- Annotations are static per tool, so `gemini_rescue` is permanently marked destructive even for a `write: false` call. Splitting it into read-only and write-capable tools would let the hints be precise, but that is a command-surface change and does not belong here.

Version:
Recommend **MINOR** (`0.15.0` → `0.16.0`) under HANDOFF §6 "new structured output fields". Not bumped in this PR: the `/gemini:rescue` write-default question is still open and would naturally batch into the same release. Entry sits under `## Unreleased`.

Rollback:
Revert this commit. The change is confined to `TOOLS` in `gemini-mcp.mjs` and its tests; no state, manifest, or command surface is involved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)