### PR TITLE
Close three field notes from the 2026-08-13 batch

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ Override via `--engine` flag or the `GEMINI_ENGINE` environment variable.
 - **AGY transport fallback**: Only a stable parsed version of 1.1.2 or newer enables stdin. Unknown and prerelease version strings fail closed to the existing positional path, preserving compatibility rather than assuming an upstream capability.
 - **AGY 1.1.10+ `.git` sandbox rule**: AGY 1.1.10 implements read-only `.git` sandbox rules during sandboxed execution, protecting git repository metadata and commit history against accidental modification during review and subagent tasks.
 - **Credential handling**: OAuth credentials in `~/.gemini/oauth_creds.json` are read only to check token expiry via `getGeminiLoginStatus()`; they are never logged, copied elsewhere, or transmitted by this plugin.
-- **`.gitignore`**: The workspace-local `.omc/` directory, which holds `/gemini:transfer` snapshots, is excluded from version control. Job state and logs live outside the repository entirely — see [How It Works](#how-it-works).
+- **`.gitignore`**: A transfer snapshot's `gitDiff` field holds the entire uncommitted diff, so `/gemini:transfer` writes `.omc/.gitignore` containing `*` when it creates the directory — the snapshots are excluded from version control in **your** repository, not only in this one. Before v0.19.0 the exclusion existed only in this repository's own `.gitignore`, so elsewhere the snapshots were untracked rather than ignored and `git add -A` committed them. An existing `.omc/.gitignore` is never overwritten. Job state and logs live outside the repository entirely — see [How It Works](#how-it-works).
 
 **What is sent, kept, and read** — including the one path that transmits without an explicit command — is documented in [`PRIVACY.md`](PRIVACY.md).
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -290,7 +290,7 @@
 - **AGY transport 回退**：只有可穩定解析為 1.1.2 以上的版本才啟用 stdin；未知版與 prerelease 字串一律 fail closed 至既有 positional 路徑，不假設上游能力。
 - **AGY 1.1.10+ `.git` 沙箱規則**：AGY 1.1.10 在沙箱模式下實作 `.git` 目錄唯讀防護規則，保護版本庫 metadata 與 commit 歷史在審查及子代理人任務期間不被意外修改。
 - **憑證處理**：`~/.gemini/oauth_creds.json` 之 OAuth 憑證僅用於 `getGeminiLoginStatus()` 檢查 token 是否過期；本外掛從不記錄、複製或傳輸之。
-- **`.gitignore`**：工作區內的 `.omc/` 目錄（存放 `/gemini:transfer` 快照）已排除於版本控制之外。工作狀態與日誌則完全不在版本庫內——詳見 [運作原理](#運作原理)。
+- **`.gitignore`**：transfer 快照的 `gitDiff` 欄位裝的是完整未提交 diff，因此 `/gemini:transfer` 在建立目錄時會寫入內容為 `*` 的 `.omc/.gitignore`——快照在**你的**版本庫裡就被排除，不只在本專案內。v0.19.0 之前該排除僅存在於本專案自己的 `.gitignore`，在其他版本庫只是「未追蹤」而非「已忽略」，`git add -A` 會一併提交。已存在的 `.omc/.gitignore` 不會被覆寫。工作狀態與日誌則完全不在版本庫內——詳見 [運作原理](#運作原理)。
 
 **送出哪些資料、保留在何處、讀取了什麼**——包含唯一一條不需明確命令即會傳輸的路徑——記載於 [`PRIVACY.md`](PRIVACY.md)（英文）。
 

--- a/plugins/gemini/scripts/gemini-companion.mjs
+++ b/plugins/gemini/scripts/gemini-companion.mjs
@@ -872,7 +872,13 @@ function getJobKindLabel(kind, jobClass) {
   return jobClass === "review" ? "review" : "rescue";
 }
 
+// `engine` here is what the caller *asked for*, and only an explicit request says
+// anything: "auto" is a request to decide later, so recording it would put a
+// non-engine into a field readers take for the engine in use. The engine actually
+// chosen is written by the runner as soon as detection returns — see
+// createJobProgressUpdater — which is what a running job under `auto` reports.
 function createCompanionJob({ prefix, kind, title, workspaceRoot, jobClass, summary, write = false, engine = null, groupId = null }) {
+  const requestedEngine = engine === "auto" ? null : engine;
   return createJobRecord({
     id: generateJobId(prefix),
     kind,
@@ -882,7 +888,7 @@ function createCompanionJob({ prefix, kind, title, workspaceRoot, jobClass, summ
     jobClass,
     summary,
     write,
-    ...(engine ? { engine } : {}),
+    ...(requestedEngine ? { engine: requestedEngine } : {}),
     ...(groupId ? { groupId } : {})
   });
 }
@@ -899,7 +905,7 @@ function createTrackedProgress(job, options = {}) {
   };
 }
 
-function buildTaskJob(workspaceRoot, taskMetadata, write) {
+function buildTaskJob(workspaceRoot, taskMetadata, write, engine = null) {
   return createCompanionJob({
     prefix: "task",
     kind: "task",
@@ -907,7 +913,8 @@ function buildTaskJob(workspaceRoot, taskMetadata, write) {
     workspaceRoot,
     jobClass: "task",
     summary: taskMetadata.summary,
-    write
+    write,
+    engine
   });
 }
 
@@ -1192,7 +1199,7 @@ export function dispatchBackgroundTask(request, { spawnFn = spawn, detectEngineF
   const resumeLast = Boolean(request.resumeLast);
   requireTaskRequest(prompt, resumeLast);
   const taskMetadata = buildTaskRunMetadata({ prompt, resumeLast });
-  const job = buildTaskJob(workspaceRoot, taskMetadata, Boolean(request.write));
+  const job = buildTaskJob(workspaceRoot, taskMetadata, Boolean(request.write), request.engine ?? null);
   const storedRequest = buildTaskRequest({
     cwd,
     model,
@@ -1296,7 +1303,8 @@ async function handleReviewCommand(argv, { reviewName, templateName, supportsFoc
     title: `Gemini ${reviewName}`,
     workspaceRoot,
     jobClass: "review",
-    summary: `${reviewName} ${target.label}`
+    summary: `${reviewName} ${target.label}`,
+    engine: options.engine ?? null
   });
 
   await runForegroundCommand(
@@ -1372,7 +1380,7 @@ async function handleTask(argv) {
     return;
   }
 
-  const job = buildTaskJob(workspaceRoot, taskMetadata, write);
+  const job = buildTaskJob(workspaceRoot, taskMetadata, write, engine);
   await runForegroundCommand(
     job,
     (progress) =>

--- a/plugins/gemini/scripts/gemini-mcp.mjs
+++ b/plugins/gemini/scripts/gemini-mcp.mjs
@@ -80,6 +80,32 @@ export const TOOLS = [
       deep: { type: "boolean", default: false }
     }
   ),
+  // The slash surface has had /gemini:adversarial-review since it shipped, and
+  // both READMEs list it under Features — but it was reachable only by a human
+  // typing the command. An agent driving this plugin through MCP saw five tools,
+  // none of which could select the adversarial template and none of which said
+  // why, so the feature was absent rather than declined.
+  //
+  // A separate tool rather than a flag on gemini_review: the two differ in the
+  // prompt template they run and in what their output is for, and an agent
+  // choosing between tools by description picks better than one guessing at a
+  // boolean.
+  tool(
+    "gemini_adversarial_review",
+    "Adversarially review the current diff with Gemini or AGY",
+    "Queue a read-only adversarial code review through the existing companion runtime. Same transport as gemini_review, but runs the adversarial template: it argues against the change rather than summarizing it, and is the one to reach for on destructive or hard-to-reverse edits. Secret-looking files are withheld by filename.",
+    { readOnlyHint: true, openWorldHint: true },
+    ["workspace"],
+    {
+      workspace: { type: "string", description: "Absolute path to the target workspace." },
+      base: { type: "string" },
+      scope: enumSchema(["auto", "working-tree", "branch"], "auto"),
+      model: { type: "string" },
+      engine: enumSchema(["auto", "gemini", "agy"]),
+      deep: { type: "boolean", default: false },
+      focus: { type: "string", description: "What the review should concentrate on." }
+    }
+  ),
   tool(
     "gemini_job_status",
     "Check a delegated job's status",
@@ -176,7 +202,16 @@ export async function callTool(name, args = {}, { runtime = DEFAULT_RUNTIME } = 
       engine: optionalEnum(args.engine, "engine", ["auto", "gemini", "agy"])
     });
   }
-  if (name === "gemini_review") {
+  if (name === "gemini_review" || name === "gemini_adversarial_review") {
+    const adversarial = name === "gemini_adversarial_review";
+    // The two tools differ by one argument, which is exactly the shape a caller
+    // gets wrong. Nothing else here validates unknown keys — the schemas declare
+    // additionalProperties: false and clients are expected to enforce it — but a
+    // focus dropped in silence means the review the caller asked for is not the
+    // review that runs, so this one is checked rather than assumed.
+    if (!adversarial && args.focus != null) {
+      throw new Error("gemini_review takes no focus. Use gemini_adversarial_review for a focused review, matching /gemini:review and /gemini:adversarial-review.");
+    }
     return runtime.dispatchBackgroundReview({
       cwd: workspace,
       base: optionalString(args.base, "base"),
@@ -184,8 +219,11 @@ export async function callTool(name, args = {}, { runtime = DEFAULT_RUNTIME } = 
       model: optionalString(args.model, "model"),
       engine: optionalEnum(args.engine, "engine", ["auto", "gemini", "agy"]),
       deep: optionalBoolean(args.deep, "deep") ?? false,
-      reviewName: "Review",
-      templateName: "review"
+      // Focus text is accepted only by the adversarial tool, matching the slash
+      // commands: /gemini:review takes no focus argument either.
+      ...(adversarial ? { focusText: optionalString(args.focus, "focus") ?? "" } : {}),
+      reviewName: adversarial ? "Adversarial Review" : "Review",
+      templateName: adversarial ? "adversarial-review" : "review"
     });
   }
 

--- a/plugins/gemini/scripts/lib/gemini.mjs
+++ b/plugins/gemini/scripts/lib/gemini.mjs
@@ -410,7 +410,7 @@ export async function runGeminiTurn(cwd, options = {}, { runCommandFn = runComma
     workspaceDir: cwd,
   });
 
-  onProgress?.({ message: `Starting ${engineInfo.engine} turn...`, phase: "running" });
+  onProgress?.({ message: `Starting ${engineInfo.engine} turn...`, phase: "running", engine: engineInfo.engine });
 
   // Snapshot before the turn, whatever mode it is in. A read-only turn needs it
   // because nothing enforces read-only (see readonly-guard.mjs); a write turn
@@ -583,6 +583,10 @@ export async function runGeminiReview(cwd, options = {}, { runCommandFn = runCom
   // output", true when only gemini could emit structured output. AGY has carried
   // the same JSON envelope since 1.1.8 (plugin v0.11.0).
   const engineInfo = detectEngineFn(requestedEngine ?? null);
+  // Reported as its own event rather than folded into the line above, which is
+  // printed before detection runs: a review job queued under `auto` otherwise had
+  // no way to say which engine it picked until it finished.
+  onProgress?.({ message: `Using ${engineInfo.engine}.`, phase: "reviewing", engine: engineInfo.engine });
   const agyStructured = engineInfo.engine === "agy" && supportsAgyStructuredOutput(engineInfo.version);
   const useJson = engineInfo.engine === "gemini" || agyStructured;
 

--- a/plugins/gemini/scripts/lib/tracked-jobs.mjs
+++ b/plugins/gemini/scripts/lib/tracked-jobs.mjs
@@ -17,6 +17,7 @@ function normalizeProgressEvent(value) {
       phase: typeof value.phase === "string" && value.phase.trim() ? value.phase.trim() : null,
       threadId: typeof value.threadId === "string" && value.threadId.trim() ? value.threadId.trim() : null,
       turnId: typeof value.turnId === "string" && value.turnId.trim() ? value.turnId.trim() : null,
+      engine: typeof value.engine === "string" && value.engine.trim() ? value.engine.trim() : null,
       stderrMessage: value.stderrMessage == null ? null : String(value.stderrMessage).trim(),
       logTitle: typeof value.logTitle === "string" && value.logTitle.trim() ? value.logTitle.trim() : null,
       logBody: value.logBody == null ? null : String(value.logBody).trimEnd()
@@ -28,6 +29,7 @@ function normalizeProgressEvent(value) {
     phase: null,
     threadId: null,
     turnId: null,
+    engine: null,
     stderrMessage: String(value ?? "").trim(),
     logTitle: null,
     logBody: null
@@ -72,6 +74,7 @@ export function createJobProgressUpdater(workspaceRoot, jobId) {
   let lastPhase = null;
   let lastThreadId = null;
   let lastTurnId = null;
+  let lastEngine = null;
 
   return (event) => {
     const normalized = normalizeProgressEvent(event);
@@ -93,6 +96,18 @@ export function createJobProgressUpdater(workspaceRoot, jobId) {
     if (normalized.turnId && normalized.turnId !== lastTurnId) {
       lastTurnId = normalized.turnId;
       patch.turnId = normalized.turnId;
+      changed = true;
+    }
+
+    // Which engine a run chose was only written when the job finished, so a
+    // running job could not answer it — and under `auto` that is exactly when the
+    // answer matters, because the choice decides which account's quota is being
+    // spent. The runner knows it the moment detection returns, which is well
+    // before the first token; it travels on the same event as the phase change
+    // that announces the turn.
+    if (normalized.engine && normalized.engine !== lastEngine) {
+      lastEngine = normalized.engine;
+      patch.engine = normalized.engine;
       changed = true;
     }
 

--- a/plugins/gemini/scripts/lib/transfer-context.mjs
+++ b/plugins/gemini/scripts/lib/transfer-context.mjs
@@ -22,6 +22,25 @@ export function checkGitConflict(cwd = process.cwd()) {
   return null;
 }
 
+// A snapshot's `gitDiff` field holds the entire uncommitted diff, so a snapshot
+// that reaches version control publishes more than its author was looking at.
+// Both READMEs claimed `.omc/` was excluded from version control; that exclusion
+// lived only in this repository's own .gitignore, so in every other repository
+// the file was merely *untracked* — visible in `git status` and swept up by
+// `git add -A`.
+//
+// `*` inside `.omc/.gitignore` ignores the directory's contents and the ignore
+// file itself, which is why nothing has to be added to the host repository's
+// .gitignore. An existing file is left alone: it may say something deliberate,
+// and this is not the place to decide it was wrong.
+export function ensureOmcIgnored(omcDir) {
+  const ignoreFile = path.join(omcDir, '.gitignore');
+  if (fs.existsSync(ignoreFile)) return ignoreFile;
+  fs.mkdirSync(omcDir, { recursive: true });
+  fs.writeFileSync(ignoreFile, '*\n', 'utf8');
+  return ignoreFile;
+}
+
 export function pruneOldTransfers(transfersDir, maxKeep = 20) {
   if (!fs.existsSync(transfersDir)) return;
   try {
@@ -149,6 +168,7 @@ export function buildTransferSnapshot({ engine = 'auto', model = null, effort = 
 
   const transfersDir = path.join(cwd, '.omc', 'transfers');
   fs.mkdirSync(transfersDir, { recursive: true });
+  ensureOmcIgnored(path.join(cwd, '.omc'));
 
   // LRU Pruning of old snapshots
   pruneOldTransfers(transfersDir, 20);

--- a/tests/gemini-mcp.test.mjs
+++ b/tests/gemini-mcp.test.mjs
@@ -14,7 +14,7 @@ function toolRequest(name, args) {
   return { jsonrpc: "2.0", id: 1, method: "tools/call", params: { name, arguments: args } };
 }
 
-test("gemini MCP advertises its identity and five tools", async () => {
+test("gemini MCP advertises its identity and six tools", async () => {
   const initialized = await handleRequest({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} });
   const pluginVersion = JSON.parse(
     fs.readFileSync(new URL("../plugins/gemini/.claude-plugin/plugin.json", import.meta.url), "utf8")
@@ -26,10 +26,59 @@ test("gemini MCP advertises its identity and five tools", async () => {
   assert.deepEqual(listed.tools.map((tool) => tool.name), [
     "gemini_rescue",
     "gemini_review",
+    "gemini_adversarial_review",
     "gemini_job_status",
     "gemini_job_result",
     "gemini_job_cancel"
   ]);
+});
+
+// Adversarial review has been on the slash surface since it shipped and is listed
+// in both READMEs under Features, but MCP exposed no way to reach it and said
+// nothing about why — so an agent driving the plugin through MCP had the feature
+// missing rather than declined.
+test("MCP can run an adversarial review, not only the standard one", async () => {
+  const workspace = makeTempDir();
+  const calls = [];
+  const runtime = {
+    dispatchBackgroundReview(input) {
+      calls.push(input);
+      return { jobId: "review-adv-1", status: "queued" };
+    }
+  };
+
+  const queued = await handleRequest(toolRequest("gemini_adversarial_review", {
+    workspace,
+    engine: "agy",
+    focus: "the migration path"
+  }), { runtime });
+
+  assert.equal(queued.structuredContent.jobId, "review-adv-1");
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].templateName, "adversarial-review", "the adversarial template is the whole point of the tool");
+  assert.equal(calls[0].reviewName, "Adversarial Review");
+  assert.equal(calls[0].focusText, "the migration path");
+});
+
+// The standard review takes no focus argument on the slash surface either, and a
+// silently ignored argument is worse than an absent one.
+test("gemini_review still queues the standard template and takes no focus", async () => {
+  const workspace = makeTempDir();
+  const calls = [];
+  const runtime = {
+    dispatchBackgroundReview(input) {
+      calls.push(input);
+      return { jobId: "review-std-1", status: "queued" };
+    }
+  };
+
+  await handleRequest(toolRequest("gemini_review", { workspace }), { runtime });
+  assert.equal(calls[0].templateName, "review");
+  assert.equal(calls[0].reviewName, "Review");
+  assert.ok(!("focusText" in calls[0]));
+
+  const rejected = await handleRequest(toolRequest("gemini_review", { workspace, focus: "x" }), { runtime });
+  assert.equal(rejected.isError, true, "an argument the tool does not accept must be refused, not dropped");
 });
 
 // The Anthropic software directory policy requires every applicable annotation,

--- a/tests/tracked-jobs.test.mjs
+++ b/tests/tracked-jobs.test.mjs
@@ -52,6 +52,23 @@ test("a changed thread id replaces the old one rather than being ignored", () =>
   });
 });
 
+// Which engine a run chose was written only when the job finished, so a running
+// job could not answer it — and a background task never carried it at queue time
+// either, while a background review did, which is how the asymmetry was found.
+// Under `auto` this is the field that says whose quota is being spent.
+test("a running job reports the engine its run resolved", () => {
+  withDataDir((cwd) => {
+    const file = seedJob(cwd, "task-engine-1");
+    const update = createJobProgressUpdater(cwd, "task-engine-1");
+
+    update({ message: "Detecting engine...", phase: "starting" });
+    assert.equal(readJobFile(file).engine, undefined, "nothing is known before detection returns");
+
+    update({ message: "Starting agy turn...", phase: "running", engine: "agy" });
+    assert.equal(readJobFile(file).engine, "agy", "a running job must name the engine it is spending quota on");
+  });
+});
+
 test("turn id is tracked independently of thread id", () => {
   withDataDir((cwd) => {
     const file = seedJob(cwd, "task-turn-1");

--- a/tests/transfer.test.mjs
+++ b/tests/transfer.test.mjs
@@ -5,6 +5,7 @@ import path from 'node:path';
 import os from 'node:os';
 import { isSecretFile, checkGitConflict, pruneOldTransfers, buildTransferSnapshot } from '../plugins/gemini/scripts/lib/transfer-context.mjs';
 import { parseTransferArgs } from '../plugins/gemini/scripts/transfer.mjs';
+import { initGitRepo, run } from './helpers.mjs';
 
 // The slash command passes the entire user tail as one quoted "$ARGUMENTS"
 // token, so flags only work if that single string is re-split first.
@@ -114,4 +115,41 @@ test('buildTransferSnapshot creates valid snapshot with model and effort', (t) =
 
   const content = JSON.parse(fs.readFileSync(snapshotPath, 'utf8'));
   assert.equal(content.effort, 'high');
+});
+
+// A snapshot's gitDiff field holds the whole uncommitted diff. Both READMEs said
+// `.omc/` was excluded from version control, but the exclusion lived only in this
+// repository's own .gitignore — so in any other repository the snapshot was
+// untracked rather than ignored, showed up in `git status`, and `git add -A`
+// committed it. Asserted through real git, because `git check-ignore` is the only
+// thing that settles whether a rule actually applies.
+test('a transfer snapshot is ignored by the repository it was written into', (t) => {
+  const repo = fs.mkdtempSync(path.join(os.tmpdir(), 'transfer-ignore-test-'));
+  t.after(() => fs.rmSync(repo, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 }));
+  initGitRepo(repo);
+  fs.writeFileSync(path.join(repo, 'app.js'), 'export const x = 1;\n');
+
+  const { snapshotPath } = buildTransferSnapshot({ cwd: repo, instructions: 'hand off' });
+  const relative = path.relative(repo, snapshotPath).split(path.sep).join('/');
+
+  const ignored = run('git', ['check-ignore', '-q', relative], { cwd: repo });
+  assert.equal(ignored.status, 0, `${relative} is not ignored, so git add -A would commit the working diff`);
+
+  const status = run('git', ['status', '--porcelain'], { cwd: repo });
+  assert.doesNotMatch(status.stdout, /\.omc/, 'the snapshot must not appear in git status');
+});
+
+// The ignore file is the user's once it exists: a repository that deliberately
+// tracks something under .omc/ has said so, and a transfer is not the moment to
+// overrule it.
+test('an existing .omc/.gitignore is left exactly as the user wrote it', (t) => {
+  const repo = fs.mkdtempSync(path.join(os.tmpdir(), 'transfer-ignore-keep-'));
+  t.after(() => fs.rmSync(repo, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 }));
+  const omc = path.join(repo, '.omc');
+  fs.mkdirSync(omc, { recursive: true });
+  fs.writeFileSync(path.join(omc, '.gitignore'), '# mine\ntransfers/\n');
+
+  buildTransferSnapshot({ cwd: repo, instructions: 'hand off' });
+
+  assert.equal(fs.readFileSync(path.join(omc, '.gitignore'), 'utf8'), '# mine\ntransfers/\n');
 });


### PR DESCRIPTION
Three `friction` field notes, all reproduced against 0.17.3 while using the plugin. They share a shape: something the documentation or another surface already promised, which this one did not deliver.

## A transfer snapshot could be committed into the user's repository — `gi-2026-08-13-e9a2`

A snapshot's `gitDiff` field holds the **entire uncommitted diff**, and both READMEs said `.omc/` was excluded from version control. That exclusion lived only in this repository's own `.gitignore`. In any other repository the snapshot was merely *untracked* — it showed up in `git status`, and `git add -A` committed it, diff and all.

`buildTransferSnapshot` now writes `.omc/.gitignore` containing `*` when it creates the directory. That ignores the contents and the ignore file itself, so nothing has to be added to the host repository's own `.gitignore`. An existing file is left alone — it may say something deliberate, and a transfer is not the moment to overrule it.

Pinned with real `git check-ignore` in a fresh repository, because nothing else settles whether an ignore rule actually applies. Both READMEs now describe what the code does, including that this changed in v0.19.0.

## A running job could not say which engine it chose — `gi-2026-08-13-8b2d`

The engine was written onto the job record only when it finished, so a running job had no answer — and under `auto` that is exactly the field that says whose quota is being spent. The asymmetry that surfaced it: a background *review* carried `engine` from queued, a background *task* never did, because only the review call site passed it.

The runner now reports the resolved engine on the same progress event that announces the turn — the pipeline that already carries `phase`, `threadId` and `turnId` — so every job kind answers it while running, `auto` included. Detection is unchanged; nothing extra is spawned.

The queue-time value stays, but no longer records `"auto"`. That is a request to decide later, not an engine, and putting it in a field readers take for the engine in use is the failure this repository spent #73 and #74 removing.

## Adversarial review was unreachable from MCP — `gi-2026-08-13-d3f8`

`/gemini:adversarial-review` has existed since it shipped and both READMEs list it under Features, but the MCP tool list held five tools, none of which could select the adversarial template and none of which said why. For an agent driving this plugin through MCP the feature was **absent rather than declined**.

`gemini_adversarial_review` is a separate tool rather than a flag on `gemini_review`: the two differ in the prompt template they run and in what their output is for, and an agent choosing between tools by description picks better than one guessing at a boolean. It takes `focus`, matching the slash command. `gemini_review` does not take one — and now refuses a `focus` rather than dropping it, since a silently ignored argument means the review that runs is not the review that was asked for.

## Verification

- 515 tests, 507 pass, 0 fail, 8 skipped
- `verify-contracts` green
- Mutation-checked: removing the ignore-file write, the engine propagation, or the adversarial template each fails exactly one new test and no others

## Observed, not fixed

The MCP surface is not documented in either README — there is no tool list to keep in sync, which is why the missing tool went unnoticed for as long as it did. That is its own change.

No version bump or changelog entry here; a release PR follows, same as 0.18.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JmaL2A1WpfbN5DiY7PzRHA