### PR TITLE
A timed-out AGY run is no longer a blank report

### DIFF
--- a/plugins/gemini/scripts/lib/agy-stream.mjs
+++ b/plugins/gemini/scripts/lib/agy-stream.mjs
@@ -1,0 +1,172 @@
+// Reader for AGY's `--output-format stream-json` event stream.
+//
+// WHY THIS EXISTS
+// ---------------
+// Under `--output-format json` a run that is cut off has nothing to show for
+// itself: the envelope only arrives at the end, and when AGY's own print timeout
+// fires it emits `{"status":"ERROR","response":""}`. The on-disk transcript does
+// not cover that case either — measured on a run that spent 193,772 tokens
+// before timing out, the transcript's response was likewise empty, because the
+// turn never reached the point of writing an answer.
+//
+// stream-json emits progress as it happens, so a cut-off run can at least say
+// how far it got, and a run cut off *while answering* keeps the part it wrote.
+//
+// No async rewrite is needed to collect it. spawnSync keeps what the child had
+// written when its timeout kills it — measured against a child emitting a line
+// every 20ms, 20/46/94 lines survived timeouts of 800/1500/3000ms, with
+// `signal: SIGTERM`. (Two earlier measurements suggesting otherwise were wrong:
+// the child had failed on a `node -e` quoting error and written nothing, which
+// shows up as `status: 1, signal: null` rather than a signal.) So the existing
+// synchronous runCommand is enough, and the streaming path that was written for
+// this was removed rather than kept as a second spawn implementation.
+//
+// THE SHAPE, AS MEASURED (AGY 1.1.12)
+// -----------------------------------
+// One JSON object per line, keyed by `event` — not `type`:
+//
+//   {"event":"init","conversation_id":"…","init":{cwd,tools,permission_mode}}
+//   {"event":"step_update","step_update":{conversation_id,step_index,state,step_type,…}}
+//   {"event":"result","result":{conversation_id,status,response,duration_seconds,num_turns,usage}}
+//
+// `step_type` has been seen as user_input, unknown, agent_response and
+// checkpoint; `state` as ACTIVE and DONE. `text_delta` appears only on
+// agent_response steps and is incremental — concatenating every delta reproduces
+// `result.response` exactly. A read-only slash command such as /quota emits
+// `command_result` instead of any step, and no turn is billed.
+//
+// Nothing here requires that list to be complete. An unrecognised event, an
+// unparseable line, or a missing field is counted and skipped: this reader's job
+// is to salvage what it can, so it must never be the thing that fails.
+
+const AGENT_RESPONSE_STEP = "agent_response";
+
+export function createAgyStreamReader() {
+  const state = {
+    conversationId: null,
+    text: "",
+    envelope: null,
+    steps: [],
+    lastStep: null,
+    events: 0,
+    eventfulLines: 0,
+    unparsedLines: 0,
+    unknownEvents: new Map()
+  };
+
+  function noteConversationId(candidate) {
+    if (typeof candidate === "string" && candidate && !state.conversationId) {
+      state.conversationId = candidate;
+    }
+  }
+
+  function accept(line) {
+    const text = String(line ?? "").trim();
+    if (!text) return;
+
+    let event;
+    try {
+      event = JSON.parse(text);
+    } catch {
+      state.unparsedLines += 1;
+      return;
+    }
+    if (!event || typeof event !== "object") {
+      state.unparsedLines += 1;
+      return;
+    }
+
+    state.events += 1;
+    const name = typeof event.event === "string" ? event.event : null;
+    // A plain `--output-format json` envelope is one valid JSON line too, and
+    // it must not be mistaken for a one-event stream. Only a line carrying an
+    // `event` key counts towards "this is a stream".
+    if (name) state.eventfulLines += 1;
+    noteConversationId(event.conversation_id);
+
+    if (name === "init") {
+      return;
+    }
+
+    if (name === "step_update") {
+      const step = event.step_update;
+      if (!step || typeof step !== "object") return;
+      noteConversationId(step.conversation_id);
+
+      const record = {
+        index: typeof step.step_index === "number" ? step.step_index : null,
+        type: typeof step.step_type === "string" ? step.step_type : "unknown",
+        state: typeof step.state === "string" ? step.state : null
+      };
+      state.steps.push(record);
+      state.lastStep = record;
+
+      // Only an agent_response delta is answer text. A delta on any other step
+      // type would be something else entirely, and appending it would corrupt
+      // the very output this exists to preserve.
+      if (record.type === AGENT_RESPONSE_STEP && typeof step.text_delta === "string") {
+        state.text += step.text_delta;
+      }
+      return;
+    }
+
+    if (name === "result") {
+      const result = event.result;
+      if (result && typeof result === "object") {
+        state.envelope = result;
+        noteConversationId(result.conversation_id);
+      }
+      return;
+    }
+
+    if (name === "command_result") {
+      // A read-only slash command answered without starting a turn.
+      return;
+    }
+
+    if (name) state.unknownEvents.set(name, (state.unknownEvents.get(name) ?? 0) + 1);
+  }
+
+  return {
+    accept,
+    get state() {
+      return state;
+    },
+    /**
+     * Whether this output is a stream at all. A `--output-format json` envelope
+     * parses as one JSON line, so the caller needs to tell the two apart before
+     * trusting anything else here.
+     */
+    looksLikeStream() {
+      return state.eventfulLines > 0;
+    },
+    /** What was written before the stream ended, if anything. */
+    partialText() {
+      return state.text;
+    },
+    /** The terminal envelope, when one arrived. */
+    envelope() {
+      return state.envelope;
+    },
+    /**
+     * A one-line description of how far the run got, for a report that would
+     * otherwise say only that it timed out.
+     */
+    progressLabel() {
+      if (!state.lastStep) return state.events > 0 ? "started, no step reported" : "no output received";
+      const { index, type, state: stepState } = state.lastStep;
+      const position = index === null ? "" : `step ${index} `;
+      return `${position}${type}${stepState ? ` (${stepState})` : ""}`;
+    }
+  };
+}
+
+/**
+ * Read a whole stream-json payload at once — for stdout captured without a live
+ * line handler, and for tests.
+ */
+export function readAgyStream(rawStdout) {
+  const reader = createAgyStreamReader();
+  for (const line of String(rawStdout ?? "").split(/\r?\n/)) reader.accept(line);
+  return reader;
+}

--- a/plugins/gemini/scripts/lib/engine.mjs
+++ b/plugins/gemini/scripts/lib/engine.mjs
@@ -124,6 +124,23 @@ export function supportsAgyStructuredOutput(version) {
   return agyVersionAtLeast(version, 1, 8);
 }
 
+// `--output-format stream-json` emits one JSON object per line as the turn
+// happens, instead of a single envelope at the end. That is the difference
+// between a timed-out run reporting nothing and one reporting how far it got —
+// and, when the timeout lands while the answer is being written, keeping that
+// part of it.
+//
+// Gated at 1.1.12 because that is the version it was measured on: `--help`
+// lists stream-json among --output-format's values there, and a real turn was
+// captured to confirm the event shape. `--output-format` itself arrived in
+// 1.1.8, but which of its values existed when is not something this repository
+// can check, and the existing convention here is to fail closed rather than
+// assume an upstream capability. A version below this keeps plain json, which
+// still works.
+export function supportsAgyStreamJson(version) {
+  return agyVersionAtLeast(version, 1, 12);
+}
+
 // AGY 1.1.11 answers the read-only slash commands (`/usage`, `/quota`,
 // `/credits`, `/model`, `/effort`, `/skills`) in print mode without starting an
 // agent turn, spending quota, or leaving a conversation behind. That is what
@@ -284,7 +301,10 @@ export function buildCliArgs(engine, options = {}) {
     if (agyModel) args.push("--model", agyModel);
     if (agyEffort) args.push("--effort", agyEffort);
     if (outputJson && supportsAgyStructuredOutput(agyVersion)) {
-      args.push("--output-format", "json");
+      // stream-json is a superset of what json returns: the same terminal
+      // envelope arrives as the final event, preceded by the progress that
+      // makes a cut-off run legible. See supportsAgyStreamJson for the gate.
+      args.push("--output-format", supportsAgyStreamJson(agyVersion) ? "stream-json" : "json");
     }
     // No --dangerously-skip-permissions. AGY's headless print mode auto-approves
     // file edits and shell commands with or without it — measured on 1.1.10,

--- a/plugins/gemini/scripts/lib/gemini.mjs
+++ b/plugins/gemini/scripts/lib/gemini.mjs
@@ -7,6 +7,7 @@ import { buildCliArgs, detectEngine, ENGINE_ENV, formatAgyTimeout, mapEffortToMo
 import { classifyCliFailure } from "./failures.mjs";
 import { binaryAvailable, runCommand } from "./process.mjs";
 import { resolveAgyBrainRoot, listConvDirs, recoverAgyResponse } from "./agy-transcript.mjs";
+import { readAgyStream } from "./agy-stream.mjs";
 
 const DEFAULT_SPAWN_TIMEOUT_MS = 600_000; // 10 minutes (gemini)
 // AGY's `agy --print` does not stream its response over a pipe in non-interactive
@@ -174,7 +175,13 @@ export function tryParseJsonFromText(text) {
 // and only an empty one — now falls back to the recovery the pre-1.1.8 path
 // already performs. See resolveAgyStructuredResult.
 function readAgyEnvelope(rawStdout) {
-  const parsed = tryParseJsonFromText(rawStdout);
+  return readAgyEnvelopeObject(tryParseJsonFromText(rawStdout));
+}
+
+// The same validation, applied to an already-parsed object. stream-json delivers
+// the envelope as the payload of its final event rather than as the whole of
+// stdout, and it has to clear exactly the same bar before being trusted.
+function readAgyEnvelopeObject(parsed) {
   if (!parsed || typeof parsed !== "object") return null;
   // A terminal status plus a payload slot is what identifies the envelope.
   // Do not require a specific status value: only SUCCESS and ERROR have been
@@ -192,8 +199,26 @@ function readAgyEnvelope(rawStdout) {
 
 // Shared by the task and review paths: turns the envelope into the neutral pieces
 // both need. The caller decides what to do with `text`.
+// A timed-out run used to report only that it timed out. Under stream-json the
+// events say how far it got, and whether any of the answer survived — both of
+// which change what the user does next, so they belong in the summary they
+// actually read rather than in a field nothing renders.
+function annotateFailureWithProgress(failure, structured) {
+  if (!failure || typeof failure.summary !== "string") return failure;
+  const notes = [];
+  if (structured.progressLabel) notes.push(`reached ${structured.progressLabel}`);
+  if (structured.salvagedText) notes.push("partial output preserved");
+  if (notes.length === 0) return failure;
+  return { ...failure, summary: `${failure.summary} (${notes.join("; ")})` };
+}
+
 function resolveAgyStructuredResult({ rawStdout, rawStderr, exitCode, result, engineInfo, brainRoot = null, conversationsBefore = null }) {
-  const envelope = readAgyEnvelope(rawStdout);
+  // stream-json (1.1.12+) and plain json (1.1.8+) are both possible here, and
+  // which one arrived is decided by what was actually printed rather than by the
+  // version, so an engine that ignores the flag still parses.
+  const stream = readAgyStream(rawStdout);
+  const streamed = stream.looksLikeStream();
+  const envelope = streamed ? readAgyEnvelopeObject(stream.envelope()) : readAgyEnvelope(rawStdout);
   const failedExit = exitCode === 0 ? 1 : exitCode;
 
   if (!envelope) {
@@ -250,12 +275,30 @@ function resolveAgyStructuredResult({ rawStdout, rawStderr, exitCode, result, en
     };
   }
 
-  const text = typeof envelope.response === "string" ? envelope.response.trim() : "";
-  const succeeded = envelope.status === "SUCCESS" && Boolean(text);
+  const envelopeText = typeof envelope.response === "string" ? envelope.response.trim() : "";
+
+  // An envelope with no response is what AGY's own print timeout produces:
+  // {"status":"ERROR","response":"","error":"timeout waiting for response"}.
+  // Under stream-json the deltas already received are the only surviving copy of
+  // whatever had been written, so they are used rather than reporting nothing.
+  // They never override a real response — only fill a gap the envelope left.
+  const salvaged = envelopeText ? "" : stream.partialText().trim();
+  const text = envelopeText || salvaged;
+
+  // Success still requires the envelope's own response. Salvaged text is partial
+  // by definition; calling it success would let a cut-off run pass for a
+  // complete one.
+  const succeeded = envelope.status === "SUCCESS" && Boolean(envelopeText);
 
   return {
     text,
-    threadId: typeof envelope.conversation_id === "string" && envelope.conversation_id ? envelope.conversation_id : null,
+    // What the caller needs to say "this is partial, and here is how far it
+    // got" instead of "it timed out". Null when nothing was salvaged.
+    salvagedText: salvaged || null,
+    progressLabel: streamed && !succeeded ? stream.progressLabel() : null,
+    threadId:
+      (typeof envelope.conversation_id === "string" && envelope.conversation_id ? envelope.conversation_id : null) ??
+      stream.state.conversationId,
     exitCode: succeeded ? 0 : failedExit,
     failure: succeeded
       ? null
@@ -394,7 +437,7 @@ export async function runGeminiTurn(cwd, options = {}, { runCommandFn = runComma
   if (agyStructured) {
     const structured = resolveAgyStructuredResult({ rawStdout, rawStderr, exitCode, result, engineInfo, brainRoot: agyBrainRoot, conversationsBefore: agyBefore });
     exitCode = structured.exitCode;
-    recoveryFailure = structured.failure;
+    recoveryFailure = annotateFailureWithProgress(structured.failure, structured);
     threadId = structured.threadId;
     if (structured.text) finalMessage = structured.text;
   } else if (engineInfo.engine === "agy") {
@@ -582,7 +625,7 @@ export async function runGeminiReview(cwd, options = {}, { runCommandFn = runCom
   if (agyStructured) {
     const structured = resolveAgyStructuredResult({ rawStdout, rawStderr, exitCode, result, engineInfo, brainRoot: agyBrainRoot, conversationsBefore: agyBefore });
     exitCode = structured.exitCode;
-    recoveryFailure = structured.failure;
+    recoveryFailure = annotateFailureWithProgress(structured.failure, structured);
     if (structured.text) {
       reviewText = structured.text;
       reviewJson = tryParseJsonFromText(reviewText);

--- a/tests/agy-stream.test.mjs
+++ b/tests/agy-stream.test.mjs
@@ -1,0 +1,270 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createAgyStreamReader, readAgyStream } from "../plugins/gemini/scripts/lib/agy-stream.mjs";
+
+// Captured verbatim from AGY 1.1.12 answering "Count from 1 to 40, one number
+// per line, nothing else." Kept as-is rather than hand-written, so a change in
+// the upstream shape shows up here as a failure rather than as a reader that
+// silently returns nothing.
+const CONV = "44d667f8-dcda-4c7b-86ef-87a19f484dcd";
+const MEASURED_STREAM = [
+  `{"event":"init","conversation_id":"${CONV}","init":{"cwd":"C:\\\\tmp","tools":["ask_permission"],"permission_mode":"default"}}`,
+  `{"event":"step_update","step_update":{"conversation_id":"${CONV}","step_index":0,"state":"DONE","step_type":"user_input"}}`,
+  `{"event":"step_update","step_update":{"conversation_id":"${CONV}","step_index":1,"state":"DONE","step_type":"unknown","duration_seconds":0.0019596}}`,
+  `{"event":"step_update","step_update":{"conversation_id":"${CONV}","step_index":2,"state":"ACTIVE","step_type":"agent_response","text_delta":"1\\n2\\n3"}}`,
+  `{"event":"step_update","step_update":{"conversation_id":"${CONV}","step_index":2,"state":"DONE","step_type":"agent_response","text_delta":"\\n","usage":{"output_tokens":246}}}`,
+  `{"event":"step_update","step_update":{"conversation_id":"${CONV}","step_index":3,"state":"DONE","step_type":"checkpoint","duration_seconds":0.6089184}}`,
+  `{"event":"result","result":{"conversation_id":"${CONV}","status":"SUCCESS","response":"1\\n2\\n3\\n","duration_seconds":4.15,"num_turns":1,"usage":{"total_tokens":14301}}}`
+].join("\n");
+
+test("concatenated agent_response deltas reproduce the final response", () => {
+  const reader = readAgyStream(MEASURED_STREAM);
+  assert.equal(reader.partialText(), reader.envelope().response);
+});
+
+test("the terminal envelope is exposed as the engine returned it", () => {
+  const envelope = readAgyStream(MEASURED_STREAM).envelope();
+  assert.equal(envelope.status, "SUCCESS");
+  assert.equal(envelope.usage.total_tokens, 14301);
+});
+
+test("the conversation id is picked up even before the result arrives", () => {
+  const reader = createAgyStreamReader();
+  reader.accept(MEASURED_STREAM.split("\n")[0]);
+  assert.equal(reader.state.conversationId, CONV);
+});
+
+test("a delta on a step that is not agent_response is never treated as answer text", () => {
+  // The failure this guards against is silent corruption of the one output the
+  // reader exists to preserve.
+  const reader = readAgyStream(
+    [
+      `{"event":"step_update","step_update":{"step_index":0,"state":"DONE","step_type":"tool_call","text_delta":"rm -rf /"}}`,
+      `{"event":"step_update","step_update":{"step_index":1,"state":"DONE","step_type":"agent_response","text_delta":"real answer"}}`
+    ].join("\n")
+  );
+  assert.equal(reader.partialText(), "real answer");
+});
+
+test("a stream cut off mid-answer keeps what was written", () => {
+  // Everything up to and including the first agent_response delta, then nothing:
+  // the shape of a run killed by a timeout.
+  const truncated = MEASURED_STREAM.split("\n").slice(0, 4).join("\n");
+  const reader = readAgyStream(truncated);
+  assert.equal(reader.partialText(), "1\n2\n3");
+  assert.equal(reader.envelope(), null, "no terminal envelope arrived");
+  assert.match(reader.progressLabel(), /agent_response/);
+});
+
+test("an unparseable line is counted, not thrown on", () => {
+  const reader = readAgyStream(`not json at all\n${MEASURED_STREAM}`);
+  assert.equal(reader.state.unparsedLines, 1);
+  assert.equal(reader.partialText(), "1\n2\n3\n", "the rest of the stream still parses");
+});
+
+test("an unrecognised event type does not stop the run", () => {
+  const reader = readAgyStream(
+    [
+      `{"event":"something_upstream_added_later","payload":{"whatever":1}}`,
+      `{"event":"step_update","step_update":{"step_index":0,"state":"DONE","step_type":"agent_response","text_delta":"ok"}}`
+    ].join("\n")
+  );
+  assert.equal(reader.partialText(), "ok");
+  assert.equal(reader.state.unknownEvents.get("something_upstream_added_later"), 1);
+});
+
+test("a read-only slash command emits no steps and no text", () => {
+  const reader = readAgyStream(
+    [
+      `{"event":"command_result","command":{"name":"usage","data":{}}}`,
+      `{"event":"result","result":{"conversation_id":"","status":"SUCCESS","response":"98%"}}`
+    ].join("\n")
+  );
+  assert.equal(reader.partialText(), "");
+  assert.equal(reader.envelope().status, "SUCCESS");
+});
+
+test("progress is reportable before anything has been answered", () => {
+  const reader = readAgyStream(MEASURED_STREAM.split("\n").slice(0, 2).join("\n"));
+  assert.match(reader.progressLabel(), /step 0 user_input/);
+});
+
+test("an empty stream reports that nothing arrived rather than failing", () => {
+  const reader = readAgyStream("");
+  assert.equal(reader.partialText(), "");
+  assert.equal(reader.envelope(), null);
+  assert.equal(reader.progressLabel(), "no output received");
+});
+
+test("CRLF line endings parse identically", () => {
+  const reader = readAgyStream(MEASURED_STREAM.replace(/\n(?={")/g, "\r\n"));
+  assert.equal(reader.partialText(), "1\n2\n3\n");
+});
+
+// --- through the real turn path ---------------------------------------------
+
+import { runGeminiTurn } from "../plugins/gemini/scripts/lib/gemini.mjs";
+import { supportsAgyStreamJson } from "../plugins/gemini/scripts/lib/engine.mjs";
+
+function agyEngine(version) {
+  return () => ({ engine: "agy", binary: "/fake/agy.exe", version });
+}
+
+function stubRun({ stdout = "", stderr = "", status = 0 } = {}) {
+  const calls = [];
+  const fn = (binary, args, opts) => {
+    calls.push({ binary, args, opts });
+    return { stdout, stderr, status };
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+function outputFormatOf(call) {
+  const at = call.args.indexOf("--output-format");
+  return at === -1 ? null : call.args[at + 1];
+}
+
+test("the stream-json gate opens at the version it was measured on", () => {
+  assert.equal(supportsAgyStreamJson("1.1.12"), true);
+  assert.equal(supportsAgyStreamJson("1.1.11"), false);
+  assert.equal(supportsAgyStreamJson("1.2.0"), true);
+});
+
+test("AGY 1.1.12 is asked for stream-json", async () => {
+  const runCommandFn = stubRun({ stdout: MEASURED_STREAM });
+  await runGeminiTurn("/repo", { prompt: "hi", write: false }, {
+    runCommandFn,
+    detectEngineFn: agyEngine("1.1.12")
+  });
+  assert.equal(outputFormatOf(runCommandFn.calls[0]), "stream-json");
+});
+
+test("AGY 1.1.11 keeps plain json, which still works", async () => {
+  const envelope = { conversation_id: "c", status: "SUCCESS", response: "done", num_turns: 1 };
+  const runCommandFn = stubRun({ stdout: `${JSON.stringify(envelope)}\n` });
+  const result = await runGeminiTurn("/repo", { prompt: "hi", write: false }, {
+    runCommandFn,
+    detectEngineFn: agyEngine("1.1.11")
+  });
+  assert.equal(outputFormatOf(runCommandFn.calls[0]), "json");
+  assert.equal(result.finalMessage, "done");
+  assert.equal(result.failure ?? null, null);
+});
+
+test("a successful stream-json turn reads the response from its final event", async () => {
+  const result = await runGeminiTurn("/repo", { prompt: "hi", write: false }, {
+    runCommandFn: stubRun({ stdout: MEASURED_STREAM }),
+    detectEngineFn: agyEngine("1.1.12")
+  });
+  assert.equal(result.status, 0);
+  assert.equal(result.finalMessage, "1\n2\n3");
+  assert.equal(result.threadId, CONV);
+  assert.equal(result.failure ?? null, null);
+});
+
+test("a print-timeout that empties the envelope still returns what was written", async () => {
+  // The exact failure this whole change exists for: AGY's own timeout emits a
+  // well-formed envelope whose response is empty, so every earlier path reported
+  // nothing at all despite the deltas having already arrived.
+  const timedOut = [
+    `{"event":"step_update","step_update":{"conversation_id":"${CONV}","step_index":2,"state":"ACTIVE","step_type":"agent_response","text_delta":"half an answer"}}`,
+    `{"event":"result","result":{"conversation_id":"${CONV}","status":"ERROR","response":"","error":"timeout waiting for response","usage":{"output_tokens":31622}}}`
+  ].join("\n");
+
+  const result = await runGeminiTurn("/repo", { prompt: "hi", write: false }, {
+    runCommandFn: stubRun({ stdout: timedOut, status: 1 }),
+    detectEngineFn: agyEngine("1.1.12")
+  });
+
+  assert.equal(result.finalMessage, "half an answer", "the salvaged text is the output");
+  assert.ok(result.failure, "and it is still reported as a failure, because it is partial");
+  assert.notEqual(result.status, 0, "a cut-off run must never pass for a complete one");
+});
+
+test("salvaged text never overrides a response the envelope actually carried", async () => {
+  const both = [
+    `{"event":"step_update","step_update":{"step_index":0,"state":"DONE","step_type":"agent_response","text_delta":"deltas"}}`,
+    `{"event":"result","result":{"conversation_id":"${CONV}","status":"SUCCESS","response":"authoritative","num_turns":1}}`
+  ].join("\n");
+
+  const result = await runGeminiTurn("/repo", { prompt: "hi", write: false }, {
+    runCommandFn: stubRun({ stdout: both }),
+    detectEngineFn: agyEngine("1.1.12")
+  });
+  assert.equal(result.finalMessage, "authoritative");
+});
+
+test("a single-line json envelope is not mistaken for a one-event stream", () => {
+  const envelope = { conversation_id: "c", status: "SUCCESS", response: "hi" };
+  const reader = readAgyStream(`${JSON.stringify(envelope)}\n`);
+  assert.equal(reader.looksLikeStream(), false);
+  assert.equal(reader.envelope(), null, "it carries no `event` key, so it is not a stream event");
+});
+
+test("a real stream is recognised as one", () => {
+  assert.equal(readAgyStream(MEASURED_STREAM).looksLikeStream(), true);
+});
+
+test("a timed-out run says how far it got, not just that it timed out", async () => {
+  // The case that started this: the timeout landed before any answer was
+  // written, so there is no text to salvage — but "reached step 2 tool_call"
+  // is the difference between a report and a shrug.
+  const beforeAnswering = [
+    `{"event":"step_update","step_update":{"conversation_id":"${CONV}","step_index":2,"state":"ACTIVE","step_type":"tool_call"}}`,
+    `{"event":"result","result":{"conversation_id":"${CONV}","status":"ERROR","response":"","error":"timeout waiting for response"}}`
+  ].join("\n");
+
+  const result = await runGeminiTurn("/repo", { prompt: "hi", write: false }, {
+    runCommandFn: stubRun({ stdout: beforeAnswering, status: 1 }),
+    detectEngineFn: agyEngine("1.1.12")
+  });
+
+  assert.ok(result.failure, "still a failure");
+  assert.match(result.failure.summary, /reached step 2 tool_call/);
+  assert.doesNotMatch(result.failure.summary, /partial output preserved/, "there was none to preserve");
+});
+
+test("when partial output survives, the summary says so", async () => {
+  const withText = [
+    `{"event":"step_update","step_update":{"step_index":2,"state":"ACTIVE","step_type":"agent_response","text_delta":"half"}}`,
+    `{"event":"result","result":{"conversation_id":"${CONV}","status":"ERROR","response":"","error":"timeout"}}`
+  ].join("\n");
+
+  const result = await runGeminiTurn("/repo", { prompt: "hi", write: false }, {
+    runCommandFn: stubRun({ stdout: withText, status: 1 }),
+    detectEngineFn: agyEngine("1.1.12")
+  });
+
+  assert.match(result.failure.summary, /partial output preserved/);
+  assert.equal(result.finalMessage, "half");
+});
+
+test("a successful run's summary is not annotated", async () => {
+  const result = await runGeminiTurn("/repo", { prompt: "hi", write: false }, {
+    runCommandFn: stubRun({ stdout: MEASURED_STREAM }),
+    detectEngineFn: agyEngine("1.1.12")
+  });
+  assert.equal(result.failure ?? null, null, "nothing to annotate on success");
+});
+
+test("a SUCCESS envelope with an empty response does not let salvaged text pass for success", async () => {
+  // The envelope is the authority on completeness. If it claims SUCCESS but
+  // carries no response, the deltas are all there is — and there is no way to
+  // know whether they are the whole answer. Returning them is right; calling
+  // the run successful is not.
+  const emptySuccess = [
+    `{"event":"step_update","step_update":{"step_index":0,"state":"ACTIVE","step_type":"agent_response","text_delta":"maybe all of it, maybe not"}}`,
+    `{"event":"result","result":{"conversation_id":"${CONV}","status":"SUCCESS","response":"","num_turns":1}}`
+  ].join("\n");
+
+  const result = await runGeminiTurn("/repo", { prompt: "hi", write: false }, {
+    runCommandFn: stubRun({ stdout: emptySuccess, status: 0 }),
+    detectEngineFn: agyEngine("1.1.12")
+  });
+
+  assert.equal(result.finalMessage, "maybe all of it, maybe not", "the text is still handed over");
+  assert.ok(result.failure, "but completeness was never established, so this is not success");
+  assert.notEqual(result.status, 0);
+});


### PR DESCRIPTION
When AGY's own print timeout fires it emits a well-formed envelope whose response is empty — `{"status":"ERROR","response":"","error":"timeout waiting for response"}` — so the run reported nothing at all. Measured on the run that prompted this: **193,772 tokens spent, and the user shown one line saying it timed out.**

From AGY 1.1.12 the engine is asked for `--output-format stream-json` instead, which emits one JSON object per line as the turn happens. The terminal envelope still arrives as the final event, so success is unchanged; what is new is that a run cut off partway reports how far it got and keeps the answer text already written.

Two starting assumptions turned out to be wrong, and finding that out changed the shape of the fix:

- **The lost tokens were not a half-written answer.** That run's transcript has an empty response and 272 characters of thinking about reading `hooks.json` — it timed out while still exploring. So the goal is not recovering an answer that was never written; it is that a cut-off run says what it reached instead of nothing.
- **No async rewrite was needed.** `spawnSync` keeps what a child had written when its timeout kills it: 20/46/94 lines survived timeouts of 800/1500/3000 ms against a child emitting every 20 ms. Two earlier measurements said otherwise and both were wrong — the child had died on a `node -e` quoting error without writing, which shows as `status: 1, signal: null` rather than a signal. A streaming spawn was written for this and then removed rather than kept as a second spawn implementation with its own Windows resolution rules.

Gated at 1.1.12 because that is where it was measured. `--output-format` itself arrived in 1.1.8, but which of its values existed when is not something this repository can establish, and the convention here is to fail closed. Below the gate, plain `json` is unchanged.

Salvaged text never overrides a response the envelope carried, and never makes a run count as successful — the envelope stays the authority on completeness, so a partial result cannot pass for a whole one.

## Live verification on AGY 1.1.13

The branch's original live check was on 1.1.12. Re-run through this merged code on 1.1.13, against a disposable git repository:

**Success path** — `task --engine agy "Reply with exactly READY and nothing else."`

```
[gemini] Turn completed.
READY
```

**Timeout path** — same command with `--timeout 30`, so AGY's own `--print-timeout` lands at 22.5 s while the turn is still producing:

```
63: On

Failure: timeout (retryable)
Summary: The CLI command timed out. (reached step 11 agent_response (ACTIVE); partial output preserved)
Next step: Retry later, reduce prompt size or review scope, or use `--engine gemini` for AGY timeouts.
```

The output is cut mid-word at a stream delta, and the summary now names the step reached. Before this branch that run printed the summary alone. `task-resume-candidate` still returned a thread id (`afb73e20-…`) for the timed-out job, so resume survives the cut.

Argv actually built, confirming the gate:

```
1.1.11 → --output-format json
1.1.12 → --output-format stream-json
1.1.13 → --output-format stream-json
```

## Merge with main

One conflict, resolved by keeping both lines: this branch and #73 each added an import at the same position (`agy-stream.mjs` here, `readonly-guard.mjs` there). Nothing else overlapped — this branch changes the head and tail of `resolveAgyStructuredResult`, #73 changed its middle and appended a new function after it.

510 tests, 502 pass, 0 fail, 8 skipped. `check-version` and `verify-contracts` green at 0.18.0.

## Not in this PR

No changelog entry or version bump — same pattern as 0.18.0, where feature PRs merged first and a release PR carried the entry and the bump. This is a behaviour change and needs one before the next tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JmaL2A1WpfbN5DiY7PzRHA