### PR TITLE
test: cover what can go wrong, delete what nothing calls

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,13 +7,13 @@
   },
   "metadata": {
     "description": "Use Gemini CLI or Antigravity CLI (agy) inside Claude Code for task delegation, code review, and adversarial review.",
-    "version": "0.16.6"
+    "version": "0.16.7"
   },
   "plugins": [
     {
       "name": "gemini",
       "description": "Gemini CLI and Antigravity CLI bridge for Claude Code task delegation and adversarial review",
-      "version": "0.16.6",
+      "version": "0.16.7",
       "author": {
         "name": "arcobaleno64",
         "email": "arcobaleno830623@gmail.com"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@arcobaleno64/gemini-plugin-cc",
-  "version": "0.16.6",
+  "version": "0.16.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@arcobaleno64/gemini-plugin-cc",
-      "version": "0.16.6",
+      "version": "0.16.7",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arcobaleno64/gemini-plugin-cc",
-  "version": "0.16.6",
+  "version": "0.16.7",
   "private": true,
   "type": "module",
   "description": "Use Gemini CLI or Antigravity CLI (agy) inside Claude Code for task delegation, code review, and adversarial review.",

--- a/plugins/gemini/.claude-plugin/plugin.json
+++ b/plugins/gemini/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gemini",
-  "version": "0.16.6",
+  "version": "0.16.7",
   "description": "Use Gemini/AGY from Claude Code to review code or delegate tasks.",
   "author": {
     "name": "arcobaleno64",

--- a/plugins/gemini/CHANGELOG.md
+++ b/plugins/gemini/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 0.16.7 — 2026-08-06 — Cover what can go wrong, delete what nothing calls
+
+A coverage pass that treated the percentage as a way to find gaps, not as the thing to raise. Two of the three findings were answered by deleting code and by *declining* to add a test.
+
+### Removed
+- **Five unused exports from `lib/fs.mjs`**: `ensureAbsolutePath`, `createTempDir`, `readJsonFile`, `writeJsonFile`, `safeReadFile`. Nothing imported any of them — not the plugin, the tests, the bench harness, or the docs. Their 28% function coverage was not a testing gap; it was five thin wrappers around one-line `fs` calls waiting to tempt someone away from the module that already does the job properly (`state.mjs` owns atomic JSON writes). `isProbablyText` and `readStdinIfPiped` each have a caller and stay.
+
+### Tests
+- **A deleted secret file no longer had to be taken on trust.** `bSidePath` has a branch for `+++ /dev/null`, which is what git writes when a file is removed — and a deletion diff carries every line of the secret with a `-` in front of it. That branch had no test. It does now, together with its mirror image: a deleted *ordinary* file must pass through untouched, because falling back to the header must not start redacting things that are not credentials.
+- **Job progress updates are pinned where a user could see them fail**: a changed thread id must replace the old one (otherwise `/gemini:status` prints a stale `gemini --resume` command to copy), a turn-only update must not drop the thread id, and an update for a job whose record was swept mid-run must be dropped quietly rather than throw or resurrect the file. Plus the reporter contract callers rely on — `null` when there is nowhere to report, and an empty thread id normalized away rather than stored.
+
+### Deliberately not tested
+Stated because "why is this line red" deserves an answer in the record rather than a future patch:
+- **The updater's skip-when-unchanged branch.** The only way to observe it is the job file's mtime, which is flaky within a millisecond and tests an optimisation rather than a promise. Reaching it would raise the branch percentage and protect nothing.
+- **A newly added secret file.** Its `--- /dev/null` sits on the a-side, which `bSidePath` never reads, so it takes the identical path to the ordinary case already covered. The test was written, then removed for asserting nothing new.
+
+### Coverage
+Line 71.09% → 71.22%, branch 65.89% → 66.62% overall — small numbers, because the work was three targeted files and one deletion. Where it landed: `tracked-jobs.mjs` branch 41.30% → 72.22%, `fs.mjs` line 65% → 84.62%, `secrets.mjs` branch 70.37% → 74.07%. The engine, credential, state, failure-classification and model-map modules were already 95–100% and were left alone.
+
 ## 0.16.6 — 2026-08-06 — A denied AGY tool call stops looking like an empty response
 
 ### Added

--- a/plugins/gemini/scripts/lib/fs.mjs
+++ b/plugins/gemini/scripts/lib/fs.mjs
@@ -1,26 +1,12 @@
 import fs from "node:fs";
-import os from "node:os";
-import path from "node:path";
 
-export function ensureAbsolutePath(cwd, maybePath) {
-  return path.isAbsolute(maybePath) ? maybePath : path.resolve(cwd, maybePath);
-}
-
-export function createTempDir(prefix = "gemini-plugin-") {
-  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
-}
-
-export function readJsonFile(filePath) {
-  return JSON.parse(fs.readFileSync(filePath, "utf8"));
-}
-
-export function writeJsonFile(filePath, value) {
-  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
-}
-
-export function safeReadFile(filePath) {
-  return fs.existsSync(filePath) ? fs.readFileSync(filePath, "utf8") : "";
-}
+// Two helpers, both with a caller. This file also held ensureAbsolutePath,
+// createTempDir, readJsonFile, writeJsonFile and safeReadFile — none of which
+// anything imported, in the plugin, the tests, the bench harness or the docs.
+// They were removed in v0.16.7 rather than covered: an untested export with no
+// caller is not a coverage gap, and keeping thin wrappers around one-line `fs`
+// calls invites a future reader to route through them instead of the module
+// that already does the job (state.mjs owns atomic JSON writes, for one).
 
 export function isProbablyText(buffer) {
   const sample = buffer.subarray(0, Math.min(buffer.length, 4096));

--- a/tests/secrets.test.mjs
+++ b/tests/secrets.test.mjs
@@ -117,3 +117,49 @@ test("redactSecretsFromDiff tolerates empty and nullish input", () => {
     assert.deepEqual(redactedFiles, []);
   }
 });
+
+// Deleting a credential file is the case the `+++ /dev/null` branch exists for:
+// the b-side names no file, so the path has to come from the header instead.
+// The removed contents are still contents — a deletion diff carries every line
+// of the secret with a `-` in front of it.
+test("redactSecretsFromDiff withholds the body of a deleted secret file", () => {
+  const diff = [
+    "diff --git a/config/.env b/config/.env",
+    "deleted file mode 100644",
+    "index 1234567..0000000",
+    "--- a/config/.env",
+    "+++ /dev/null",
+    "@@ -1,2 +0,0 @@",
+    "-API_TOKEN=DELETED_SECRET_LEAK",
+    "-DB_PASSWORD=hunter2",
+    ""
+  ].join("\n");
+
+  const { text, redactedFiles } = redactSecretsFromDiff(diff);
+  assert.ok(!text.includes("DELETED_SECRET_LEAK"), "the deleted secret's value survived redaction");
+  assert.ok(!text.includes("hunter2"));
+  assert.deepEqual(redactedFiles, ["config/.env"]);
+  assert.ok(text.startsWith("diff --git a/config/.env b/config/.env"), "the header must survive so the review knows the file changed");
+});
+
+// The same branch, but for an ordinary file: falling back to the header must not
+// start redacting things that are not secrets.
+test("a deleted ordinary file is left alone", () => {
+  const diff = [
+    "diff --git a/src/old.js b/src/old.js",
+    "deleted file mode 100644",
+    "--- a/src/old.js",
+    "+++ /dev/null",
+    "@@ -1 +0,0 @@",
+    "-export const gone = true;",
+    ""
+  ].join("\n");
+
+  const { text, redactedFiles } = redactSecretsFromDiff(diff);
+  assert.equal(text, diff);
+  assert.deepEqual(redactedFiles, []);
+});
+
+// Not covered here: a newly added secret file. Its `--- /dev/null` sits on the
+// a-side, which bSidePath never reads, so it takes the identical path to the
+// ordinary case above and would assert nothing the first test does not.

--- a/tests/tracked-jobs.test.mjs
+++ b/tests/tracked-jobs.test.mjs
@@ -1,0 +1,102 @@
+import fs from "node:fs";
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { makeTempDir } from "./helpers.mjs";
+import { createJobProgressUpdater, createProgressReporter } from "../plugins/gemini/scripts/lib/tracked-jobs.mjs";
+import { resolveJobFile, readJobFile, upsertJob, writeJobFile } from "../plugins/gemini/scripts/lib/state.mjs";
+
+// createJobProgressUpdater writes the fields /gemini:status reads back — phase,
+// and the thread and turn ids used to build the `gemini --resume` line a user
+// copies.
+//
+// These cover behaviour a user could observe going wrong: a stale resume
+// command, a thread id lost when only the turn changed, a worker throwing
+// because its job record was swept while it was still running. The updater also
+// skips writing when nothing changed; that branch is deliberately *not* pinned
+// here, because the only way to observe it is file mtime — flaky within a
+// millisecond, and a test of an optimisation rather than of a promise. Reaching
+// it would raise the branch percentage and protect nothing.
+
+function withDataDir(body) {
+  const dir = makeTempDir("gemini-tracked-");
+  const names = ["GEMINI_COMPANION_DATA", "CLAUDE_PLUGIN_DATA"];
+  const previous = Object.fromEntries(names.map((n) => [n, process.env[n]]));
+  process.env.GEMINI_COMPANION_DATA = dir;
+  delete process.env.CLAUDE_PLUGIN_DATA;
+  try {
+    return body(dir);
+  } finally {
+    for (const n of names) {
+      if (previous[n] == null) delete process.env[n];
+      else process.env[n] = previous[n];
+    }
+    fs.rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 });
+  }
+}
+
+function seedJob(cwd, id) {
+  upsertJob(cwd, { id, status: "running", title: "T", jobClass: "task" });
+  writeJobFile(cwd, id, { id, status: "running", title: "T", jobClass: "task" });
+  return resolveJobFile(cwd, id);
+}
+
+test("a changed thread id replaces the old one rather than being ignored", () => {
+  withDataDir((cwd) => {
+    const file = seedJob(cwd, "task-thread-2");
+    const update = createJobProgressUpdater(cwd, "task-thread-2");
+
+    update({ message: "first", threadId: "thr_1" });
+    update({ message: "resumed", threadId: "thr_2" });
+    assert.equal(readJobFile(file).threadId, "thr_2", "the status line would print a stale resume command");
+  });
+});
+
+test("turn id is tracked independently of thread id", () => {
+  withDataDir((cwd) => {
+    const file = seedJob(cwd, "task-turn-1");
+    const update = createJobProgressUpdater(cwd, "task-turn-1");
+
+    update({ message: "a", threadId: "thr_1", turnId: "turn_1" });
+    update({ message: "b", turnId: "turn_2" });
+
+    const stored = readJobFile(file);
+    assert.equal(stored.turnId, "turn_2");
+    assert.equal(stored.threadId, "thr_1", "the thread id was dropped when only the turn changed");
+  });
+});
+
+// The job file can be gone — a session-end sweep, or a pruned record — while the
+// worker is still reporting. That must not throw and must not recreate the file.
+test("an update for a job whose file has vanished is dropped quietly", () => {
+  withDataDir((cwd) => {
+    const file = seedJob(cwd, "task-gone-1");
+    const update = createJobProgressUpdater(cwd, "task-gone-1");
+    fs.rmSync(file, { force: true });
+
+    assert.doesNotThrow(() => update({ message: "still running", phase: "running" }));
+    assert.equal(fs.existsSync(file), false, "a deleted job record was resurrected");
+  });
+});
+
+// createProgressReporter returns null when it has nowhere to report, so callers
+// can use `progress?.()` without branching on configuration.
+test("a reporter with no destination is null rather than a no-op function", () => {
+  assert.equal(createProgressReporter(), null);
+  assert.equal(createProgressReporter({}), null);
+  assert.equal(typeof createProgressReporter({ onEvent: () => {} }), "function");
+});
+
+test("a reporter forwards the normalized event to onEvent", () => {
+  const seen = [];
+  const report = createProgressReporter({ onEvent: (e) => seen.push(e) });
+
+  report({ message: "  spaced  ", phase: " running ", threadId: "" });
+  report("bare string");
+
+  assert.equal(seen[0].message, "spaced");
+  assert.equal(seen[0].phase, "running");
+  assert.equal(seen[0].threadId, null, "an empty thread id must not be recorded as one");
+  assert.equal(seen[1].message, "bare string");
+  assert.equal(seen[1].phase, null);
+});


### PR DESCRIPTION
Summary:
A coverage pass that used the percentage to **find** gaps rather than as the thing to raise. Two of the three findings were answered by deleting code and by declining to write a test. Releases as `0.16.7`.

Starting point:
71.09% line / 65.89% branch overall. The engine, credential, state, failure-classification and model-map modules were already 95–100%, so the number pointed at three places worth looking at — and only one of them turned out to be a missing test.

**1. `lib/fs.mjs` — 28% function coverage was dead code, not a gap**
Five exports had no importer anywhere: `ensureAbsolutePath`, `createTempDir`, `readJsonFile`, `writeJsonFile`, `safeReadFile`. Not in the plugin, the tests, the bench harness, or the docs — checked across `*.mjs`, `*.md` and `*.json`.

They are five thin wrappers around one-line `fs` calls, and keeping them invites a future reader to route through `writeJsonFile` instead of `state.mjs`, which owns atomic JSON writes for a reason. **Deleted.** `isProbablyText` and `readStdinIfPiped` each have a caller and stay.

**2. `secrets.mjs` — a real gap, in a security path**
`bSidePath` has a branch for `+++ /dev/null`, which is what git writes when a file is **deleted**. A deletion diff carries every line of the secret with a `-` in front of it, and that branch had no test.

Now covered, together with its mirror: a deleted **ordinary** file must pass through untouched, because falling back to the header must not start redacting things that are not credentials.

**3. `tracked-jobs.mjs` — branch 41.30%, the lowest in the repo**
Pinned where a user could watch it fail:
- a changed thread id must replace the old one — otherwise `/gemini:status` prints a stale `gemini --resume` command for the user to copy
- a turn-only update must not drop the thread id
- an update for a job whose record was swept mid-run must be dropped quietly, not throw and not resurrect the file
- the reporter contract callers depend on: `null` when there is nowhere to report, empty thread id normalized away rather than stored

Deliberately **not** covered, and why:
The user raised Goodhart's law mid-review, which is the right frame for this kind of work. Four tests were written and then removed for reaching a red branch without protecting anything observable:

| Removed test | Why |
|---|---|
| Repeated thread id skips the write | Only observable via file mtime — flaky within a millisecond, and a test of an optimisation rather than a promise |
| A bare log line writes nothing | Same branch, same objection |
| A newly added secret file is redacted | Its `--- /dev/null` is on the a-side, which `bSidePath` never reads; identical path to a case already covered |

The first two are recorded in a comment in `tracked-jobs.test.mjs` and the third in `secrets.test.mjs`, so the red lines have an answer in the record rather than inviting a future patch to "fix" them.

Coverage, reported as an outcome rather than a goal:

| | before | after |
|---|---|---|
| `tracked-jobs.mjs` branch | 41.30% | **72.22%** |
| `fs.mjs` line | 65.00% | **84.62%** |
| `secrets.mjs` branch | 70.37% | **74.07%** |
| overall line / branch | 71.09 / 65.89 | 71.22 / 66.62 |

The overall figure barely moves because the work was three files and one deletion. That is the intended shape.

Validation:
- `npm test` — 359 tests, 354 pass, 0 fail, 5 skipped (was 352/347/0/5 on main; +7 net new)
- `npm run check-version` — matches 0.16.7
- `npm run verify-contracts` — passed
- `claude plugin validate ./plugins/gemini --strict` — passed
- `claude plugin validate . --strict` — passed
- `git diff --check` — clean

Behavior change:
**None.** Five unreferenced exports removed; everything else is tests.

Version:
Dead-code removal with no importer, plus tests → **PATCH**.

Rollback:
Revert this commit. The five unused exports return, along with the untested deletion path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
