### PR TITLE
`ready` now means the engine answers (v0.17.2)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,13 +7,13 @@
   },
   "metadata": {
     "description": "Use Gemini CLI or Antigravity CLI (agy) inside Claude Code for task delegation, code review, and adversarial review.",
-    "version": "0.17.1"
+    "version": "0.17.2"
   },
   "plugins": [
     {
       "name": "gemini",
       "description": "Gemini CLI and Antigravity CLI bridge for Claude Code task delegation and adversarial review",
-      "version": "0.17.1",
+      "version": "0.17.2",
       "author": {
         "name": "arcobaleno64",
         "email": "arcobaleno830623@gmail.com"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@arcobaleno64/gemini-plugin-cc",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@arcobaleno64/gemini-plugin-cc",
-      "version": "0.17.1",
+      "version": "0.17.2",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arcobaleno64/gemini-plugin-cc",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "private": true,
   "type": "module",
   "description": "Use Gemini CLI or Antigravity CLI (agy) inside Claude Code for task delegation, code review, and adversarial review.",

--- a/plugins/gemini/.claude-plugin/plugin.json
+++ b/plugins/gemini/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gemini",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "description": "Use Gemini/AGY from Claude Code to review code or delegate tasks.",
   "author": {
     "name": "arcobaleno64",

--- a/plugins/gemini/CHANGELOG.md
+++ b/plugins/gemini/CHANGELOG.md
@@ -1,5 +1,56 @@
 # Changelog
 
+## 0.17.2 — 2026-08-12 — `ready` now means the engine answers
+
+Everything here sits behind `--engine gemini`, which only started reaching the
+runtime in 0.17.1 — before that the flag was discarded, so none of this had ever
+been exercised. Each was measured on a live account before being changed.
+
+**Setup reported `ready` for an engine that rejects every request.** With no env
+API key, a stale keychain entry was enough to reach `"readyState": "ready"` with
+an empty `nextSteps`, while `geminiAuth.detail` in the same payload said the OAuth
+token had expired four days earlier. A real request returned HTTP 400
+`API_KEY_INVALID`. `getGeminiLoginStatus` now reports a `state` — `valid`,
+`expired`, `missing`, `unreadable` — and an `expired` file blocks the `ready`
+claim, downgrading to `partial` with a next step that names the expiry.
+
+Deliberately narrow: only `expired`, never `missing`. Gemini CLI 0.53.1 migrates
+OAuth into the keychain and deletes the file, so a healthy install also has no
+file — treating absence as evidence would restore the false "not authenticated"
+the keychain check exists to prevent. `loggedIn` and `detail` are unchanged.
+
+**Google's own API-key rejection classified as `unknown`.** The auth pattern held
+`invalid api key`; Google says `API key not valid` / `API_KEY_INVALID`, which is
+not a word-order variant. So a rejected credential produced "The CLI failed with
+an unclassified error" and advised retrying with a narrower prompt — advice that
+can never work. Both spellings now classify as `auth`. `INVALID_ARGUMENT` and the
+bare 400 are deliberately not matched: they also cover malformed requests,
+including a bad `--model` id, and auth is tested before the model check.
+
+**New `setup --probe-gemini`, and it is not free.** The file check can only prove
+staleness; a credential living only in the keychain cannot be judged from disk at
+all. This probe makes a real request and classifies the answer: `verified`,
+`logged-out` (with proof), or `unknown` for any other failure. Unlike
+`--probe-agy`, whose `/quota` question the account answers without starting a
+turn, this spends a turn when the credential works — it costs nothing only when
+the credential is already broken. The flag's own documentation and its result
+detail both say so. A `logged-out` probe reports `not-ready` for an explicit
+`--engine gemini`, and stays `partial` under `auto`, because auto routes to an
+available AGY when gemini's credential does not work.
+
+**A flag the shell split apart now names the real cause.** A double-quoted value
+inside a slash command's argument string closes that quoting early, so
+`--base "my branch"` arrives as `--base my`. That is already rejected, but the
+message advised prefixing `--`, which cannot help a command that takes no prompt
+text. It now says to use single quotes, which survive to the runtime's own
+splitter. `commands/adversarial-review.md` documents the matching case for focus
+text, where the shell swallows `--background` and the review runs in the
+foreground.
+
+Also fixed: three command-markdown sentences added in 0.17.1 contained a literal
+`$ARGUMENTS`, which is substituted along with everything else — at runtime they
+read as instructions about the user's own arguments.
+
 ## 0.17.1 — 2026-08-12 — The flags you typed now reach the engine
 
 Found by using the plugin on its own repository. All three were reproduced

--- a/plugins/gemini/CHANGELOG.md
+++ b/plugins/gemini/CHANGELOG.md
@@ -51,6 +51,61 @@ Also fixed: three command-markdown sentences added in 0.17.1 contained a literal
 `$ARGUMENTS`, which is substituted along with everything else — at runtime they
 read as instructions about the user's own arguments.
 
+### Review of the above, before release
+
+A code review of this release found eight further defects in it, six of them in
+the probe added here. All were reproduced before being changed.
+
+**`--probe-gemini` spent a turn it then threw away.** Nothing gated the probe on
+the selected engine, while AGY readiness never consults `geminiAuth` and every
+gemini-derived next step is guarded on the same condition — so
+`setup --engine agy --probe-gemini` billed a request whose answer was discarded.
+It is now skipped there, and `nextSteps` says it was skipped: a flag that silently
+does nothing is how a user concludes the credential was checked.
+
+**The probe result impersonated the OAuth file.** Under `--probe-gemini`,
+`geminiAuth` is the probe's answer, where `loggedIn: true` means "the API accepted
+a request" — not "the file is valid". Reading it for `geminiCredentialSource`
+reported `oauth-file` for precisely the case the probe exists to serve (0.53.1
+deleted the file; the credential is in the keychain), and the stale-file next step
+quoted the probe: "the OAuth file says it is stale: Gemini CLI rejected the
+probe…", then advised running the probe that had just run. Source naming and file
+evidence now read a separate, free file check. An inconclusive probe no longer
+erases that evidence either — it used to replace it wholesale, so an expired file
+plus a timed-out probe read as `ready`.
+
+**An inconclusive probe disclosed nothing.** `unknown` pushed no next step, so a
+user who had just paid for a request read a report that looked like no probe had
+run. It now surfaces the probe's own detail, which states that the request may
+have reached the API and may therefore have been billed. The timeout also rose
+from 30s to 120s: at 30s a healthy-but-slow credential was killed mid-request,
+which bills the turn and still answers `unknown`.
+
+**The probe could not see an error in the JSON envelope.** It requests
+`--output-format json`, and in that mode gemini can carry the error in a stdout
+envelope rather than on stderr, where `classifyCliFailure` does not look unless
+told the output is structured. Measured on 0.54.4 the auth error arrives on
+stderr, so this was latent rather than live; the envelope path is now handled the
+way `probeAgyLogin` already handled it.
+
+**The probe ignored the caller's directory.** The `cwd` handed to it by the
+readiness seam was swallowed by an options destructure, so it ran in the process
+cwd — a workspace `.gemini/settings.json` did not apply, and the probe could
+disagree with the very turn it predicts.
+
+**Readiness read `process.env` directly**, unlike every other input, so the new
+readiness tests asserted correctly only on a machine with no `GEMINI_API_KEY`
+exported: `GEMINI_API_KEY=x npm test` failed. The environment is now injected like
+the rest, and `sessionRuntime` is computed from the same one so a single payload
+cannot describe two environments.
+
+Two documentation defects: `setup`'s `argument-hint` never listed
+`--probe-gemini`, leaving it undiscoverable from the slash command, and a bullet
+inserted between "Copy the line as written:" and its fenced command left that
+instruction pointing at prose. Both now have guards — `argument-hint` must list
+every flag the companion's own usage advertises, and a copy-this-line instruction
+must be followed immediately by the line.
+
 ## 0.17.1 — 2026-08-12 — The flags you typed now reach the engine
 
 Found by using the plugin on its own repository. All three were reproduced

--- a/plugins/gemini/commands/adversarial-review.md
+++ b/plugins/gemini/commands/adversarial-review.md
@@ -59,10 +59,10 @@ node "${CLAUDE_PLUGIN_ROOT}/scripts/gemini-companion.mjs" adversarial-review "$A
 Background flow:
 - Run the companion with its own `--background` flag in the FOREGROUND (the companion detaches its own worker and returns immediately).
 - `--background` goes INSIDE the quoted argument string below, not beside it. A token placed next to that quoted string makes it a second argv element, and the flags inside it are then read as focus text instead of flags. Copy the line as written:
-- If the user's focus text contains double quotes, they close that quoting early and the shell splits the line: `--background` lands inside the focus text and the review runs in the foreground. Ask the user for focus text without double quotes (single quotes are safe) rather than trying to escape it.
 ```bash
 node "${CLAUDE_PLUGIN_ROOT}/scripts/gemini-companion.mjs" adversarial-review "$ARGUMENTS --background"
 ```
+- If the user's focus text contains double quotes, they close that quoting early and the shell splits the line: `--background` lands inside the focus text and the review runs in the foreground. Ask the user for focus text without double quotes (single quotes are safe) rather than trying to escape it.
 - This enqueues the review, spawns a detached `review-worker`, and returns a job id right away. The result persists even if this Claude session is interrupted.
 - Do not use `run_in_background: true` and do not call `BashOutput` — the companion already detached; this call returns immediately.
 - Relay the returned job id: "Gemini adversarial review started in the background as `<job-id>`. Check `/gemini:status <job-id>` for progress and `/gemini:result <job-id>` when it finishes."

--- a/plugins/gemini/commands/adversarial-review.md
+++ b/plugins/gemini/commands/adversarial-review.md
@@ -58,7 +58,8 @@ node "${CLAUDE_PLUGIN_ROOT}/scripts/gemini-companion.mjs" adversarial-review "$A
 
 Background flow:
 - Run the companion with its own `--background` flag in the FOREGROUND (the companion detaches its own worker and returns immediately).
-- `--background` goes INSIDE the quoted expansion, not beside it. A token placed next to `"$ARGUMENTS"` makes the expansion a second argv element, and the flags inside it are then read as focus text instead of flags:
+- `--background` goes INSIDE the quoted argument string below, not beside it. A token placed next to that quoted string makes it a second argv element, and the flags inside it are then read as focus text instead of flags. Copy the line as written:
+- If the user's focus text contains double quotes, they close that quoting early and the shell splits the line: `--background` lands inside the focus text and the review runs in the foreground. Ask the user for focus text without double quotes (single quotes are safe) rather than trying to escape it.
 ```bash
 node "${CLAUDE_PLUGIN_ROOT}/scripts/gemini-companion.mjs" adversarial-review "$ARGUMENTS --background"
 ```

--- a/plugins/gemini/commands/review.md
+++ b/plugins/gemini/commands/review.md
@@ -53,7 +53,7 @@ node "${CLAUDE_PLUGIN_ROOT}/scripts/gemini-companion.mjs" review "$ARGUMENTS"
 
 Background flow:
 - Run the companion with its own `--background` flag in the FOREGROUND (the companion detaches its own worker and returns immediately).
-- `--background` goes INSIDE the quoted expansion, not beside it. A token placed next to `"$ARGUMENTS"` makes the expansion a second argv element, and the flags inside it are then read as one positional this command does not accept — which is how `--base` and `--scope` were silently discarded:
+- `--background` goes INSIDE the quoted argument string below, not beside it. A token placed next to that quoted string makes it a second argv element, and the flags inside it are then read as one positional this command does not accept — which is how `--base` and `--scope` were silently discarded. Copy the line as written:
 ```bash
 node "${CLAUDE_PLUGIN_ROOT}/scripts/gemini-companion.mjs" review "$ARGUMENTS --background"
 ```

--- a/plugins/gemini/commands/setup.md
+++ b/plugins/gemini/commands/setup.md
@@ -1,6 +1,6 @@
 ---
 description: Check whether Gemini CLI / AGY is ready and optionally toggle the stop-time review gate
-argument-hint: '[--engine <agy|gemini>] [--probe-agy] [--enable-review-gate|--disable-review-gate]'
+argument-hint: '[--engine <agy|gemini>] [--probe-agy] [--probe-gemini] [--enable-review-gate|--disable-review-gate]'
 allowed-tools: Bash(node:*), Bash(npm:*), Bash(curl:*), AskUserQuestion
 ---
 
@@ -111,10 +111,17 @@ auto routes to AGY when gemini's credential does not work.
 Output rules:
 - Present the final setup output to the user.
 - `geminiReady` and `geminiAuth.loggedIn` answer different questions and can
-  disagree: `geminiAuth` inspects the OAuth file alone, while readiness uses the
-  full credential resolution (env API key, that file, then the OS keychain).
-  `geminiCredentialSource` names the one that actually applied — quote it rather
-  than reporting the pair as a contradiction.
+  disagree: without `--probe-gemini`, `geminiAuth` inspects the OAuth file alone,
+  while readiness uses the full credential resolution (env API key, that file,
+  then the OS keychain). `geminiCredentialSource` names the one that actually
+  applied — quote it rather than reporting the pair as a contradiction.
+- Under `--probe-gemini`, `geminiAuth` is the probe's answer instead, so
+  `loggedIn: true` there means the API accepted a request — not that the OAuth
+  file is valid. `geminiCredentialSource` still names the file/keychain/env
+  source, so the two remain safe to quote together.
+- `--probe-gemini` is not run when `--engine agy` is selected, and `nextSteps`
+  says so: AGY readiness does not consult the Gemini credential, and the probe
+  costs a turn.
 - If installation was skipped, present the original setup output.
 - If Gemini is installed but not authenticated, preserve the guidance to run `!gemini` once to complete OAuth authentication. The plugin authenticates by running `gemini`; there is no separate login subcommand.
 - If the setup output (`nextSteps` / `geminiPlanTier`) includes a 2026-06-18 EOL heads-up, surface it: personal-plan Gemini CLI free access ends then. After that date, either upgrade to Gemini Code Assist Standard/Enterprise to keep the gemini engine, or use `--engine agy` (the plugin recovers AGY responses from its on-disk transcript because `agy --print` does not pipe output — upstream google-gemini/gemini-cli#27466).

--- a/plugins/gemini/commands/setup.md
+++ b/plugins/gemini/commands/setup.md
@@ -4,9 +4,9 @@ argument-hint: '[--engine <agy|gemini>] [--probe-agy] [--enable-review-gate|--di
 allowed-tools: Bash(node:*), Bash(npm:*), Bash(curl:*), AskUserQuestion
 ---
 
-Run this exactly as written — `--json` belongs inside the quoted expansion. A
-token placed beside `"$ARGUMENTS"` makes the expansion a second argv element,
-and every flag inside it is then read as one positional and ignored, which is how
+Run this exactly as written — `--json` belongs inside the quoted argument string.
+A token placed beside that quoted string makes it a second argv element, and every
+flag inside it is then read as one positional and ignored, which is how
 `/gemini:setup --engine gemini` came back reporting a different engine:
 
 ```bash
@@ -87,6 +87,26 @@ login without starting a turn or spending quota (AGY 1.1.11+; below that it
 declines and says so). A verified AGY then reports `readyState: "ready"`; a probe
 that comes back `logged-out` reports `not-ready`, and the fix is to run `agy`
 once interactively.
+
+There is a matching `--probe-gemini`, and **it is not free**. Gemini CLI has no
+question the account answers without generating, so the probe makes a real
+request: on a credential that no longer works it costs nothing (the API refuses it
+before generating), but on a working credential it spends a turn. Do not offer it
+by reflex the way `--probe-agy` can be offered — suggest it only when the report
+says a stored gemini credential cannot be trusted, or when the user asks whether
+gemini really works:
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/scripts/gemini-companion.mjs" setup "--json --probe-gemini $ARGUMENTS"
+```
+
+Without it, gemini readiness is read off disk, which can only prove staleness, not
+health: a present-but-expired `oauth_creds.json` now blocks the `ready` claim and
+reports `partial`, while a credential living only in the OS keychain cannot be
+judged at all (0.53.1 migrates the file into the keychain and deletes it). A probe
+that comes back `logged-out` reports `not-ready` for an explicitly requested
+`--engine gemini`, and stays `partial` under `auto` when AGY is installed, because
+auto routes to AGY when gemini's credential does not work.
 
 Output rules:
 - Present the final setup output to the user.

--- a/plugins/gemini/scripts/gemini-companion.mjs
+++ b/plugins/gemini/scripts/gemini-companion.mjs
@@ -286,7 +286,10 @@ export function buildSetupReport(cwd, actionsTaken = [], options = {}) {
   // credential in its OS keychain, and the interesting cases here are about a
   // credential that resolves but does not work. Forcing it with GEMINI_API_KEY
   // instead would change the answer — an env key deliberately outranks the file.
-  const geminiCredentialedFn = options.geminiCredentialedFn ?? hasGeminiCredentials;
+  // Handed the same env as everything else here: an injected key must count as a
+  // credential, or the report names `env-api-key` as the source while reporting
+  // that no credential resolved.
+  const geminiCredentialedFn = options.geminiCredentialedFn ?? (() => hasGeminiCredentials({ env }));
   const geminiCredentialed = geminiCredentialedFn();
   // Same injection seam as detectEngine/runGeminiTurn: the readiness mapping is
   // the part worth testing, and it should not require a real AGY to reach.

--- a/plugins/gemini/scripts/gemini-companion.mjs
+++ b/plugins/gemini/scripts/gemini-companion.mjs
@@ -60,6 +60,7 @@ import {
   getGeminiLoginStatus,
   getAgyLoginStatus,
   probeAgyLogin,
+  probeGeminiLogin,
   getGeminiPlanTier,
   hasGeminiCredentials,
   getSessionRuntimeStatus,
@@ -104,7 +105,7 @@ function printUsage() {
   console.log(
     [
       "Usage:",
-      "  node scripts/gemini-companion.mjs setup [--json] [--probe-agy] [--enable-review-gate|--disable-review-gate]",
+      "  node scripts/gemini-companion.mjs setup [--json] [--probe-agy] [--probe-gemini] [--enable-review-gate|--disable-review-gate]",
       "  node scripts/gemini-companion.mjs adversarial-review [--wait|--background] [--deep] [--base <ref>] [--scope <auto|working-tree|branch>] [--model <model>] [--effort <level>] [--engine agy|gemini|auto] [--engines gemini,agy] [--timeout <seconds>] [focus text]",
       "  node scripts/gemini-companion.mjs review [--wait|--background] [--deep] [--base <ref>] [--scope <auto|working-tree|branch>] [--model <model>] [--effort <level>] [--engine agy|gemini|auto] [--timeout <seconds>]",
       "  node scripts/gemini-companion.mjs task [--background] [--write] [--resume-last|--resume|--fresh] [--model <model>] [--effort <low|medium|high>] [--engine agy|gemini|auto] [--timeout <seconds>] [prompt]",
@@ -166,8 +167,16 @@ function parseCommandInput(argv, config = {}) {
   const normalized = normalizeArgv(argv);
   const leading = describeLeadingFlag(normalized, config);
   if (leading?.unknown) {
+    // Whitespace inside a single flag did not come from anyone's keyboard. A slash
+    // command expands into one quoted word, so a double-quoted value *inside* that
+    // word closes the quoting early and the shell splits the flag apart:
+    // `--base "my branch"` arrives as `--base my` plus `branch ...`. Telling that
+    // user to prefix `--` is useless advice — the fix is single quotes, which
+    // survive to the runtime's own splitter (lib/args.mjs).
     throw new Error(
-      `Unknown option "${leading.unknown}". Run \`node scripts/gemini-companion.mjs help\` for usage. If it is prompt text, put \`--\` before it.`
+      /\s/.test(leading.unknown.trim())
+        ? `Unknown option "${leading.unknown}". A double-quoted value closes the slash command's own quoting early, so the shell split this flag apart. Use single quotes instead, e.g. \`--base 'my branch'\`.`
+        : `Unknown option "${leading.unknown}". Run \`node scripts/gemini-companion.mjs help\` for usage. If it is prompt text, put \`--\` before it.`
     );
   }
 
@@ -222,11 +231,23 @@ export function buildSetupReport(cwd, actionsTaken = [], options = {}) {
   // installed, and pass locally while failing on any runner that does not.
   const agyAvailabilityFn = options.agyAvailabilityFn ?? getAgyAvailability;
   const agyStatus = agyAvailabilityFn();
-  const geminiAuth = getGeminiLoginStatus(cwd);
-  // `geminiAuth` reports the OAuth *file* only. Readiness must use the full
-  // credential check auto-routing uses — env keys and the OS keychain included —
-  // or setup reports "not authenticated" for a user whose next command works.
-  const geminiCredentialed = hasGeminiCredentials();
+  // Same seam as AGY below: unprobed, this reads the OAuth file; `--probe-gemini`
+  // asks the API instead. Unlike `--probe-agy` that is not free, so nothing here
+  // probes unless the caller asked.
+  const geminiLoginStatusFn =
+    options.geminiLoginStatusFn ?? (options.probedGemini ? probeGeminiLogin : getGeminiLoginStatus);
+  const geminiAuth = geminiLoginStatusFn(cwd);
+  // `geminiAuth` reports the OAuth *file* only (unless probed). Readiness must use
+  // the full credential check auto-routing uses — env keys and the OS keychain
+  // included — or setup reports "not authenticated" for a user whose next command
+  // works.
+  // Injected for the same reason as the availability probes: without a seam the
+  // readiness assertions only hold on a machine that happens to have a gemini
+  // credential in its OS keychain, and the interesting cases here are about a
+  // credential that resolves but does not work. Forcing it with GEMINI_API_KEY
+  // instead would change the answer — an env key deliberately outranks the file.
+  const geminiCredentialedFn = options.geminiCredentialedFn ?? hasGeminiCredentials;
+  const geminiCredentialed = geminiCredentialedFn();
   // Same injection seam as detectEngine/runGeminiTurn: the readiness mapping is
   // the part worth testing, and it should not require a real AGY to reach.
   const agyLoginStatusFn =
@@ -248,7 +269,27 @@ export function buildSetupReport(cwd, actionsTaken = [], options = {}) {
   const engineKnown =
     requestedEngine === "" || requestedEngine === "auto" || requestedEngine === "gemini" || requestedEngine === "agy";
   const agySelected = requestedEngine === "agy";
-  const geminiReady = geminiStatus.available && geminiCredentialed;
+  const geminiApiKeyInEnvForReadiness = Boolean(
+    String(process.env.GEMINI_API_KEY ?? "").trim() || String(process.env.GOOGLE_API_KEY ?? "").trim()
+  );
+  // A credential that resolves is not a credential that works, and this is the one
+  // case where we hold proof of the difference: `state: "expired"` means the OAuth
+  // file is present and says so. `/gemini:setup --engine gemini` used to answer
+  // `ready` with no next steps for an account that returns API_KEY_INVALID on
+  // every request, because the keychain still had a (stale) entry and outvoted the
+  // file. Positive evidence of staleness now blocks the `ready` claim.
+  //
+  // Only `expired` — not `missing`. 0.53.1 migrates OAuth into the keychain and
+  // deletes the file, so a healthy install also has no file; treating that as
+  // evidence would recreate the false "not authenticated" that the keychain check
+  // was added to fix. A probe that verified the credential outranks the file.
+  const geminiStaleFileEvidence =
+    !geminiApiKeyInEnvForReadiness && geminiAuth.state === "expired" && geminiAuth.verifiable !== true;
+  // A probe that came back rejected is the strongest evidence available, and it
+  // outranks a resolvable keychain entry — the same rule AGY already follows.
+  const geminiProbedLoggedOut = geminiAuth.state === "logged-out" && geminiAuth.verifiable === true;
+  const geminiReady =
+    geminiStatus.available && geminiCredentialed && !geminiStaleFileEvidence && !geminiProbedLoggedOut;
   const agyAvailable = agyStatus.available;
   // `geminiReady: true` beside `geminiAuth.loggedIn: false` reads as a
   // contradiction and was reported as one. Both are correct and they answer
@@ -301,9 +342,15 @@ export function buildSetupReport(cwd, actionsTaken = [], options = {}) {
             : "partial"
         : geminiReady
           ? "ready"
-          : agyAvailable
-            ? "partial"
-            : "not-ready";
+          : // An explicitly selected gemini whose probe came back rejected is
+            // not-ready, not partial: the same "a verified negative is worse than
+            // unknown" rule as AGY. Under `auto` it stays partial, because auto
+            // routes to an available AGY when gemini's credential does not work.
+            requestedEngine === "gemini" && geminiProbedLoggedOut
+            ? "not-ready"
+            : agyAvailable
+              ? "partial"
+              : "not-ready";
 
   const nextSteps = [];
   if (!engineKnown) {
@@ -340,6 +387,17 @@ export function buildSetupReport(cwd, actionsTaken = [], options = {}) {
   }
   if (!agySelected && geminiStatus.available && !geminiCredentialed) {
     nextSteps.push("Run `gemini` once to authenticate, or set GEMINI_API_KEY.");
+  }
+  // Both of the gemini "resolvable but does not work" cases. Without these the
+  // report was silent: `readyState` said `ready` and `nextSteps` was empty while
+  // `geminiAuth.detail` said the token had expired days earlier.
+  if (!agySelected && geminiStaleFileEvidence) {
+    nextSteps.push(
+      `Gemini CLI has a stored credential, but the OAuth file says it is stale: ${geminiAuth.detail} If a keychain credential is meant to be in use instead, \`setup --probe-gemini\` checks it against the API — that one spends a turn when the credential works, unlike \`--probe-agy\`.`
+    );
+  }
+  if (!agySelected && geminiProbedLoggedOut) {
+    nextSteps.push(geminiAuth.detail);
   }
   if (!agySelected && !geminiStatus.available && agyAvailable) {
     nextSteps.push(
@@ -401,7 +459,7 @@ export function buildSetupReport(cwd, actionsTaken = [], options = {}) {
 function handleSetup(argv) {
   const { options } = parseCommandInput(argv, {
     valueOptions: ["cwd", "engine"],
-    booleanOptions: ["json", "enable-review-gate", "disable-review-gate", "probe-agy"]
+    booleanOptions: ["json", "enable-review-gate", "disable-review-gate", "probe-agy", "probe-gemini"]
   });
 
   const cwd = resolveCommandCwd(options);
@@ -421,7 +479,8 @@ function handleSetup(argv) {
 
   const finalReport = buildSetupReport(cwd, actionsTaken, {
     engine: requestedEngine,
-    probedAgy: Boolean(options["probe-agy"])
+    probedAgy: Boolean(options["probe-agy"]),
+    probedGemini: Boolean(options["probe-gemini"])
   });
   outputResult(options.json ? finalReport : renderSetupReport(finalReport), options.json);
 }

--- a/plugins/gemini/scripts/gemini-companion.mjs
+++ b/plugins/gemini/scripts/gemini-companion.mjs
@@ -231,12 +231,52 @@ export function buildSetupReport(cwd, actionsTaken = [], options = {}) {
   // installed, and pass locally while failing on any runner that does not.
   const agyAvailabilityFn = options.agyAvailabilityFn ?? getAgyAvailability;
   const agyStatus = agyAvailabilityFn();
+  // Readiness is computed for the engine the user actually selected (via
+  // `--engine` or GEMINI_ENGINE). Resolved here, above the auth seams, because
+  // the gemini probe below spends a turn and must not spend it for an engine this
+  // run does not report on.
+  const requestedEngine = String(options.engine ?? "").trim().toLowerCase();
+  // Validate against the same set the runtime resolver accepts (detectEngine).
+  // An unrecognized engine must fail the preflight rather than inheriting Gemini
+  // readiness — otherwise the next command resolves the same value and throws.
+  const engineKnown =
+    requestedEngine === "" || requestedEngine === "auto" || requestedEngine === "gemini" || requestedEngine === "agy";
+  const agySelected = requestedEngine === "agy";
+  // Injected for the same reason as every other input here: read straight from
+  // process.env, the readiness assertions below only hold on a machine with no
+  // GEMINI_API_KEY exported, so they passed locally and failed on any runner (or
+  // developer) that had one.
+  const env = options.env ?? process.env;
+  const geminiApiKeyInEnv = Boolean(
+    String(env.GEMINI_API_KEY ?? "").trim() || String(env.GOOGLE_API_KEY ?? "").trim()
+  );
   // Same seam as AGY below: unprobed, this reads the OAuth file; `--probe-gemini`
   // asks the API instead. Unlike `--probe-agy` that is not free, so nothing here
-  // probes unless the caller asked.
+  // probes unless the caller asked — and not even then when `--engine agy` is
+  // selected, because AGY readiness ignores `geminiAuth` entirely and every
+  // gemini-derived next step below is guarded by `!agySelected`. Billing a turn
+  // for an answer this run then discards is the one cost this flag must not have.
+  const probeGemini = Boolean(options.probedGemini) && !agySelected;
+  // Derived from the gate rather than restating its condition: as two independent
+  // expressions they could disagree, and the failure mode of that disagreement is
+  // a report saying "not run" for a probe that ran and billed.
+  const geminiProbeSkippedForAgy = Boolean(options.probedGemini) && !probeGemini;
   const geminiLoginStatusFn =
-    options.geminiLoginStatusFn ?? (options.probedGemini ? probeGeminiLogin : getGeminiLoginStatus);
+    options.geminiLoginStatusFn ?? (probeGemini ? probeGeminiLogin : getGeminiLoginStatus);
   const geminiAuth = geminiLoginStatusFn(cwd);
+  // Which credential applied, and whether the OAuth file says it is stale, are
+  // questions about the *file* — and under `--probe-gemini` `geminiAuth` is the
+  // probe result, where `loggedIn: true` means "the API answered", not "the file
+  // is valid". Reading the probe there named `oauth-file` for precisely the
+  // 0.53.1 case the probe exists to serve: file deleted, credential in the
+  // keychain. The extra read only happens when probing, and it is free and local.
+  //
+  // Keyed on "did this run probe", not on `geminiAuth.verifiable`: an inconclusive
+  // probe reports `verifiable: false`, exactly like a file check, so that field
+  // cannot tell the two apart — and reading it there let a timed-out probe erase
+  // the expired file underneath it.
+  const geminiFileStatusFn = options.geminiFileStatusFn ?? getGeminiLoginStatus;
+  const geminiFileAuth = probeGemini ? geminiFileStatusFn(cwd) : geminiAuth;
   // `geminiAuth` reports the OAuth *file* only (unless probed). Readiness must use
   // the full credential check auto-routing uses — env keys and the OS keychain
   // included — or setup reports "not authenticated" for a user whose next command
@@ -256,22 +296,13 @@ export function buildSetupReport(cwd, actionsTaken = [], options = {}) {
   const geminiPlanTier = getGeminiPlanTier();
   const config = getConfig(workspaceRoot) ?? {};
 
-  // Readiness is computed for the engine the user actually selected (via
-  // `--engine` or GEMINI_ENGINE). The default/gemini path mirrors upstream: the
-  // auto-preferred engine must be installed AND authenticated. Explicit `--engine agy`
-  // must NOT inherit Gemini's ready state — it depends on the AGY binary (whose
-  // auth cannot be verified non-interactively), so AGY-present is "partial" and
-  // AGY-missing is "not-ready".
-  const requestedEngine = String(options.engine ?? "").trim().toLowerCase();
-  // Validate against the same set the runtime resolver accepts (detectEngine).
-  // An unrecognized engine must fail the preflight rather than inheriting Gemini
-  // readiness — otherwise the next command resolves the same value and throws.
-  const engineKnown =
-    requestedEngine === "" || requestedEngine === "auto" || requestedEngine === "gemini" || requestedEngine === "agy";
-  const agySelected = requestedEngine === "agy";
-  const geminiApiKeyInEnvForReadiness = Boolean(
-    String(process.env.GEMINI_API_KEY ?? "").trim() || String(process.env.GOOGLE_API_KEY ?? "").trim()
-  );
+  // The default/gemini path mirrors upstream: the auto-preferred engine must be
+  // installed AND authenticated. Explicit `--engine agy` must NOT inherit Gemini's
+  // ready state — it depends on the AGY binary (whose auth cannot be verified
+  // non-interactively), so AGY-present is "partial" and AGY-missing is
+  // "not-ready". (`requestedEngine` / `agySelected` are resolved above, before the
+  // auth seams, so the paid probe can be gated on them.)
+  //
   // A credential that resolves is not a credential that works, and this is the one
   // case where we hold proof of the difference: `state: "expired"` means the OAuth
   // file is present and says so. `/gemini:setup --engine gemini` used to answer
@@ -282,9 +313,12 @@ export function buildSetupReport(cwd, actionsTaken = [], options = {}) {
   // Only `expired` — not `missing`. 0.53.1 migrates OAuth into the keychain and
   // deletes the file, so a healthy install also has no file; treating that as
   // evidence would recreate the false "not authenticated" that the keychain check
-  // was added to fix. A probe that verified the credential outranks the file.
+  // was added to fix. A probe that verified the credential outranks the file —
+  // but only a *verified* one: an inconclusive probe used to erase the file
+  // evidence too, because the probe result replaced it wholesale.
+  const geminiProbeVerified = geminiAuth.state === "verified" && geminiAuth.verifiable === true;
   const geminiStaleFileEvidence =
-    !geminiApiKeyInEnvForReadiness && geminiAuth.state === "expired" && geminiAuth.verifiable !== true;
+    !geminiApiKeyInEnv && !geminiProbeVerified && geminiFileAuth.state === "expired";
   // A probe that came back rejected is the strongest evidence available, and it
   // outranks a resolvable keychain entry — the same rule AGY already follows.
   const geminiProbedLoggedOut = geminiAuth.state === "logged-out" && geminiAuth.verifiable === true;
@@ -302,15 +336,13 @@ export function buildSetupReport(cwd, actionsTaken = [], options = {}) {
   // Resolved in the order hasGeminiCredentials uses, which is the order the CLI
   // itself uses: an env API key wins over the OAuth file, which wins over the
   // keychain. Reporting the file whenever it happens to be valid would name the
-  // wrong source for an API-key user.
-  const geminiApiKeyInEnv = Boolean(
-    String(process.env.GEMINI_API_KEY ?? "").trim() || String(process.env.GOOGLE_API_KEY ?? "").trim()
-  );
+  // wrong source for an API-key user. (`geminiApiKeyInEnv` is resolved above, from
+  // the injected env, alongside the other readiness inputs.)
   const geminiCredentialSource = !geminiStatus.available
     ? "engine-unavailable"
     : geminiApiKeyInEnv
       ? "env-api-key"
-      : geminiAuth.loggedIn
+      : geminiFileAuth.loggedIn
         ? "oauth-file"
         : geminiCredentialed
           ? "os-keychain"
@@ -391,13 +423,36 @@ export function buildSetupReport(cwd, actionsTaken = [], options = {}) {
   // Both of the gemini "resolvable but does not work" cases. Without these the
   // report was silent: `readyState` said `ready` and `nextSteps` was empty while
   // `geminiAuth.detail` said the token had expired days earlier.
-  if (!agySelected && geminiStaleFileEvidence) {
+  // Quotes the *file* status, and only offers the probe when one has not already
+  // answered. Reading `geminiAuth` here produced "the OAuth file says it is stale:
+  // Gemini CLI rejected the probe…" followed by advice to run the probe that had
+  // just run — the same confusion of the two sources as the source naming above.
+  // A verified-rejected probe is strictly stronger evidence and its own step names
+  // the identical fix, so it stands alone rather than being said twice.
+  if (!agySelected && geminiStaleFileEvidence && !geminiProbedLoggedOut) {
+    const probeOffer = probeGemini
+      ? ""
+      : " If a keychain credential is meant to be in use instead, `setup --probe-gemini` checks it against the API — that one spends a turn when the credential works, unlike `--probe-agy`.";
     nextSteps.push(
-      `Gemini CLI has a stored credential, but the OAuth file says it is stale: ${geminiAuth.detail} If a keychain credential is meant to be in use instead, \`setup --probe-gemini\` checks it against the API — that one spends a turn when the credential works, unlike \`--probe-agy\`.`
+      `Gemini CLI has a stored credential, but the OAuth file says it is stale: ${geminiFileAuth.detail}${probeOffer}`
     );
   }
   if (!agySelected && geminiProbedLoggedOut) {
     nextSteps.push(geminiAuth.detail);
+  }
+  // A probe that could not decide still costs money, and this was the one place
+  // the flag could hide a spend: `unknown` pushed nothing, so the report read as
+  // if no probe had run. The AGY branch above already discloses its own
+  // inconclusive probe; its detail says whether the request may have been billed.
+  if (!agySelected && probeGemini && geminiAuth.state === "unknown") {
+    nextSteps.push(geminiAuth.detail);
+  }
+  // Skipping the probe is the right call (its answer would be discarded), but a
+  // silently ignored flag is how a user concludes the credential was checked.
+  if (geminiProbeSkippedForAgy) {
+    nextSteps.push(
+      "`--probe-gemini` was not run: `--engine agy` was selected, so the Gemini credential is not what this report describes, and the probe spends a turn. Drop `--engine agy` to check it."
+    );
   }
   if (!agySelected && !geminiStatus.available && agyAvailable) {
     nextSteps.push(
@@ -442,6 +497,10 @@ export function buildSetupReport(cwd, actionsTaken = [], options = {}) {
     // happens to be installed on the machine running the test.
     sessionRuntime: getSessionRuntimeStatus({
       requestedEngine,
+      // Same env the readiness fields were computed from, for the same reason the
+      // availability probes are handed over: one payload must not describe an
+      // injected environment in one field and the ambient machine in another.
+      env,
       geminiAvailabilityFn: () => geminiStatus,
       agyAvailabilityFn: () => agyStatus
     }),

--- a/plugins/gemini/scripts/lib/failures.mjs
+++ b/plugins/gemini/scripts/lib/failures.mjs
@@ -194,7 +194,18 @@ export function classifyCliFailure(input = {}) {
   if (data.promptTooLong || data.promptNul || /prompt .*too long|context length|token limit|NUL byte|positional prompt/i.test(structuredText)) {
     return normalizeFailure("prompt-too-long", data);
   }
-  if (/oauth|unauth|authenticat|login required|invalid api key|permission denied|\b401\b|\b403\b/i.test(structuredText)) {
+  // `api key not valid` and `API_KEY_INVALID` are Google's actual wording, and
+  // they are not word-order variants of `invalid api key` — a live 400 from
+  // generativelanguage.googleapis.com fell through to `unknown`, whose next step
+  // ("retry with a narrower prompt") can never fix a rejected credential.
+  // Deliberately not matched: `INVALID_ARGUMENT` and `\b400\b`. Both also cover
+  // malformed requests, and a bad `--model` id returns exactly that status — auth
+  // is tested before the model check below, so either one would swallow it.
+  if (
+    /oauth|unauth|authenticat|login required|invalid api key|api key not valid|API_KEY_INVALID|permission denied|\b401\b|\b403\b/i.test(
+      structuredText
+    )
+  ) {
     return normalizeFailure("auth", data);
   }
   if (/quota|billing|RESOURCE_EXHAUSTED/i.test(structuredText)) {

--- a/plugins/gemini/scripts/lib/gemini-auth.mjs
+++ b/plugins/gemini/scripts/lib/gemini-auth.mjs
@@ -209,7 +209,14 @@ export function getGeminiPlanTier() {
 // to prevent. Affected users (headless Linux, WSL, or GEMINI_FORCE_FILE_STORAGE)
 // can still select the engine explicitly with `--engine gemini`.
 export function hasGeminiCredentials(options = {}) {
-  if (String(process.env.GEMINI_API_KEY ?? "").trim() || String(process.env.GOOGLE_API_KEY ?? "").trim()) {
+  // `env` is injectable so a caller that computes the rest of its answer from an
+  // injected environment gets one consistent answer. Without it, buildSetupReport
+  // could read an injected key for the credential *source* while this function
+  // read the real environment for whether a credential exists at all — which is
+  // how a setup test passed locally off an unrelated keychain entry and failed on
+  // a runner that had none.
+  const env = options.env ?? process.env;
+  if (String(env.GEMINI_API_KEY ?? "").trim() || String(env.GOOGLE_API_KEY ?? "").trim()) {
     return true;
   }
   if (getGeminiLoginStatus().loggedIn) return true;

--- a/plugins/gemini/scripts/lib/gemini-auth.mjs
+++ b/plugins/gemini/scripts/lib/gemini-auth.mjs
@@ -121,21 +121,51 @@ function geminiHomeDir() {
   return process.env.GEMINI_HOME ?? path.join(os.homedir(), ".gemini");
 }
 
+// `state` distinguishes the three ways `loggedIn: false` happens, because they
+// are not equally informative and readiness has to tell them apart:
+//
+//   missing    — no file. Proves nothing: 0.53.1 migrates the file into the
+//                keychain and deletes it, so a working install looks like this.
+//   expired    — the file is there and says the token is stale. This is positive
+//                evidence, and the only reason `/gemini:setup --engine gemini`
+//                could have known not to report `ready` for an account that
+//                answers API_KEY_INVALID on every request.
+//   unreadable — present but not parseable. Unknown, not evidence.
+//
+// `verifiable: false` on every branch: this reads a file, it never asks the API.
+// The shape matches probeAgyLogin/probeGeminiLogin so the readiness table can
+// consume either without caring which produced it. `loggedIn` and `detail` are
+// unchanged — render.mjs and hasGeminiCredentials read only those.
 export function getGeminiLoginStatus() {
   const credFile = path.join(geminiHomeDir(), "oauth_creds.json");
   if (!fs.existsSync(credFile)) {
-    return { loggedIn: false, detail: `No credentials at ${credFile}. Run \`gemini\` to authenticate.` };
+    return {
+      loggedIn: false,
+      state: "missing",
+      verifiable: false,
+      detail: `No credentials at ${credFile}. Run \`gemini\` to authenticate.`
+    };
   }
   try {
     const creds = JSON.parse(fs.readFileSync(credFile, "utf8"));
     const expiry = creds?.expiry_date ?? creds?.expiry ?? creds?.token?.expiry_date;
     if (expiry && Date.now() > Number(expiry)) {
-      return { loggedIn: false, detail: `OAuth token expired at ${new Date(Number(expiry)).toISOString()}. Run \`gemini\` to re-authenticate.` };
+      return {
+        loggedIn: false,
+        state: "expired",
+        verifiable: false,
+        detail: `OAuth token expired at ${new Date(Number(expiry)).toISOString()}. Run \`gemini\` to re-authenticate.`
+      };
     }
   } catch {
-    return { loggedIn: false, detail: `Cannot read credentials at ${credFile}. Run \`gemini\` to authenticate.` };
+    return {
+      loggedIn: false,
+      state: "unreadable",
+      verifiable: false,
+      detail: `Cannot read credentials at ${credFile}. Run \`gemini\` to authenticate.`
+    };
   }
-  return { loggedIn: true, detail: `OAuth credentials found at ${credFile}` };
+  return { loggedIn: true, state: "valid", verifiable: false, detail: `OAuth credentials found at ${credFile}` };
 }
 
 // Personal (free) Gemini plans lose CLI access on 2026-06-18; Gemini Code Assist

--- a/plugins/gemini/scripts/lib/gemini.mjs
+++ b/plugins/gemini/scripts/lib/gemini.mjs
@@ -834,10 +834,21 @@ export function probeAgyLogin({ runCommandFn = runCommand, detectEngineFn = dete
 // It exists because the file check cannot see the case that matters most: once
 // gemini 0.53.1 migrates OAuth into the keychain and deletes oauth_creds.json,
 // an invalid keychain credential is indistinguishable from a good one on disk.
-export const GEMINI_PROBE_TIMEOUT_MS = 30_000;
+// A one-word prompt answers in seconds, so this ceiling is not about the model —
+// it is about not being the reason the answer is inconclusive. At 30s a healthy
+// but slow credential (cold start, slow network) was SIGTERM-killed mid-request,
+// which bills the turn and *still* reports `unknown`: the user pays and learns
+// nothing. A real turn gets DEFAULT_SPAWN_TIMEOUT_MS (600s); the probe does not
+// need that much, but it needs enough that a timeout means something is wrong.
+export const GEMINI_PROBE_TIMEOUT_MS = 120_000;
 const GEMINI_PROBE_PROMPT = "ok";
 
-export function probeGeminiLogin({ runCommandFn = runCommand, detectEngineFn = detectEngine } = {}) {
+// `cwd` is positional to match the seam it is installed into
+// (`geminiLoginStatusFn(cwd)`, shared with getGeminiLoginStatus). It used to be
+// swallowed by the options destructuring, which silently ran the probe in the
+// process cwd — so a workspace `.gemini/settings.json` (auth type, model) did
+// not apply and the probe could disagree with the very turn it predicts.
+export function probeGeminiLogin(cwd = undefined, { runCommandFn = runCommand, detectEngineFn = detectEngine } = {}) {
   let engineInfo;
   try {
     engineInfo = detectEngineFn("gemini");
@@ -851,6 +862,7 @@ export function probeGeminiLogin({ runCommandFn = runCommand, detectEngineFn = d
   const args = buildCliArgs("gemini", { prompt: GEMINI_PROBE_PROMPT, useStdin: true, outputJson: true });
   const result = runCommandFn(engineInfo.binary, args, {
     input: GEMINI_PROBE_PROMPT,
+    cwd,
     timeout: GEMINI_PROBE_TIMEOUT_MS,
     maxBuffer: MAX_BUFFER
   });
@@ -864,14 +876,25 @@ export function probeGeminiLogin({ runCommandFn = runCommand, detectEngineFn = d
     };
   }
 
-  const reason = String(result.stderr ?? "").trim();
+  // The probe asks for `--output-format json`, and in that mode gemini can carry
+  // the error in a stdout envelope (`{ error: { message } }`) instead of on
+  // stderr — see isModelNotFoundError above. classifyCliFailure only folds stdout
+  // into its comparison text when `structured: true`, so without this the probe
+  // would answer `unknown` for exactly the rejected credential it exists to
+  // detect. Measured on 0.54.4 the auth error arrives on stderr, so this is the
+  // envelope path held open, not the path in use.
+  const envelope = tryParseJsonFromText(stripAnsi(result.stdout ?? ""));
+  const rawEnvelopeError = typeof envelope?.error === "string" ? envelope.error : envelope?.error?.message;
+  const envelopeError = String(rawEnvelopeError ?? "").trim();
+  const reason = envelopeError || String(result.stderr ?? "").trim();
   const failure = classifyCliFailure({
     engine: "gemini",
     status: result.status,
     signal: result.signal,
     error: result.error,
     stdout: result.stdout,
-    stderr: result.stderr
+    stderr: result.stderr,
+    structuredError: envelopeError
   });
   if (failure.category === "auth") {
     return {
@@ -882,11 +905,14 @@ export function probeGeminiLogin({ runCommandFn = runCommand, detectEngineFn = d
     };
   }
   // As with AGY: a probe that failed for another reason is not proof of a logout.
+  // Unlike the auth branch, this one cannot promise the request was free — a
+  // timeout in particular means it was in flight when we killed it. Say so: the
+  // rest of this flag's contract is that its cost is never a surprise.
   return {
     loggedIn: false,
     state: "unknown",
     verifiable: false,
-    detail: `Gemini CLI ${version} did not complete the probe (${failure.category}), so its authentication state is still unknown.${reason ? ` (${shortenProbeReason(reason)})` : ""}`
+    detail: `Gemini CLI ${version} did not complete the probe (${failure.category}), so its authentication state is still unknown. The request may have reached the API, so it may have spent a turn.${reason ? ` (${shortenProbeReason(reason)})` : ""}`
   };
 }
 

--- a/plugins/gemini/scripts/lib/gemini.mjs
+++ b/plugins/gemini/scripts/lib/gemini.mjs
@@ -822,6 +822,79 @@ export function probeAgyLogin({ runCommandFn = runCommand, detectEngineFn = dete
   };
 }
 
+// Deliberately NOT the twin of probeAgyLogin, despite the matching name and
+// return shape: AGY's `/quota` is answered by the account without starting a
+// turn, so probing it is free. Gemini CLI has no such question — the only way to
+// learn whether a stored credential still works is to make a request. On a
+// rejected credential that costs nothing (the API answers 400 before generating
+// anything), but on a working one it spends a real turn. Every place that offers
+// this flag has to say so, or a user who learned `--probe-agy` will assume it is
+// free here too.
+//
+// It exists because the file check cannot see the case that matters most: once
+// gemini 0.53.1 migrates OAuth into the keychain and deletes oauth_creds.json,
+// an invalid keychain credential is indistinguishable from a good one on disk.
+export const GEMINI_PROBE_TIMEOUT_MS = 30_000;
+const GEMINI_PROBE_PROMPT = "ok";
+
+export function probeGeminiLogin({ runCommandFn = runCommand, detectEngineFn = detectEngine } = {}) {
+  let engineInfo;
+  try {
+    engineInfo = detectEngineFn("gemini");
+  } catch {
+    return { loggedIn: false, state: "unavailable", verifiable: false, detail: "Gemini CLI binary not found." };
+  }
+
+  const version = engineInfo.version ?? "(unknown version)";
+  // Shortest possible request, over the same stdin transport a real turn uses,
+  // so what the probe proves is what a real turn would do.
+  const args = buildCliArgs("gemini", { prompt: GEMINI_PROBE_PROMPT, useStdin: true, outputJson: true });
+  const result = runCommandFn(engineInfo.binary, args, {
+    input: GEMINI_PROBE_PROMPT,
+    timeout: GEMINI_PROBE_TIMEOUT_MS,
+    maxBuffer: MAX_BUFFER
+  });
+
+  if ((result.status ?? (result.error ? 1 : 0)) === 0) {
+    return {
+      loggedIn: true,
+      state: "verified",
+      verifiable: true,
+      detail: `Gemini CLI ${version} completed a request, so its credential works. This spent a turn.`
+    };
+  }
+
+  const reason = String(result.stderr ?? "").trim();
+  const failure = classifyCliFailure({
+    engine: "gemini",
+    status: result.status,
+    signal: result.signal,
+    error: result.error,
+    stdout: result.stdout,
+    stderr: result.stderr
+  });
+  if (failure.category === "auth") {
+    return {
+      loggedIn: false,
+      state: "logged-out",
+      verifiable: true,
+      detail: `Gemini CLI ${version} rejected the probe as unauthenticated, so its stored credential does not work. Run \`gemini\` once interactively to sign in, or set GEMINI_API_KEY. No turn was spent — the request was refused before any generation.`
+    };
+  }
+  // As with AGY: a probe that failed for another reason is not proof of a logout.
+  return {
+    loggedIn: false,
+    state: "unknown",
+    verifiable: false,
+    detail: `Gemini CLI ${version} did not complete the probe (${failure.category}), so its authentication state is still unknown.${reason ? ` (${shortenProbeReason(reason)})` : ""}`
+  };
+}
+
+function shortenProbeReason(reason) {
+  const collapsed = reason.replace(/\s+/g, " ").trim();
+  return collapsed.length > 200 ? `${collapsed.slice(0, 197)}...` : collapsed;
+}
+
 export function getSessionRuntimeStatus(options = {}) {
   // Unlike the Codex app-server (a shared persistent runtime), the Gemini plugin
   // invokes the CLI directly per command, so the runtime label describes which

--- a/tests/commands.test.mjs
+++ b/tests/commands.test.mjs
@@ -195,3 +195,47 @@ test("every command that relays model output marks it as untrusted data", () => 
     );
   }
 });
+
+// "Copy the line as written:" is load-bearing — it is what stops the model from
+// paraphrasing an invocation whose quoting matters. A later bullet was inserted
+// between that sentence and its fenced command, leaving the instruction pointing
+// at prose and the fence reading as part of the warning above it.
+test("a copy-this-line instruction is immediately followed by the line", () => {
+  for (const file of fs.readdirSync(COMMANDS_DIR).filter((name) => name.endsWith(".md"))) {
+    const lines = readCommand(file).split(/\r?\n/);
+    lines.forEach((line, index) => {
+      if (!/Copy the line as written:\s*$/.test(line)) return;
+      assert.match(
+        lines[index + 1] ?? "",
+        /^```/,
+        `${file}:${index + 1} points at the next line, which is not a fenced command`
+      );
+    });
+  }
+});
+
+// argument-hint is the only place a flag is discoverable from the slash command,
+// so a flag the companion advertises in its own usage must appear there too.
+// `--probe-gemini` shipped invisible: printUsage and the body were updated, the
+// hint was not.
+test("setup's argument-hint lists the flags its usage advertises", () => {
+  const companion = fs.readFileSync(
+    path.join(ROOT, "plugins", "gemini", "scripts", "gemini-companion.mjs"),
+    "utf8"
+  );
+  const usageLine = companion
+    .split(/\r?\n/)
+    .find((line) => line.includes("gemini-companion.mjs setup ["));
+  assert.ok(usageLine, "printUsage must still document the setup subcommand");
+
+  const hint = readCommand("setup.md")
+    .split(/\r?\n/)
+    .find((line) => line.startsWith("argument-hint:"));
+  assert.ok(hint, "setup.md must declare an argument-hint");
+
+  for (const flag of usageLine.match(/--[a-z][a-z-]+/g) ?? []) {
+    // `--json` is supplied by the command file itself, never by the user.
+    if (flag === "--json") continue;
+    assert.ok(hint.includes(flag), `argument-hint omits ${flag}, so it is undiscoverable`);
+  }
+});

--- a/tests/failures.test.mjs
+++ b/tests/failures.test.mjs
@@ -112,3 +112,37 @@ test("classifyCliFailure does not treat transport words in model prose as transp
   });
   assert.notEqual(failure.category, "rate-limit");
 });
+
+// Verbatim from a live gemini 0.54.4 run on 2026-08-12 (`gemini -p "say OK"`
+// against an account whose consumer access ended): HTTP 400, exit 1, no tokens
+// spent. It classified as `unknown`, whose next step is "retry with a narrower
+// prompt" — advice that cannot fix a rejected credential. The pattern it missed
+// is word order: Google says "API key not valid", the classifier had "invalid
+// api key".
+test("Google's own API-key rejection classifies as auth, not unknown", () => {
+  const stderr =
+    'Error when talking to Gemini API _ApiError: {"error":{"message":"{\n  \\"error\\": {\n    ' +
+    '\\"code\\": 400,\n    \\"message\\": \\"API key not valid. Please pass a valid API key.\\",\n    ' +
+    '\\"status\\": \\"INVALID_ARGUMENT\\",\n    \\"details\\": [\n      {\n        ' +
+    '\\"@type\\": \\"type.googleapis.com/google.rpc.ErrorInfo\\",\n        \\"reason\\": \\"API_KEY_INVALID\\"\n' +
+    '      }\n    ]\n  }\n}\n","code":400,"status":"Bad Request"}}';
+  const failure = classifyCliFailure({ engine: "gemini", status: 1, stdout: "", stderr });
+
+  assert.equal(failure.category, "auth");
+  assert.match(failure.nextStep, /gemini/, "the next step must point at re-authenticating");
+  assert.doesNotMatch(failure.nextStep, /narrower prompt/);
+});
+
+// The status Google returns for a rejected key is also what it returns for a
+// malformed request, including a bad --model id. Auth is tested before the model
+// check, so matching the status rather than the key wording would swallow it.
+test("a bad model id is still a model failure, not an auth failure", () => {
+  const failure = classifyCliFailure({
+    engine: "gemini",
+    status: 1,
+    stdout: "",
+    stderr: '{"error":{"code":400,"status":"INVALID_ARGUMENT","message":"models/nope-1.0 is not found or not supported"}}'
+  });
+
+  assert.notEqual(failure.category, "auth");
+});

--- a/tests/plan-tier.test.mjs
+++ b/tests/plan-tier.test.mjs
@@ -81,26 +81,34 @@ test("hasGeminiCredentials treats an API key as a credential", (t) => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "gemini-auth-"));
   t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
 
+  // GEMINI_HOME is still read from the real process env (geminiHomeDir), so the
+  // empty fixture directory has to go there.
   const prevHome = process.env.GEMINI_HOME;
-  const prevKey = process.env.GEMINI_API_KEY;
   process.env.GEMINI_HOME = dir; // no oauth_creds.json here
   t.after(() => {
     if (prevHome === undefined) delete process.env.GEMINI_HOME; else process.env.GEMINI_HOME = prevHome;
-    if (prevKey === undefined) delete process.env.GEMINI_API_KEY; else process.env.GEMINI_API_KEY = prevKey;
   });
 
-  // The keychain probe would otherwise consult the real keychain of whatever
-  // machine runs this, which decides the assertion instead of the fixture.
-  const noKeychain = { env: { GEMINI_COMPANION_DISABLE_KEYCHAIN: "1" } };
+  // `options.env` is the environment this call consults, for the API key as well
+  // as the keychain opt-out. It used to be read by the keychain path alone, so
+  // this test set the key on the real process env and passed an env holding only
+  // the opt-out; under one consistent meaning the key belongs in the same object.
+  // The opt-out stays because the keychain probe would otherwise consult whatever
+  // machine runs this, and decide the assertion instead of the fixture.
+  const noKeychain = { GEMINI_COMPANION_DISABLE_KEYCHAIN: "1" };
 
-  delete process.env.GEMINI_API_KEY;
-  assert.equal(hasGeminiCredentials(noKeychain), false);
+  assert.equal(hasGeminiCredentials({ env: { ...noKeychain } }), false);
 
-  process.env.GEMINI_API_KEY = "  ";
-  assert.equal(hasGeminiCredentials(noKeychain), false, "whitespace is not a credential");
+  assert.equal(
+    hasGeminiCredentials({ env: { ...noKeychain, GEMINI_API_KEY: "  " } }),
+    false,
+    "whitespace is not a credential"
+  );
 
-  process.env.GEMINI_API_KEY = "AIza-test-key";
-  assert.equal(hasGeminiCredentials(noKeychain), true);
+  assert.equal(hasGeminiCredentials({ env: { ...noKeychain, GEMINI_API_KEY: "AIza-test-key" } }), true);
+  // GOOGLE_API_KEY is the documented alternative and must not be forgotten when
+  // the lookup moves to an injected environment.
+  assert.equal(hasGeminiCredentials({ env: { ...noKeychain, GOOGLE_API_KEY: "AIza-test-key" } }), true);
 });
 
 // --- keychain probe ---

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -769,6 +769,28 @@ test("a leading unknown flag is an error, not prompt text", () => {
   );
 });
 
+// A flag with whitespace in it was split by the shell, not typed that way: a
+// double-quoted value inside the slash command's own quoted argument string closes
+// that quoting early. The generic advice to prefix `--` cannot help here — review
+// takes no prompt text at all — so the message has to name the real cause.
+test("a flag the shell split apart says to use single quotes", () => {
+  const { repo, binDir } = setupRepo("review");
+  commit(repo, "README.md", "hello\n");
+
+  // process.execPath, not "node": the helper only skips the shell for an absolute
+  // command, and cmd.exe would re-split "--base my" into two arguments, which is
+  // the very shape this test needs to arrive intact.
+  const result = run(process.execPath, [SCRIPT, "review", "--base my", "branch --wait"], {
+    cwd: repo,
+    env: buildEnv(binDir)
+  });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /Unknown option "--base my"/);
+  assert.match(result.stderr, /single quotes/);
+  assert.doesNotMatch(result.stderr, /put `--` before it/);
+});
+
 test("`--` still delivers a prompt that starts with a dash", () => {
   const { repo, binDir } = setupRepo("task");
   commit(repo, "README.md", "hello\n");

--- a/tests/setup-readiness.test.mjs
+++ b/tests/setup-readiness.test.mjs
@@ -175,9 +175,14 @@ test("the report names the credential that satisfied gemini readiness", () => {
   // Injected rather than assigned onto process.env: mutating the real env made
   // this test order-dependent with anything else that reads it, and it is the same
   // seam that keeps the readiness assertions below off the runner's environment.
+  //
+  // The keychain opt-out travels with it so the injected key is the *only* thing
+  // that can satisfy `geminiReady`. Without it this passed on a developer machine
+  // off an unrelated keychain entry while failing on CI, which had none — the
+  // wrong-reason pass that hides whether the env is read at all.
   const report = buildSetupReport(makeTempDir(), [], {
     engine: "gemini",
-    env: { GEMINI_API_KEY: "test-key" },
+    env: { GEMINI_API_KEY: "test-key", GEMINI_COMPANION_DISABLE_KEYCHAIN: "1" },
     geminiAvailabilityFn: () => ({ available: true, version: "0.53.1" }),
     agyLoginStatusFn: () => agyStatus("unknown")
   });

--- a/tests/setup-readiness.test.mjs
+++ b/tests/setup-readiness.test.mjs
@@ -2,7 +2,12 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import { buildSetupReport } from "../plugins/gemini/scripts/gemini-companion.mjs";
-import { getSessionRuntimeStatus, probeAgyLogin, probeGeminiLogin } from "../plugins/gemini/scripts/lib/gemini.mjs";
+import {
+  GEMINI_PROBE_TIMEOUT_MS,
+  getSessionRuntimeStatus,
+  probeAgyLogin,
+  probeGeminiLogin
+} from "../plugins/gemini/scripts/lib/gemini.mjs";
 import { makeTempDir } from "./helpers.mjs";
 
 // ---------------------------------------------------------------------------
@@ -167,20 +172,18 @@ test("a probed-and-logged-out AGY is not-ready, not partial", () => {
 // `geminiAuth.loggedIn: false`. Both are true and they answer different
 // questions; the report now names which credential satisfied readiness.
 test("the report names the credential that satisfied gemini readiness", () => {
-  const previous = process.env.GEMINI_API_KEY;
-  process.env.GEMINI_API_KEY = "test-key";
-  try {
-    const report = buildSetupReport(makeTempDir(), [], {
-      engine: "gemini",
-      geminiAvailabilityFn: () => ({ available: true, version: "0.53.1" }),
-      agyLoginStatusFn: () => agyStatus("unknown")
-    });
-    assert.equal(report.geminiCredentialSource, "env-api-key");
-    assert.equal(report.geminiReady, true);
-  } finally {
-    if (previous === undefined) delete process.env.GEMINI_API_KEY;
-    else process.env.GEMINI_API_KEY = previous;
-  }
+  // Injected rather than assigned onto process.env: mutating the real env made
+  // this test order-dependent with anything else that reads it, and it is the same
+  // seam that keeps the readiness assertions below off the runner's environment.
+  const report = buildSetupReport(makeTempDir(), [], {
+    engine: "gemini",
+    env: { GEMINI_API_KEY: "test-key" },
+    geminiAvailabilityFn: () => ({ available: true, version: "0.53.1" }),
+    agyLoginStatusFn: () => agyStatus("unknown")
+  });
+
+  assert.equal(report.geminiCredentialSource, "env-api-key");
+  assert.equal(report.geminiReady, true);
 });
 
 test("the credential source says so plainly when there is no engine", () => {
@@ -324,9 +327,14 @@ function geminiProbeStatus(state) {
   };
 }
 
+// `env: {}` is not decoration. Readiness reads GEMINI_API_KEY / GOOGLE_API_KEY,
+// an env key outranks the file, and this suite used to read them straight from
+// `process.env` — so this assertion passed only on a machine with neither
+// exported. Verified: before the seam, `GEMINI_API_KEY=x node --test` failed here.
 test("an expired OAuth file blocks the ready claim even when a credential resolves", () => {
   const report = buildSetupReport(makeTempDir(), [], {
     engine: "gemini",
+    env: {},
     geminiAvailabilityFn: () => ({ available: true, detail: "0.54.4" }),
     agyAvailabilityFn: () => ({ available: true, detail: "1.1.12" }),
     geminiCredentialedFn: () => true,
@@ -352,6 +360,7 @@ test("a missing OAuth file is not evidence, because 0.53.1 deletes it", () => {
   // swallow it.
   const report = buildSetupReport(makeTempDir(), [], {
     engine: "gemini",
+    env: {},
     geminiAvailabilityFn: () => ({ available: true, detail: "0.54.4" }),
     agyAvailabilityFn: () => ({ available: false, detail: null }),
     geminiCredentialedFn: () => true,
@@ -363,14 +372,34 @@ test("a missing OAuth file is not evidence, because 0.53.1 deletes it", () => {
   assert.equal(report.ready, true);
 });
 
+// An env API key is the top of the resolution order, so it legitimately outranks
+// a stale file — and this is the pair that proves the env above is actually read
+// rather than ignored in both directions.
+test("an env API key outranks the stale-file evidence", () => {
+  const report = buildSetupReport(makeTempDir(), [], {
+    engine: "gemini",
+    env: { GEMINI_API_KEY: "test-key" },
+    geminiAvailabilityFn: () => ({ available: true, detail: "0.54.4" }),
+    agyAvailabilityFn: () => ({ available: false, detail: null }),
+    geminiCredentialedFn: () => true,
+    geminiLoginStatusFn: () => geminiFileStatus("expired"),
+    agyLoginStatusFn: () => agyStatus("unknown")
+  });
+
+  assert.equal(report.readyState, "ready");
+  assert.equal(report.geminiCredentialSource, "env-api-key");
+});
+
 test("a probe that comes back rejected is not-ready for an explicit --engine gemini", () => {
   const report = buildSetupReport(makeTempDir(), [], {
     engine: "gemini",
     probedGemini: true,
+    env: {},
     geminiAvailabilityFn: () => ({ available: true, detail: "0.54.4" }),
     agyAvailabilityFn: () => ({ available: true, detail: "1.1.12" }),
     geminiCredentialedFn: () => true,
     geminiLoginStatusFn: () => geminiProbeStatus("logged-out"),
+    geminiFileStatusFn: () => geminiFileStatus("missing"),
     agyLoginStatusFn: () => agyStatus("unknown")
   });
 
@@ -382,10 +411,12 @@ test("a rejected gemini stays partial under auto, because auto routes to AGY", (
   const report = buildSetupReport(makeTempDir(), [], {
     engine: "",
     probedGemini: true,
+    env: {},
     geminiAvailabilityFn: () => ({ available: true, detail: "0.54.4" }),
     agyAvailabilityFn: () => ({ available: true, detail: "1.1.12" }),
     geminiCredentialedFn: () => true,
     geminiLoginStatusFn: () => geminiProbeStatus("logged-out"),
+    geminiFileStatusFn: () => geminiFileStatus("missing"),
     agyLoginStatusFn: () => agyStatus("unknown")
   });
 
@@ -396,15 +427,161 @@ test("a verified probe outranks the file and reaches ready", () => {
   const report = buildSetupReport(makeTempDir(), [], {
     engine: "gemini",
     probedGemini: true,
+    env: {},
     geminiAvailabilityFn: () => ({ available: true, detail: "0.54.4" }),
     agyAvailabilityFn: () => ({ available: false, detail: null }),
     geminiCredentialedFn: () => true,
     geminiLoginStatusFn: () => geminiProbeStatus("verified"),
+    // Deliberately the worst file evidence available: a *verified* probe is the
+    // one thing that outranks it.
+    geminiFileStatusFn: () => geminiFileStatus("expired"),
     agyLoginStatusFn: () => agyStatus("unknown")
   });
 
   assert.equal(report.readyState, "ready");
   assert.equal(report.ready, true);
+});
+
+// Under --probe-gemini, `geminiAuth` is the probe's answer, where `loggedIn: true`
+// means "the API accepted a request" — not "the OAuth file is valid". Naming the
+// source off that reported `oauth-file` for the exact case the probe exists to
+// serve: 0.53.1 deleted the file and the credential lives in the keychain.
+test("a verified probe does not rename the keychain as the OAuth file", () => {
+  const report = buildSetupReport(makeTempDir(), [], {
+    engine: "gemini",
+    probedGemini: true,
+    env: {},
+    geminiAvailabilityFn: () => ({ available: true, detail: "0.54.4" }),
+    agyAvailabilityFn: () => ({ available: false, detail: null }),
+    geminiCredentialedFn: () => true,
+    geminiLoginStatusFn: () => geminiProbeStatus("verified"),
+    geminiFileStatusFn: () => geminiFileStatus("missing"),
+    agyLoginStatusFn: () => agyStatus("unknown")
+  });
+
+  assert.equal(report.geminiCredentialSource, "os-keychain");
+});
+
+// An inconclusive probe replaced the file status wholesale, so it *erased* the one
+// piece of evidence the free check had produced: an expired file plus a probe that
+// timed out read as `ready`.
+test("an inconclusive probe does not erase the expired file underneath it", () => {
+  const report = buildSetupReport(makeTempDir(), [], {
+    engine: "gemini",
+    probedGemini: true,
+    env: {},
+    geminiAvailabilityFn: () => ({ available: true, detail: "0.54.4" }),
+    agyAvailabilityFn: () => ({ available: false, detail: null }),
+    geminiCredentialedFn: () => true,
+    geminiLoginStatusFn: () => geminiProbeStatus("unknown"),
+    geminiFileStatusFn: () => geminiFileStatus("expired"),
+    agyLoginStatusFn: () => agyStatus("unknown")
+  });
+
+  assert.notEqual(report.readyState, "ready");
+  assert.equal(report.ready, false);
+});
+
+// The stale-file step quotes the file, and stops offering a probe once one has
+// answered. Reading the probe there produced "the OAuth file says it is stale:
+// Gemini CLI rejected the probe…" followed by advice to run the probe that had
+// just run — measured on a real `setup --probe-gemini --engine gemini`.
+test("the stale-file step quotes the file, not the probe standing in front of it", () => {
+  const report = buildSetupReport(makeTempDir(), [], {
+    engine: "gemini",
+    probedGemini: true,
+    env: {},
+    geminiAvailabilityFn: () => ({ available: true, detail: "0.54.4" }),
+    agyAvailabilityFn: () => ({ available: false, detail: null }),
+    geminiCredentialedFn: () => true,
+    geminiLoginStatusFn: () => geminiProbeStatus("unknown"),
+    geminiFileStatusFn: () => geminiFileStatus("expired", "OAuth token expired at 2026-08-08."),
+    agyLoginStatusFn: () => agyStatus("unknown")
+  });
+
+  const stale = report.nextSteps.find((step) => /OAuth file says it is stale/.test(step));
+  assert.ok(stale, `expected a stale-file step; got ${JSON.stringify(report.nextSteps)}`);
+  assert.match(stale, /OAuth token expired at 2026-08-08\./);
+  assert.doesNotMatch(stale, /rejected the probe|reported unknown/, "it must not quote the probe");
+  assert.doesNotMatch(stale, /spends a turn/, "a probe already ran; do not offer it again");
+});
+
+test("a rejected probe says what to do once, not twice", () => {
+  const report = buildSetupReport(makeTempDir(), [], {
+    engine: "gemini",
+    probedGemini: true,
+    env: {},
+    geminiAvailabilityFn: () => ({ available: true, detail: "0.54.4" }),
+    agyAvailabilityFn: () => ({ available: false, detail: null }),
+    geminiCredentialedFn: () => true,
+    geminiLoginStatusFn: () => geminiProbeStatus("logged-out"),
+    geminiFileStatusFn: () => geminiFileStatus("expired"),
+    agyLoginStatusFn: () => agyStatus("unknown")
+  });
+
+  assert.deepEqual(report.nextSteps, ["Gemini probe reported logged-out."]);
+});
+
+// The probe costs a turn. `unknown` used to push nothing, so a user who had just
+// paid for a request read a report that looked like no probe had run.
+test("an inconclusive probe is disclosed instead of passing in silence", () => {
+  const report = buildSetupReport(makeTempDir(), [], {
+    engine: "gemini",
+    probedGemini: true,
+    env: {},
+    geminiAvailabilityFn: () => ({ available: true, detail: "0.54.4" }),
+    agyAvailabilityFn: () => ({ available: false, detail: null }),
+    geminiCredentialedFn: () => true,
+    geminiLoginStatusFn: () => geminiProbeStatus("unknown"),
+    geminiFileStatusFn: () => geminiFileStatus("missing"),
+    agyLoginStatusFn: () => agyStatus("unknown")
+  });
+
+  assert.ok(
+    report.nextSteps.some((step) => /Gemini probe reported unknown/.test(step)),
+    `an inconclusive probe must say so; got ${JSON.stringify(report.nextSteps)}`
+  );
+});
+
+// Nothing gated the paid probe on the engine, while AGY readiness ignores
+// geminiAuth entirely and every gemini next step is guarded by !agySelected — so
+// this combination billed a turn whose answer was then discarded.
+// The gate is only observable through what the report says, because an injected
+// `geminiLoginStatusFn` replaces the probe either way — so the assertion is the
+// disclosure, paired with its complement below so it cannot be satisfied by
+// always pushing the line.
+test("--probe-gemini does not spend a turn for an AGY run", () => {
+  const report = buildSetupReport(makeTempDir(), [], {
+    engine: "agy",
+    probedGemini: true,
+    env: {},
+    geminiAvailabilityFn: () => ({ available: true, detail: "0.54.4" }),
+    agyAvailabilityFn: () => AGY_INSTALLED,
+    geminiCredentialedFn: () => true,
+    geminiLoginStatusFn: () => geminiFileStatus("missing"),
+    agyLoginStatusFn: () => agyStatus("unknown")
+  });
+
+  assert.ok(
+    report.nextSteps.some((step) => /`--probe-gemini` was not run/.test(step)),
+    `a skipped flag must be said out loud; got ${JSON.stringify(report.nextSteps)}`
+  );
+});
+
+test("--probe-gemini is not announced as skipped when it is the point of the run", () => {
+  const report = buildSetupReport(makeTempDir(), [], {
+    engine: "gemini",
+    probedGemini: true,
+    env: {},
+    geminiAvailabilityFn: () => ({ available: true, detail: "0.54.4" }),
+    agyAvailabilityFn: () => ({ available: false, detail: null }),
+    geminiCredentialedFn: () => true,
+    geminiLoginStatusFn: () => geminiProbeStatus("verified"),
+    geminiFileStatusFn: () => geminiFileStatus("missing"),
+    agyLoginStatusFn: () => agyStatus("unknown")
+  });
+
+  assert.doesNotMatch(report.nextSteps.join("\n"), /`--probe-gemini` was not run/);
 });
 
 // ---------------------------------------------------------------------------
@@ -416,7 +593,7 @@ test("the gemini probe reports a rejected credential as logged out, with proof",
     status: 1,
     stderr: '{"error":{"code":400,"message":"API key not valid. Please pass a valid API key.","status":"INVALID_ARGUMENT"}}'
   });
-  const status = probeGeminiLogin({
+  const status = probeGeminiLogin(undefined, {
     runCommandFn,
     detectEngineFn: () => ({ engine: "gemini", binary: "gemini", version: "0.54.4" })
   });
@@ -431,7 +608,7 @@ test("the gemini probe reports a rejected credential as logged out, with proof",
 });
 
 test("the gemini probe says a completed request cost a turn", () => {
-  const status = probeGeminiLogin({
+  const status = probeGeminiLogin(undefined, {
     runCommandFn: stubRun({ status: 0, stdout: '{"response":"ok"}' }),
     detectEngineFn: () => ({ engine: "gemini", binary: "gemini", version: "0.54.4" })
   });
@@ -441,19 +618,67 @@ test("the gemini probe says a completed request cost a turn", () => {
   assert.match(status.detail, /spent a turn/, "the cost must be visible where the result is read");
 });
 
+// The probe asks for --output-format json, and in that mode gemini can put the
+// error in a stdout envelope instead of on stderr. classifyCliFailure only reads
+// stdout when told the output is structured, so without that this answered
+// `unknown` for the one failure the probe exists to detect. (Measured on 0.54.4
+// the auth error arrives on stderr — this holds the envelope path open.)
+test("the gemini probe reads an auth error out of the JSON envelope", () => {
+  const envelope = {
+    error: {
+      message:
+        '{"error":{"code":400,"message":"API key not valid. Please pass a valid API key.","status":"INVALID_ARGUMENT"}}'
+    }
+  };
+  const status = probeGeminiLogin(undefined, {
+    runCommandFn: stubRun({ status: 1, stdout: `${JSON.stringify(envelope)}\n`, stderr: "" }),
+    detectEngineFn: () => ({ engine: "gemini", binary: "gemini", version: "0.54.4" })
+  });
+
+  assert.equal(status.state, "logged-out");
+  assert.equal(status.verifiable, true, "an envelope-carried refusal is the same proof");
+});
+
 test("a gemini probe that fails for another reason leaves the state unknown", () => {
-  const status = probeGeminiLogin({
+  const status = probeGeminiLogin(undefined, {
     runCommandFn: stubRun({ status: 1, stderr: "socket hang up" }),
     detectEngineFn: () => ({ engine: "gemini", binary: "gemini", version: "0.54.4" })
   });
 
   assert.equal(status.state, "unknown");
   assert.equal(status.verifiable, false, "a network failure is not proof of a logout");
+  // The auth branch can promise the request was free; this one cannot, and a
+  // timeout in particular was killed in flight. Not saying so was the one place
+  // this flag could hide a spend.
+  assert.match(status.detail, /may have spent a turn/);
+});
+
+// The seam hands it a cwd (`geminiLoginStatusFn(cwd)`), which the options
+// destructuring used to swallow — so the probe ran in the process cwd, a workspace
+// `.gemini/settings.json` did not apply, and the probe could disagree with the
+// very turn it is supposed to predict.
+test("the gemini probe runs where the caller asked", () => {
+  const runCommandFn = stubRun({ status: 0, stdout: '{"response":"ok"}' });
+  probeGeminiLogin("/some/workspace", {
+    runCommandFn,
+    detectEngineFn: () => ({ engine: "gemini", binary: "gemini", version: "0.54.4" })
+  });
+
+  assert.equal(runCommandFn.calls[0].opts.cwd, "/some/workspace");
+});
+
+// A one-word prompt does not need long, but at 30s a healthy-but-slow credential
+// was killed mid-request: billed, and still reported `unknown`.
+test("the gemini probe timeout is not itself a reason to be inconclusive", () => {
+  assert.ok(
+    GEMINI_PROBE_TIMEOUT_MS >= 60_000,
+    `a probe that pays for a turn must not give up in ${GEMINI_PROBE_TIMEOUT_MS}ms`
+  );
 });
 
 test("the gemini probe does not spawn when the binary is absent", () => {
   const runCommandFn = stubRun({ status: 0 });
-  const status = probeGeminiLogin({
+  const status = probeGeminiLogin(undefined, {
     runCommandFn,
     detectEngineFn: () => {
       throw new Error("Gemini engine requested but gemini binary is not available.");

--- a/tests/setup-readiness.test.mjs
+++ b/tests/setup-readiness.test.mjs
@@ -2,7 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import { buildSetupReport } from "../plugins/gemini/scripts/gemini-companion.mjs";
-import { getSessionRuntimeStatus, probeAgyLogin } from "../plugins/gemini/scripts/lib/gemini.mjs";
+import { getSessionRuntimeStatus, probeAgyLogin, probeGeminiLogin } from "../plugins/gemini/scripts/lib/gemini.mjs";
 import { makeTempDir } from "./helpers.mjs";
 
 // ---------------------------------------------------------------------------
@@ -298,4 +298,168 @@ test("the label matches the engine the real resolver picks, not a stub", () => {
   });
   assert.equal(missing.selected, null, "a requested engine that is not installed cannot be the runtime");
   assert.equal(missing.label, "installed, but no engine is ready");
+});
+
+// ---------------------------------------------------------------------------
+// gemini readiness, and --probe-gemini
+//
+// The defect: `/gemini:setup --engine gemini` answered `"readyState": "ready"`
+// with `"nextSteps": []` for an account that returns API_KEY_INVALID on every
+// request (measured live, 2026-08-12). The keychain still held an entry, so the
+// credential *resolved*; the OAuth file in the same payload said the token had
+// expired four days earlier, and readiness ignored it. That flag only became
+// reachable in 0.17.1 — before, `--engine gemini` was silently dropped.
+// ---------------------------------------------------------------------------
+
+function geminiFileStatus(state, detail = `OAuth file reported ${state}.`) {
+  return { loggedIn: state === "valid", state, verifiable: false, detail };
+}
+
+function geminiProbeStatus(state) {
+  return {
+    loggedIn: state === "verified",
+    state,
+    verifiable: state === "verified" || state === "logged-out",
+    detail: `Gemini probe reported ${state}.`
+  };
+}
+
+test("an expired OAuth file blocks the ready claim even when a credential resolves", () => {
+  const report = buildSetupReport(makeTempDir(), [], {
+    engine: "gemini",
+    geminiAvailabilityFn: () => ({ available: true, detail: "0.54.4" }),
+    agyAvailabilityFn: () => ({ available: true, detail: "1.1.12" }),
+    geminiCredentialedFn: () => true,
+    geminiLoginStatusFn: () => geminiFileStatus("expired", "OAuth token expired at 2026-08-08T04:28:48.236Z."),
+    agyLoginStatusFn: () => agyStatus("unknown")
+  });
+
+  assert.notEqual(report.readyState, "ready", "a stale credential must not read as ready");
+  assert.equal(report.ready, false);
+  assert.ok(
+    report.nextSteps.some((step) => /stale|expired/i.test(step)),
+    `the report must say what to do; got ${JSON.stringify(report.nextSteps)}`
+  );
+  assert.ok(
+    report.nextSteps.some((step) => /probe-gemini/.test(step) && /spends a turn/.test(step)),
+    "offering --probe-gemini must disclose that it costs a turn"
+  );
+});
+
+test("a missing OAuth file is not evidence, because 0.53.1 deletes it", () => {
+  // The keychain-only install is healthy and must keep reading as ready — this is
+  // the case the credential check was added for, and the expiry rule must not
+  // swallow it.
+  const report = buildSetupReport(makeTempDir(), [], {
+    engine: "gemini",
+    geminiAvailabilityFn: () => ({ available: true, detail: "0.54.4" }),
+    agyAvailabilityFn: () => ({ available: false, detail: null }),
+    geminiCredentialedFn: () => true,
+    geminiLoginStatusFn: () => geminiFileStatus("missing"),
+    agyLoginStatusFn: () => agyStatus("unknown")
+  });
+
+  assert.equal(report.readyState, "ready");
+  assert.equal(report.ready, true);
+});
+
+test("a probe that comes back rejected is not-ready for an explicit --engine gemini", () => {
+  const report = buildSetupReport(makeTempDir(), [], {
+    engine: "gemini",
+    probedGemini: true,
+    geminiAvailabilityFn: () => ({ available: true, detail: "0.54.4" }),
+    agyAvailabilityFn: () => ({ available: true, detail: "1.1.12" }),
+    geminiCredentialedFn: () => true,
+    geminiLoginStatusFn: () => geminiProbeStatus("logged-out"),
+    agyLoginStatusFn: () => agyStatus("unknown")
+  });
+
+  assert.equal(report.readyState, "not-ready", "a verified negative is worse than unknown");
+  assert.equal(report.ready, false);
+});
+
+test("a rejected gemini stays partial under auto, because auto routes to AGY", () => {
+  const report = buildSetupReport(makeTempDir(), [], {
+    engine: "",
+    probedGemini: true,
+    geminiAvailabilityFn: () => ({ available: true, detail: "0.54.4" }),
+    agyAvailabilityFn: () => ({ available: true, detail: "1.1.12" }),
+    geminiCredentialedFn: () => true,
+    geminiLoginStatusFn: () => geminiProbeStatus("logged-out"),
+    agyLoginStatusFn: () => agyStatus("unknown")
+  });
+
+  assert.equal(report.readyState, "partial");
+});
+
+test("a verified probe outranks the file and reaches ready", () => {
+  const report = buildSetupReport(makeTempDir(), [], {
+    engine: "gemini",
+    probedGemini: true,
+    geminiAvailabilityFn: () => ({ available: true, detail: "0.54.4" }),
+    agyAvailabilityFn: () => ({ available: false, detail: null }),
+    geminiCredentialedFn: () => true,
+    geminiLoginStatusFn: () => geminiProbeStatus("verified"),
+    agyLoginStatusFn: () => agyStatus("unknown")
+  });
+
+  assert.equal(report.readyState, "ready");
+  assert.equal(report.ready, true);
+});
+
+// ---------------------------------------------------------------------------
+// probeGeminiLogin
+// ---------------------------------------------------------------------------
+
+test("the gemini probe reports a rejected credential as logged out, with proof", () => {
+  const runCommandFn = stubRun({
+    status: 1,
+    stderr: '{"error":{"code":400,"message":"API key not valid. Please pass a valid API key.","status":"INVALID_ARGUMENT"}}'
+  });
+  const status = probeGeminiLogin({
+    runCommandFn,
+    detectEngineFn: () => ({ engine: "gemini", binary: "gemini", version: "0.54.4" })
+  });
+
+  assert.equal(status.state, "logged-out");
+  assert.equal(status.verifiable, true, "a classified auth refusal is proof, not a guess");
+  assert.equal(status.loggedIn, false);
+  assert.match(status.detail, /No turn was spent/);
+  // The prompt travels on stdin, like every other gemini call in this plugin.
+  assert.equal(runCommandFn.calls[0].opts.input, "ok");
+  assert.ok(!runCommandFn.calls[0].args.includes("-p"), "stdin transport must not also pass -p");
+});
+
+test("the gemini probe says a completed request cost a turn", () => {
+  const status = probeGeminiLogin({
+    runCommandFn: stubRun({ status: 0, stdout: '{"response":"ok"}' }),
+    detectEngineFn: () => ({ engine: "gemini", binary: "gemini", version: "0.54.4" })
+  });
+
+  assert.equal(status.state, "verified");
+  assert.equal(status.loggedIn, true);
+  assert.match(status.detail, /spent a turn/, "the cost must be visible where the result is read");
+});
+
+test("a gemini probe that fails for another reason leaves the state unknown", () => {
+  const status = probeGeminiLogin({
+    runCommandFn: stubRun({ status: 1, stderr: "socket hang up" }),
+    detectEngineFn: () => ({ engine: "gemini", binary: "gemini", version: "0.54.4" })
+  });
+
+  assert.equal(status.state, "unknown");
+  assert.equal(status.verifiable, false, "a network failure is not proof of a logout");
+});
+
+test("the gemini probe does not spawn when the binary is absent", () => {
+  const runCommandFn = stubRun({ status: 0 });
+  const status = probeGeminiLogin({
+    runCommandFn,
+    detectEngineFn: () => {
+      throw new Error("Gemini engine requested but gemini binary is not available.");
+    }
+  });
+
+  assert.equal(status.state, "unavailable");
+  assert.equal(runCommandFn.calls.length, 0);
 });


### PR DESCRIPTION
Everything here sits behind `--engine gemini`, which only started reaching the runtime in 0.17.1 — before that the flag was discarded, so none of it had ever been exercised. Fixing one flag opened a batch of previously unreachable paths, which is where these came from. Each was measured on a live account before being changed.

## Setup reported `ready` for an engine that rejects every request

`/gemini:setup --engine gemini` answered:

```json
"ready": true, "readyState": "ready", "nextSteps": [],
"geminiCredentialSource": "os-keychain",
"geminiAuth": { "loggedIn": false, "detail": "OAuth token expired at 2026-08-08T04:28:48.236Z..." }
```

A real request on the same account: HTTP 400 `API_KEY_INVALID`, exit 1, no tokens spent. A credential that *resolves* is not a credential that *works*.

`getGeminiLoginStatus` now reports a `state` (`valid` / `expired` / `missing` / `unreadable`) alongside the unchanged `loggedIn` and `detail`, and an `expired` file blocks the `ready` claim — `partial`, with a next step naming the expiry.

**Only `expired`, never `missing`.** Gemini CLI 0.53.1 migrates OAuth into the keychain and deletes the file, so a healthy install also has no file. Treating absence as evidence would restore the false "not authenticated" the keychain check was added to prevent. Both directions are pinned by tests.

## Google's own API-key rejection classified as `unknown`

The auth pattern held `invalid api key`. Google says `API key not valid` / `API_KEY_INVALID` — not a word-order variant. So the failure came back "The CLI failed with an unclassified error" and advised *retrying with a narrower prompt*, which can never fix a rejected credential.

`INVALID_ARGUMENT` and the bare `400` are deliberately **not** matched: both also cover malformed requests, including a bad `--model` id, and auth is tested before the model check — either one would swallow it. A test pins that too.

## New `setup --probe-gemini`, and it is not free

The file check can only prove staleness; a credential living only in the keychain cannot be judged from disk at all. The probe makes a real request and classifies the answer: `verified`, `logged-out` (with proof), or `unknown` for any other failure.

Unlike `--probe-agy` — whose `/quota` question the account answers without starting a turn — **this spends a turn when the credential works.** It costs nothing only when the credential is already broken. The flag's own documentation and its result detail both say so, because two similar-looking flags with different costs is how a user gets surprised.

Readiness table: probed `verified` → `ready`; probed `logged-out` → `not-ready` for an explicit `--engine gemini`, but `partial` under `auto`, because auto routes to an available AGY when gemini's credential does not work.

## A flag the shell split apart now names the real cause

A double-quoted value closes the slash command's own argument string early, so `--base "my branch"` reaches the runtime as `--base my`. That is already rejected, but the message advised prefixing `--` — useless for a command that takes no prompt text. It now says to use single quotes, which survive to the runtime's splitter. `commands/adversarial-review.md` documents the matching case for focus text, where the shell swallows `--background` and the review silently runs in the foreground.

Also fixed: three command-markdown sentences added in 0.17.1 contained a literal `$ARGUMENTS`, which is substituted like everything else — at runtime they read as instructions about the user's own arguments.

## Verification

- `npm test`: **425 tests, 420 pass, 0 fail** (5 platform-skipped); `check-version` and `verify-contracts` green at 0.17.2.
- Every change mutation-checked, including **both directions** of the expiry rule: dropping it turns the expired case red, widening it to any non-`valid` state turns the missing case red.
- End-to-end on a live account, at zero token cost because the credential is already rejected:
  - `setup "--json --engine gemini"` → `partial`, `ready: false`, next step naming the expiry and the probe's cost.
  - `setup "--json --probe-gemini --engine gemini"` → `not-ready`, `state: "logged-out"`, `verifiable: true`, detail confirming no turn was spent.
  - `setup "--json"` under `GEMINI_ENGINE=agy` → unchanged: `partial`, `selected: "agy"`, AGY's own next step intact.

Two test-quality notes worth the reviewer's attention:

- `buildSetupReport` gained a `geminiCredentialedFn` seam. Without it the expiry assertions only hold on a machine that happens to have a gemini credential in its OS keychain, and would have gone green on CI **for the wrong reason**. `GEMINI_API_KEY` cannot stand in, because an env key deliberately outranks the file.
- The split-flag test spawns `process.execPath`, not `"node"`: the test helper only skips the shell for an absolute command, and cmd.exe would re-split the very argument the test needs to arrive intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
