### PR TITLE
Show jobs that belong to no session, and keep tests out of real plugin data

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "node": ">=18.0.0"
   },
   "scripts": {
-    "test": "node --test tests/*.test.mjs bench/*.test.mjs",
+    "test": "node --import ./tests/isolate-state.mjs --test tests/*.test.mjs bench/*.test.mjs",
     "bump-version": "node scripts/bump-version.mjs",
     "check-version": "node scripts/bump-version.mjs --check",
     "verify-contracts": "node scripts/verify-contracts.mjs",

--- a/plugins/gemini/scripts/gemini-companion.mjs
+++ b/plugins/gemini/scripts/gemini-companion.mjs
@@ -590,10 +590,12 @@ async function waitForSingleJobSnapshot(cwd, reference, options = {}) {
 async function resolveLatestTrackedTaskThread(cwd, options = {}) {
   const workspaceRoot = resolveWorkspaceRoot(cwd);
   // Only consider jobs from the current Claude session so a resume never jumps
-  // into another session's (or another project's) thread.
-  const jobs = sortJobsNewestFirst(filterJobsForCurrentSession(listJobs(workspaceRoot))).filter(
-    (job) => job.id !== options.excludeJobId
-  );
+  // into another session's (or another project's) thread. Untagged jobs are
+  // excluded here too, unlike the listing paths: showing a job the user can see
+  // and cancel is one thing, silently continuing its conversation is another.
+  const jobs = sortJobsNewestFirst(
+    filterJobsForCurrentSession(listJobs(workspaceRoot), { includeUnattributed: false })
+  ).filter((job) => job.id !== options.excludeJobId);
   const activeTask = jobs.find((job) => job.jobClass === "task" && (job.status === "queued" || job.status === "running"));
   if (activeTask) {
     throw new Error(`Task ${activeTask.id} is still running. Use /gemini:status before continuing it.`);
@@ -1515,8 +1517,13 @@ async function handleTaskResumeCandidate(argv) {
   });
   const cwd = resolveCommandCwd(options);
   const workspaceRoot = resolveCommandWorkspace(options);
-  // Resume candidates are scoped to the current Claude session by default.
-  const jobs = sortJobsNewestFirst(filterJobsForCurrentSession(listJobs(workspaceRoot)));
+  // Resume candidates are scoped to the current Claude session by default, and
+  // must agree with resolveLatestTrackedTaskThread — this command exists to tell
+  // the agent what that one will pick, so an untagged job offered here and
+  // refused there would be worse than not offering it.
+  const jobs = sortJobsNewestFirst(
+    filterJobsForCurrentSession(listJobs(workspaceRoot), { includeUnattributed: false })
+  );
   const activeTask = jobs.find((job) => job.jobClass === "task" && (job.status === "queued" || job.status === "running"));
   if (activeTask) {
     // `available` mirrors upstream codex-companion (rescue.md keys off it). Do not

--- a/plugins/gemini/scripts/gemini-mcp.mjs
+++ b/plugins/gemini/scripts/gemini-mcp.mjs
@@ -204,6 +204,15 @@ export async function callTool(name, args = {}, { runtime = DEFAULT_RUNTIME } = 
   // the CLI or a slash command reported `No job found` from gemini_job_result
   // and gemini_job_cancel while gemini_job_status returned it fine — not
   // intermittently, always.
+  //
+  // `all: true` is the answer to that and stays. It is not a workaround for the
+  // other half of the same missing session id — jobs queued HERE being untagged,
+  // and so unreachable from the slash commands. That half is fixed where it
+  // belongs, in filterJobsForCurrentSession: an untagged job is now shown by the
+  // discovery paths, because "nobody could say whose it is" was never the same
+  // claim as "it is someone else's". Removing `all: true` would still break these
+  // three tools, because a job queued by a slash command is tagged, and this
+  // process has no id to match it against.
   const jobId = requiredString(args.jobId, "jobId");
   if (name === "gemini_job_status") return runtime.getJobStatus({ cwd: workspace, jobId });
   if (name === "gemini_job_result") return runtime.getJobResult({ cwd: workspace, jobId, all: true });

--- a/plugins/gemini/scripts/lib/job-control.mjs
+++ b/plugins/gemini/scripts/lib/job-control.mjs
@@ -25,12 +25,30 @@ export function getCurrentSessionId(options = {}) {
 // hidden. This keeps the default scope honest — `--resume-last` can never
 // silently continue another session's thread, and status/result never expose
 // unrelated job output. Explicit `--all` remains the way to cross sessions.
+//
+// An UNTAGGED job is a third case, and it used to be sorted onto the wrong side.
+// "No sessionId" does not mean "another session's": it means nobody could say.
+// The MCP server is launched from .mcp.json and never receives
+// GEMINI_COMPANION_SESSION_ID (the lifecycle hook can only export into
+// CLAUDE_ENV_FILE, which reaches later Bash commands, not a server started
+// alongside them), so every job it queues is untagged — and was therefore
+// invisible to `/gemini:status` in any session, which is every session inside
+// Claude Code. Measured: a completed untagged job appears in neither `running`,
+// `recent`, nor `latestFinished`. The user could not see the review they had
+// just started, and could not cancel it, because cancel resolves through the
+// same filter.
+//
+// So discovery admits untagged jobs, and only jobs belonging to a *different*
+// session stay hidden — the leak the filter was built for is untouched.
+// `includeUnattributed: false` is for the one caller that must stay stricter:
+// resume continues a conversation rather than merely listing one.
 export function filterJobsForCurrentSession(jobs, options = {}) {
   const sessionId = getCurrentSessionId(options);
   if (!sessionId) {
     return jobs.filter((job) => !job.sessionId);
   }
-  return jobs.filter((job) => job.sessionId === sessionId);
+  const includeUnattributed = options.includeUnattributed !== false;
+  return jobs.filter((job) => job.sessionId === sessionId || (includeUnattributed && !job.sessionId));
 }
 
 function getJobTypeLabel(job) {

--- a/tests/contract.test.mjs
+++ b/tests/contract.test.mjs
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 import assert from "node:assert/strict";
@@ -220,4 +221,35 @@ test("--check stays silent about a changelog that does not exist", () => {
   const root = makeFixture("1.2.3");
   const result = run("node", [BUMP, "--root", root, "--check"], { cwd: ROOT });
   assert.equal(result.status, 0, result.stderr);
+});
+
+// Job state lives under CLAUDE_PLUGIN_DATA, which Claude Code sets in the
+// environment its commands run in — so a suite run from inside a session
+// inherited the real one, and every temp workspace a test created left a
+// permanent state directory in the developer's own plugin data. Nothing reclaims
+// them: pruneJobStore bounds the jobs inside a workspace, and nothing bounds the
+// number of workspaces. Measured on the machine this was found on, 9626 of 9651
+// directories under that state root were named `gemini-plugin-test*`.
+//
+// Probed through a child process rather than read off this one's environment, so
+// the guard says the same thing whether or not the suite was launched via
+// `npm test`.
+test("npm test keeps job state out of the developer's plugin data", () => {
+  const pkg = readJson(path.join(ROOT, "package.json"));
+  assert.match(pkg.scripts.test, /--import \.\/tests\/isolate-state\.mjs/, "npm test must preload the state isolator");
+
+  const inherited = path.join(ROOT, "not-a-real-plugin-data-dir");
+  const probe = run(
+    process.execPath,
+    ["--import", "./tests/isolate-state.mjs", "-e", "console.log(JSON.stringify([process.env.CLAUDE_PLUGIN_DATA, process.env.GEMINI_COMPANION_DATA]))"],
+    { cwd: ROOT, env: { ...process.env, CLAUDE_PLUGIN_DATA: inherited, GEMINI_COMPANION_DATA: inherited } }
+  );
+  assert.equal(probe.status, 0, probe.stderr);
+
+  // Both names, not one: state.mjs reads GEMINI_COMPANION_DATA first, so leaving
+  // a developer's own override standing would defeat the redirect.
+  for (const value of JSON.parse(probe.stdout)) {
+    assert.notEqual(value, inherited, "the inherited plugin data dir must not survive the preload");
+    assert.equal(path.dirname(value), os.tmpdir(), "state must be redirected into a fresh temp directory");
+  }
 });

--- a/tests/isolate-state.mjs
+++ b/tests/isolate-state.mjs
@@ -1,0 +1,41 @@
+// Preloaded by `npm test` via --import, before any test file is evaluated.
+//
+// Job state lives under CLAUDE_PLUGIN_DATA, which Claude Code sets — so a suite
+// run from inside a Claude Code session inherited the real one, and every temp
+// workspace a test created got a permanent state directory in the user's own
+// plugin data. Measured on the machine this was found on: 9651 directories under
+// .../plugins/data/gemini-gemini-plugin-cc/state, 9626 of them named
+// `gemini-plugin-test*`, holding 40088 job files. They are never reclaimed —
+// pruneJobStore bounds jobs within a workspace, and nothing bounds the number of
+// workspaces.
+//
+// Both names are set here, not just one: GEMINI_COMPANION_DATA takes priority in
+// state.mjs, so leaving a developer's own override in place would defeat this.
+//
+// Individual tests still override these (state.test.mjs pins the precedence
+// rules, and several suites point at their own data dir); they save and restore
+// around their cases, which now restores to this directory rather than the real
+// one.
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const dir = fs.mkdtempSync(path.join(os.tmpdir(), "gemini-plugin-state-"));
+process.env.CLAUDE_PLUGIN_DATA = dir;
+process.env.GEMINI_COMPANION_DATA = dir;
+
+// The test runner passes its own execArgv down, so this module is evaluated once
+// per test-file process, and each gets its own directory to clean up. That is why
+// the cleanup can be unconditional: nothing here is shared between files.
+//
+// Best effort. A detached worker a test spawned may still hold a handle, which
+// on Windows makes the directory undeletable; the OS reclaims temp either way,
+// and failing here would fail an otherwise passing run.
+process.on("exit", () => {
+  try {
+    fs.rmSync(dir, { recursive: true, force: true });
+  } catch {
+    // left for the OS
+  }
+});

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -1838,6 +1838,53 @@ test("status hides other-session jobs when the session id is unset (but --all st
   assert.deepEqual(allIds, ["task-a", "task-b"]);
 });
 
+// An untagged job is a third case, distinct from "mine" and "another session's".
+// The MCP server is launched from .mcp.json and never receives
+// GEMINI_COMPANION_SESSION_ID, so every job it queues carries no sessionId — and
+// being treated as another session's made those jobs invisible in every session,
+// which is every session inside Claude Code. The user could not see or cancel a
+// review they had just started through gemini_review.
+
+function untaggedJob(id, updatedAt) {
+  const { sessionId, ...rest } = sessionJob(id, "unused", updatedAt);
+  return rest;
+}
+
+test("status shows a job that belongs to no session", () => {
+  const workspace = makeTempDir();
+  seedState(workspace, [untaggedJob("task-mcp", "2026-03-18T15:30:00.000Z")]);
+  const env = { ...process.env, GEMINI_COMPANION_SESSION_ID: "sess-current" };
+
+  const payload = JSON.parse(run("node", [SCRIPT, "status", "--json"], { cwd: workspace, env }).stdout);
+  const ids = [payload.latestFinished?.id, ...payload.recent.map((job) => job.id)].filter(Boolean);
+  assert.ok(ids.includes("task-mcp"), `an untagged job stayed hidden: ${JSON.stringify(ids)}`);
+});
+
+test("showing untagged jobs does not also show another session's", () => {
+  // The leak the filter was built for, pinned against the fix for the one above.
+  const workspace = makeTempDir();
+  seedState(workspace, [
+    untaggedJob("task-mcp", "2026-03-18T15:30:00.000Z"),
+    sessionJob("task-other", "sess-other", "2026-03-18T15:35:00.000Z")
+  ]);
+  const env = { ...process.env, GEMINI_COMPANION_SESSION_ID: "sess-current" };
+
+  const payload = JSON.parse(run("node", [SCRIPT, "status", "--json"], { cwd: workspace, env }).stdout);
+  const ids = [payload.latestFinished?.id, ...payload.recent.map((job) => job.id)].filter(Boolean);
+  assert.deepEqual(ids.sort(), ["task-mcp"]);
+});
+
+test("an untagged thread is visible but not silently resumable", () => {
+  // Listing a job the user can then see and cancel is not the same as
+  // continuing its conversation without being asked. Resume stays strict.
+  const workspace = makeTempDir();
+  seedState(workspace, [untaggedJob("task-mcp", "2026-03-18T15:30:00.000Z")]);
+  const env = { ...process.env, GEMINI_COMPANION_SESSION_ID: "sess-current" };
+
+  const payload = JSON.parse(run("node", [SCRIPT, "task-resume-candidate", "--json"], { cwd: workspace, env }).stdout);
+  assert.equal(payload.available, false);
+});
+
 // result/cancel must honor the same default session scope as status, so an
 // explicit id can never reach — or act on — another Claude session's job
 // without an explicit --all.
@@ -1849,6 +1896,10 @@ test("result is scoped to the current session and needs --all to read another se
     status: "completed",
     title: "Gemini Task",
     threadId: "thr_task-other",
+    // The per-job file is the store, so the tag has to be here and not only in
+    // the seeded index — without it this job is untagged rather than another
+    // session's, which is a different case and no longer hidden.
+    sessionId: "sess-other",
     result: { rawOutput: "Other session output." }
   });
   const env = { ...process.env, GEMINI_COMPANION_SESSION_ID: "sess-current" };


### PR DESCRIPTION
Two findings from the dogfooding pass, both traceable to the same missing piece: an MCP server launched from `.mcp.json` never receives `GEMINI_COMPANION_SESSION_ID`.

## 1. Untagged jobs were treated as another session's

`filterJobsForCurrentSession` had one bucket for "not mine". Three categories exist: mine, another session's, and **untagged** — a job nobody could attribute. Jobs queued through the MCP tools land in the third, because that server has no session id to stamp them with (the `SessionStart` hook can only export into `CLAUDE_ENV_FILE`, which reaches later Bash commands, not a server started alongside them).

Treating untagged as "someone else's" made every MCP-queued job invisible to `/gemini:status` and uncancellable from the slash commands. Untagged is now shown by the discovery paths; the resume paths (`--resume-last`, cancel's "the one active job" shortcut) pass `includeUnattributed: false` and stay strict, because guessing wrong there resumes the wrong conversation.

`all: true` on `gemini_job_result` / `gemini_job_cancel` stays. Those tools are addressed by an explicit job id, so the session filter cannot do discovery work for them; without it, a job queued by a slash command reported `No job found` — always, not intermittently. The rationale is written into `gemini-mcp.mjs` next to the flag.

Verified with a probe that seeds one untagged and one session-tagged job: before, `status --json` returned the untagged job nowhere; after, both appear.

## 2. The suite wrote thousands of directories into the developer's plugin data

Job state lives under `CLAUDE_PLUGIN_DATA`, which Claude Code sets in the environment its commands run in — so a suite run from inside a session inherited the real one, and every temp workspace a test created left a permanent state directory behind. Nothing reclaims them: `pruneJobStore` bounds the jobs inside a workspace, and nothing bounds the number of workspaces. Measured here: 9626 of 9651 directories under that state root were named `gemini-plugin-test*`, holding 40088 job files.

`npm test` now preloads `tests/isolate-state.mjs`, which redirects both `CLAUDE_PLUGIN_DATA` and `GEMINI_COMPANION_DATA` (the second because `state.mjs` reads it first) into a fresh temp directory it removes on exit.

Measured in the shell that actually carries `CLAUDE_PLUGIN_DATA`: two suites added 4 directories to the real state root without the preload, 0 with it. A full run added 0 and left no temp directory behind.

## Tests

487 tests, 479 pass, 0 fail, 8 skipped. Both new behaviours mutation-checked: dropping `--import` from the test script and redirecting only one of the two env names each make the new contract test fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JmaL2A1WpfbN5DiY7PzRHA