### PR TITLE
release: v0.16.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,13 +6,13 @@
   },
   "metadata": {
     "description": "Use Gemini CLI or Antigravity CLI (agy) inside Claude Code for task delegation, code review, and adversarial review.",
-    "version": "0.15.0"
+    "version": "0.16.0"
   },
   "plugins": [
     {
       "name": "gemini",
       "description": "Gemini CLI and Antigravity CLI bridge for Claude Code task delegation and adversarial review",
-      "version": "0.15.0",
+      "version": "0.16.0",
       "author": {
         "name": "arcobaleno64"
       },

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -5,7 +5,7 @@ sends it, and what it keeps. Every claim here is checkable against the source
 files cited beside it. If you find a statement that the code does not support,
 that is a bug — report it as described in [`SECURITY.md`](SECURITY.md).
 
-Applies to plugin version 0.14.x.
+Applies to plugin version 0.16.x.
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,8 +6,8 @@ Only the current MINOR line is supported. Update this table with every MINOR bum
 
 | Version | Supported |
 |---|---|
-| 0.15.x | :white_check_mark: |
-| < 0.15.0 | :x: |
+| 0.16.x | :white_check_mark: |
+| < 0.16.0 | :x: |
 
 ## Security Model & Trust Boundaries
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@arcobaleno64/gemini-plugin-cc",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@arcobaleno64/gemini-plugin-cc",
-      "version": "0.15.0",
+      "version": "0.16.0",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arcobaleno64/gemini-plugin-cc",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "private": true,
   "type": "module",
   "description": "Use Gemini CLI or Antigravity CLI (agy) inside Claude Code for task delegation, code review, and adversarial review.",

--- a/plugins/gemini/.claude-plugin/plugin.json
+++ b/plugins/gemini/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gemini",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "Use Gemini/AGY from Claude Code to review code or delegate tasks.",
   "author": {
     "name": "arcobaleno64",

--- a/plugins/gemini/CHANGELOG.md
+++ b/plugins/gemini/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-## Unreleased
+## 0.16.0 — 2026-08-05 — Write is opt-in, and every claim about the engines is measured
+
+Three changes that all came from the same question: does the plugin's description of what it does survive contact with the engines? Two did not.
+
+`/gemini:rescue` was write-capable by default, inherited from an upstream that can afford it because it confines the run with a sandbox this port has none of. And `--dangerously-skip-permissions`, the most alarming flag in the codebase, turned out to grant nothing at all — headless AGY auto-approves either way. Both were found by running fourteen measured turns against a disposable repository rather than by reading flags, which is how the threat model had described this surface until now.
+
+Separately, the credential check could not see the credentials Gemini CLI actually stores, so `auto` routed past working installations in silence.
 
 ### Breaking
 - **`/gemini:rescue` no longer edits files unless you pass `--write`.** The rescue subagent had instructed itself to add `--write` unless the user asked otherwise — inherited verbatim from upstream `codex-plugin-cc`, where it is safe because upstream confines a write run with `sandbox: "workspace-write"`. This port has no such boundary, so the same default was write-capable *and* unconfined. The default is inverted; the feature is untouched.
@@ -37,6 +43,12 @@
 - `--dangerously-skip-permissions` is asserted absent across four AGY turn shapes, including the write and resumed-write turns where it would plausibly be re-added, and `--sandbox` is asserted absent so it is not adopted as a boundary later.
 - The gemini path is pinned in both directions — `--yolo` present on a write turn, absent on a read-only one — so neither half is dropped by analogy with the AGY path, and `--approval-mode` is asserted absent across four turn shapes.
 - One test requires the annotations to exist and be well-formed on every tool, including the policy's 64-character name limit, and refuses a meaningless `destructiveHint` on a read-only tool. A second pins each tool's hints individually — a wrong hint is worse than a missing one, because a client acts on it.
+
+### Compatibility
+- **No change to any command, flag, engine selection, transport, model, or job-state format.** Node ≥ 18, Gemini CLI ≥ 0.40, AGY ≥ 1.0.3 as before.
+- **What changes for you:** `/gemini:rescue` without `--write` now investigates instead of editing, and `auto` may now select gemini where it previously fell through to AGY, because the credential it could not see is now visible. Both are described above.
+- Three observable values move toward the truth rather than changing contract: `geminiReady` and `readyState` in `/gemini:setup --json` for users whose credential was previously invisible, and the "authenticate" next-step text, which no longer names OAuth as the only option.
+- **Why MINOR and not MAJOR.** An inverted permission default is a MAJOR trigger under the release policy. It ships as MINOR under the `0.x` allowance for a labeled breaking change carrying migration instructions — the same call taken for the job-state move in 0.15.0. The migration is one flag.
 
 ### Known limitations
 - **Nothing constrains where a `--write` run may reach.** Two of the measured runs wrote outside the workspace, and no flag on either engine prevents it. This release makes the exposure opt-in and accurately described; it does not remove it. The real fix is an engine-side path boundary that does not yet exist.


### PR DESCRIPTION
Summary:
Bumps every version source to `0.16.0`, consolidates the three merged PRs' `## Unreleased` entries into one dated release entry, and moves `SECURITY.md` to the `0.16.x` support line.

Why:
#46, #47 and #48 each left the version alone so no single PR would publish a changelog describing a fraction of the release. This is that step.

`SECURITY.md` is not optional here: `tests/privacy-doc.test.mjs` derives the expected supported-version row from `package.json`, so a bump without it fails CI. That is what the test exists for.

SemVer:
**MINOR, not MAJOR, and the reasoning is recorded in the changelog rather than left in a PR thread.** An inverted permission default is a MAJOR trigger under the release policy. It ships as MINOR under the `0.x` allowance for a labeled breaking change carrying migration instructions — the same call taken for the job-state move in 0.15.0. The migration is one flag.

What the release contains:
- **Breaking** — `/gemini:rescue` no longer edits files unless `--write` is passed (#47). The subagent had instructed itself to add `--write` unless asked otherwise, inherited verbatim from upstream `codex-plugin-cc`, where it is safe because upstream confines the run with `sandbox: "workspace-write"`. This port has no such boundary. The MCP path already defaulted `write: false`; the two entry points now agree.
- **Security** — `--dangerously-skip-permissions` removed from the AGY path, `--sandbox` deliberately not adopted, `--yolo` kept on the gemini path with evidence, `--approval-mode plan` deliberately not adopted (#47).
- **Fixed** — the credential check now sees the keychain entries Gemini CLI actually writes, and `/gemini:setup` computes readiness from the same check auto-routing uses (#48).
- **Added** — MCP tool annotations: `title`, `readOnlyHint`, `openWorldHint`, `destructiveHint`/`idempotentHint` on all five tools (#46).
- **Documentation** — `docs/THREAT-MODEL.md` §7.2 rewritten around fourteen measured runs, both READMEs, `PRIVACY.md`, `docs/known-diffs.md` (#47, #48). `PRIVACY.md`'s "applies to" line is also corrected here; it had sat at `0.14.x` through two releases.
- **Compatibility / Known limitations / Not tested** — carried forward in full, including the unbounded reach of a `--write` run, the undetected encrypted-file credential fallback, and the platforms never exercised.

The through-line:
Two of the three came from the same question — does the plugin's description of what it does survive contact with the engines? Fourteen measured turns against a disposable repository said no twice: `--dangerously-skip-permissions` granted nothing on headless AGY, and `--sandbox` is not a path boundary. §7.2 had described both from reading flags. The gemini engine was then measured too, and behaves the opposite way: `--yolo` is a genuine gate, so it stays.

Security impact:
Strictly reduces default exposure. One inert permission-bypass flag is gone and write capability is now opt-in. Adds **no** boundary — see Known limitations, which says so plainly.

Data/privacy impact:
The default rescue run no longer binds the engine to your repository. One new local read is added and documented in `PRIVACY.md` §3 with the exact commands: an existence-only keychain probe, never the stored value, never enumerating.

Validation:
- `npm test` — 326 tests, 321 pass, 0 fail, 5 skipped
- `npm run check-version` — all version metadata matches 0.16.0
- `npm run verify-contracts` — passed for gemini@gemini-plugin-cc v0.16.0
- `claude plugin validate ./plugins/gemini --strict` — passed
- `claude plugin validate . --strict` — passed
- `git diff --check` — clean

Follow-up filed:
#49 — on Windows the gemini engine still spawns through the shell, which emits Node 24's DEP0190. The only non-constant value reaching that command line is the model id, whitelisted by `SAFE_MODEL_ID`; the fix needs a decision on invoking the `.cmd` shim safely and a live Windows test, so it is filed rather than rushed into this release.

Rollback:
Revert this commit to return every version source to 0.15.0. The three feature commits are independent and revert separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
