### PR TITLE
Document the MCP surface, and keep the list honest by test

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,16 +249,7 @@ The plugin also ships an MCP server (`.mcp.json` → `scripts/gemini-mcp.mjs`), 
 
 ### Slash-only, by omission
 
-Not yet on the MCP surface. Listed so a gap is visible rather than discovered:
-
-| Not available | Use instead |
-|---|---|
-| `/gemini:setup` (and the probe flags) | The slash command or the CLI — this is interactive by design |
-| `/gemini:transfer` | The slash command; it writes a workspace-local snapshot and needs the model to author the instructions file |
-| `--timeout <seconds>` | Not exposed; MCP jobs take the per-engine default |
-| `--resume-last` / `--resume` | Not exposed; every `gemini_rescue` starts a fresh turn |
-| `--engines gemini,agy` (dual-engine review) | The slash command or the CLI |
-| The [Review Gate](#review-gate-optional) | Configured through `/gemini:setup`, then applies to the whole session |
+Listed so the gap is visible rather than discovered: `/gemini:setup` and its probe flags (interactive by design), `/gemini:transfer` (it writes a workspace-local snapshot and needs the model to author the instructions file), `--timeout`, `--resume-last`, and `--engines gemini,agy` are not on this surface — use the slash command or the CLI. MCP jobs take the per-engine default timeout, and every `gemini_rescue` starts a fresh turn. The [Review Gate](#review-gate-optional) is configured through `/gemini:setup` and then applies to the whole session, whichever surface queued the job.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -224,6 +224,44 @@ Cancels a running or queued background job.
 
 ---
 
+## MCP Tools
+
+The plugin also ships an MCP server (`.mcp.json` → `scripts/gemini-mcp.mjs`), so an agent can drive it without a human typing a slash command. This surface is **not** a mirror of the commands above — read the two tables together before assuming a feature is reachable.
+
+| Tool | Required | Optional | Read-only | Reaches Google |
+|---|---|---|---|---|
+| `gemini_rescue` | `workspace`, `prompt` | `write`, `model`, `effort`, `engine` | no | yes |
+| `gemini_review` | `workspace` | `base`, `scope`, `model`, `engine`, `deep` | yes | yes |
+| `gemini_adversarial_review` | `workspace` | `base`, `scope`, `model`, `engine`, `deep`, `focus` | yes | yes |
+| `gemini_job_status` | `workspace`, `jobId` | — | yes | no |
+| `gemini_job_result` | `workspace`, `jobId` | — | yes | no |
+| `gemini_job_cancel` | `workspace`, `jobId` | — | no | no |
+
+`workspace` is required on every tool and must be an absolute path to an existing directory. There is no implicit "current directory" here: the server is launched once per session from `.mcp.json`, not per invocation from a shell.
+
+**The first three queue a background job and return immediately** with a `jobId`. Nothing arrives with that response — poll `gemini_job_status`, then collect with `gemini_job_result`. A job started and never collected is quota spent for nothing, which is this plugin's most expensive failure mode.
+
+**`write: false` is an intent, not a sandbox.** AGY has no read-only mode, so a delegated turn can still edit files; the run compares the workspace before and after and reports what it wrote. `gemini_rescue` is annotated `destructiveHint: true` for that reason even though `write` defaults to false — annotations describe the worst a tool can do and cannot vary with arguments. See [`docs/THREAT-MODEL.md`](docs/THREAT-MODEL.md) §7.2.
+
+**The three job tools are addressed by job id and deliberately cross sessions.** A caller holding an id has already identified the job, so the session filter that keeps the *discovery* paths honest cannot do any work for them — and applying it broke them outright, because this server never receives a session id (see below).
+
+**Jobs queued here belong to no session.** `.mcp.json` gives the server no way to learn `GEMINI_COMPANION_SESSION_ID`: the `SessionStart` hook can only export into `CLAUDE_ENV_FILE`, which reaches later Bash commands, not a server started alongside them. Before v0.18.0 those untagged jobs were sorted with "another session's" and were invisible to `/gemini:status` and uncancellable from the slash commands. They are shown now — "nobody could say whose it is" is not the same claim as "it is someone else's".
+
+### Slash-only, by omission
+
+Not yet on the MCP surface. Listed so a gap is visible rather than discovered:
+
+| Not available | Use instead |
+|---|---|
+| `/gemini:setup` (and the probe flags) | The slash command or the CLI — this is interactive by design |
+| `/gemini:transfer` | The slash command; it writes a workspace-local snapshot and needs the model to author the instructions file |
+| `--timeout <seconds>` | Not exposed; MCP jobs take the per-engine default |
+| `--resume-last` / `--resume` | Not exposed; every `gemini_rescue` starts a fresh turn |
+| `--engines gemini,agy` (dual-engine review) | The slash command or the CLI |
+| The [Review Gate](#review-gate-optional) | Configured through `/gemini:setup`, then applies to the whole session |
+
+---
+
 ## Review Gate (Optional)
 
 An optional stop-time gate that runs an adversarial review before Claude Code can stop, whenever a `--write` task completed in the session. Disabled by default.

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -247,16 +247,7 @@
 
 ### 僅限斜線命令（明列缺口）
 
-以下尚未進入 MCP 介面。列出來是為了讓缺口可見，而不是等人踩到：
-
-| 不可用 | 改用 |
-|---|---|
-| `/gemini:setup`（含 probe 旗標） | 斜線命令或 CLI——這本質上是互動式的 |
-| `/gemini:transfer` | 斜線命令；它會寫入工作區內的快照，且需要模型自行撰寫 instructions 檔 |
-| `--timeout <秒>` | 未開放；MCP 工作採各引擎的預設值 |
-| `--resume-last` / `--resume` | 未開放；每次 `gemini_rescue` 都是全新的 turn |
-| `--engines gemini,agy`（雙引擎審查） | 斜線命令或 CLI |
-| [Review Gate](#review-gate可選) | 由 `/gemini:setup` 設定，之後對整個 session 生效 |
+列出來是為了讓缺口可見，而不是等人踩到：`/gemini:setup` 與其 probe 旗標（本質上是互動式的）、`/gemini:transfer`（會寫入工作區內的快照，且需要模型自行撰寫 instructions 檔）、`--timeout`、`--resume-last`、`--engines gemini,agy` 都不在這個介面上——請改用斜線命令或 CLI。MCP 工作採各引擎的預設 timeout，且每次 `gemini_rescue` 都是全新的 turn。[Review Gate](#review-gate可選) 由 `/gemini:setup` 設定，之後對整個 session 生效，與工作由哪個介面排入無關。
 
 ---
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -222,6 +222,44 @@
 
 ---
 
+## MCP 工具
+
+本外掛同時提供一個 MCP server（`.mcp.json` → `scripts/gemini-mcp.mjs`），讓 agent 不必等人手打斜線命令就能驅動它。**這個介面並非上面命令表的鏡像**——判斷某個功能是否構得到之前，兩張表要一起看。
+
+| 工具 | 必填 | 選填 | 唯讀 | 連外 |
+|---|---|---|---|---|
+| `gemini_rescue` | `workspace`、`prompt` | `write`、`model`、`effort`、`engine` | 否 | 是 |
+| `gemini_review` | `workspace` | `base`、`scope`、`model`、`engine`、`deep` | 是 | 是 |
+| `gemini_adversarial_review` | `workspace` | `base`、`scope`、`model`、`engine`、`deep`、`focus` | 是 | 是 |
+| `gemini_job_status` | `workspace`、`jobId` | — | 是 | 否 |
+| `gemini_job_result` | `workspace`、`jobId` | — | 是 | 否 |
+| `gemini_job_cancel` | `workspace`、`jobId` | — | 否 | 否 |
+
+`workspace` 每個工具都必填，且必須是既存目錄的絕對路徑。這裡沒有隱含的「當前目錄」：server 由 `.mcp.json` 在 session 啟動時起一次，不是每次呼叫從 shell 起。
+
+**前三個會排入背景工作並立即回傳** `jobId`。那個回應裡沒有結果——要以 `gemini_job_status` 輪詢，再用 `gemini_job_result` 取回。**起了不收等於白花錢**，這是本外掛最貴的失敗模式。
+
+**`write: false` 是意圖，不是沙箱。** AGY 沒有唯讀模式，被委派的 turn 仍可能改檔案；執行前後會比對工作區並回報實際寫入了什麼。`gemini_rescue` 標註 `destructiveHint: true` 正是因此——即使 `write` 預設為 false，annotation 描述的是該工具**最壞**能做到什麼，且無法隨參數變動。詳見 [`docs/THREAT-MODEL.md`](docs/THREAT-MODEL.md) §7.2。
+
+**三個 job 工具以 job id 定址，且刻意跨 session。** 持有 id 的呼叫者已經指明了是哪個 job，那道用來讓**發現**路徑保持誠實的 session 過濾對他們毫無作用——而套上去反而直接弄壞它們，因為這個 server 從來收不到 session id（見下）。
+
+**在此排入的工作不屬於任何 session。** `.mcp.json` 沒有任何途徑讓 server 得知 `GEMINI_COMPANION_SESSION_ID`：`SessionStart` hook 只能匯出到 `CLAUDE_ENV_FILE`，那只到得了之後的 Bash 命令，到不了與其一同啟動的 server。v0.18.0 之前這些無主工作被歸到「別的 session 的」那一側，因此在 `/gemini:status` 看不到、也無法取消。現在會顯示了——「沒人能說它屬於誰」與「它屬於別人」是兩件不同的事。
+
+### 僅限斜線命令（明列缺口）
+
+以下尚未進入 MCP 介面。列出來是為了讓缺口可見，而不是等人踩到：
+
+| 不可用 | 改用 |
+|---|---|
+| `/gemini:setup`（含 probe 旗標） | 斜線命令或 CLI——這本質上是互動式的 |
+| `/gemini:transfer` | 斜線命令；它會寫入工作區內的快照，且需要模型自行撰寫 instructions 檔 |
+| `--timeout <秒>` | 未開放；MCP 工作採各引擎的預設值 |
+| `--resume-last` / `--resume` | 未開放；每次 `gemini_rescue` 都是全新的 turn |
+| `--engines gemini,agy`（雙引擎審查） | 斜線命令或 CLI |
+| [Review Gate](#review-gate可選) | 由 `/gemini:setup` 設定，之後對整個 session 生效 |
+
+---
+
 ## Review Gate（可選）
 
 可選的停止時審查閘門，當本次 session 有 `--write` 工作完成時，在 Claude Code 停止前自動執行對抗性審查。預設停用。

--- a/tests/gemini-mcp.test.mjs
+++ b/tests/gemini-mcp.test.mjs
@@ -4,7 +4,7 @@ import fs from "node:fs";
 import path from "node:path";
 import test from "node:test";
 
-import { handleRequest } from "../plugins/gemini/scripts/gemini-mcp.mjs";
+import { handleRequest, TOOLS } from "../plugins/gemini/scripts/gemini-mcp.mjs";
 import { dispatchBackgroundTask } from "../plugins/gemini/scripts/gemini-companion.mjs";
 import { readStoredJob } from "../plugins/gemini/scripts/lib/job-control.mjs";
 import { writeJobFile } from "../plugins/gemini/scripts/lib/state.mjs";
@@ -79,6 +79,39 @@ test("gemini_review still queues the standard template and takes no focus", asyn
 
   const rejected = await handleRequest(toolRequest("gemini_review", { workspace, focus: "x" }), { runtime });
   assert.equal(rejected.isError, true, "an argument the tool does not accept must be refused, not dropped");
+});
+
+// Neither README documented the MCP surface at all, which is the structural
+// reason adversarial review could be missing from it for as long as it was: there
+// was no list for a missing tool to be missing from. Both directions are asserted,
+// so adding a tool without documenting it fails, and documenting a tool that does
+// not exist fails too — the second is how a rename would otherwise leave a README
+// promising a tool no client can call.
+function parseReadmeToolNames(readme, heading) {
+  const afterHeading = readme.split(new RegExp(`^##\\s+${heading}\\s*$`, "m"))[1];
+  assert.ok(afterHeading, `README must have a \`## ${heading}\` section`);
+  const body = afterHeading.split(/^---\s*$/m)[0];
+  const names = new Set();
+  for (const line of body.split(/\r?\n/)) {
+    if (!/^\|\s*`gemini_/.test(line)) continue;
+    const first = line.split("|").map((cell) => cell.trim()).filter(Boolean)[0];
+    for (const match of first.matchAll(/`(gemini_[a-z_]+)`/g)) names.add(match[1]);
+  }
+  return names;
+}
+
+test("both READMEs list exactly the MCP tools the server serves", () => {
+  const served = new Set(TOOLS.map((tool) => tool.name));
+  for (const [file, heading] of [["README.md", "MCP Tools"], ["README.zh-TW.md", "MCP 工具"]]) {
+    const readme = fs.readFileSync(new URL(`../${file}`, import.meta.url), "utf8");
+    const documented = parseReadmeToolNames(readme, heading);
+    for (const name of served) {
+      assert.ok(documented.has(name), `${file} does not document \`${name}\``);
+    }
+    for (const name of documented) {
+      assert.ok(served.has(name), `${file} documents \`${name}\`, which the server does not serve`);
+    }
+  }
 });
 
 // The Anthropic software directory policy requires every applicable annotation,


### PR DESCRIPTION
Neither README described the MCP server at all. That is the structural reason adversarial review could be absent from it until #78: there was no list for a missing tool to be missing from, so the gap could only be found by reading `gemini-mcp.mjs`.

## What the section says

Both READMEs now carry `## MCP Tools` / `## MCP 工具`:

- the six tools, with required and optional arguments and their read-only / reaches-Google annotations
- `workspace` is required on every tool and always absolute — the server is launched once from `.mcp.json`, so there is no implicit "current directory"
- the first three queue a background job and return only a `jobId`; **a job started and never collected is quota spent for nothing**, which is this plugin's most expensive failure mode
- `write: false` is an intent, not a sandbox, and why `gemini_rescue` is annotated `destructiveHint: true` regardless
- why the three job tools cross sessions, and why a job queued here belongs to none — both follow from the same missing session id, and both looked like bugs before #74

A short paragraph then lists what is deliberately *not* on this surface: setup, transfer, `--timeout`, `--resume-last`, dual-engine review, the review gate. A gap someone can read is a gap someone can close.

## The guard

Pinned in both directions, modelled on the existing README model-alias guard:

- a tool the server serves and a README omits → fails
- a tool a README claims and the server does not serve → fails

The second matters as much as the first: it is how a rename would otherwise leave a README promising something no client can call.

## Second commit

The "slash-only" material started as a six-row table to say five things are absent — written while adding a section to a README that is already long, which is the overcorrection this PR should not also be making. It is prose now: same content, nine lines shorter across both files.

## Verification

- 516 tests, 508 pass, 0 fail, 8 skipped
- `verify-contracts` green at 0.19.0
- Documentation and tests only; no behaviour change

## Related

Measured while answering "are the docs too heavy?": docs total 3463 lines against 7910 lines of plugin code. The READMEs at ~444 each are the heavy part, and the specific duplication is `## Parity with codex-plugin-cc` and its two subsections, which restate `docs/COMPARISON.md`, `docs/PARITY_AUDIT*.md` and `docs/known-diffs.md` without a test holding them in sync. Moving those out is its own change, not this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JmaL2A1WpfbN5DiY7PzRHA