### PR TITLE
release: v0.16.1 with a verified contact address

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,19 +2,21 @@
   "name": "gemini-plugin-cc",
   "owner": {
     "name": "arcobaleno64",
-    "login": "arcobaleno64"
+    "login": "arcobaleno64",
+    "email": "arcobaleno830623@gmail.com"
   },
   "metadata": {
     "description": "Use Gemini CLI or Antigravity CLI (agy) inside Claude Code for task delegation, code review, and adversarial review.",
-    "version": "0.16.0"
+    "version": "0.16.1"
   },
   "plugins": [
     {
       "name": "gemini",
       "description": "Gemini CLI and Antigravity CLI bridge for Claude Code task delegation and adversarial review",
-      "version": "0.16.0",
+      "version": "0.16.1",
       "author": {
-        "name": "arcobaleno64"
+        "name": "arcobaleno64",
+        "email": "arcobaleno830623@gmail.com"
       },
       "source": "./plugins/gemini"
     }

--- a/README.md
+++ b/README.md
@@ -381,6 +381,9 @@ Documented, non-blocking constraints — see the linked sections for detail:
 - **A bug** — open a [bug report](https://github.com/arcobaleno64/gemini-plugin-cc/issues/new?template=bug_report.yml). Include the exact command and your `/gemini:setup` output; those two answer most questions on their own.
 - **An engine version or platform we have not verified** — open a [compatibility report](https://github.com/arcobaleno64/gemini-plugin-cc/issues/new?template=compatibility_report.yml). "It works on X" is as useful as "it breaks on X", because the docs only claim what has actually been run.
 - **A security vulnerability** — do not open an issue. Use [private disclosure](https://github.com/arcobaleno64/gemini-plugin-cc/security/advisories/new); see [`SECURITY.md`](SECURITY.md).
+- **Anything else, or you cannot use GitHub** — email <arcobaleno830623@gmail.com>. GitHub is the faster route for anything that belongs in public, because the answer stays where the next person will find it.
+
+This is a single-maintainer project, not a staffed support desk. Everything above reaches one person.
 
 Reviewing the plugin rather than using it? [`docs/verifying-without-credentials.md`](docs/verifying-without-credentials.md) is the complete offline path — no account, no API key. For a run of every command end to end against a stand-in engine, start with `node scripts/reviewer-demo.mjs`.
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -379,6 +379,9 @@ Claude Code
 - **臭蟲**——開一則 [bug report](https://github.com/arcobaleno64/gemini-plugin-cc/issues/new?template=bug_report.yml)。請附完整命令與 `/gemini:setup` 輸出，這兩項通常就足以定位問題。
 - **尚未驗證的引擎版本或平台**——開一則 [compatibility report](https://github.com/arcobaleno64/gemini-plugin-cc/issues/new?template=compatibility_report.yml)。「在 X 上可用」與「在 X 上壞掉」同樣有價值，因為文件只聲稱實際跑過的部分。
 - **安全性漏洞**——請勿開 issue，改用 [私密回報](https://github.com/arcobaleno64/gemini-plugin-cc/security/advisories/new)；詳見 [`SECURITY.md`](SECURITY.md)。
+- **其他事項，或你無法使用 GitHub**——來信 <arcobaleno830623@gmail.com>。凡是適合公開的內容，走 GitHub 較快，因為答案會留在下一個人找得到的地方。
+
+本專案由單一維護者經營，並非有專職人力的支援窗口；以上管道都是同一個人在收。
 
 若你是要審查本外掛而非使用它：[`docs/verifying-without-credentials.md`](docs/verifying-without-credentials.md)（英文）記載完整的離線驗證路徑，不需帳號、不需 API key。若想直接看每個命令的端到端執行（以替身引擎驅動），從 `node scripts/reviewer-demo.mjs` 開始。
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -34,8 +34,9 @@ What the plugin sends, keeps, and reads — and the single path that transmits w
 
 If you discover a potential security vulnerability within `gemini-plugin-cc`, please **do not** open a public GitHub issue.
 
-Instead, report it responsibly via:
-- **Private Security Disclosure**: Submit via [GitHub Security Advisories](https://github.com/arcobaleno64/gemini-plugin-cc/security/advisories/new)
+Instead, report it responsibly via either of:
+- **Private Security Disclosure** (preferred): Submit via [GitHub Security Advisories](https://github.com/arcobaleno64/gemini-plugin-cc/security/advisories/new). It keeps the report, the discussion, and the eventual advisory in one place.
+- **Email**: <arcobaleno830623@gmail.com>, for anyone who cannot or would rather not use GitHub. This address is monitored by the maintainer; it is not a team inbox, so expect one person's response times.
 
 ### Response Expectations
 - **Initial Response**: Within 48 hours.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@arcobaleno64/gemini-plugin-cc",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@arcobaleno64/gemini-plugin-cc",
-      "version": "0.16.0",
+      "version": "0.16.1",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arcobaleno64/gemini-plugin-cc",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "private": true,
   "type": "module",
   "description": "Use Gemini CLI or Antigravity CLI (agy) inside Claude Code for task delegation, code review, and adversarial review.",

--- a/plugins/gemini/.claude-plugin/plugin.json
+++ b/plugins/gemini/.claude-plugin/plugin.json
@@ -1,9 +1,10 @@
 {
   "name": "gemini",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "Use Gemini/AGY from Claude Code to review code or delegate tasks.",
   "author": {
     "name": "arcobaleno64",
+    "email": "arcobaleno830623@gmail.com",
     "url": "https://github.com/arcobaleno64"
   },
   "homepage": "https://github.com/arcobaleno64/gemini-plugin-cc",

--- a/plugins/gemini/CHANGELOG.md
+++ b/plugins/gemini/CHANGELOG.md
@@ -1,8 +1,14 @@
 # Changelog
 
-## Unreleased
+## 0.16.1 — 2026-08-05 — A reviewer can now verify the plugin, and reach a person
+
+Both changes close the last two open items in the Anthropic Software Directory Policy. Neither alters how the plugin behaves.
 
 ### Added
+- **A contact address that receives mail: <arcobaleno830623@gmail.com>.** Policy 3.B asks for "verified contact information and support channels for users with product or security concerns". Until now the repository carried none: both manifests listed a name and a GitHub URL, and every route to the maintainer went through GitHub. The address is now in `plugin.json`, `marketplace.json`, `SECURITY.md`, and the Support section of both READMEs.
+  - GitHub Security Advisories remains the **preferred** route for vulnerabilities — it keeps the report, the discussion, and the advisory together. Email exists for people who cannot or would rather not use GitHub.
+  - A `@users.noreply.github.com` address was considered and rejected: it cannot receive mail, so it would satisfy the letter of a contact field while failing the thing the field is for.
+  - Both README Support sections now say plainly that this is a single-maintainer project rather than a staffed support desk, so response expectations are set by the docs and not by assumption.
 - **`node scripts/reviewer-demo.mjs` runs every command end to end with no Google account, no OAuth, and no API key.** It answers the Anthropic Software Directory Policy's request (3.D) for "a standard testing account with sample data to verify full Software functionality" — which this plugin cannot satisfy literally, because it issues no accounts. It bridges to a CLI the user installs and authenticates with credentials Google issues, and consumer access ended on 2026-06-18. What is offered instead is a run: setup, foreground task, the background job lifecycle, review, adversarial review, cancelling a live process tree, and a transfer export with a planted `.env` withheld.
   - The stand-in engine is `tests/fixtures/fake-gemini.cjs`, the fixture the suite already uses, reused rather than reimplemented so it cannot drift into describing behavior no test checks. The plugin's own code paths are real throughout — argv construction, engine detection, stdin transport, envelope parsing, job state, rendering, redaction.
   - **The canned replies are labelled as canned**, at the top and at each step, and the closing summary names what only a credentialed run can answer. A walkthrough that let fixture text pass for model output would be worse than no walkthrough.
@@ -10,6 +16,12 @@
 
 ### Tests
 - The walkthrough is pinned by `tests/reviewer-demo.test.mjs`, which asserts each step reached real plugin output rather than only printing its heading, and independently verifies the redaction claim against the files left on disk — the transfer snapshots *and* the job logs — instead of trusting the demo's own summary line.
+
+### Compatibility
+- **No behavior change of any kind.** No command, flag, engine selection, transport, model, or job-state format is touched. The two manifests gain an `email` field, which both schemas already accept (verified against `claude plugin validate --strict`).
+
+### Not tested
+- **That the published address is monitored.** That is a commitment by the maintainer, not something a test can assert. It is stated here so a reader knows which claims in this repository are mechanically checked and which are not.
 
 ## 0.16.0 — 2026-08-05 — Write is opt-in, and every claim about the engines is measured
 


### PR DESCRIPTION
Summary:
Publishes a contact address that receives mail, and releases it as `0.16.1` together with the reviewer walkthrough from #51. This closes the last open item in the Anthropic Software Directory Policy.

Why:
Policy **3.B** — "Developers must provide verified contact information and support channels for users with product or security concerns." The repository carried none. Both manifests listed a name and a GitHub URL; every route to the maintainer went through GitHub. Someone who cannot or will not use GitHub had no way to report anything, and a directory reviewer had no address to verify.

What changed:
`arcobaleno830623@gmail.com` now appears in:
- `plugins/gemini/.claude-plugin/plugin.json` → `author.email`
- `.claude-plugin/marketplace.json` → `owner.email` and the plugin entry's `author.email`
- `SECURITY.md` → a second reporting route
- `README.md` and `README.zh-TW.md` → Support

Both manifest schemas already accept the field. That was checked against `claude plugin validate --strict` before writing it, not assumed.

Two decisions worth stating:
1. **GitHub Security Advisories stays preferred for vulnerabilities.** It keeps the report, the discussion, and the resulting advisory in one place. Email is the fallback, not the replacement, and `SECURITY.md` says which is which.
2. **A `@users.noreply.github.com` address was considered and rejected.** It cannot receive mail, so it would have filled the contact field while failing the only thing that field is for — a contact route that looks compliant and silently discards reports is worse than an empty field.

Both Support sections now also say plainly that this is a single-maintainer project rather than a staffed support desk, so response expectations come from the documentation instead of from what a published address usually implies.

Release contents (`0.16.1`):
- **Added** — the contact address (this PR); `scripts/reviewer-demo.mjs`, the credential-free walkthrough of every command (#51).
- **Tests** — `tests/reviewer-demo.test.mjs` (#51).
- **Compatibility** — no behavior change of any kind. No command, flag, engine selection, transport, model, or job-state format is touched.
- **Not tested** — that the published address is monitored. That is a commitment by the maintainer, not something a test can assert, and the changelog says so rather than leaving a reader to assume every claim in this repository is mechanically checked.

SemVer:
**PATCH.** Additive metadata and documentation; no contract, behavior, or surface change. `SECURITY.md`'s supported-versions table already reads `0.16.x` and needs no edit — the rule there is "only the current MINOR line".

Security impact:
None to the code. It adds a disclosure route, which is the point.

Data/privacy impact:
None to users. The address is the maintainer's own, published deliberately.

Validation:
- `npm test` — 329 tests, 324 pass, 0 fail, 5 skipped
- `npm run check-version` — all version metadata matches 0.16.1
- `npm run verify-contracts` — passed for gemini@gemini-plugin-cc v0.16.1
- `claude plugin validate ./plugins/gemini --strict` — passed
- `claude plugin validate . --strict` — passed
- `git diff --check` — clean

Directory policy status after this merges:
Both open items are closed — 3.D by #51's walkthrough, 3.B here. The plugin is not submitted to any directory yet; that is a separate decision.

Rollback:
Revert this commit. The address disappears from five files and the version returns to 0.16.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
