### PR TITLE
Ask before spending the user's quota

### DIFF
--- a/plugins/gemini/commands/setup.md
+++ b/plugins/gemini/commands/setup.md
@@ -91,10 +91,23 @@ once interactively.
 There is a matching `--probe-gemini`, and **it is not free**. Gemini CLI has no
 question the account answers without generating, so the probe makes a real
 request: on a credential that no longer works it costs nothing (the API refuses it
-before generating), but on a working credential it spends a turn. Do not offer it
-by reflex the way `--probe-agy` can be offered — suggest it only when the report
-says a stored gemini credential cannot be trusted, or when the user asks whether
-gemini really works:
+before generating), but on a working credential it spends a turn.
+
+**Hard rule: unless the user typed `--probe-gemini` themselves, use
+`AskUserQuestion` exactly once before running it, and do not run it if they
+decline.** This command already asks before installing an npm package; spending
+the user's quota is the more expensive of the two and must not be the one decision
+made for them. "Does gemini actually work?" is a reason to *offer* the probe, not
+a licence to spend a turn answering it.
+
+- Put the decline option first — the free file check has already run, so declining
+  still leaves a usable report.
+- Say the cost in the option itself, not only in the question:
+  - `Skip the probe (keep the free disk check)`
+  - `Probe now — spends one turn if the credential works`
+- If the user typed the flag, they have already chosen; run it without asking.
+
+Then, and only then:
 
 ```bash
 node "${CLAUDE_PLUGIN_ROOT}/scripts/gemini-companion.mjs" setup "--json --probe-gemini $ARGUMENTS"

--- a/tests/commands.test.mjs
+++ b/tests/commands.test.mjs
@@ -239,3 +239,40 @@ test("setup's argument-hint lists the flags its usage advertises", () => {
     assert.ok(hint.includes(flag), `argument-hint omits ${flag}, so it is undiscoverable`);
   }
 });
+
+// A documented invocation that spends the user's quota must be gated by a
+// question, not by prose asking the model to use restraint. `--probe-gemini`
+// costs a turn when the credential works, and setup.md already mandates
+// AskUserQuestion before the cheaper act of installing an npm package — the
+// expensive one must not be the decision made on the user's behalf.
+test("a quota-spending invocation is gated by AskUserQuestion", () => {
+  for (const file of fs.readdirSync(COMMANDS_DIR).filter((name) => name.endsWith(".md"))) {
+    const source = readCommand(file);
+    const lines = source.split(/\r?\n/);
+    const spendingLine = lines.findIndex((line) => /--probe-gemini/.test(line) && /gemini-companion\.mjs/.test(line));
+    if (spendingLine === -1) continue;
+
+    // Look back over the passage that introduces the invocation, not the whole
+    // file: a mention of AskUserQuestion 80 lines earlier for an unrelated
+    // install prompt would not gate this one.
+    const passage = lines.slice(Math.max(0, spendingLine - 25), spendingLine).join("\n");
+    assert.match(
+      passage,
+      /AskUserQuestion/,
+      `${file} runs --probe-gemini without an AskUserQuestion gate in the surrounding passage`
+    );
+    // Inside a backticked option label, not merely somewhere in the passage: the
+    // prose above already says "it spends a turn", so a looser match was satisfied
+    // by the explanation while the option the user actually clicks said nothing.
+    // Line-scoped because a negated character class still crosses newlines — the
+    // first version of this matched from a backtick two paragraphs up.
+    assert.ok(
+      passage.split(/\r?\n/).some((line) => /`[^`]*spends (a|one) turn[^`]*`/.test(line)),
+      `${file} must put the cost in the option the user picks, not only in the prose`
+    );
+    assert.ok(
+      source.includes("allowed-tools:") && /AskUserQuestion/.test(source.split("---")[1] ?? ""),
+      `${file} must declare AskUserQuestion in allowed-tools for that gate to be usable`
+    );
+  }
+});


### PR DESCRIPTION
`setup.md` already mandates `AskUserQuestion` before installing an npm package. The more expensive act — `--probe-gemini`, which spends a turn when the credential works — had **no gate at all**, only prose asking the model for restraint.

Worse, one line of that prose ("or when the user asks whether gemini really works") reads as licence to spend a turn answering a question the user only asked out loud. Documenting a cost is not the same as asking before incurring it.

### The rule

> **Hard rule: unless the user typed `--probe-gemini` themselves, use `AskUserQuestion` exactly once before running it, and do not run it if they decline.**

- The decline option comes **first** — the free disk check has already produced a usable report, so declining is not a dead end.
- The cost is stated **in the option the user clicks**, not only in the surrounding explanation: `Probe now — spends one turn if the credential works`.
- If the user typed the flag, they already chose; run it without asking.

### The guard took three attempts to make real

The first two versions of the `commands.test.mjs` assertion were satisfied by the very prose they were meant to replace. A negated character class crosses newlines, so ``/`[^`]*spends a turn[^`]*`/`` matched starting from a backtick two paragraphs above the options — the assertion passed while the option label said nothing about cost. It is line-scoped now.

Mutation testing confirms all three failure modes are caught:

| Mutation | Caught |
|---|---|
| Weaken the hard rule to "use restraint" | ✅ |
| Move the cost out of the option label | ✅ (only after the line-scoped fix) |
| Drop `AskUserQuestion` from `allowed-tools` | ✅ |

439 tests, 434 pass, 0 fail; `verify-contracts` and `check-version` green. Documentation and tests only — no runtime change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)