### PR TITLE
Say which paid results eviction deleted

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ Claude Code
 
 Background mode spawns a detached worker child process (`task-worker` for `/gemini:rescue`, `review-worker` for `/gemini:review` and `/gemini:adversarial-review`) and returns a job ID immediately. State is polled via `/gemini:status`, so a background result survives even if the Claude session is interrupted.
 
-Job state is written to Claude Code's per-plugin data directory — `$CLAUDE_PLUGIN_DATA/state/<workspace>-<hash>/`, holding `state.json` and one `.json` plus `.log` per job, most recent 50 kept. Outside Claude Code, where that variable is unset, it falls back to `<system temp>/gemini-companion/<workspace>-<hash>/`; the OS eventually cleans that, so a job left running across a temp sweep can disappear. Set `GEMINI_COMPANION_DATA` to pin the location yourself.
+Job state is written to Claude Code's per-plugin data directory — `$CLAUDE_PLUGIN_DATA/state/<workspace>-<hash>/`, holding `state.json` and one `.json` plus `.log` per job, most recent 50 kept. **A 51st job deletes the oldest finished one**, and its result is then gone — `/gemini:result` cannot retrieve it, whether or not you ever read it. The plugin prints a warning naming what it removed, so this is never silent; a queued or running job is never evicted. Outside Claude Code, where that variable is unset, it falls back to `<system temp>/gemini-companion/<workspace>-<hash>/`; the OS eventually cleans that, so a job left running across a temp sweep can disappear. Set `GEMINI_COMPANION_DATA` to pin the location yourself.
 
 The workspace-local `.omc/` directory is a separate thing: it holds `/gemini:transfer` snapshots only, not job state.
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -328,7 +328,7 @@ Claude Code
 
 背景模式會產生一個分離的 `task-worker` 子程序並立即回傳工作 ID，可透過 `/gemini:status` 查詢；即使 Claude 會話中斷，背景結果仍然存在。
 
-工作狀態寫入 Claude Code 的每外掛資料目錄——`$CLAUDE_PLUGIN_DATA/state/<workspace>-<hash>/`，內含 `state.json` 以及每個工作各一份 `.json` 與 `.log`，最多保留最近 50 筆。在 Claude Code 之外、該變數未設定時，改用 `<系統暫存目錄>/gemini-companion/<workspace>-<hash>/`；該處會被作業系統定期清理，故跨越清理週期仍在執行的工作可能消失。可設定 `GEMINI_COMPANION_DATA` 自行指定位置。
+工作狀態寫入 Claude Code 的每外掛資料目錄——`$CLAUDE_PLUGIN_DATA/state/<workspace>-<hash>/`，內含 `state.json` 以及每個工作各一份 `.json` 與 `.log`，最多保留最近 50 筆。**第 51 個工作會刪掉最舊的那個已完成工作**，其結果隨即消失——不論你先前是否讀過，`/gemini:result` 都再也取不回來。外掛會印出警告並列出被刪除的工作，所以這件事不會無聲發生；queued 或 running 的工作永遠不會被刪。在 Claude Code 之外、該變數未設定時，改用 `<系統暫存目錄>/gemini-companion/<workspace>-<hash>/`；該處會被作業系統定期清理，故跨越清理週期仍在執行的工作可能消失。可設定 `GEMINI_COMPANION_DATA` 自行指定位置。
 
 工作區內的 `.omc/` 是另一回事：它只存放 `/gemini:transfer` 快照，不存工作狀態。
 

--- a/plugins/gemini/scripts/lib/state.mjs
+++ b/plugins/gemini/scripts/lib/state.mjs
@@ -328,7 +328,26 @@ export function writeJobFile(cwd, jobId, payload) {
   const isNewJob = !fs.existsSync(jobFile);
   atomicWriteJson(jobFile, payload);
   if (isNewJob) {
-    pruneJobStore(cwd, { keepId: jobId });
+    // Say it out loud. Every job this deletes was a real spend, and the deletion
+    // used to be completely silent: the return value was discarded here, so a
+    // 51st job removed the oldest finished result and its log with nothing in the
+    // output to show it had happened. `most recent 50 kept` in the README reads as
+    // housekeeping, not as "a result you have not read can disappear".
+    //
+    // Deliberately does NOT claim the results were uncollected: nothing records
+    // whether `/gemini:result` ever read a job, so that would be a guess. State
+    // what was removed and let the reader judge.
+    //
+    // Warning lives here rather than in pruneJobStore so that function stays a
+    // pure store operation — a caller that wants a silent prune still has one.
+    const evicted = pruneJobStore(cwd, { keepId: jobId });
+    if (evicted.length > 0) {
+      const shown = evicted.slice(0, 5).map((job) => job.id);
+      const ids = shown.join(", ") + (evicted.length > shown.length ? `, +${evicted.length - shown.length} more` : "");
+      process.stderr.write(
+        `[gemini-companion] Warning: the job store is capped at ${MAX_JOBS}, so making room for ${jobId} removed ${evicted.length} finished job(s) and their logs: ${ids}. Those results can no longer be retrieved with \`/gemini:result\`.\n`
+      );
+    }
   }
   return jobFile;
 }

--- a/tests/state.test.mjs
+++ b/tests/state.test.mjs
@@ -401,3 +401,66 @@ test("an unreadable job file is still listed as failed", () => {
   assert.equal(corrupt.status, "failed");
   assert.equal(corrupt.failure.category, "invalid-json");
 });
+
+// Eviction deletes results that were already paid for, and it used to do so in
+// complete silence: writeJobFile discarded pruneJobStore's return value, so the
+// 51st job removed the oldest finished result and its log with nothing in the
+// output. "most recent 50 kept" in the README reads as housekeeping, not as "a
+// result you have not read can disappear".
+test("making room for a new job says which finished results it deleted", () => {
+  const workspace = makeTempDir();
+  for (let index = 0; index < 50; index += 1) {
+    seedJobOnDisk(workspace, `job-${index}`, {
+      updatedAt: new Date(Date.UTC(2026, 0, 1, 0, index, 0)).toISOString()
+    });
+  }
+
+  const written = [];
+  const original = process.stderr.write;
+  process.stderr.write = (chunk, ...rest) => {
+    written.push(String(chunk));
+    return original.call(process.stderr, chunk, ...rest);
+  };
+  try {
+    writeJobFile(workspace, "job-new", {
+      id: "job-new",
+      status: "queued",
+      updatedAt: new Date(Date.UTC(2026, 0, 2)).toISOString()
+    });
+  } finally {
+    process.stderr.write = original;
+  }
+
+  const warning = written.find((line) => /job store is capped/.test(line));
+  assert.ok(warning, `expected an eviction warning; got ${JSON.stringify(written)}`);
+  assert.match(warning, /removed 1 finished job\(s\)/);
+  assert.match(warning, /job-0\b/, "the warning must name what was deleted");
+  assert.match(warning, /gemini:result/, "it must say what is no longer retrievable");
+  // It must not claim the result was uncollected: nothing records whether
+  // /gemini:result ever read a job, so that would be a guess presented as fact.
+  assert.doesNotMatch(warning, /uncollected|never (read|collected)/i);
+  assert.equal(fs.existsSync(resolveJobFile(workspace, "job-0")), false);
+});
+
+test("a new job that evicts nothing stays quiet", () => {
+  const workspace = makeTempDir();
+  seedJobOnDisk(workspace, "job-only");
+
+  const written = [];
+  const original = process.stderr.write;
+  process.stderr.write = (chunk, ...rest) => {
+    written.push(String(chunk));
+    return original.call(process.stderr, chunk, ...rest);
+  };
+  try {
+    writeJobFile(workspace, "job-second", { id: "job-second", status: "queued" });
+  } finally {
+    process.stderr.write = original;
+  }
+
+  assert.equal(
+    written.filter((line) => /job store is capped/.test(line)).length,
+    0,
+    "under the cap there is nothing to report"
+  );
+});


### PR DESCRIPTION
Every job the store evicts was a real spend, and the deletion was **completely silent**: `writeJobFile` discarded `pruneJobStore`'s return value, so a 51st job removed the oldest finished result and its log with nothing in the output to show it happened. The README's "most recent 50 kept" reads as housekeeping, not as "a result you have not read can disappear".

```
[gemini-companion] Warning: the job store is capped at 50, so making room for
job-new removed 1 finished job(s) and their logs: job-0. Those results can no
longer be retrieved with `/gemini:result`.
```

### What it deliberately does not say

It does **not** claim the results were uncollected. Nothing records whether `/gemini:result` ever read a job — there is no `collectedAt` field — so "you never collected these" would be a guess presented as fact. A test asserts the warning does not use that wording, so the restraint is pinned, not just the message.

Adding such a field was considered and rejected: it needs a schema change, a write on the read path, and a migration answer for existing job records, and buys only fewer warnings for tidy users of a path that fires above 50 jobs.

### Placement

The warning is in `writeJobFile`, not `pruneJobStore`, so the store operation stays pure and a silent prune remains available to any future caller. Long lists truncate to five ids plus `+N more`. A queued or running job is still never evictable (unchanged).

Both READMEs now state the consequence rather than only the cap.

### Verification

Mutation-tested, all caught: reverting to a discarded return value, dropping the id list from the message, and warning when nothing was evicted. 441 tests, 436 pass, 0 fail; contracts, version, and every in-page README anchor green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)