### PR TITLE
fix: route reviews through the same engine selection as everything else

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,13 +7,13 @@
   },
   "metadata": {
     "description": "Use Gemini CLI or Antigravity CLI (agy) inside Claude Code for task delegation, code review, and adversarial review.",
-    "version": "0.16.2"
+    "version": "0.16.3"
   },
   "plugins": [
     {
       "name": "gemini",
       "description": "Gemini CLI and Antigravity CLI bridge for Claude Code task delegation and adversarial review",
-      "version": "0.16.2",
+      "version": "0.16.3",
       "author": {
         "name": "arcobaleno64",
         "email": "arcobaleno830623@gmail.com"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@arcobaleno64/gemini-plugin-cc",
-  "version": "0.16.2",
+  "version": "0.16.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@arcobaleno64/gemini-plugin-cc",
-      "version": "0.16.2",
+      "version": "0.16.3",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arcobaleno64/gemini-plugin-cc",
-  "version": "0.16.2",
+  "version": "0.16.3",
   "private": true,
   "type": "module",
   "description": "Use Gemini CLI or Antigravity CLI (agy) inside Claude Code for task delegation, code review, and adversarial review.",

--- a/plugins/gemini/.claude-plugin/plugin.json
+++ b/plugins/gemini/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gemini",
-  "version": "0.16.2",
+  "version": "0.16.3",
   "description": "Use Gemini/AGY from Claude Code to review code or delegate tasks.",
   "author": {
     "name": "arcobaleno64",

--- a/plugins/gemini/CHANGELOG.md
+++ b/plugins/gemini/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.16.3 — 2026-08-05 — Review picks its engine the same way every other command does
+
+### Fixed
+- **`/gemini:review` and `/gemini:adversarial-review` sent every review to an unauthenticated gemini CLI rather than to a working AGY.** With no `--engine` given, the review path passed `"gemini"` as its default, which `detectEngine` reads as an **explicit** request — and an explicit request deliberately skips the credential check, because a user who names an engine should get that engine or a clear error. So an installed-but-unauthenticated gemini was selected and failed every review, with AGY sitting available beside it. Only a *missing gemini binary* ever reached the fallback.
+  - The review path now passes `null`, exactly as the task path always has, so both reach the same `auto` routing and the same credential check that v0.16.0 fixed.
+  - **What changes for you:** if you have a working gemini credential, nothing. If you do not, reviews now run on AGY and succeed instead of failing on authentication. An explicit `--engine gemini` still selects gemini and still reports the credential problem, which is the point of asking by name.
+  - The stated reason for the preference — "prefer gemini for JSON output" — had been obsolete since v0.11.0, when AGY 1.1.8's JSON envelope gave both engines the same structured contract.
+
+### Documentation
+- `REVIEW_SCHEMA` in `gemini-companion.mjs` looked like dead code and is not. It names a real file that two prompts and the bench scorer depend on; it is unread at runtime only because the contract travels to the model inside the prompt, since the gemini engine has no flag that accepts a schema file. AGY 1.1.8's `--json-schema` does, and that remains an open follow-up. The comment now says all of this, so the next reader does not delete it.
+
+### Tests
+- Engine selection is pinned three ways: that a review with no engine specified asks for the same thing a task does, that an explicit `--engine` is passed through untouched, and that the review path never names gemini by itself. Verified against the previous code — the first and third fail there, which is what makes them worth keeping.
+
 ## 0.16.2 — 2026-08-05 — The engine no longer starts through cmd.exe on Windows
 
 ### Fixed

--- a/plugins/gemini/scripts/gemini-companion.mjs
+++ b/plugins/gemini/scripts/gemini-companion.mjs
@@ -67,6 +67,13 @@ import { MODEL_MAP_METADATA, MODEL_ALIAS_ENTRIES } from "./lib/model-map.mjs";
 
 const ROOT_DIR = path.resolve(fileURLToPath(new URL("..", import.meta.url)));
 const SELF_PATH = fileURLToPath(import.meta.url);
+// The review output contract. Not read at runtime: the shape is carried to the
+// model inside the prompt (`prompts/review.md`, and the reference in
+// `skills/gemini-prompting/`) rather than handed to the CLI as a schema file,
+// because the gemini engine has no flag that accepts one. AGY 1.1.8 does
+// (`--json-schema`); adopting it is an open follow-up, and this is the path it
+// would use. Kept deliberately — the file it names exists and is the written
+// form of a contract two prompts and the bench scorer all depend on.
 const REVIEW_SCHEMA = path.join(ROOT_DIR, "schemas", "review-output.schema.json");
 const DEFAULT_STATUS_WAIT_TIMEOUT_MS = 240000;
 const DEFAULT_STATUS_POLL_INTERVAL_MS = 2000;

--- a/plugins/gemini/scripts/lib/gemini.mjs
+++ b/plugins/gemini/scripts/lib/gemini.mjs
@@ -384,13 +384,19 @@ export async function runGeminiReview(cwd, options = {}, { runCommandFn = runCom
   // share this runner, so the progress line must reflect the actual mode.
   onProgress?.({ message: `Starting ${isAdversarial ? "adversarial review" : "review"}...`, phase: "reviewing" });
 
-  // prefer gemini for JSON output, unless forced to agy
-  let engineInfo;
-  try {
-    engineInfo = detectEngineFn(requestedEngine ?? "gemini");
-  } catch {
-    engineInfo = detectEngineFn(requestedEngine ?? null);
-  }
+  // Same engine selection as a task: whatever the user asked for, else `auto`.
+  //
+  // This used to pass "gemini" as the default, which made an unspecified engine
+  // look like an explicit request — and an explicit request deliberately skips
+  // the credential check, because a user naming an engine should get that engine
+  // or a clear error. So a gemini CLI that was installed but unauthenticated was
+  // selected here and failed every review, while a working AGY sat beside it.
+  // Only a *missing* gemini binary reached the fallback.
+  //
+  // The reason for the preference is also gone: it was "prefer gemini for JSON
+  // output", true when only gemini could emit structured output. AGY has carried
+  // the same JSON envelope since 1.1.8 (plugin v0.11.0).
+  const engineInfo = detectEngineFn(requestedEngine ?? null);
   const agyStructured = engineInfo.engine === "agy" && supportsAgyStructuredOutput(engineInfo.version);
   const useJson = engineInfo.engine === "gemini" || agyStructured;
 

--- a/tests/agy-envelope.test.mjs
+++ b/tests/agy-envelope.test.mjs
@@ -219,3 +219,61 @@ test("AGY 1.1.10 review reports invalid-json when the response is not findings J
   // The envelope parsed; its payload did not. Those are different failures.
   assert.equal(result.failure.category, "invalid-json");
 });
+
+// --- engine selection ---
+// The review path used to pass "gemini" as its default, which reads to
+// detectEngine as an *explicit* request — and an explicit request deliberately
+// skips the credential check, because a user naming an engine should get it or a
+// clear error. The result was that a gemini CLI installed but unauthenticated
+// captured every review and failed it, with a working AGY sitting beside it.
+// Only a missing gemini *binary* reached the fallback.
+
+function recordingEngine() {
+  const calls = [];
+  const fn = (requested) => {
+    calls.push(requested);
+    return { engine: "agy", binary: "/fake/agy.exe", version: "1.1.10" };
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+test("a review with no engine asked for routes through auto, exactly like a task", async () => {
+  const reviewEngine = recordingEngine();
+  await runGeminiReview("/repo", { prompt: "review this" }, {
+    runCommandFn: stubRun({ stdout: JSON.stringify({ ...SUCCESS_ENVELOPE, response: '{"verdict":"approve","summary":"ok","findings":[],"next_steps":[]}' }) }),
+    detectEngineFn: reviewEngine
+  });
+
+  const taskEngine = recordingEngine();
+  await runGeminiTurn("/repo", { prompt: "do this", write: false }, {
+    runCommandFn: stubRun({ stdout: JSON.stringify(SUCCESS_ENVELOPE) }),
+    detectEngineFn: taskEngine
+  });
+
+  assert.deepEqual(reviewEngine.calls, [null], "review still names an engine of its own");
+  assert.deepEqual(reviewEngine.calls, taskEngine.calls, "review and task disagree on engine selection");
+});
+
+test("an explicitly requested engine is still passed through untouched", async () => {
+  for (const requested of ["gemini", "agy", "auto"]) {
+    const engine = recordingEngine();
+    await runGeminiReview("/repo", { prompt: "review this", engine: requested }, {
+      runCommandFn: stubRun({ stdout: JSON.stringify({ ...SUCCESS_ENVELOPE, response: '{"verdict":"approve","summary":"ok","findings":[],"next_steps":[]}' }) }),
+      detectEngineFn: engine
+    });
+    assert.deepEqual(engine.calls, [requested]);
+  }
+});
+
+// detectEngine is the single place that decides, and it already refuses an
+// unauthenticated gemini under `auto` (engine.test.mjs). This asserts the review
+// path actually reaches that decision rather than pre-empting it.
+test("an unauthenticated gemini no longer captures the review path", async () => {
+  const engine = recordingEngine();
+  await runGeminiReview("/repo", { prompt: "review this" }, {
+    runCommandFn: stubRun({ stdout: JSON.stringify({ ...SUCCESS_ENVELOPE, response: '{"verdict":"approve","summary":"ok","findings":[],"next_steps":[]}' }) }),
+    detectEngineFn: engine
+  });
+  assert.ok(!engine.calls.includes("gemini"), "review asked for gemini by name and skipped the credential check");
+});


### PR DESCRIPTION
Summary:
`/gemini:review` and `/gemini:adversarial-review` sent every review to an unauthenticated gemini CLI instead of a working AGY. Releases as `0.16.3`.

The defect:
```js
engineInfo = detectEngineFn(requestedEngine ?? "gemini");   // review (gemini.mjs:390)
engineInfo = detectEngineFn(requestedEngine ?? null);       // task   (gemini.mjs:208)
```

`detectEngine` treats a named engine as an **explicit** request, and an explicit request deliberately skips the credential check — someone who names an engine should get that engine or a clear error, not a silent substitution. Passing `"gemini"` as a *default* therefore opted the review path out of the check entirely.

The result: an installed-but-unauthenticated gemini was selected and failed every review, while a working AGY sat available beside it. The `try/catch` around it only helped when the gemini **binary was missing**, because that is the only condition `detectEngine("gemini")` throws on.

This is precisely the failure #48 fixed for `auto` routing in v0.16.0. Review went around it.

The rationale was also obsolete:
The comment read "prefer gemini for JSON output". That was true when only gemini could emit structured output. AGY has carried the same JSON envelope since 1.1.8 — shipped in plugin v0.11.0, ten releases ago.

What changes for you:
- **With a working gemini credential:** nothing.
- **Without one:** reviews run on AGY and succeed, instead of failing on authentication.
- **With `--engine gemini` explicitly:** unchanged — gemini is selected and the credential problem is reported. That is the point of naming an engine.

Live verification:
On a disposable repo with the gemini credential hidden (`GEMINI_COMPANION_DISABLE_KEYCHAIN=1`, OAuth expired), `review --wait` now runs on AGY and returns real structured findings against the corpus's planted defects — SQL injection, hardcoded JWT secret, loose password comparison. Before this commit the same command failed on authentication.

Tests:
Three, and they were checked against the previous code rather than assumed to be meaningful — the first and third **fail** there:
1. A review with no engine specified asks `detectEngine` for the same thing a task does.
2. An explicit `--engine gemini|agy|auto` is passed through untouched.
3. The review path never names gemini on its own.

Not deleted: `REVIEW_SCHEMA`:
It reads as dead code — defined, never referenced — and I nearly removed it after checking for `schemas/` in the repository root, where it does not exist. It resolves against the **plugin** root, where it does: `plugins/gemini/schemas/review-output.schema.json`, the written form of a contract that `prompts/review.md`, the `gemini-prompting` skill, and the bench scorer all depend on.

It is unread at runtime because the contract travels to the model inside the prompt — the gemini engine has no flag that accepts a schema file. AGY 1.1.8's `--json-schema` does, and adopting it is an open follow-up; this constant is the path it would use. A comment now records all of this so the next reader does not repeat my mistake.

Validation:
- `npm test` — 340 tests, 335 pass, 0 fail, 5 skipped (was 337/332/0/5 on main; +3 new tests)
- `npm run check-version` — matches 0.16.3
- `npm run verify-contracts` — passed
- `claude plugin validate ./plugins/gemini --strict` — passed
- `claude plugin validate . --strict` — passed
- `git diff --check` — clean

Not tested:
- **A live review on the gemini engine.** The credentialed gemini path could not be exercised: the test API key from earlier in this work hit its spend cap, and consumer CLI access ended 2026-06-18. Selection is asserted by unit test; the AGY leg was run for real.
- Whether AGY and gemini produce *comparable* review quality. This changes which engine is chosen when one is unusable, not a judgment that they are equivalent reviewers.

Version:
Bug fix, no contract change → **PATCH**.

Rollback:
Revert this commit. Reviews return to naming gemini by default, and to failing when it has no credential.

Remaining follow-ups from the parity audit, untouched here: `--json-schema` adoption, `stream-json` for real background-phase reporting, and AGY's workspace binding for file *reads*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
