### PR TITLE
Release 0.19.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,13 +7,13 @@
   },
   "metadata": {
     "description": "Use Gemini CLI or Antigravity CLI (agy) inside Claude Code for task delegation, code review, and adversarial review.",
-    "version": "0.18.0"
+    "version": "0.19.0"
   },
   "plugins": [
     {
       "name": "gemini",
       "description": "Gemini CLI and Antigravity CLI bridge for Claude Code task delegation and adversarial review",
-      "version": "0.18.0",
+      "version": "0.19.0",
       "author": {
         "name": "arcobaleno64",
         "email": "arcobaleno830623@gmail.com"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,8 +6,8 @@ Only the current MINOR line is supported. Update this table with every MINOR bum
 
 | Version | Supported |
 |---|---|
-| 0.18.x | :white_check_mark: |
-| < 0.18.0 | :x: |
+| 0.19.x | :white_check_mark: |
+| < 0.19.0 | :x: |
 
 ## Security Model & Trust Boundaries
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@arcobaleno64/gemini-plugin-cc",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@arcobaleno64/gemini-plugin-cc",
-      "version": "0.18.0",
+      "version": "0.19.0",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arcobaleno64/gemini-plugin-cc",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "private": true,
   "type": "module",
   "description": "Use Gemini CLI or Antigravity CLI (agy) inside Claude Code for task delegation, code review, and adversarial review.",

--- a/plugins/gemini/.claude-plugin/plugin.json
+++ b/plugins/gemini/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gemini",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "Use Gemini/AGY from Claude Code to review code or delegate tasks.",
   "author": {
     "name": "arcobaleno64",

--- a/plugins/gemini/CHANGELOG.md
+++ b/plugins/gemini/CHANGELOG.md
@@ -1,5 +1,95 @@
 # Changelog
 
+## 0.19.0 — 2026-08-17 — What it reached, what it wrote, which engine it used
+
+Three things a run could not tell you afterwards, and one it wrote without asking.
+
+### A timed-out AGY run reported nothing at all
+
+When AGY's own print timeout fires it emits a well-formed envelope whose response
+is empty — `{"status":"ERROR","response":"","error":"timeout waiting for
+response"}` — so the plugin had a valid answer meaning "nothing". Measured on the
+run that prompted this: **193,772 tokens spent, and one line saying it timed out.**
+
+From AGY 1.1.12 the engine is asked for `--output-format stream-json`, which emits
+one JSON object per line as the turn happens. The terminal envelope still arrives
+as the final event, so success is unchanged; a run cut off partway now reports how
+far it got and keeps the answer text already written:
+
+    Failure: timeout (retryable)
+    Summary: The CLI command timed out. (reached step 11 agent_response (ACTIVE);
+    partial output preserved)
+
+Two assumptions this started from were wrong, and finding that out changed the fix.
+The lost tokens were not a half-written answer — that transcript has an empty
+response and 272 characters of thinking about reading `hooks.json`, so the turn
+timed out while still exploring; the goal is that a cut-off run says what it
+reached, not that a never-written answer is recovered. And no async rewrite was
+needed: `spawnSync` keeps what a child had written when its timeout kills it
+(20/46/94 lines survived timeouts of 800/1500/3000 ms against a child emitting
+every 20 ms). Two earlier measurements said otherwise and both were wrong — the
+child had died on a quoting error without writing, which shows as
+`status: 1, signal: null` rather than a signal. A streaming spawn was written for
+this and then removed rather than kept as a second spawn implementation with its
+own Windows resolution rules.
+
+Salvaged text never overrides a response the envelope carried, and never makes a
+run count as successful: the envelope stays the authority on completeness, so a
+partial result cannot pass for a whole one. Gated at 1.1.12, where it was
+measured; below that, plain `json` is unchanged.
+
+### A transfer snapshot could be committed into your repository
+
+A snapshot's `gitDiff` field holds the entire uncommitted diff, and both READMEs
+said the workspace-local `.omc/` directory was excluded from version control. That
+exclusion existed only in *this* repository's `.gitignore`. Anywhere else the
+snapshot was merely untracked — it appeared in `git status`, and `git add -A`
+committed it, diff and all.
+
+`/gemini:transfer` now writes `.omc/.gitignore` containing `*` when it creates the
+directory, which ignores the contents and the ignore file itself, so nothing has
+to be added to the host repository. An existing `.omc/.gitignore` is never
+overwritten: it may say something deliberate. Pinned with a real `git check-ignore`
+in a fresh repository, because nothing else settles whether a rule applies.
+
+### A running job could not say which engine it chose
+
+The engine was written onto the job record only on completion, so a running job
+had no answer — and under `auto` that is the field that says whose quota is being
+spent. The asymmetry that surfaced it: a background review carried `engine` from
+queued, a background task never did, because only the review call site passed it.
+
+The resolved engine now travels on the same progress event that announces the
+turn — the pipeline already carrying `phase`, `threadId` and `turnId` — so every
+job kind answers it while running, `auto` included, with no extra detection. The
+queue-time value stays but no longer records `"auto"`: that is a request to decide
+later, not an engine, and a field readers take for the engine in use must not hold
+one.
+
+### Adversarial review was unreachable from MCP
+
+`/gemini:adversarial-review` has existed since it shipped and both READMEs list it
+under Features, but the MCP tool list held five tools, none of which could select
+the template and none of which said why — for an agent driving the plugin through
+MCP the feature was absent rather than declined. `gemini_adversarial_review` is a
+separate tool rather than a flag on `gemini_review`, because the two differ in the
+template they run and an agent choosing by description picks better than one
+guessing at a boolean. It takes `focus`, matching the slash command;
+`gemini_review` does not, and refuses one rather than dropping it.
+
+### Engine
+
+**`--mode plan` is tested and not adopted.** AGY 1.1.12 fixed `--mode` being
+ignored in headless `-p` runs, which made it worth testing against the "AGY has no
+read-only mode" premise in `docs/THREAT-MODEL.md` §7.2. Six runs on 1.1.13: it
+refuses the edit tool and lets a shell command write the same file, exit 0 — a
+tool policy, not a write boundary, and unusable for the same reason `--sandbox`
+is. It is also mutually exclusive with `--disable-slash-commands`, which every AGY
+spawn passes from 1.1.9 up so a prompt beginning with `/` is not executed as a
+command; AGY says so on stderr, readable only because 1.1.12 stopped swallowing
+startup diagnostics into the log file. The measurement is recorded in §7.2 beside
+the 1.1.10 table.
+
 ## 0.18.0 — 2026-08-17 — Arguments out of the shell, and claims backed by a check
 
 Nine findings from a dogfooding security pass, plus the release gate that would


### PR DESCRIPTION
Changelog and version metadata for everything merged since `v0.18.0`: #76, #77, #78.

**Minor, not patch.** Two changes reach users:

- On AGY 1.1.12+ the engine is asked for `--output-format stream-json` instead of `json`. Success is unchanged — the same terminal envelope arrives as the final event — but a run cut off by AGY's own print timeout now reports how far it got and keeps any answer text already written, where it previously reported nothing at all.
- `/gemini:transfer` writes `.omc/.gitignore` into the workspace it runs in. That is a new file in the user's repository, and it is the fix for a snapshot holding the whole uncommitted diff being swept into a commit by `git add -A`.

`SECURITY.md`'s supported-versions table follows the MINOR bump, as its own contract test requires.

## What the entry covers

| PR | |
|---|---|
| #76 | `--mode plan` measured on AGY 1.1.13 and **not adopted** — it gates the edit tools and lets a shell command write the same file, so THREAT-MODEL §7.2's "AGY has no read-only mode" stands |
| #77 | `stream-json`, so a timed-out AGY run reports what it reached instead of a blank |
| #78 | Three field notes: transfer snapshots ignored in the user's own repository, a running job naming the engine it chose, adversarial review reachable from MCP |

## Verification

- 515 tests, 507 pass, 0 fail, 8 skipped
- `npm run check-version` — matches 0.19.0 and finds the changelog entry
- `npm run verify-contracts` — passes at 0.19.0

Live checks already run on AGY 1.1.13 during #76 and #77: `--probe-agy` verified without spending a turn, a successful `stream-json` turn, a forced-timeout turn returning `reached step 11 agent_response (ACTIVE); partial output preserved`, and six `--mode plan` runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JmaL2A1WpfbN5DiY7PzRHA