### PR TITLE
feat: add a credential-free walkthrough of every command

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,7 +382,7 @@ Documented, non-blocking constraints — see the linked sections for detail:
 - **An engine version or platform we have not verified** — open a [compatibility report](https://github.com/arcobaleno64/gemini-plugin-cc/issues/new?template=compatibility_report.yml). "It works on X" is as useful as "it breaks on X", because the docs only claim what has actually been run.
 - **A security vulnerability** — do not open an issue. Use [private disclosure](https://github.com/arcobaleno64/gemini-plugin-cc/security/advisories/new); see [`SECURITY.md`](SECURITY.md).
 
-Reviewing the plugin rather than using it? [`docs/verifying-without-credentials.md`](docs/verifying-without-credentials.md) is the complete offline path — no account, no API key.
+Reviewing the plugin rather than using it? [`docs/verifying-without-credentials.md`](docs/verifying-without-credentials.md) is the complete offline path — no account, no API key. For a run of every command end to end against a stand-in engine, start with `node scripts/reviewer-demo.mjs`.
 
 ---
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -380,7 +380,7 @@ Claude Code
 - **尚未驗證的引擎版本或平台**——開一則 [compatibility report](https://github.com/arcobaleno64/gemini-plugin-cc/issues/new?template=compatibility_report.yml)。「在 X 上可用」與「在 X 上壞掉」同樣有價值，因為文件只聲稱實際跑過的部分。
 - **安全性漏洞**——請勿開 issue，改用 [私密回報](https://github.com/arcobaleno64/gemini-plugin-cc/security/advisories/new)；詳見 [`SECURITY.md`](SECURITY.md)。
 
-若你是要審查本外掛而非使用它：[`docs/verifying-without-credentials.md`](docs/verifying-without-credentials.md)（英文）記載完整的離線驗證路徑，不需帳號、不需 API key。
+若你是要審查本外掛而非使用它：[`docs/verifying-without-credentials.md`](docs/verifying-without-credentials.md)（英文）記載完整的離線驗證路徑，不需帳號、不需 API key。若想直接看每個命令的端到端執行（以替身引擎驅動），從 `node scripts/reviewer-demo.mjs` 開始。
 
 ---
 

--- a/docs/verifying-without-credentials.md
+++ b/docs/verifying-without-credentials.md
@@ -70,17 +70,71 @@ you care about — in particular a `--write` run, which is write-capable and has
 path sandbox (see [`THREAT-MODEL.md` §7.2](THREAT-MODEL.md)).
 
 Running a command against it does require an authenticated engine. The
-repository is the credential-free part; the engine call is not.
+repository is the credential-free part; the engine call is not. Section 4 closes
+that gap.
 
 ---
 
-## 4. What needs credentials, and what that buys
+## 4. Every command, run end to end, with no engine
+
+```bash
+node scripts/reviewer-demo.mjs --list    # the steps, without running them
+node scripts/reviewer-demo.mjs           # run them
+node scripts/reviewer-demo.mjs --keep    # ... and leave the workspace to inspect
+```
+
+This is the answer to "provide a standard testing account with sample data for
+Anthropic to verify full Software functionality" (Anthropic Software Directory
+Policy 3.D). **This plugin issues no accounts.** It is a bridge to a Gemini CLI
+or AGY binary that you install and authenticate yourself, with credentials
+Google issues — and consumer CLI access ended on 2026-06-18. There is no account
+to hand over, so what is offered instead is a run of every command.
+
+It builds a disposable workspace, puts a stand-in engine on `PATH`, and drives
+the real commands through their real code paths:
+
+| Step | What it demonstrates |
+|---|---|
+| `setup` | engine detection, version probe, credential check |
+| `task` | foreground delegation, prompt on stdin, read-only default |
+| `task --background`, `status`, `result` | the job lifecycle end to end |
+| `review` | working-tree diff sent, structured findings parsed back out |
+| `adversarial-review` | the same diff with the adversarial prompt and focus text |
+| `cancel` | terminating a live process tree, job recorded as cancelled |
+| `transfer` | context export, with a planted `.env` withheld |
+
+The stand-in is `tests/fixtures/fake-gemini.cjs` — the same fixture the test
+suite uses, reused rather than reimplemented so it cannot drift into describing
+behavior the tests do not check. It speaks the real CLI's contract: a version
+line on `--version`, and a `{ session_id, response }` JSON envelope with the
+prompt arriving on stdin.
+
+**What this proves and what it does not.** The plugin's behavior is real:
+argv construction, engine detection, stdin transport, envelope parsing, job
+state, rendering, and secret redaction all execute normally. The *text* the
+engine returns is canned, and the script says so at the top and at every step.
+It cannot tell you anything about model quality, real authentication, quota, or
+how a live agentic engine behaves once loose in a workspace.
+
+The redaction step is checkable rather than asserted: run with `--keep`, then
+grep the snapshot under `sample-repo/.omc/transfers/` for
+`demo-secret-value-do-not-send`. The file is listed as changed; its contents are
+not there. `tests/reviewer-demo.test.mjs` makes the same check against the files
+on disk, including the job logs, so the claim cannot rot silently.
+
+Nothing is written outside the temp workspace, and it is removed on exit unless
+you pass `--keep`.
+
+---
+
+## 5. What needs credentials, and what that buys
 
 | Step | Needs auth | What it adds |
 |---|---|---|
 | `npm test`, `verify-contracts`, `check-version` | no | every contract and regression assertion |
 | `claude plugin validate` | no | manifest schema conformance |
 | `npm run bench` | no | scoring against planted defects, replayed |
+| `node scripts/reviewer-demo.mjs` | no | every command run end to end against a stand-in engine |
 | `npm run bench:live` | **yes** | re-records cassettes from real engine runs |
 | `/gemini:review`, `/gemini:rescue`, `/gemini:transfer` end to end | **yes** | an actual delegated run |
 

--- a/plugins/gemini/CHANGELOG.md
+++ b/plugins/gemini/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased
+
+### Added
+- **`node scripts/reviewer-demo.mjs` runs every command end to end with no Google account, no OAuth, and no API key.** It answers the Anthropic Software Directory Policy's request (3.D) for "a standard testing account with sample data to verify full Software functionality" — which this plugin cannot satisfy literally, because it issues no accounts. It bridges to a CLI the user installs and authenticates with credentials Google issues, and consumer access ended on 2026-06-18. What is offered instead is a run: setup, foreground task, the background job lifecycle, review, adversarial review, cancelling a live process tree, and a transfer export with a planted `.env` withheld.
+  - The stand-in engine is `tests/fixtures/fake-gemini.cjs`, the fixture the suite already uses, reused rather than reimplemented so it cannot drift into describing behavior no test checks. The plugin's own code paths are real throughout — argv construction, engine detection, stdin transport, envelope parsing, job state, rendering, redaction.
+  - **The canned replies are labelled as canned**, at the top and at each step, and the closing summary names what only a credentialed run can answer. A walkthrough that let fixture text pass for model output would be worse than no walkthrough.
+  - It is a repository tool: nothing under `plugins/gemini/` changed, nothing imports it, and it ships with the repository rather than the plugin.
+
+### Tests
+- The walkthrough is pinned by `tests/reviewer-demo.test.mjs`, which asserts each step reached real plugin output rather than only printing its heading, and independently verifies the redaction claim against the files left on disk — the transfer snapshots *and* the job logs — instead of trusting the demo's own summary line.
+
 ## 0.16.0 — 2026-08-05 — Write is opt-in, and every claim about the engines is measured
 
 Three changes that all came from the same question: does the plugin's description of what it does survive contact with the engines? Two did not.

--- a/scripts/reviewer-demo.mjs
+++ b/scripts/reviewer-demo.mjs
@@ -1,0 +1,347 @@
+#!/usr/bin/env node
+// reviewer-demo.mjs — exercise every user-facing command with no Google account,
+// no OAuth, and no API key.
+//
+// WHY THIS EXISTS
+// ---------------
+// The Anthropic Software Directory Policy (3.D) asks a developer to "provide a
+// standard testing account with sample data for Anthropic to verify full
+// Software functionality". This plugin issues no accounts: it is a bridge to a
+// Gemini CLI or AGY binary that the user installs and authenticates themselves,
+// with credentials Google issues, and consumer CLI access ended on 2026-06-18.
+// There is no account to hand over.
+//
+// What can be handed over is this: a run of every command against a stand-in
+// engine, on a disposable repository, producing real plugin output. It verifies
+// everything the plugin itself does — argv construction, engine detection,
+// stdin transport, JSON envelope parsing, job lifecycle, secret redaction,
+// rendering. It cannot verify what only Google can answer, and it says so at
+// every step rather than letting a canned reply pass for model output.
+//
+// SCOPE
+// -----
+// This script is a repository tool. It is not part of the installed plugin, it
+// is not on any command path a user reaches, and nothing under plugins/gemini/
+// imports it. The stand-in engine is the same fixture the test suite uses
+// (tests/fixtures/fake-gemini.cjs), reused rather than reimplemented so it
+// cannot drift into describing behavior the tests do not check.
+//
+// USAGE
+// -----
+//   node scripts/reviewer-demo.mjs            run every step, then clean up
+//   node scripts/reviewer-demo.mjs --keep     leave the workspace in place
+//   node scripts/reviewer-demo.mjs --list     print the steps without running
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+import { installFakeGemini } from "../tests/fake-gemini-fixture.mjs";
+import { initGitRepo } from "../tests/helpers.mjs";
+
+// Git and the engine probes reach bare command names, which spawn through the
+// shell on Windows and emit Node 24's DEP0190. That warning is about this
+// repository's own code (see issue #49) and has nothing to teach a reviewer
+// reading a functional walkthrough, so it is silenced here and in every child.
+process.noDeprecation = true;
+
+const REPO_ROOT = fileURLToPath(new URL("..", import.meta.url));
+const COMPANION = path.join(REPO_ROOT, "plugins", "gemini", "scripts", "gemini-companion.mjs");
+const TRANSFER = path.join(REPO_ROOT, "plugins", "gemini", "scripts", "transfer.mjs");
+
+const BOLD = "[1m";
+const DIM = "[2m";
+const CYAN = "[36m";
+const YELLOW = "[33m";
+const RESET = "[0m";
+const color = process.stdout.isTTY && !process.env.NO_COLOR;
+const c = (code, text) => (color ? `${code}${text}${RESET}` : text);
+
+let stepNumber = 0;
+
+function heading(title, explanation) {
+  stepNumber += 1;
+  process.stdout.write(`\n${c(BOLD, `── ${stepNumber}. ${title} `.padEnd(72, "─"))}\n`);
+  process.stdout.write(`${c(DIM, explanation)}\n\n`);
+}
+
+function note(text) {
+  process.stdout.write(`${c(YELLOW, "   note: ")}${c(DIM, text)}\n`);
+}
+
+// Job ids are `<kind>-<base36 time>-<hex>` (lib/state.mjs generateJobId).
+const JOB_ID = /\b((?:task|review)-[a-z0-9]+-[0-9a-f]+)\b/;
+
+// Print the command the way a reviewer would type it, then run it verbatim.
+function show(args, options = {}) {
+  const display = ["node", path.relative(REPO_ROOT, options.script ?? COMPANION), ...args]
+    .map((part) => (/\s/.test(part) ? JSON.stringify(part) : part))
+    .join(" ");
+  process.stdout.write(`${c(CYAN, "$ ")}${display}\n`);
+
+  const result = spawnSync(process.execPath, ["--no-deprecation", options.script ?? COMPANION, ...args], {
+    cwd: options.cwd,
+    env: options.env,
+    encoding: "utf8",
+    windowsHide: true
+  });
+
+  const body = stripAnsi(`${result.stdout ?? ""}${result.stderr ?? ""}`).trimEnd();
+  if (body) process.stdout.write(indent(body) + "\n");
+  if (result.status !== 0 && !options.allowFailure) {
+    throw new Error(`step ${stepNumber} exited ${result.status}`);
+  }
+  return { ...result, body };
+}
+
+// The commands colorize their own output; NO_COLOR is not honored on every
+// path, and nested escapes make a captured transcript hard to read.
+function stripAnsi(text) {
+  // eslint-disable-next-line no-control-regex
+  return String(text).replace(/\[[0-9;]*m/g, "");
+}
+
+function indent(text) {
+  return text.split(/\r?\n/).map((line) => (line ? `  ${line}` : line)).join("\n");
+}
+
+// A workspace with a planted defect for review to find, a secret file to prove
+// redaction, and one commit so a diff exists.
+function buildWorkspace(root) {
+  const repo = path.join(root, "sample-repo");
+  fs.mkdirSync(repo, { recursive: true });
+  initGitRepo(repo);
+
+  fs.writeFileSync(path.join(repo, "README.md"), "# sample\n\nDisposable repository for the reviewer demo.\n", "utf8");
+  fs.writeFileSync(
+    path.join(repo, "src.js"),
+    "export function firstItem(items) {\n  return items[0].name;\n}\n",
+    "utf8"
+  );
+  spawnSync("git", ["add", "-A"], { cwd: repo, windowsHide: true });
+  spawnSync("git", ["commit", "-m", "initial"], { cwd: repo, windowsHide: true });
+
+  // Uncommitted change: this is what review and transfer will pick up.
+  fs.writeFileSync(
+    path.join(repo, "src.js"),
+    "export function firstItem(items) {\n  // no empty-collection guard\n  return items[0].name;\n}\n",
+    "utf8"
+  );
+  // A credential-looking file. Its contents must never appear in what is sent.
+  fs.writeFileSync(path.join(repo, ".env"), "API_TOKEN=demo-secret-value-do-not-send\n", "utf8");
+
+  return repo;
+}
+
+function buildEnv(binDir, dataDir) {
+  const sep = process.platform === "win32" ? ";" : ":";
+  return {
+    ...process.env,
+    PATH: `${binDir}${sep}${process.env.PATH}`,
+    GEMINI_ENGINE: "gemini",
+    GEMINI_HOME: path.join(binDir, "gemini-home"),
+    // Job state goes to the disposable directory, never the reviewer's own.
+    GEMINI_COMPANION_DATA: dataDir,
+    // The credential check would otherwise probe the reviewer's real keychain.
+    GEMINI_COMPANION_DISABLE_KEYCHAIN: "1",
+    NO_COLOR: "1"
+  };
+}
+
+// Switch the stand-in engine's canned reply. Written by installFakeGemini and
+// read on each invocation, so it can change between steps.
+function setScenario(binDir, scenario) {
+  fs.writeFileSync(
+    path.join(binDir, "fake-gemini-config.json"),
+    JSON.stringify({ scenario }, null, 2),
+    "utf8"
+  );
+}
+
+// The shared fixture answers instantly, so a job started for the cancel step
+// finishes before the cancel arrives and taskkill reports a process that no
+// longer exists — a race, not a defect, but it demonstrates nothing. Swap in a
+// stand-in that blocks until killed so cancellation has something to cancel.
+// Restored by reinstalling the fixture afterwards.
+function installSlowGemini(binDir, seconds = 120) {
+  const source = [
+    "#!/usr/bin/env node",
+    '"use strict";',
+    'if (process.argv.slice(2).includes("--version")) {',
+    '  process.stdout.write("gemini-cli test 0.0.0-fake-slow\\n");',
+    "  process.exit(0);",
+    "}",
+    "process.stdin.resume();",
+    `setTimeout(() => process.exit(0), ${seconds * 1000});`
+  ].join("\n");
+
+  fs.writeFileSync(path.join(binDir, "gemini"), source, "utf8");
+  if (process.platform === "win32") {
+    fs.writeFileSync(path.join(binDir, "gemini.cmd"), `@echo off\r\nnode "%~dp0gemini" %*\r\n`, "utf8");
+  } else {
+    fs.chmodSync(path.join(binDir, "gemini"), 0o755);
+  }
+}
+
+function waitForJob(env, cwd, jobId, timeoutMs = 60_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const probe = spawnSync(process.execPath, ["--no-deprecation", COMPANION, "status", jobId, "--json"], {
+      cwd, env, encoding: "utf8", windowsHide: true
+    });
+    try {
+      const payload = JSON.parse(probe.stdout);
+      const job = payload.job ?? payload.jobs?.[0] ?? payload;
+      if (job && ["completed", "failed", "cancelled", "canceled"].includes(String(job.status))) return job.status;
+    } catch {
+      // status not written yet — keep waiting
+    }
+    sleep(400);
+  }
+  return "timed-out";
+}
+
+function sleep(ms) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+// A cancelled worker can still hold its log file open for a moment, and Windows
+// refuses to delete a directory containing an open handle. Retry briefly rather
+// than ending a successful walkthrough on a cleanup error.
+function removeWorkspace(root) {
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    try {
+      fs.rmSync(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 200 });
+      process.stdout.write(`\n${c(DIM, "workspace removed (pass --keep to inspect it)")}\n`);
+      return;
+    } catch (error) {
+      if (!["EPERM", "EBUSY", "ENOTEMPTY", "EACCES"].includes(error?.code)) throw error;
+      sleep(500);
+    }
+  }
+  process.stdout.write(
+    `\n${c(YELLOW, "could not remove the workspace — a worker may still hold a file open.")}\n` +
+    `${c(DIM, `delete it manually: ${root}`)}\n`
+  );
+}
+
+const STEPS = [
+  "setup — engine detection and readiness",
+  "task — foreground delegation",
+  "task --background, status, result — the job lifecycle",
+  "review — structured findings over a real diff",
+  "adversarial-review — the same diff, adversarial prompt",
+  "cancel — terminating a job",
+  "transfer — context export with secret redaction"
+];
+
+function main() {
+  const argv = process.argv.slice(2);
+  if (argv.includes("--help") || argv.includes("-h")) {
+    process.stdout.write("Usage: node scripts/reviewer-demo.mjs [--keep] [--list]\n");
+    return;
+  }
+  if (argv.includes("--list")) {
+    STEPS.forEach((s, i) => process.stdout.write(`${i + 1}. ${s}\n`));
+    return;
+  }
+  const keep = argv.includes("--keep");
+
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "gemini-reviewer-demo-"));
+  const binDir = path.join(root, "bin");
+  const dataDir = path.join(root, "plugin-data");
+  fs.mkdirSync(binDir, { recursive: true });
+  fs.mkdirSync(dataDir, { recursive: true });
+
+  installFakeGemini(binDir, "task");
+  const repo = buildWorkspace(root);
+  const env = buildEnv(binDir, dataDir);
+
+  process.stdout.write(`${c(BOLD, "gemini-plugin-cc — credential-free functional walkthrough")}\n`);
+  process.stdout.write(`${c(DIM, `workspace: ${root}`)}\n`);
+  process.stdout.write(
+    `${c(YELLOW, "Every model reply below comes from tests/fixtures/fake-gemini.cjs, a stand-in engine.")}\n` +
+    `${c(YELLOW, "The plugin's own behavior is real; the text the engine returns is canned.")}\n`
+  );
+
+  try {
+    heading(STEPS[0], "Detects the engine on PATH, reads its version, and reports whether it has a usable credential.");
+    show(["setup"], { cwd: repo, env });
+    note("The stand-in answers --version like the real CLI, so this is the real detection path.");
+
+    heading(STEPS[1], "Delegates a task and renders the reply. The prompt travels on stdin, never argv.");
+    setScenario(binDir, "task");
+    show(["task", "explain what firstItem does and whether it is safe"], { cwd: repo, env });
+    note("Read-only by default since v0.16.0 — no --write, so the engine is not bound to this repository.");
+
+    heading(STEPS[2], "Runs the same delegation detached, then polls and collects it.");
+    const started = show(["task", "--background", "add a regression test for the empty case"], { cwd: repo, env });
+    const jobId = (started.body.match(JOB_ID) ?? [])[1];
+    if (jobId) {
+      const status = waitForJob(env, repo, jobId);
+      process.stdout.write(`${c(DIM, `  (waited for ${jobId} → ${status})`)}\n`);
+      show(["status", "--all"], { cwd: repo, env });
+      show(["result", jobId], { cwd: repo, env, allowFailure: true });
+    } else {
+      note("No job id was printed; skipping status/result for this run.");
+    }
+
+    heading(STEPS[3], "Sends the working-tree diff and parses the structured findings back out of the JSON envelope.");
+    setScenario(binDir, "review-findings");
+    show(["review", "--wait"], { cwd: repo, env });
+    note("Severity, file, line range and confidence are parsed from the envelope, not printed verbatim.");
+
+    heading(STEPS[4], "Same diff, adversarial prompt, optional focus text.");
+    show(["adversarial-review", "--wait", "focus on error handling"], { cwd: repo, env });
+
+    heading(STEPS[5], "Terminates a running job's process tree, then shows the job recorded as cancelled.");
+    installSlowGemini(binDir);
+    note("The stand-in is swapped for one that blocks, so there is a live process to cancel.");
+    const toCancel = show(["task", "--background", "a job that will be cancelled"], { cwd: repo, env });
+    const cancelId = (toCancel.body.match(JOB_ID) ?? [])[1];
+    if (cancelId) {
+      sleep(2000); // let the worker spawn the engine before killing the tree
+      show(["cancel", cancelId], { cwd: repo, env, allowFailure: true });
+      show(["status", cancelId], { cwd: repo, env, allowFailure: true });
+    } else {
+      note("No job id was printed; skipping cancel for this run.");
+    }
+    installFakeGemini(binDir, "task");
+
+    heading(STEPS[6], "Exports the workspace context for a hand-off, with credential-looking files withheld.");
+    show(["--engine", "gemini", "review this change"], { cwd: repo, env, script: TRANSFER });
+    note("`.env` was included in the snapshot as a changed file, but its contents were replaced. Grep the snapshot under .omc/transfers/ for 'demo-secret-value' — it is not there.");
+
+    const snapshotDir = path.join(repo, ".omc", "transfers");
+    if (fs.existsSync(snapshotDir)) {
+      const leaked = fs.readdirSync(snapshotDir)
+        .filter((f) => f.endsWith(".json"))
+        .some((f) => fs.readFileSync(path.join(snapshotDir, f), "utf8").includes("demo-secret-value"));
+      process.stdout.write(
+        leaked
+          ? `${c(YELLOW, "  CHECKED: secret value FOUND in the snapshot — this is a defect, please report it.")}\n`
+          : `${c(DIM, "  checked: the secret value is absent from every snapshot on disk.")}\n`
+      );
+    }
+
+    process.stdout.write(`\n${c(BOLD, "── Done ".padEnd(72, "─"))}\n`);
+    process.stdout.write(
+      `${c(DIM, "Verified here: engine detection, stdin transport, envelope parsing, job\n" +
+      "lifecycle, review rendering, secret redaction, and the read-only default.\n" +
+      "Not verified here: anything only Google can answer — model quality, real\n" +
+      "auth, quota, and the agentic behavior of a live engine inside a workspace.\n" +
+      "See docs/verifying-without-credentials.md for what a credentialed run adds.")}\n`
+    );
+  } finally {
+    if (keep) {
+      process.stdout.write(`\n${c(DIM, `kept: ${root}`)}\n`);
+    } else {
+      removeWorkspace(root);
+    }
+  }
+}
+
+main();

--- a/tests/reviewer-demo.test.mjs
+++ b/tests/reviewer-demo.test.mjs
@@ -1,0 +1,100 @@
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import assert from "node:assert/strict";
+import { fileURLToPath } from "node:url";
+
+import { run } from "./helpers.mjs";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const SCRIPT = path.join(ROOT, "scripts", "reviewer-demo.mjs");
+
+// This script is what a directory reviewer runs instead of the testing account
+// this plugin cannot issue (Anthropic Software Directory Policy 3.D). If it
+// breaks, the only evidence of full functionality that does not need a Google
+// credential breaks with it — and nothing else in the suite would notice,
+// because it drives the commands from outside rather than importing them.
+
+test("reviewer-demo lists its steps without running anything", () => {
+  const result = run("node", [SCRIPT, "--list"], { cwd: ROOT });
+  assert.equal(result.status, 0, result.stderr);
+  for (const command of ["setup", "task", "review", "adversarial-review", "cancel", "transfer"]) {
+    assert.match(result.stdout, new RegExp(command), `step list omits ${command}`);
+  }
+});
+
+test("reviewer-demo runs every command end to end", (t) => {
+  // --keep so the redaction claim can be checked against the files on disk
+  // rather than taken from the demo's own summary line.
+  const result = run("node", [SCRIPT, "--keep"], { cwd: ROOT });
+  const kept = (result.stdout.match(/^kept: (.+)$/m) ?? [])[1];
+  t.after(() => {
+    if (kept) fs.rmSync(kept, { recursive: true, force: true, maxRetries: 10, retryDelay: 300 });
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+
+  // Each step must have produced plugin output, not just printed a heading — a
+  // silently skipped step would still exit 0.
+  const expected = [
+    /# Gemini Setup/,
+    /Status: ready/,
+    /Handled the requested task\./,          // foreground delegation
+    /started in the background as/,          // detached job
+    /# Gemini Status/,
+    /# Gemini Review/,
+    /# Gemini Adversarial Review/,
+    /Missing empty-state guard/,             // structured finding parsed from the envelope
+    /# Gemini Cancel/,
+    /\| cancelled \|/,                       // recorded cancelled, not merely killed
+    /transfer snapshot created/
+  ];
+  for (const pattern of expected) {
+    assert.match(result.stdout, pattern, `walkthrough never reached ${pattern}`);
+  }
+
+  // A reviewer must not be left believing canned text came from a model.
+  assert.match(result.stdout, /stand-in engine/);
+  assert.match(result.stdout, /Not verified here/);
+  assert.doesNotMatch(result.stderr, /DeprecationWarning/, "reviewer-facing output must be free of Node warnings");
+});
+
+test("reviewer-demo's redaction claim holds against the files it leaves behind", (t) => {
+  const result = run("node", [SCRIPT, "--keep"], { cwd: ROOT });
+  const kept = (result.stdout.match(/^kept: (.+)$/m) ?? [])[1];
+  t.after(() => {
+    if (kept) fs.rmSync(kept, { recursive: true, force: true, maxRetries: 10, retryDelay: 300 });
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.ok(kept, "--keep did not report the workspace path");
+
+  const secret = "demo-secret-value-do-not-send";
+  const envFile = path.join(kept, "sample-repo", ".env");
+  assert.ok(fs.existsSync(envFile), "the demo did not plant a credential file to withhold");
+  assert.match(fs.readFileSync(envFile, "utf8"), new RegExp(secret), "the planted secret is not what the check looks for");
+
+  const transfers = path.join(kept, "sample-repo", ".omc", "transfers");
+  const snapshots = fs.readdirSync(transfers).filter((name) => name.endsWith(".json"));
+  assert.ok(snapshots.length > 0, "the transfer step produced no snapshot");
+
+  for (const name of snapshots) {
+    const body = fs.readFileSync(path.join(transfers, name), "utf8");
+    assert.ok(body.includes(".env"), `${name} should record that .env changed`);
+    assert.ok(!body.includes(secret), `${name} leaked the credential it claims to withhold`);
+  }
+
+  // The job log is written by the plugin and kept on disk; nothing in the
+  // walkthrough should have put the credential there either.
+  const stateDir = path.join(kept, "plugin-data");
+  const leaks = [];
+  const walk = (dir) => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else if (fs.readFileSync(full, "utf8").includes(secret)) leaks.push(full);
+    }
+  };
+  if (fs.existsSync(stateDir)) walk(stateDir);
+  assert.deepEqual(leaks, [], "the credential reached plugin job state");
+});


### PR DESCRIPTION
Summary:
Answers Anthropic Software Directory Policy **3.D** — "Developers must provide a standard testing account with sample data for Anthropic to verify full Software functionality" — which this plugin cannot satisfy literally, and explains why in the artifact itself rather than in a submission form.

Why a script and not an account:
This plugin issues no accounts. It is a bridge to a Gemini CLI or AGY binary the user installs and authenticates themselves, with credentials **Google** issues, and consumer CLI access ended 2026-06-18. There is nothing to hand over. The policy states no exception for software without its own account system, so "we have no accounts" alone would be a non-answer. What is offered instead is a run of every command.

What it does:
`node scripts/reviewer-demo.mjs` builds a disposable workspace, puts a stand-in engine on `PATH`, and drives the real commands through their real code paths.

| Step | Demonstrates |
|---|---|
| `setup` | engine detection, version probe, credential check |
| `task` | foreground delegation, prompt on stdin, the read-only default from #47 |
| `task --background`, `status`, `result` | the job lifecycle end to end |
| `review` | working-tree diff sent, structured findings parsed back out of the envelope |
| `adversarial-review` | same diff, adversarial prompt, focus text |
| `cancel` | terminating a live process tree; job recorded `cancelled` |
| `transfer` | context export with a planted `.env` withheld |

`--list` prints the steps without running them; `--keep` leaves the workspace for inspection.

Honesty, which is the part that matters:
The plugin's behavior is real throughout — argv construction, engine detection, stdin transport, envelope parsing, job state, rendering, redaction. The **text the engine returns is canned**, and the script says so in its banner, and again in the closing summary, which names exactly what only a credentialed run can answer: model quality, real auth, quota, and how a live agentic engine behaves once loose in a workspace. A walkthrough that let fixture text pass for model output would be worse than no walkthrough.

The redaction step is **checkable, not asserted**: run with `--keep`, then grep `sample-repo/.omc/transfers/` for `demo-secret-value-do-not-send`. The file is listed as changed; its contents are not there.

Reuse, not reimplementation:
The stand-in is `tests/fixtures/fake-gemini.cjs` — the fixture the suite already uses. Writing a second one would have let the walkthrough drift into demonstrating behavior no test checks.

Scope:
A repository tool. **Nothing under `plugins/gemini/` changed** (`git diff -- plugins/gemini/scripts/` is empty), nothing imports it, it is on no command path a user reaches, and it ships with the repository rather than the plugin. No new dependency; Node standard library only.

Three things found while building it, fixed here rather than papered over:
1. **Job ids are `<kind>-<base36>-<hex>`.** A naive `job[-_]…` match found nothing, so the status, result and cancel steps silently skipped while the script still exited 0.
2. **Cancelling an already-finished job** made `taskkill` report a process that no longer exists — a race, not a defect, but it demonstrates nothing and printed a localized error. The cancel step now swaps in a stand-in that blocks, so there is a live process tree to terminate.
3. **Windows cleanup.** A cancelled worker can hold its log open past exit, and Windows refuses to delete a directory containing an open handle. Cleanup retries instead of ending a successful walkthrough on an `EPERM`.

Validation:
- `npm test` — 329 tests, 324 pass, 0 fail, 5 skipped (was 326/321/0/5 on main; +3 new tests)
- `npm run check-version` — matches 0.16.0
- `npm run verify-contracts` — passed
- `claude plugin validate ./plugins/gemini --strict` — passed
- `claude plugin validate . --strict` — passed
- `git diff --check` — clean
- The walkthrough itself run repeatedly on Windows: exit 0, no stderr, no leftover temp directory.

Fixture tests:
`tests/reviewer-demo.test.mjs` asserts each step reached real plugin output rather than only printing its heading — a skipped step would otherwise still exit 0 — and **independently verifies the redaction claim against the files on disk**, both the transfer snapshots and the job logs, instead of trusting the demo's own summary line. It also fails if reviewer-facing output ever carries a Node warning.

Not covered:
- **macOS and Linux.** The script is platform-neutral and CI runs the test on `ubuntu-latest`, but the walkthrough was exercised by hand only on Windows.
- **Anything requiring a live engine**, by construction. That boundary is the point, and the script states it.

Version:
Additive, no contract change → **PATCH** when next released. Not bumped here.

Rollback:
Delete the two new files. Nothing else references them except three documentation lines.

Related:
Policy item 3.B (verified contact information) is still open — the manifests carry no email. Both manifest schemas accept one; that is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
