### PR TITLE
fix: classify AGY's headless permission denial instead of calling it empty

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,13 +7,13 @@
   },
   "metadata": {
     "description": "Use Gemini CLI or Antigravity CLI (agy) inside Claude Code for task delegation, code review, and adversarial review.",
-    "version": "0.16.5"
+    "version": "0.16.6"
   },
   "plugins": [
     {
       "name": "gemini",
       "description": "Gemini CLI and Antigravity CLI bridge for Claude Code task delegation and adversarial review",
-      "version": "0.16.5",
+      "version": "0.16.6",
       "author": {
         "name": "arcobaleno64",
         "email": "arcobaleno830623@gmail.com"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@arcobaleno64/gemini-plugin-cc",
-  "version": "0.16.5",
+  "version": "0.16.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@arcobaleno64/gemini-plugin-cc",
-      "version": "0.16.5",
+      "version": "0.16.6",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arcobaleno64/gemini-plugin-cc",
-  "version": "0.16.5",
+  "version": "0.16.6",
   "private": true,
   "type": "module",
   "description": "Use Gemini CLI or Antigravity CLI (agy) inside Claude Code for task delegation, code review, and adversarial review.",

--- a/plugins/gemini/.claude-plugin/plugin.json
+++ b/plugins/gemini/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gemini",
-  "version": "0.16.5",
+  "version": "0.16.6",
   "description": "Use Gemini/AGY from Claude Code to review code or delegate tasks.",
   "author": {
     "name": "arcobaleno64",

--- a/plugins/gemini/CHANGELOG.md
+++ b/plugins/gemini/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.16.6 — 2026-08-06 — A denied AGY tool call stops looking like an empty response
+
+### Added
+- **`tool-permission-denied`, a failure category for AGY's headless soft-denial.** When a tool needs a permission AGY cannot prompt for, it exits **0** with empty stdout and explains itself on stderr. The classifier had no rule for that wording, so the run landed on `no-output` — which is marked **retryable**, and retrying a denied permission never succeeds. It is now classified, marked not retryable, and the message says what to actually do.
+  - Recovered from an unmerged worktree left over from the v0.8.0 era. The classification and its test were written then; what is new here is that the surrounding classifier had moved on, so it was reapplied rather than merged.
+  - **The advice was rewritten.** AGY's own message ends "re-run with `--dangerously-skip-permissions`". This plugin removed that flag in v0.16.0 — it granted nothing for edits and shell commands ([`docs/THREAT-MODEL.md` §7.2](../../docs/THREAT-MODEL.md)) — and offers no way to reinstate it, so repeating that suggestion would point users at something they cannot reach from here. The next step now names the allow-rule they can add and the interactive `agy` run that can ask on their behalf.
+  - The classifier still *matches* AGY's wording including the flag name. That the plugin no longer passes the flag does not stop AGY from mentioning it.
+
+### Tests
+- The live AGY denial message is classified as expected and marked not retryable.
+- A second test asserts the next step **never names `--dangerously-skip-permissions`**, so the original wording cannot come back with a future copy-paste.
+
 ## 0.16.5 — 2026-08-05 — Job phases stop claiming detail that does not exist
 
 ### Changed

--- a/plugins/gemini/scripts/lib/failures.mjs
+++ b/plugins/gemini/scripts/lib/failures.mjs
@@ -10,6 +10,7 @@ export const FAILURE_CATEGORIES = new Set([
   "transcript-missing",
   "transcript-ambiguous",
   "invalid-json",
+  "tool-permission-denied",
   "cancelled",
   "stale-job",
   "unknown"
@@ -70,6 +71,17 @@ const DEFAULTS = {
     retryable: true,
     summary: "The CLI returned output that was not valid structured JSON.",
     nextStep: "Retry the command; if it repeats, inspect the job log and run `/gemini:setup`."
+  },
+  "tool-permission-denied": {
+    retryable: false,
+    summary: "AGY auto-denied a tool call because headless mode cannot prompt for permission.",
+    // AGY's own message suggests re-running with --dangerously-skip-permissions.
+    // That is not advice this plugin can pass on: the flag was removed in v0.16.0
+    // (it granted nothing for edits and shell commands, docs/THREAT-MODEL.md 7.2)
+    // and there is no option that puts it back, so telling a user to "re-run
+    // with" it would name something they cannot reach from here. The allow-rule
+    // is the part they can act on; an interactive `agy` run is the other.
+    nextStep: "Add an allow-rule under `permissions.allow` in AGY's settings.json for the denied command, or run `agy` interactively once so it can ask."
   },
   cancelled: {
     retryable: true,
@@ -212,6 +224,15 @@ export function classifyCliFailure(input = {}) {
 
   if (data.invalidJson || /invalid json|JSON\.parse|Could not parse structured JSON|unexpected token/i.test(structuredText)) {
     return normalizeFailure("invalid-json", data);
+  }
+
+  // AGY exits 0 with empty stdout when a tool needed a permission it could not
+  // prompt for, which would otherwise land on "no-output" — retryable, and
+  // retrying never helps. Matched on AGY's own wording, including its suggestion
+  // to pass --dangerously-skip-permissions; that the plugin no longer offers the
+  // flag does not stop AGY from naming it.
+  if (/headless mode cannot prompt for|was auto-denied\b|dangerously-skip-permissions/i.test(structuredText)) {
+    return normalizeFailure("tool-permission-denied", data);
   }
   if (data.noOutput || (!String(stdout).trim() && !String(trusted).trim() && (data.status == null || data.status === 0))) {
     return normalizeFailure("no-output", data);

--- a/tests/failures.test.mjs
+++ b/tests/failures.test.mjs
@@ -75,6 +75,29 @@ test("classifyCliFailure identifies prompt-too-long preflight failures", () => {
   assert.match(failure.nextStep, /shorten|gemini/i);
 });
 
+// Verbatim wording from a live AGY run. The exit status is 0 and stdout is
+// empty, so without this rule the failure lands on "no-output" — which is marked
+// retryable, and retrying a denied permission never succeeds.
+test("classifyCliFailure identifies AGY headless tool-permission soft-denials", () => {
+  const failure = classifyCliFailure({
+    status: 0,
+    stdout: "",
+    stderr: 'jetski: no output produced — a tool required the "command" permission that headless mode cannot prompt for, so it was auto-denied. Add an allow-rule under permissions.allow in settings.json (e.g. command(<target>)). Alternatively, re-run with --dangerously-skip-permissions to auto-approve all tools.'
+  });
+  assert.equal(failure.category, "tool-permission-denied");
+  assert.equal(failure.retryable, false);
+  assert.match(failure.nextStep, /allow-rule/i);
+});
+
+// The plugin removed --dangerously-skip-permissions in v0.16.0 and offers no way
+// to reinstate it, so the advice must not tell a user to re-run with it — even
+// though AGY's own message does, and the classifier still matches that wording.
+test("the tool-permission next step does not name a flag the plugin cannot pass", () => {
+  const failure = classifyCliFailure({ status: 0, stdout: "", stderr: "a tool was auto-denied" });
+  assert.equal(failure.category, "tool-permission-denied");
+  assert.doesNotMatch(failure.nextStep, /dangerously-skip-permissions/);
+});
+
 test("classifyCliFailure falls back to unknown", () => {
   const failure = classifyCliFailure({ stderr: "unexpected failure shape" });
   assert.equal(failure.category, "unknown");


### PR DESCRIPTION
Summary:
AGY's headless permission denial was being classified as `no-output`, which is marked **retryable**. Retrying a denied permission never succeeds. Now its own category, with advice a user can act on. Releases as `0.16.6`.

The defect:
When a tool needs a permission AGY cannot prompt for in headless mode, AGY exits **0** with **empty stdout** and explains itself on stderr:

```
jetski: no output produced — a tool required the "command" permission that headless
mode cannot prompt for, so it was auto-denied. Add an allow-rule under
permissions.allow in settings.json (e.g. command(<target>)). Alternatively, re-run
with --dangerously-skip-permissions to auto-approve all tools.
```

Exit 0 plus empty stdout is exactly the `no-output` shape, so that is where it landed — retryable, and the user was advised to do the one thing that cannot help.

Provenance, stated plainly:
Recovered from an unmerged worktree left over from the v0.8.0 era. The rule and its test were written then and never landed. The classifier around them has changed since (it grew AGY's invalid-model wording), so this **reapplies the idea** rather than merging a stale branch.

The advice had to be rewritten:
AGY's message ends "re-run with `--dangerously-skip-permissions`". The original patch passed that through verbatim. This plugin **removed that flag in v0.16.0** — it granted nothing for edits and shell commands ([`docs/THREAT-MODEL.md` §7.2](docs/THREAT-MODEL.md)) — and exposes no option that puts it back. Repeating the suggestion would point users at something unreachable from here.

The next step now names what they can actually do: the allow-rule under `permissions.allow`, or one interactive `agy` run so it can ask.

The classifier still *matches* the flag name in AGY's output. What this plugin no longer passes has no bearing on what AGY prints.

Tests:
- The live denial message classifies as `tool-permission-denied` and is marked not retryable.
- **The next step is asserted never to name `--dangerously-skip-permissions`.** The original wording is one copy-paste away from returning, and nothing else would catch it.

Validation:
- `npm test` — 352 tests, 347 pass, 0 fail, 5 skipped (was 350/345/0/5 on main; +2 new tests)
- `npm run check-version` — matches 0.16.6
- `npm run verify-contracts` — passed
- `claude plugin validate ./plugins/gemini --strict` — passed
- `claude plugin validate . --strict` — passed
- `git diff --check` — clean

Not tested:
- **A live denial.** The classifier is driven by wording captured verbatim from a real AGY run, but no run was provoked into denying a permission for this change. The failure shape is asserted from that recorded text.

Version:
New failure category, no contract change → **PATCH**. Behavior changes only for a run that previously reported `no-output` with a retry suggestion.

Rollback:
Revert this commit. The denial returns to being reported as an empty response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
