### PR TITLE
Measure AGY --mode plan, and record why it is not a boundary

### DIFF
--- a/docs/THREAT-MODEL.md
+++ b/docs/THREAT-MODEL.md
@@ -98,6 +98,23 @@ The plugin's function is to take content it did not author and hand it to an age
 
 **Residual, unchanged.** Nothing constrains where any AGY run may reach — runs 1 and 3 wrote outside the workspace, the correction above shows an unoriented run doing the same, and no flag on either engine prevents it. `--write` remains meaningful as the opt-in that says "edits are expected", and it is what the subagent and MCP defaults key off. It is not a sandbox. The real fix remains an engine-side path boundary.
 
+**Measured on AGY 1.1.13, 2026-08-17.** Six headless runs against a disposable git repository, prompt on stdin, `--output-format json`, matching how the plugin invokes the engine. AGY 1.1.12 fixed `--mode` being ignored in headless `-p` runs, which is what made `--mode plan` worth testing against conclusion 4 above. It does not survive the test.
+
+| `--mode plan` | `--disable-slash-commands` | Orientation | Action | Outcome |
+|---|---|---|---|---|
+| — | yes | `--add-dir` | edit tool → in workspace | wrote |
+| yes | yes | `--add-dir` | edit tool → in workspace | wrote |
+| yes | — | `--add-dir` | edit tool → in workspace | refused, asked for plan approval |
+| yes | — | `--add-dir` | edit tool → in workspace (repeat) | refused, reproduced |
+| yes | — | `--add-dir` | **shell command → in workspace** | **wrote, exit 0** |
+| yes | — | `--new-project` | edit tool → in workspace | refused, asked for plan approval |
+
+1. **Plan mode gates the edit tools; it does not gate the terminal.** Run 5 asked for `cmd /c echo … > probe-4.txt` and got it, with plan mode active, exit 0, and the file on disk. Runs 3, 4 and 6 refused the same write through the edit tool. That makes `--mode plan` a tool policy, not a write boundary — the same shape as `--sandbox` in the table above, and for the same reason it cannot be relied on: a prompt injection that asks for a shell command is not covered by it.
+2. **`--mode plan` is mutually exclusive with `--disable-slash-commands`.** Run 2 wrote the file and AGY said why on stderr: `warning: --mode plan has no effect while slash command expansion is disabled`. The plugin passes `--disable-slash-commands` on every AGY spawn from 1.1.9 up, because the prompt is raw user text at position 0 and a task beginning with `/` would otherwise be executed as an AGY command. Adopting plan mode means giving that up — to gain a policy run 5 already walked through. That warning is readable at all only because AGY 1.1.12 stopped swallowing startup diagnostics into the log file; below it, this combination failed silently.
+3. **Orientation does not change plan mode.** `--add-dir` and `--new-project` produced identical edit-tool refusals (runs 3 and 6), consistent with the orientation table above: these flags say where "here" is, and nothing else.
+
+Conclusion 4 above therefore stands unchanged on 1.1.13: **AGY still has no read-only mode.** `--mode plan` is tested and not adopted. The after-the-fact workspace comparison the review and task paths run (`lib/readonly-guard.mjs`, v0.18.0) remains the honest answer — it reports what a turn wrote, because nothing available prevents it from writing.
+
 **Measured on gemini CLI 0.53.1, 2026-08-05**, against the same disposable repository and the same stdin transport, on a temporary API key. The gemini engine behaves the *opposite* way to AGY, so nothing above transfers between them.
 
 | `--yolo` | other flags | Action | Outcome |

--- a/plugins/gemini/scripts/lib/engine.mjs
+++ b/plugins/gemini/scripts/lib/engine.mjs
@@ -296,6 +296,14 @@ export function buildCliArgs(engine, options = {}) {
     // command may reach (network, .git), not where anything may write. A run
     // with --sandbox wrote outside the workspace through both the edit tool and
     // a shell command. See docs/THREAT-MODEL.md 7.2.
+    //
+    // --mode plan is not used either, and could not be while --disable-slash-commands
+    // is: AGY turns plan mode off whenever slash-command expansion is off, and says
+    // so on stderr — "warning: --mode plan has no effect while slash command
+    // expansion is disabled" (measured on 1.1.13, 2026-08-17; readable only from
+    // 1.1.12, which stopped swallowing startup diagnostics into the log file).
+    // Dropping the opt-out to gain it would buy no boundary anyway: plan mode
+    // refuses the edit tool and lets a shell command write the same file, exit 0.
     // Both branches below do the same job: tell AGY where "here" is. Without
     // either, a turn reports its cwd as ~/.gemini/antigravity-cli/scratch and
     // every relative path — read or write — lands there instead of in the


### PR DESCRIPTION
AGY 1.1.12 fixed `--mode` being ignored in headless `-p` runs. That made `--mode plan` worth testing against conclusion 4 of `docs/THREAT-MODEL.md` §7.2 — **"AGY has no read-only mode"** — which is the premise the `readOnlyNotice` added in #73 exists because of.

Six runs on AGY 1.1.13, disposable git repository, prompt on stdin, `--output-format json`, matching how the plugin invokes the engine.

| `--mode plan` | `--disable-slash-commands` | Orientation | Action | Outcome |
|---|---|---|---|---|
| — | yes | `--add-dir` | edit tool | wrote |
| yes | yes | `--add-dir` | edit tool | wrote |
| yes | — | `--add-dir` | edit tool | refused, asked for plan approval |
| yes | — | `--add-dir` | edit tool (repeat) | refused, reproduced |
| yes | — | `--add-dir` | **shell command** | **wrote, exit 0** |
| yes | — | `--new-project` | edit tool | refused, asked for plan approval |

**It gates the edit tools, not the terminal.** Run 5 asked for `cmd /c echo … > probe-4.txt` and got it — plan mode active, exit 0, file on disk with the expected contents. That is a tool policy, not a write boundary: the same shape as `--sandbox` one table up, and unusable for the same reason, since an injected instruction that asks for a shell command is not covered by it.

**It is also mutually exclusive with `--disable-slash-commands`**, which the plugin passes on every AGY spawn from 1.1.9 up so a prompt beginning with `/` is not executed as an AGY command. Run 2 wrote the file and AGY said why on stderr:

```
warning: --mode plan has no effect while slash command expansion is disabled
```

Adopting plan mode would mean giving up that opt-out to gain a policy run 5 already walked through. The warning is readable at all only because 1.1.12 stopped swallowing startup diagnostics into the log file — below that version this combination failed silently.

**Orientation does not change it.** `--add-dir` and `--new-project` produced identical refusals, consistent with the orientation table above.

Conclusion 4 stands unchanged on 1.1.13. `lib/readonly-guard.mjs` remains the honest answer: it reports what a turn wrote, because nothing available prevents it from writing.

## Scope

Documentation and comments only — the new paragraph in `engine.mjs` sits beside the existing `--dangerously-skip-permissions` and `--sandbox` notes and changes no argv. 487 tests, 479 pass, 0 fail, 8 skipped.

No version bump: no behaviour change, and `check-version` is satisfied by the existing 0.18.0 entry. The released 0.18.0 changelog line calling this "worth measuring" is deliberately left as written — this repository keeps dated probe records and supersedes them elsewhere rather than overwriting them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JmaL2A1WpfbN5DiY7PzRHA