### PR TITLE
Move the parity reference out of the READMEs, and guard the pointer

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,27 +367,9 @@ The workspace-local `.omc/` directory is a separate thing: it holds `/gemini:tra
 
 ## Parity with codex-plugin-cc
 
-This plugin is a high-fidelity port of [openai/codex-plugin-cc](https://github.com/openai/codex-plugin-cc). The public slash-command surface, background job model, and state/result/status/cancel flow mirror the upstream; the execution backends are the first-class Gemini CLI and AGY engines rather than the Codex app server.
+A high-fidelity port of [openai/codex-plugin-cc](https://github.com/openai/codex-plugin-cc): the slash-command surface, background job model, and state/result/status/cancel flow mirror the upstream, while the execution backends are the Gemini CLI and AGY engines rather than the Codex app server.
 
-### Compatibility Matrix
-
-| Upstream (Codex) | This plugin (Gemini) | Parity |
-|---|---|---|
-| `/codex:setup` | `/gemini:setup` | **Gemini-specific divergence** — checks Gemini OAuth or AGY binary readiness for the selected first-class engine instead of Codex auth |
-| `/codex:review` | `/gemini:review` | **best-effort equivalent** — prompt / CLI-adapter review, not a native reviewer |
-| `/codex:adversarial-review` | `/gemini:adversarial-review` | **best-effort equivalent** — adversarial prompt over the same diff target |
-| `/codex:rescue` | `/gemini:rescue` | **1:1 parity** — same forwarder/subagent contract and flags |
-| `/codex:transfer` | `/gemini:transfer` | **1:1 parity** — exports session snapshot and generates AGY / Gemini CLI handoff launch commands |
-| `/codex:status` | `/gemini:status` | **1:1 parity** — same job model; `--all` crosses Claude sessions |
-| `/codex:result` | `/gemini:result` | **Gemini-specific divergence** — surfaces the Gemini session id + `gemini --resume` |
-| `/codex:cancel` | `/gemini:cancel` | **1:1 parity** — same process-tree termination (POSIX + Windows) |
-
-### Codex app server vs Gemini CLI adapter
-
-- **Runtime**: Codex uses a persistent app-server with native review and persistent threads. This plugin invokes the selected first-class Gemini CLI or AGY engine directly *per command* (no shared runtime); `auto` uses capability-based Gemini→AGY ordering.
-- **Standard review**: In the Codex plugin, `/codex:review` is a *native* reviewer. Here, `/gemini:review` is a **prompt-based / CLI-adapter equivalent** — it sends the diff to Gemini with a pragmatic-review prompt and parses structured JSON back. It is not a native Gemini reviewer.
-- **Sandbox**: Codex exposes `read-only` / `workspace-write` sandboxes and confines a write-capable run to the workspace. **Neither Gemini CLI nor AGY offers an equivalent path boundary this plugin can impose**, so it has none. AGY's `--sandbox` is not one — measured on 1.1.10, a run with it enabled wrote outside the workspace through both the edit tool and a shell command; it restricts what a terminal command may reach, not where anything may write. Gemini CLI's same-named flag is a *container* sandbox that refuses to start without Docker or Podman, so it was not measured and is not required of users. What `--write` controls differs per engine, and only on gemini is it a capability: there it adds `--yolo`, without which the model is offered no write or shell tools at all. **On AGY it is not a boundary.** Every run is oriented on your repository — `--add-dir` when read-only, `--new-project` when writing — and neither flag withholds write, because AGY has no read-only mode. An unoriented run could still read and write any absolute path; all it lacked was knowing where your repository was, which is not a protection worth the loss of every legitimate use. See [`docs/THREAT-MODEL.md` §7.2](docs/THREAT-MODEL.md). (`--approval-mode plan` is not used — it *does* work headless, but it re-declares the write tools to the model and injects a planning workflow, making it a weaker read-only shape than passing nothing.)
-- **Thread/session resume**: Codex persists threads on the app server. Here, resume relies on the Gemini CLI **session id** captured from the JSON envelope; `/gemini:result` prints `gemini --resume <session-id>`, and `--resume-last` continues the latest thread *for the current Claude session*.
+The per-command compatibility matrix and the runtime, review, sandbox and resume differences are in [`docs/parity.md`](docs/parity.md). Dated audits against specific upstream versions sit beside it.
 
 ---
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -365,27 +365,9 @@ Claude Code
 
 ## 與 codex-plugin-cc 的對應
 
-本外掛為 [openai/codex-plugin-cc](https://github.com/openai/codex-plugin-cc) 的高保真移植版。公開的斜線命令介面、背景工作模型，以及 state/result/status/cancel 流程皆鏡像上游；執行後端則為第一級支援的 Gemini CLI 與 AGY 引擎，而非 Codex app server。
+本外掛為 [openai/codex-plugin-cc](https://github.com/openai/codex-plugin-cc) 的高保真移植版：斜線命令介面、背景工作模型與 state/result/status/cancel 流程皆鏡像上游，執行後端則為 Gemini CLI 與 AGY 引擎，而非 Codex app server。
 
-### 相容性對照表
-
-| 上游（Codex） | 本外掛（Gemini） | 對應程度 |
-|---|---|---|
-| `/codex:setup` | `/gemini:setup` | **Gemini 專屬差異** — 依所選第一級引擎檢查 Gemini OAuth 或 AGY binary readiness，而非 Codex 認證 |
-| `/codex:review` | `/gemini:review` | **最佳等效** — prompt／CLI adapter 審查，非原生審查器 |
-| `/codex:adversarial-review` | `/gemini:adversarial-review` | **最佳等效** — 對同一 diff target 施以對抗性 prompt |
-| `/codex:rescue` | `/gemini:rescue` | **1:1 對等** — 相同的 forwarder／subagent 合約與旗標 |
-| `/codex:transfer` | `/gemini:transfer` | **1:1 對等** — 匯出會話快照並產生 AGY / Gemini CLI 移交接手啟動命令 |
-| `/codex:status` | `/gemini:status` | **1:1 對等** — 相同工作模型；`--all` 跨 Claude session |
-| `/codex:result` | `/gemini:result` | **Gemini 專屬差異** — 顯示 Gemini session id 與 `gemini --resume` |
-| `/codex:cancel` | `/gemini:cancel` | **1:1 對等** — 相同的 process-tree 終止（POSIX 與 Windows） |
-
-### Codex app server 與 Gemini CLI adapter
-
-- **執行時**：Codex 使用常駐 app-server，具原生審查與持久 thread。本外掛則於*每次命令*直接呼叫所選的第一級 Gemini CLI 或 AGY 引擎（無共享執行時）；`auto` 採 Gemini→AGY 的 capability-based 順序。
-- **標準審查**：Codex 外掛之 `/codex:review` 為*原生*審查器；本外掛之 `/gemini:review` 為 **prompt／CLI adapter 等效實作**——將 diff 連同務實審查 prompt 送交 Gemini 並解析回傳之結構化 JSON，並非原生 Gemini 審查器。
-- **沙箱**：Codex 提供 `read-only`／`workspace-write` 沙箱，並將可寫入的執行限制在工作區內。**Gemini CLI 與 AGY 皆未提供本外掛可施加的對應路徑邊界**，故本外掛亦無。AGY 的 `--sandbox` 不是——1.1.10 實測，啟用它的執行仍透過編輯工具與 shell 指令寫到工作區外；它限制的是終端機指令能碰到什麼（網路、`.git`），不是誰能寫到哪。Gemini CLI 同名旗標則是**容器**沙箱，未安裝 Docker 或 Podman 即拒絕啟動，故未實測，亦不強制使用者安裝。`--write` 在兩引擎的意義不同，且只有在 gemini 上它才是一道能力閘門：那裡它加的是 `--yolo`，不加時模型根本不會被提供寫入與 shell 工具。**在 AGY 上它不是邊界。** 每次執行都會定位到你的版本庫——唯讀用 `--add-dir`，寫入用 `--new-project`——而兩個旗標都不限制寫入，因為 AGY 沒有唯讀模式。未定位的執行仍可讀寫任何絕對路徑，它缺的只是「不知道你的版本庫在哪」，而那個保護不值得賠上所有正當用途。詳見 [`docs/THREAT-MODEL.md` §7.2](docs/THREAT-MODEL.md)。（不採 `--approval-mode plan`：它其實可在無 TTY 下運作，但會把寫入工具重新宣告給模型並注入規劃流程提示，比什麼都不加更弱。）
-- **Thread／session 接續**：Codex 於 app-server 持久化 thread。本外掛之接續依賴自 JSON 信封擷取之 Gemini CLI **session id**；`/gemini:result` 會印出 `gemini --resume <session-id>`，而 `--resume-last` 接續*當前 Claude session* 之最新 thread。
+逐命令的相容性對照表，以及執行時、審查、沙箱與接續四項差異，見 [`docs/parity.zh-TW.md`](docs/parity.zh-TW.md)。對照特定上游版本的稽核快照存於同一目錄。
 
 ---
 

--- a/docs/parity.md
+++ b/docs/parity.md
@@ -1,0 +1,29 @@
+# Parity with codex-plugin-cc
+
+繁體中文版：[`parity.zh-TW.md`](parity.zh-TW.md)
+
+This plugin is a high-fidelity port of [openai/codex-plugin-cc](https://github.com/openai/codex-plugin-cc). The public slash-command surface, background job model, and state/result/status/cancel flow mirror the upstream; the execution backends are the first-class Gemini CLI and AGY engines rather than the Codex app server.
+
+This file describes the **current** state. Point-in-time audits, kept because they answer *when* a behaviour changed, live alongside it: [`PARITY_AUDIT.md`](PARITY_AUDIT.md) (v0.6.0 baseline, with the v0.6.1 remediation table) and [`PARITY_AUDIT_v0.11.1.md`](PARITY_AUDIT_v0.11.1.md) (2026-08-04, against upstream v1.0.6).
+
+## Compatibility Matrix
+
+| Upstream (Codex) | This plugin (Gemini) | Parity |
+|---|---|---|
+| `/codex:setup` | `/gemini:setup` | **Gemini-specific divergence** — checks Gemini OAuth or AGY binary readiness for the selected first-class engine instead of Codex auth |
+| `/codex:review` | `/gemini:review` | **best-effort equivalent** — prompt / CLI-adapter review, not a native reviewer |
+| `/codex:adversarial-review` | `/gemini:adversarial-review` | **best-effort equivalent** — adversarial prompt over the same diff target |
+| `/codex:rescue` | `/gemini:rescue` | **1:1 parity** — same forwarder/subagent contract and flags |
+| `/codex:transfer` | `/gemini:transfer` | **1:1 parity** — exports session snapshot and generates AGY / Gemini CLI handoff launch commands |
+| `/codex:status` | `/gemini:status` | **1:1 parity** — same job model; `--all` crosses Claude sessions |
+| `/codex:result` | `/gemini:result` | **Gemini-specific divergence** — surfaces the Gemini session id + `gemini --resume` |
+| `/codex:cancel` | `/gemini:cancel` | **1:1 parity** — same process-tree termination (POSIX + Windows) |
+
+Upstream has no equivalent of this plugin's MCP server; see [MCP Tools](../README.md#mcp-tools) for what that surface exposes and what it deliberately omits.
+
+## Codex app server vs Gemini CLI adapter
+
+- **Runtime**: Codex uses a persistent app-server with native review and persistent threads. This plugin invokes the selected first-class Gemini CLI or AGY engine directly *per command* (no shared runtime); `auto` uses capability-based Gemini→AGY ordering.
+- **Standard review**: In the Codex plugin, `/codex:review` is a *native* reviewer. Here, `/gemini:review` is a **prompt-based / CLI-adapter equivalent** — it sends the diff to Gemini with a pragmatic-review prompt and parses structured JSON back. It is not a native Gemini reviewer.
+- **Sandbox**: Codex exposes `read-only` / `workspace-write` sandboxes and confines a write-capable run to the workspace. **Neither Gemini CLI nor AGY offers an equivalent path boundary this plugin can impose**, so it has none. AGY's `--sandbox` is not one — measured on 1.1.10, a run with it enabled wrote outside the workspace through both the edit tool and a shell command; it restricts what a terminal command may reach, not where anything may write. Gemini CLI's same-named flag is a *container* sandbox that refuses to start without Docker or Podman, so it was not measured and is not required of users. What `--write` controls differs per engine, and only on gemini is it a capability: there it adds `--yolo`, without which the model is offered no write or shell tools at all. **On AGY it is not a boundary.** Every run is oriented on your repository — `--add-dir` when read-only, `--new-project` when writing — and neither flag withholds write, because AGY has no read-only mode. An unoriented run could still read and write any absolute path; all it lacked was knowing where your repository was, which is not a protection worth the loss of every legitimate use. See [`THREAT-MODEL.md` §7.2](THREAT-MODEL.md). Neither engine's plan mode is used: gemini's `--approval-mode plan` re-declares the write tools to the model and injects a planning workflow, making it a weaker read-only shape than passing nothing, and AGY's `--mode plan` gates the edit tools while letting a shell command write the same file (measured on 1.1.13) — and is disabled outright whenever `--disable-slash-commands` is passed, which is every AGY spawn from 1.1.9 up.
+- **Thread/session resume**: Codex persists threads on the app server. Here, resume relies on the Gemini CLI **session id** captured from the JSON envelope; `/gemini:result` prints `gemini --resume <session-id>`, and `--resume-last` continues the latest thread *for the current Claude session*. On AGY the id is pinned with `--conversation`; on gemini it cannot be, because `--resume` accepts only `latest` or an index, so the landing is compared against the tracked thread and a mismatch is reported.

--- a/docs/parity.zh-TW.md
+++ b/docs/parity.zh-TW.md
@@ -1,0 +1,29 @@
+# 與 codex-plugin-cc 的對應
+
+English: [`parity.md`](parity.md)
+
+本外掛為 [openai/codex-plugin-cc](https://github.com/openai/codex-plugin-cc) 的高保真移植版。公開的斜線命令介面、背景工作模型，以及 state/result/status/cancel 流程皆鏡像上游；執行後端則為第一級支援的 Gemini CLI 與 AGY 引擎，而非 Codex app server。
+
+本檔描述的是**當前**狀態。有日期的稽核快照另存於旁——保留它們是因為它們回答「行為是何時改變的」：[`PARITY_AUDIT.md`](PARITY_AUDIT.md)（v0.6.0 基準，含 v0.6.1 修復彙整表）與 [`PARITY_AUDIT_v0.11.1.md`](PARITY_AUDIT_v0.11.1.md)（2026-08-04，對照上游 v1.0.6）。
+
+## 相容性對照表
+
+| 上游（Codex） | 本外掛（Gemini） | 對應程度 |
+|---|---|---|
+| `/codex:setup` | `/gemini:setup` | **Gemini 專屬差異** — 依所選第一級引擎檢查 Gemini OAuth 或 AGY binary readiness，而非 Codex 認證 |
+| `/codex:review` | `/gemini:review` | **最佳等效** — prompt／CLI adapter 審查，非原生審查器 |
+| `/codex:adversarial-review` | `/gemini:adversarial-review` | **最佳等效** — 對同一 diff target 施以對抗性 prompt |
+| `/codex:rescue` | `/gemini:rescue` | **1:1 對等** — 相同的 forwarder／subagent 合約與旗標 |
+| `/codex:transfer` | `/gemini:transfer` | **1:1 對等** — 匯出會話快照並產生 AGY / Gemini CLI 移交接手啟動命令 |
+| `/codex:status` | `/gemini:status` | **1:1 對等** — 相同工作模型；`--all` 跨 Claude session |
+| `/codex:result` | `/gemini:result` | **Gemini 專屬差異** — 顯示 Gemini session id 與 `gemini --resume` |
+| `/codex:cancel` | `/gemini:cancel` | **1:1 對等** — 相同的 process-tree 終止（POSIX 與 Windows） |
+
+上游沒有與本外掛 MCP server 對應的東西；該介面提供什麼、又刻意不提供什麼，見 [MCP 工具](../README.zh-TW.md#mcp-工具)。
+
+## Codex app server 與 Gemini CLI adapter
+
+- **執行時**：Codex 使用常駐 app-server，具原生審查與持久 thread。本外掛則於*每次命令*直接呼叫所選的第一級 Gemini CLI 或 AGY 引擎（無共享執行時）；`auto` 採 Gemini→AGY 的 capability-based 順序。
+- **標準審查**：Codex 外掛之 `/codex:review` 為*原生*審查器；本外掛之 `/gemini:review` 為 **prompt／CLI adapter 等效實作**——將 diff 連同務實審查 prompt 送交 Gemini 並解析回傳之結構化 JSON，並非原生 Gemini 審查器。
+- **沙箱**：Codex 提供 `read-only`／`workspace-write` 沙箱，並將可寫入的執行限制在工作區內。**Gemini CLI 與 AGY 皆未提供本外掛可施加的對應路徑邊界**，故本外掛亦無。AGY 的 `--sandbox` 不是——1.1.10 實測，啟用它的執行仍透過編輯工具與 shell 指令寫到工作區外；它限制的是終端機指令能碰到什麼（網路、`.git`），不是誰能寫到哪。Gemini CLI 同名旗標則是**容器**沙箱，未安裝 Docker 或 Podman 即拒絕啟動，故未實測，亦不強制使用者安裝。`--write` 在兩引擎的意義不同，且只有在 gemini 上它才是一道能力閘門：那裡它加的是 `--yolo`，不加時模型根本不會被提供寫入與 shell 工具。**在 AGY 上它不是邊界。** 每次執行都會定位到你的版本庫——唯讀用 `--add-dir`，寫入用 `--new-project`——而兩個旗標都不限制寫入，因為 AGY 沒有唯讀模式。未定位的執行仍可讀寫任何絕對路徑，它缺的只是「不知道你的版本庫在哪」，而那個保護不值得賠上所有正當用途。詳見 [`THREAT-MODEL.md` §7.2](THREAT-MODEL.md)。兩個引擎的 plan 模式皆不採用：gemini 的 `--approval-mode plan` 會把寫入工具重新宣告給模型並注入規劃流程提示，比什麼都不加更弱；AGY 的 `--mode plan` 則只擋編輯工具，shell 指令照樣寫得進同一個檔案（1.1.13 實測），且只要傳了 `--disable-slash-commands` 就會被整個停用——而 1.1.9 以上每次 AGY spawn 都會傳。
+- **Thread／session 接續**：Codex 於 app-server 持久化 thread。本外掛之接續依賴自 JSON 信封擷取之 Gemini CLI **session id**；`/gemini:result` 會印出 `gemini --resume <session-id>`，而 `--resume-last` 接續*當前 Claude session* 之最新 thread。在 AGY 上該 id 以 `--conversation` 釘住；在 gemini 上釘不住，因為 `--resume` 只接受 `latest` 或索引，故改為比對實際落點與追蹤中的 thread，不一致就回報。

--- a/tests/privacy-doc.test.mjs
+++ b/tests/privacy-doc.test.mjs
@@ -33,6 +33,27 @@ test("every entry document links to PRIVACY.md", () => {
   }
 });
 
+// Same failure mode, generalised. Material moved out of a README into docs/ is
+// only moved if the pointer resolves; a link that rots leaves the README
+// promising an explanation the reader cannot reach, which is worse than the long
+// version it replaced. Repo-relative links only — external URLs are not this
+// suite's to verify, and anchors are checked no further than the file.
+const LINKED = ["README.md", "README.zh-TW.md", "SECURITY.md", "PRIVACY.md", "CONTRIBUTING.md"];
+
+test("every repo-relative link in the entry documents resolves", () => {
+  for (const file of LINKED) {
+    const dir = path.dirname(path.join(ROOT, file));
+    for (const match of read(file).matchAll(/\]\(([^)\s]+)\)/g)) {
+      const target = match[1];
+      if (/^(https?:|mailto:|#)/.test(target)) continue;
+      const [relative] = target.split("#");
+      if (!relative) continue;
+      const resolved = path.resolve(dir, relative);
+      assert.ok(fs.existsSync(resolved), `${file} links to ${target}, which does not exist`);
+    }
+  }
+});
+
 test("SECURITY.md declares support for the shipped minor line", () => {
   const version = JSON.parse(read("package.json")).version;
   const minorLine = `${version.split(".").slice(0, 2).join(".")}.x`;


### PR DESCRIPTION
Follow-up to "are the introductory docs too heavy?" — measured: docs total 3463 lines against 7910 lines of plugin code, and the READMEs were the heavy part.

## A correction first

I told the user this parity material was already duplicated by `docs/COMPARISON.md` and the parity audits. Reading them says otherwise:

- `docs/COMPARISON.md` is positioning against AGY-only plugins and never mentions codex-plugin-cc
- `docs/PARITY_AUDIT.md` and `docs/PARITY_AUDIT_v0.11.1.md` are dated, scored snapshots against specific upstream versions

Nothing held the **current** parity reference except the READMEs. So this is a move, not a deduplication, and nothing is deleted.

## The move

`docs/parity.md` and `docs/parity.zh-TW.md` now hold the compatibility matrix and the four runtime differences, each linking to the dated audits for *when* a behaviour changed. Both READMEs keep a two-sentence summary and a pointer — 27 lines down to 9 apiece.

Two paragraphs were stale where they sat, and are corrected in the move rather than carried across unchanged:

- the **sandbox** bullet now covers AGY's `--mode plan` alongside gemini's `--approval-mode plan` — measured on 1.1.13 in #76: it gates the edit tools, lets a shell command write the same file, and is disabled outright whenever `--disable-slash-commands` is passed
- the **resume** bullet now says the AGY id is pinned with `--conversation` while gemini's cannot be, which is what #73 changed

## The guard

Every repo-relative link in the entry documents must resolve. Material moved into `docs/` is only moved if the pointer works — a rotted link leaves the README promising an explanation the reader cannot reach, which is worse than the long version it replaced.

Generalised from the existing `PRIVACY.md` link test, whose own comment names this exact failure mode: *"the way a policy doc actually rots is that a README rewrite drops the link and nobody notices"*. Mutation-checked — repointing `docs/parity.md` at a missing file fails it.

## Net effect

| | before this work | now |
|---|---|---|
| `README.md` | 453 | 426 |
| `README.zh-TW.md` | 451 | 424 |

Both are shorter than when this started, with the entire MCP surface documented in between (#80).

517 tests, 509 pass, 0 fail, 8 skipped. `verify-contracts` green. Documentation and tests only; no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JmaL2A1WpfbN5DiY7PzRHA