### PR TITLE
docs: say what a contribution has to clear

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,7 @@
+# Contributing
+
+[繁體中文說明 →](CONTRIBUTING.zh-TW.md)
+
+- Documentation fixes: open a pull request directly.
+- Code changes: open an issue first, so the approach can be agreed before the work.
+- Every pull request must pass `npm test` and `npm run verify-contracts`.

--- a/CONTRIBUTING.zh-TW.md
+++ b/CONTRIBUTING.zh-TW.md
@@ -1,0 +1,5 @@
+# 貢獻指南
+
+- 文件修正：直接開 pull request。
+- 程式變更：請先開 issue，讓作法在動工前先取得共識。
+- 所有 pull request 都必須通過 `npm test` 與 `npm run verify-contracts`。


### PR DESCRIPTION
Three rules, split by what they cost to review:

- documentation fix → straight to a pull request
- code change → issue first, so the approach is agreed before anyone writes it
- either way, `npm test` and `npm run verify-contracts` are the bar

Bilingual like the README, and linked the same way (`[繁體中文說明 →]`).

Prompted by #60: an outside PR arrived with a correct wording fix and two stray blank lines, and there was nothing in the repo saying what was expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)