### PR TITLE
chore: stop reporting job phases the engine never told us

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,13 +7,13 @@
   },
   "metadata": {
     "description": "Use Gemini CLI or Antigravity CLI (agy) inside Claude Code for task delegation, code review, and adversarial review.",
-    "version": "0.16.4"
+    "version": "0.16.5"
   },
   "plugins": [
     {
       "name": "gemini",
       "description": "Gemini CLI and Antigravity CLI bridge for Claude Code task delegation and adversarial review",
-      "version": "0.16.4",
+      "version": "0.16.5",
       "author": {
         "name": "arcobaleno64",
         "email": "arcobaleno830623@gmail.com"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@arcobaleno64/gemini-plugin-cc",
-  "version": "0.16.4",
+  "version": "0.16.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@arcobaleno64/gemini-plugin-cc",
-      "version": "0.16.4",
+      "version": "0.16.5",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arcobaleno64/gemini-plugin-cc",
-  "version": "0.16.4",
+  "version": "0.16.5",
   "private": true,
   "type": "module",
   "description": "Use Gemini CLI or Antigravity CLI (agy) inside Claude Code for task delegation, code review, and adversarial review.",

--- a/plugins/gemini/.claude-plugin/plugin.json
+++ b/plugins/gemini/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gemini",
-  "version": "0.16.4",
+  "version": "0.16.5",
   "description": "Use Gemini/AGY from Claude Code to review code or delegate tasks.",
   "author": {
     "name": "arcobaleno64",

--- a/plugins/gemini/CHANGELOG.md
+++ b/plugins/gemini/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.16.5 — 2026-08-05 — Job phases stop claiming detail that does not exist
+
+### Changed
+- **The background-job phase fallback no longer pretends to know what the engine is doing.** It scanned the progress log for tool-level prefixes — `"searching:"`, `"running command:"`, `"applying "` — and reported `investigating`, `verifying` or `editing`. Every one of those branches was unreachable, for two independent reasons:
+  - **Nothing writes such lines.** The log receives only the six messages `lib/gemini.mjs` emits (`"Detecting engine..."`, `"Starting <engine> turn..."`, `"Turn completed."` and the review equivalents). `runCommand` is `spawnSync`, so the engine's output arrives in one blocking return, not as events — there is nothing to narrate mid-run.
+  - **The comparison could not have matched anyway.** Every logged line is written as `[<iso timestamp>] <message>`, and the preview keeps only lines beginning with `[`, so `startsWith("searching:")` was false by construction.
+  - **No behavior change.** The removed code could not execute, so no job's reported phase differs. What remains is what is actually known: the job's status, and its class when the status says nothing.
+
+### Not adopted, with the measurement behind the decision
+- **AGY 1.1.8's `--output-format stream-json` cannot supply those phases, so it was not adopted.** Measured on 1.1.10, 2026-08-05: the stream carries an `init` event, `step_update` events, and a terminal `result` event that still holds the full response. The `step_type` values are `tool`, `agent_response`, `user_input`, `checkpoint` and `unknown` — and **`tool` carries no tool name and no arguments**, so "read a file" cannot be told from "run the tests" or "edit something". The phases the deleted code reported were never obtainable from any source.
+- What the stream *does* offer that today's path does not is `text_delta`: incremental output while the model is still writing. That is genuinely useful for a background job, and it needs `runCommand` to become asynchronous — which would reach every caller, the result assembly, timeout handling, and the injection seam the tests are built on, while still keeping the existing path for the gemini engine and for AGY below 1.1.8. Estimated two to three days and left open deliberately rather than started and abandoned.
+
+### Tests
+- Four cases pin the fallback: a job's own `phase` always wins; each status maps as documented; a log full of tool-shaped lines does **not** move the phase; and the set of progress messages the engine emits is asserted to contain no tool-level text — so if a future change starts emitting richer progress, that test fails and the phase logic is revisited deliberately rather than by accident.
+
 ## 0.16.4 — 2026-08-05 — A read-only AGY task can see the repository again
 
 ### Fixed

--- a/plugins/gemini/scripts/lib/job-control.mjs
+++ b/plugins/gemini/scripts/lib/job-control.mjs
@@ -109,13 +109,31 @@ function formatElapsedDuration(startValue, endValue = null) {
   return `${seconds}s`;
 }
 
-function looksLikeVerificationCommand(line) {
-  return /\b(test|tests|lint|build|typecheck|type-check|check|verify|validate|pytest|jest|vitest|cargo test|npm test|pnpm test|yarn test|go test|mvn test|gradle test|tsc|eslint|ruff)\b/i.test(
-    line
-  );
-}
-
-function inferLegacyJobPhase(job, progressPreview = []) {
+// Phase for a job whose own `phase` field is absent — a record written before
+// the field existed, or one whose progress event never landed.
+//
+// It used to also scan the progress log for tool-level prefixes ("searching:",
+// "running command:", "applying ") and report `investigating`, `verifying` or
+// `editing`. Those tests could not have passed under any input: every line is
+// written as `[<iso timestamp>] <message>` (appendLogLine) and the preview keeps
+// only lines starting with "[", so `startsWith("searching:")` was false by
+// construction.
+//
+// Nothing wrote such lines either. The log receives only the six progress
+// messages `lib/gemini.mjs` emits — "Detecting engine...", "Starting <engine>
+// turn...", "Turn completed." and their review equivalents — because
+// `runCommand` is `spawnSync`: the engine's output arrives in one blocking
+// return, not as events, so there is nothing to narrate mid-run.
+//
+// Nor is that detail obtainable. AGY 1.1.8's `--output-format stream-json` was
+// measured on 1.1.10 (2026-08-05): it emits `step_type` values of `tool`,
+// `agent_response`, `user_input`, `checkpoint` and `unknown` — and **`tool`
+// carries no tool name or arguments**, so read-versus-run-tests-versus-edit
+// cannot be distinguished from it either. Reporting those phases would have
+// required inventing them.
+//
+// What remains is what is actually known: the job's own status, and its class.
+function fallbackJobPhase(job) {
   switch (job.status) {
     case "queued":
       return "queued";
@@ -126,45 +144,8 @@ function inferLegacyJobPhase(job, progressPreview = []) {
     case "completed":
       return "done";
     default:
-      break;
+      return job.jobClass === "review" ? "reviewing" : "running";
   }
-
-  for (let index = progressPreview.length - 1; index >= 0; index -= 1) {
-    const line = progressPreview[index].toLowerCase();
-    if (line.startsWith("starting gemini") || line.startsWith("thread ready") || line.startsWith("turn started")) {
-      return "starting";
-    }
-    if (line.startsWith("reviewer started") || line.includes("review mode")) {
-      return "reviewing";
-    }
-    if (line.startsWith("searching:") || line.startsWith("calling ") || line.startsWith("running tool:")) {
-      return "investigating";
-    }
-    if (line.startsWith("starting collaboration tool:")) {
-      return "investigating";
-    }
-    if (line.startsWith("running command:")) {
-      return looksLikeVerificationCommand(line)
-        ? "verifying"
-        : job.jobClass === "review"
-          ? "reviewing"
-          : "investigating";
-    }
-    if (line.startsWith("command completed:")) {
-      return looksLikeVerificationCommand(line) ? "verifying" : "running";
-    }
-    if (line.startsWith("applying ") || line.startsWith("file changes ")) {
-      return "editing";
-    }
-    if (line.startsWith("turn completed")) {
-      return "finalizing";
-    }
-    if (line.startsWith("gemini error:") || line.startsWith("failed:")) {
-      return "failed";
-    }
-  }
-
-  return job.jobClass === "review" ? "reviewing" : "running";
 }
 
 export function enrichJob(job, options = {}) {
@@ -185,7 +166,7 @@ export function enrichJob(job, options = {}) {
 
   return {
     ...enriched,
-    phase: enriched.phase ?? inferLegacyJobPhase(enriched, enriched.progressPreview)
+    phase: enriched.phase ?? fallbackJobPhase(enriched)
   };
 }
 

--- a/tests/job-phase.test.mjs
+++ b/tests/job-phase.test.mjs
@@ -1,0 +1,79 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { enrichJob } from "../plugins/gemini/scripts/lib/job-control.mjs";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+// enrichJob reports a phase for the status line. A job carries its own `phase`,
+// written by the progress updater; the fallback covers records written before
+// that field existed, or one whose event never landed.
+//
+// The fallback used to also scan the progress log for tool-level prefixes and
+// report `investigating` / `verifying` / `editing`. Nothing ever wrote those
+// lines, and the tests below exist so the branches are not reintroduced on the
+// assumption that something might.
+
+function job(overrides = {}) {
+  return { id: "task-1", status: "running", jobClass: "task", logFile: null, ...overrides };
+}
+
+test("a job's own phase always wins over the fallback", () => {
+  assert.equal(enrichJob(job({ phase: "reviewing" })).phase, "reviewing");
+  assert.equal(enrichJob(job({ status: "completed", phase: "done" })).phase, "done");
+});
+
+test("the fallback reports status, and class only when the status says nothing", () => {
+  assert.equal(enrichJob(job({ status: "queued" })).phase, "queued");
+  assert.equal(enrichJob(job({ status: "cancelled" })).phase, "cancelled");
+  assert.equal(enrichJob(job({ status: "failed" })).phase, "failed");
+  assert.equal(enrichJob(job({ status: "completed" })).phase, "done");
+  assert.equal(enrichJob(job({ status: "running", jobClass: "task" })).phase, "running");
+  assert.equal(enrichJob(job({ status: "running", jobClass: "review" })).phase, "reviewing");
+});
+
+// The removed branches keyed off raw log lines with prefixes like "searching:".
+// They could never have matched: every logged line is written as
+// `[<iso timestamp>] <message>` (appendLogLine) and the preview keeps only lines
+// starting with "[", so `line.startsWith("searching:")` was false by
+// construction — not merely unreached for want of a producer.
+test("progress log content does not influence the phase", (t) => {
+  const logFile = path.join(ROOT, "tests", `.tmp-phase-${process.pid}.log`);
+  fs.writeFileSync(
+    logFile,
+    [
+      "[2026-08-05T00:00:00.000Z] searching: src/auth.js",
+      "[2026-08-05T00:00:01.000Z] running command: npm test",
+      "[2026-08-05T00:00:02.000Z] applying edits to src/auth.js",
+      "[2026-08-05T00:00:03.000Z] file changes written"
+    ].join("\n") + "\n",
+    "utf8"
+  );
+  t.after(() => fs.rmSync(logFile, { force: true }));
+
+  const enriched = enrichJob(job({ status: "running", jobClass: "task", logFile }));
+  assert.equal(enriched.phase, "running", "a log line decided the phase again");
+  assert.ok(enriched.progressPreview.length > 0, "the preview is still shown to the user");
+});
+
+// The claim the deleted code rested on: that something emits tool-level lines.
+// This asserts the actual set of progress messages, so if a future change starts
+// emitting richer ones, this test fails and the phase logic can be revisited
+// deliberately rather than by accident.
+test("the engine emits only coarse progress messages, which is why phases are coarse", () => {
+  const source = fs.readFileSync(path.join(ROOT, "plugins", "gemini", "scripts", "lib", "gemini.mjs"), "utf8");
+  const messages = [...source.matchAll(/onProgress\?\.\(\{\s*message:\s*(`[^`]*`|"[^"]*"|[^,]+)/g)]
+    .map((m) => m[1].trim());
+
+  assert.ok(messages.length > 0, "no progress messages found — the extraction broke, not the code");
+  for (const message of messages) {
+    assert.doesNotMatch(
+      message,
+      /searching:|running command:|running tool:|applying |file changes |command completed:/i,
+      `a tool-level progress message appeared (${message}); the phase fallback may now be able to do better`
+    );
+  }
+});


### PR DESCRIPTION
Summary:
Removes a background-job phase fallback that reported detail the engine never provided, and records the measurement showing that detail is not obtainable at all. Releases as `0.16.5`.

What was there:
`inferLegacyJobPhase` scanned the progress log for tool-level prefixes — `"searching:"`, `"running command:"`, `"applying "` — and reported `investigating`, `verifying` or `editing`.

**Every one of those branches was dead, for two independent reasons:**

1. **Nothing writes such lines.** The log receives only the six messages `lib/gemini.mjs` emits: `"Detecting engine..."`, `"Starting <engine> turn..."`, `"Turn completed."` and the review equivalents. `runCommand` is `spawnSync` — the engine's output arrives in one blocking return, not as events, so there is nothing to narrate mid-run.
2. **The comparison could not have matched anyway.** Every logged line is written `[<iso timestamp>] <message>` (`appendLogLine`), and `readJobProgressPreview` keeps only lines starting with `[`. So `line.startsWith("searching:")` was false *by construction*, regardless of what any producer wrote.

The second reason is why this is a pure deletion: **no job's reported phase changes.** The code could not execute.

What remains is what is actually known: the job's status, and its class when the status says nothing.

Why not fix it with `stream-json` instead — which is what the follow-up note proposed:
Measured on AGY 1.1.10, 2026-08-05. `--output-format stream-json` emits an `init` event, `step_update` events, and a terminal `result` event that still carries the full response.

| `step_type` | count in a 7-tool-call run |
|---|---|
| `tool` | 12 |
| `agent_response` | 11 |
| `user_input` | 1 |
| `checkpoint` | 1 |
| `unknown` | 1 |

**`tool` carries no tool name and no arguments.** "Read a file" cannot be distinguished from "run the tests" or "edit something". The phases the deleted code reported were never obtainable from any source — it was not waiting on a feature, it was describing something that does not exist.

What `stream-json` does offer, and why it is still open:
`text_delta` — incremental output while the model is still writing. That is genuinely useful for a background job, and it is the only real win here. It requires `runCommand` to become asynchronous, which reaches every caller, the result assembly, timeout handling, and the injection seam the tests are built on, while still keeping the current path for the gemini engine and for AGY below 1.1.8. Estimated two to three days, and left open deliberately rather than started and abandoned.

Tests:
Four cases, including two that exist specifically to stop the deleted branches coming back on a false premise:
- A job's own `phase` always wins over the fallback.
- Each status maps as documented.
- **A log full of tool-shaped lines does not move the phase** — written with the real `[timestamp]` format, so it demonstrates the by-construction argument rather than restating it.
- **The engine's progress messages are asserted to contain no tool-level text.** If a future change starts emitting richer progress, that test fails and the phase logic gets revisited deliberately instead of by accident.

Validation:
- `npm test` — 350 tests, 345 pass, 0 fail, 5 skipped (was 346/341/0/5 on main; +4 new tests)
- `npm run check-version` — matches 0.16.5
- `npm run verify-contracts` — passed
- `claude plugin validate ./plugins/gemini --strict` — passed
- `claude plugin validate . --strict` — passed
- `git diff --check` — clean

Behavior change:
**None.** The removed code was unreachable. This is a correctness-of-description change, not a functional one.

Version:
Internal cleanup, no contract or behavior change → **PATCH**.

Rollback:
Revert this commit. The dead branches return, still unable to execute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
