### PR TITLE
Index docs/, and make an orphan document impossible

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,6 +405,8 @@ Documented, non-blocking constraints — see the linked sections for detail:
 
 This is a single-maintainer project, not a staffed support desk. Everything above reaches one person.
 
+Deeper material lives in [`docs/`](docs/README.md), which separates reference kept current from dated records that are never rewritten — reading one as the other is the easiest mistake to make there.
+
 Reviewing the plugin rather than using it? [`docs/verifying-without-credentials.md`](docs/verifying-without-credentials.md) is the complete offline path — no account, no API key. For a run of every command end to end against a stand-in engine, start with `node scripts/reviewer-demo.mjs`.
 
 ---

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -403,6 +403,8 @@ Claude Code
 
 本專案由單一維護者經營，並非有專職人力的支援窗口；以上管道都是同一個人在收。
 
+更深入的材料放在 [`docs/`](docs/README.zh-TW.md)，該頁把「持續更新的參考文件」與「永不重寫的有日期記錄」分開——把後者當成現況來讀，是那個目錄最容易犯的錯。
+
 若你是要審查本外掛而非使用它：[`docs/verifying-without-credentials.md`](docs/verifying-without-credentials.md)（英文）記載完整的離線驗證路徑，不需帳號、不需 API key。若想直接看每個命令的端到端執行（以替身引擎驅動），從 `node scripts/reviewer-demo.mjs` 開始。
 
 ---

--- a/docs/AGY_1.1.2_MACOS_LINUX_VALIDATION.md
+++ b/docs/AGY_1.1.2_MACOS_LINUX_VALIDATION.md
@@ -1,5 +1,9 @@
 # AGY 1.1.2 macOS/Linux 驗證清單
 
+> **有日期的記錄，不是現況。** 本檔量的是外掛 v0.7.1 對 AGY **1.1.2**；當前為 AGY 1.1.13，其間新增了 `--output-format json`／`stream-json`（1.1.8／1.1.12）、print 模式的 slash command 展開（1.1.9）、真正生效的 `--model`／`--effort`（1.1.10）與唯讀 slash command（1.1.11）——本檔一項都沒涵蓋。沒有人在較新版本上重跑過這份清單。
+>
+> 保留它是因為它回答「當時在 macOS/Linux 上量到什麼」，那是別處沒有的資料。當前行為請看 [`../plugins/gemini/CHANGELOG.md`](../plugins/gemini/CHANGELOG.md) 與 [`THREAT-MODEL.md`](THREAT-MODEL.md) §7.2；文件分類見 [`README.zh-TW.md`](README.zh-TW.md)。
+
 本清單驗證 `gemini-plugin-cc` v0.7.1 對真實 Antigravity CLI 1.1.2 的 stdin、stdout、transcript、背景工作、review、錯誤與 OAuth headless 行為。POSIX fake fixture 只能作為自動化基線，不能取代真實 AGY binary 與服務端回應。
 
 ## 固定範圍與安全界線

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,31 @@
+# Documentation index
+
+繁體中文版：[`README.zh-TW.md`](README.zh-TW.md)
+
+Two kinds of file live here, and telling them apart matters more than their size. **Reference** describes how the plugin behaves now and is corrected when behaviour changes. A **dated record** describes what was measured on a specific day against specific versions; it is never rewritten, because its value is answering *when* something changed. Reading a dated record as if it were current is the mistake this page exists to prevent.
+
+Start with the [README](../README.md). Nothing here is required reading to use the plugin.
+
+## Reference — kept current
+
+| File | Answers |
+|---|---|
+| [`THREAT-MODEL.md`](THREAT-MODEL.md) | What an untrusted repository can make a delegated agent do, mapped to OWASP LLM Top 10. §7.2 is the one to read before trusting any "read-only" claim. |
+| [`parity.md`](parity.md) · [`parity.zh-TW.md`](parity.zh-TW.md) | How this plugin maps to `codex-plugin-cc`, command by command, and where the runtimes differ. |
+| [`known-diffs.md`](known-diffs.md) | Deliberate divergences from upstream, with the reason each one is kept. |
+| [`COMPARISON.md`](COMPARISON.md) | Positioning against AGY-only and multi-host plugins — what this plugin does and does not claim. |
+| [`MODEL_COMPARISON.md`](MODEL_COMPARISON.md) | Why review depth differs between engines, and how much of it is harness rather than model. Contains dated probe records, each marked where superseded. |
+| [`adapter-contract.md`](adapter-contract.md) | The interface an engine adapter has to satisfy. |
+| [`version-sources.md`](version-sources.md) | Which file is authoritative for each version string, and what keeps them in lockstep. |
+| [`verifying-without-credentials.md`](verifying-without-credentials.md) | How to exercise the engine paths without a Gemini or AGY account. |
+
+## Dated records — never rewritten
+
+| File | Measured against | Superseded by |
+|---|---|---|
+| [`PARITY_AUDIT.md`](PARITY_AUDIT.md) | plugin v0.6.0 vs upstream v1.0.4, 2026-06-02 | `PARITY_AUDIT_v0.11.1.md` |
+| [`PARITY_AUDIT_v0.6.1.md`](PARITY_AUDIT_v0.6.1.md) | plugin v0.6.1 re-score | `PARITY_AUDIT_v0.11.1.md` |
+| [`PARITY_AUDIT_v0.11.1.md`](PARITY_AUDIT_v0.11.1.md) | plugin v0.11.1 vs upstream v1.0.6, 2026-08-04 | current state: [`parity.md`](parity.md) |
+| [`AGY_1.1.2_MACOS_LINUX_VALIDATION.md`](AGY_1.1.2_MACOS_LINUX_VALIDATION.md) | plugin v0.7.1 against AGY **1.1.2**, macOS/Linux | nothing re-ran it; see the banner in the file |
+
+Behaviour measured after the newest of these lives in the [CHANGELOG](../plugins/gemini/CHANGELOG.md) and in `THREAT-MODEL.md` §7.2, both of which carry their own measurement dates.

--- a/docs/README.zh-TW.md
+++ b/docs/README.zh-TW.md
@@ -1,0 +1,31 @@
+# 文件索引
+
+English: [`README.md`](README.md)
+
+這裡放兩種檔案，**分清楚它們比檔案多長更重要**。**參考文件**描述外掛當前的行為，行為變了就跟著更正。**有日期的記錄**描述的是某一天、對特定版本量到的結果，永遠不重寫——它的價值正是回答「某件事是何時改變的」。把有日期的記錄當成現況來讀，正是這一頁存在要防止的錯誤。
+
+請從 [README](../README.zh-TW.md) 開始。這裡沒有任何一份是使用本外掛的必讀。
+
+## 參考文件——持續更新
+
+| 檔案 | 回答什麼 |
+|---|---|
+| [`THREAT-MODEL.md`](THREAT-MODEL.md) | 不可信的版本庫能讓被委派的 agent 做到什麼，對照 OWASP LLM Top 10。相信任何「唯讀」宣稱之前，先讀 §7.2。 |
+| [`parity.zh-TW.md`](parity.zh-TW.md) · [`parity.md`](parity.md) | 本外掛與 `codex-plugin-cc` 的逐命令對應，以及兩者執行時的差異。 |
+| [`known-diffs.md`](known-diffs.md) | 與上游的刻意差異，以及每一項保留的理由。 |
+| [`COMPARISON.md`](COMPARISON.md) | 相對於 AGY-only 與多宿主外掛的定位——本外掛主張什麼、不主張什麼。 |
+| [`MODEL_COMPARISON.md`](MODEL_COMPARISON.md) | 各引擎審查深度為何不同，其中多少是 harness 而非模型造成的。內含有日期的探測記錄，已被取代者皆已標註。 |
+| [`adapter-contract.md`](adapter-contract.md) | 引擎 adapter 必須滿足的介面。 |
+| [`version-sources.md`](version-sources.md) | 每個版本字串以哪個檔案為準，以及靠什麼維持一致。 |
+| [`verifying-without-credentials.md`](verifying-without-credentials.md) | 沒有 Gemini 或 AGY 帳號時，如何演練引擎路徑。 |
+
+## 有日期的記錄——永不重寫
+
+| 檔案 | 對照對象 | 被誰取代 |
+|---|---|---|
+| [`PARITY_AUDIT.md`](PARITY_AUDIT.md) | 外掛 v0.6.0 對上游 v1.0.4，2026-06-02 | `PARITY_AUDIT_v0.11.1.md` |
+| [`PARITY_AUDIT_v0.6.1.md`](PARITY_AUDIT_v0.6.1.md) | 外掛 v0.6.1 重評 | `PARITY_AUDIT_v0.11.1.md` |
+| [`PARITY_AUDIT_v0.11.1.md`](PARITY_AUDIT_v0.11.1.md) | 外掛 v0.11.1 對上游 v1.0.6，2026-08-04 | 當前狀態見 [`parity.zh-TW.md`](parity.zh-TW.md) |
+| [`AGY_1.1.2_MACOS_LINUX_VALIDATION.md`](AGY_1.1.2_MACOS_LINUX_VALIDATION.md) | 外掛 v0.7.1 對 AGY **1.1.2**，macOS/Linux | 無人重跑；見該檔開頭的說明 |
+
+比上述最新一份更晚量到的行為，記在 [CHANGELOG](../plugins/gemini/CHANGELOG.md) 與 `THREAT-MODEL.md` §7.2，兩者各自帶有量測日期。

--- a/tests/privacy-doc.test.mjs
+++ b/tests/privacy-doc.test.mjs
@@ -38,7 +38,15 @@ test("every entry document links to PRIVACY.md", () => {
 // promising an explanation the reader cannot reach, which is worse than the long
 // version it replaced. Repo-relative links only — external URLs are not this
 // suite's to verify, and anchors are checked no further than the file.
-const LINKED = ["README.md", "README.zh-TW.md", "SECURITY.md", "PRIVACY.md", "CONTRIBUTING.md"];
+const LINKED = [
+  "README.md",
+  "README.zh-TW.md",
+  "SECURITY.md",
+  "PRIVACY.md",
+  "CONTRIBUTING.md",
+  "plugins/gemini/CHANGELOG.md",
+  ...fs.readdirSync(path.join(ROOT, "docs")).filter((f) => f.endsWith(".md")).map((f) => `docs/${f}`)
+];
 
 test("every repo-relative link in the entry documents resolves", () => {
   for (const file of LINKED) {
@@ -62,4 +70,21 @@ test("SECURITY.md declares support for the shipped minor line", () => {
     new RegExp(`\\|\\s*${minorLine.replaceAll(".", "\\.")}\\s*\\|`),
     `SECURITY.md does not list ${minorLine} as supported`
   );
+});
+
+// docs/AGY_1.1.2_MACOS_LINUX_VALIDATION.md sat at 249 lines — the largest file in
+// docs/ — with zero inbound links from anywhere in the repository, pinning AGY
+// 1.1.2 while the plugin was being run against 1.1.13. Nothing was wrong with
+// keeping it; what was wrong is that no reader could tell it existed, or that it
+// was a dated record rather than the current answer. An index only prevents that
+// while it is complete, and an index nobody is forced to update stops being one.
+test("the docs index lists every file in docs/", () => {
+  const dir = path.join(ROOT, "docs");
+  const present = fs.readdirSync(dir).filter((f) => f.endsWith(".md") && !f.startsWith("README"));
+  for (const index of ["docs/README.md", "docs/README.zh-TW.md"]) {
+    const text = read(index);
+    for (const file of present) {
+      assert.ok(text.includes(`(${file})`), `${index} does not list \`${file}\``);
+    }
+  }
 });


### PR DESCRIPTION
Second slimming round. The first moved material out of the READMEs; this one makes `docs/` legible, because a directory nobody can navigate is not smaller than a long README — it is just harder to read.

## The orphan

`docs/AGY_1.1.2_MACOS_LINUX_VALIDATION.md` is the **largest file in `docs/`** at 249 lines, with **zero inbound links** from anywhere in the repository. It pins AGY **1.1.2**; the plugin is now run against 1.1.13, and everything from `--output-format json` (1.1.8) through the read-only slash commands (1.1.11) landed after it. Nobody re-ran it.

Keeping it is right — it answers what was measured on macOS/Linux at the time, which nothing else does. What was wrong is that no reader could discover it, and nothing on the page said it was a dated record rather than the current answer. It now carries a banner saying both.

## The index

`docs/README.md` and `docs/README.zh-TW.md` split the directory in two:

- **Reference — kept current**: `THREAT-MODEL.md`, `parity.md`, `known-diffs.md`, `COMPARISON.md`, `MODEL_COMPARISON.md`, `adapter-contract.md`, `version-sources.md`, `verifying-without-credentials.md`
- **Dated records — never rewritten**: the three `PARITY_AUDIT*` files and the AGY 1.1.2 validation, each with what it was measured against and what supersedes it

The distinction is the whole point. Reading a dated record as current is the mistake this directory invites, and it is how a superseded audit gets quoted as today's behaviour. Both READMEs link the index from their Support section.

## Nothing moved, deliberately

Moving the audits into an `archive/` was the obvious shape and is wrong here: `plugins/gemini/CHANGELOG.md:923` links `PARITY_AUDIT_v0.6.1.md`, and a released changelog entry is not editable under this repository's own convention. The move would either break that link or require rewriting a published record.

## Guards

Both mutation-checked:

| Guard | Mutation | Result |
|---|---|---|
| the index lists every file in `docs/` | drop a new `.md` into `docs/` | `docs/README.md does not list ORPHAN_TEST.md` |
| repo-relative links resolve, now across `docs/*.md` and the CHANGELOG too | repoint one index link at a missing file | `links to THREAT-MODEL-gone.md, which does not exist` |

An index only prevents orphans while it is complete, and one nobody is forced to update stops being one. All existing links already resolved, so the second guard pins the state rather than fixing a break.

518 tests, 510 pass, 0 fail, 8 skipped. `verify-contracts` green. Documentation and tests only; no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JmaL2A1WpfbN5DiY7PzRHA