### PR TITLE
Name who chose the review scope

### DIFF
--- a/plugins/gemini/scripts/gemini-companion.mjs
+++ b/plugins/gemini/scripts/gemini-companion.mjs
@@ -8,7 +8,7 @@ import { fileURLToPath } from "node:url";
 
 import { parseArgs, normalizeArgv } from "./lib/args.mjs";
 import { detectEngine, ENGINE_ENV, normalizeAgyEffort, normalizeAgyRequestedModel, normalizeRequestedModel, supportsAgyModelSelection, VALID_EFFORT_LEVELS } from "./lib/engine.mjs";
-import { collectReviewContext, ensureGitRepository, resolveReviewTarget } from "./lib/git.mjs";
+import { collectReviewContext, describeReviewTarget, ensureGitRepository, resolveReviewTarget } from "./lib/git.mjs";
 import { readStdinIfPiped } from "./lib/fs.mjs";
 import { binaryAvailable, terminateProcessTree } from "./lib/process.mjs";
 import { loadPromptTemplate, interpolateTemplate } from "./lib/prompts.mjs";
@@ -678,6 +678,10 @@ async function executeReviewRun(request) {
   // persist a vacuous approve that only surfaces at /gemini:result.
   if (context.isEmpty) {
     const targetLabel = context.target?.label ?? "the requested scope";
+    // The message keeps the plain label — it is also the job summary, read in
+    // listings — while the Target line below carries the provenance, which is what
+    // separates "the repository really is clean" from "that is not the scope I
+    // meant".
     const message = `Nothing to review — ${targetLabel} has no changes.`;
     return {
       exitStatus: 0,
@@ -691,7 +695,7 @@ async function executeReviewRun(request) {
         gemini: null,
         result: null
       },
-      rendered: `# Gemini ${reviewName}\n\nTarget: ${targetLabel}\n\n${message}\n`,
+      rendered: `# Gemini ${reviewName}\n\nTarget: ${describeReviewTarget(context.target)}\n\n${message}\n`,
       summary: message,
       jobTitle: `Gemini ${reviewName}`,
       jobClass: "review",
@@ -734,12 +738,16 @@ async function executeReviewRun(request) {
     payload,
     rendered: fallbackBanner + renderTruncationBanner(truncation) + renderReviewResult(parsed, {
       reviewLabel: reviewName,
-      targetLabel: context.target?.label ?? "",
+      targetLabel: describeReviewTarget(context.target),
       reasoningSummary: result.reasoningSummary
     }),
     summary: parsed.parsed?.summary ?? parsed.parseError ?? "Review completed.",
     jobTitle: `Gemini ${reviewName}`,
     jobClass: "review",
+    // Stays the plain label: this one is stored on the job record and shown inline
+    // in job listings, where an existing consumer may already be printing it inside
+    // a sentence. The provenance goes in the rendered Target line above, which is
+    // the place a reader looks when the scope surprised them.
     targetLabel: context.target?.label ?? "",
     ...(result.status !== 0 && result.failure ? { failure: result.failure } : {})
   };

--- a/plugins/gemini/scripts/lib/git.mjs
+++ b/plugins/gemini/scripts/lib/git.mjs
@@ -172,6 +172,21 @@ export function resolveReviewTarget(cwd, options = {}) {
   };
 }
 
+// The label alone answers "what was reviewed" but not "who chose it", and those
+// are different questions when the answer is surprising. `Nothing to review —
+// working tree diff has no changes` is a correct answer to a question the user may
+// not have asked: with neither --base nor --scope given, the scope was picked here,
+// from whether the tree happened to be dirty. Naming that is how a reader tells a
+// clean repository from a misunderstood request, without re-running anything.
+//
+// `explicit` is already computed by resolveReviewTarget and already travels in the
+// JSON payload; only the line humans read left it out.
+export function describeReviewTarget(target) {
+  const label = target?.label ?? "the requested scope";
+  if (!target || target.explicit !== false) return label;
+  return `${label} (inferred — no \`--base\` or \`--scope\` given)`;
+}
+
 function formatSection(title, body) {
   return [`## ${title}`, "", body.trim() ? body.trim() : "(none)", ""].join("\n");
 }

--- a/tests/git.test.mjs
+++ b/tests/git.test.mjs
@@ -3,7 +3,7 @@ import path from "node:path";
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { allocateBudget, assembleReviewContent, collectReviewContext, formatUntrackedFile, getWorkingTreeState, resolveReviewTarget } from "../plugins/gemini/scripts/lib/git.mjs";
+import { allocateBudget, assembleReviewContent, collectReviewContext, describeReviewTarget, formatUntrackedFile, getWorkingTreeState, resolveReviewTarget } from "../plugins/gemini/scripts/lib/git.mjs";
 import { initGitRepo, makeTempDir, run, writeExecutable } from "./helpers.mjs";
 
 function commitInitial(cwd) {
@@ -465,4 +465,37 @@ test("the truncation notice is bounded by the number of files it names", () => {
     assembled.content.length <= 400_000,
     `the payload must respect the cap, got ${assembled.content.length} characters`
   );
+});
+
+// `Nothing to review — working tree diff has no changes` is a correct answer to a
+// question the user may not have asked: with neither --base nor --scope given, the
+// scope was chosen here from whether the tree happened to be dirty. The label said
+// what was reviewed but never who chose it, so a misunderstood request and a clean
+// repository looked identical.
+test("describeReviewTarget marks a scope the plugin chose, and stays quiet when the user chose", () => {
+  const inferred = describeReviewTarget({ label: "working tree diff", explicit: false });
+  assert.match(inferred, /working tree diff/);
+  assert.match(inferred, /inferred/, "a scope the plugin picked must say so");
+  assert.match(inferred, /--base|--scope/, "it must name what the user can pass to choose");
+
+  const chosen = describeReviewTarget({ label: "branch diff against main", explicit: true });
+  assert.equal(chosen, "branch diff against main", "an explicit request needs no explanation");
+});
+
+test("describeReviewTarget survives a target it cannot read", () => {
+  assert.equal(describeReviewTarget(null), "the requested scope");
+  assert.equal(describeReviewTarget({}), "the requested scope");
+});
+
+// End to end through the real resolver: an auto scope on a dirty tree is inferred,
+// and passing --base makes the same repository explicit.
+test("an auto scope is reported as inferred, and --base is not", () => {
+  const cwd = makeTempDir();
+  initGitRepo(cwd);
+  commitInitial(cwd);
+  fs.writeFileSync(path.join(cwd, "app.js"), "console.log('v2');\n");
+
+  assert.match(describeReviewTarget(resolveReviewTarget(cwd, {})), /inferred/);
+  assert.doesNotMatch(describeReviewTarget(resolveReviewTarget(cwd, { base: "HEAD~1" })), /inferred/);
+  assert.doesNotMatch(describeReviewTarget(resolveReviewTarget(cwd, { scope: "working-tree" })), /inferred/);
 });


### PR DESCRIPTION
`Nothing to review — working tree diff has no changes` is a correct answer to a question the user may not have asked. With neither `--base` nor `--scope` given, the scope is chosen by the plugin from whether the tree happened to be dirty — so a **misunderstood request** and a **genuinely clean repository** printed the same line.

```
Target: branch diff against master (inferred — no `--base` or `--scope` given)
Target: working tree diff
```

Measured end to end on a throwaway repo (the empty-diff path never calls an engine, so this cost nothing): an auto scope is annotated, an explicit `--scope working-tree` is not.

### Nothing new is computed

`resolveReviewTarget` has always returned `explicit`, and it already travels in the JSON payload. Only the line humans read left it out — this is a rendering omission, not a missing feature. An explicit request gets no annotation, so the normal case gains no noise.

### Considered and rejected: a `--explain` flag

It puts the burden on the user to know it exists and to re-run at exactly the moment something has already gone wrong. Worse, a second resolution path can drift from the real one, and a dry run that disagrees with the actual run is worse than none.

### Deliberately still the plain label

- the `Nothing to review …` sentence — it is also the job summary, shown inline in listings
- `targetLabel` stored on the job record — an existing consumer may already print it mid-sentence (Hyrum)

### Verification

Mutation-tested, all caught: never annotating, annotating an explicit target too, and dropping the flag names from the annotation. 442 tests, 437 pass, 0 fail; contracts and version green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)