### PR TITLE
docs: give the issue CONTRIBUTING asks for somewhere to go

### DIFF
--- a/.github/ISSUE_TEMPLATE/change_proposal.yml
+++ b/.github/ISSUE_TEMPLATE/change_proposal.yml
@@ -1,0 +1,86 @@
+name: Change proposal
+description: A code change you would like made, or would like to make yourself.
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        `CONTRIBUTING.md` asks for this before a code change, so the approach can
+        be agreed before anyone writes it. Documentation fixes need none of this —
+        open a pull request directly.
+
+        If the plugin is doing something wrong rather than missing something, the
+        bug report template asks better questions.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: The problem
+      description: >
+        What you were trying to do, and where the plugin stopped being enough.
+        Describe the situation, not the fix — the fix is the next field, and they
+        are worth keeping apart.
+      placeholder: |
+        Reviewing a 40-file branch, I want the findings grouped by file, because
+        reading them in severity order means jumping around the diff.
+    validations:
+      required: true
+
+  - type: textarea
+    id: evidence
+    attributes:
+      label: What you observed
+      description: >
+        What you ran and what came back. A proposal grounded in one real run is
+        worth more than one grounded in what the code looks like it does — and if
+        the behavior turns out to already exist, this is the field that shows it.
+      render: text
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: What you propose
+      description: >
+        The change itself. A flag, a field, a different default — as concrete as
+        you can make it, including what it would be called.
+      placeholder: |
+        `/gemini:review --group-by file`, defaulting to the current severity order.
+    validations:
+      required: true
+
+  - type: textarea
+    id: blast-radius
+    attributes:
+      label: What existing behavior would change
+      description: >
+        Output someone could already be depending on: JSON field names or order,
+        exit codes, log and error text, an existing flag's default. "Nothing —
+        it is additive" is a complete answer, and saying so explicitly is the
+        point of the question.
+      placeholder: "Nothing — new flag, existing default unchanged."
+    validations:
+      required: true
+
+  - type: dropdown
+    id: who-implements
+    attributes:
+      label: Who would implement it
+      description: Either answer is fine. It changes what the reply should contain.
+      options:
+        - I would like to implement it myself
+        - I am proposing it for someone else to pick up
+        - Not sure yet
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: What you tried or considered instead
+      description: >
+        Existing flags, a wrapper script, doing it by hand. If one of them almost
+        worked, why it did not is usually the most useful part of the proposal.
+    validations:
+      required: false

--- a/plugins/gemini/scripts/lib/gemini.mjs
+++ b/plugins/gemini/scripts/lib/gemini.mjs
@@ -179,7 +179,9 @@ function readAgyEnvelope(rawStdout) {
   // A terminal status plus a payload slot is what identifies the envelope.
   // Do not require a specific status value: only SUCCESS and ERROR have been
   // observed, and whether that vocabulary is closed is an open question with
-  // upstream (antigravity-cli#546). Treat anything other than SUCCESS as failure.
+  // upstream (antigravity-cli#778 — #546 asked for the envelope itself and was
+  // closed once it shipped; the undocumented error contract was split out).
+  // Treat anything other than SUCCESS as failure.
   if (typeof parsed.status !== "string" || !parsed.status) return null;
   if (!("response" in parsed) && !("error" in parsed)) return null;
   // conversation_id is "" on the observed ERROR envelope and may be absent


### PR DESCRIPTION
`CONTRIBUTING.md` (#64) tells contributors to open an issue before a code change, and the only templates were `bug_report` and `compatibility_report` — the one path the document requires had no form behind it.

`change_proposal.yml` asks what this repo actually answers proposals with:

- **what you observed on a real run**, not what the code looks like it does — and if the behavior already exists, that field is where it shows up
- **what existing output would change** (JSON field names, exit codes, error text, a flag's default). `Nothing — it is additive` is the expected answer; saying it explicitly is the point
- who would implement it, because it changes what the reply should contain

Also repoints a stale reference in `readAgyEnvelope`: it cited `antigravity-cli#546` for the open question about the envelope's status vocabulary, but #546 asked for the envelope itself and was closed 2026-08-11 once it shipped. The undocumented error contract was split into #778, which is where that question now lives.

Verified: all four templates parse as YAML, and `enhancement` is a label that exists in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)