### PR TITLE
Correct the instructions the rescue subagent loads, and pin them by test

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,13 +7,13 @@
   },
   "metadata": {
     "description": "Use Gemini CLI or Antigravity CLI (agy) inside Claude Code for task delegation, code review, and adversarial review.",
-    "version": "0.19.0"
+    "version": "0.19.1"
   },
   "plugins": [
     {
       "name": "gemini",
       "description": "Gemini CLI and Antigravity CLI bridge for Claude Code task delegation and adversarial review",
-      "version": "0.19.0",
+      "version": "0.19.1",
       "author": {
         "name": "arcobaleno64",
         "email": "arcobaleno830623@gmail.com"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@arcobaleno64/gemini-plugin-cc",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@arcobaleno64/gemini-plugin-cc",
-      "version": "0.19.0",
+      "version": "0.19.1",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arcobaleno64/gemini-plugin-cc",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "private": true,
   "type": "module",
   "description": "Use Gemini CLI or Antigravity CLI (agy) inside Claude Code for task delegation, code review, and adversarial review.",

--- a/plugins/gemini/.claude-plugin/plugin.json
+++ b/plugins/gemini/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gemini",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "description": "Use Gemini/AGY from Claude Code to review code or delegate tasks.",
   "author": {
     "name": "arcobaleno64",

--- a/plugins/gemini/CHANGELOG.md
+++ b/plugins/gemini/CHANGELOG.md
@@ -1,5 +1,70 @@
 # Changelog
 
+## 0.19.1 — 2026-08-17 — The instructions the subagent loads, checked against the code
+
+`plugins/gemini/skills/` is not commentary. The `gemini:gemini-rescue` subagent
+loads those files and follows them. Nothing tested them, so they drifted three
+releases behind the code that is supposed to be their subject, and one of the
+drifted lines was a safety default.
+
+### `--write` was documented as the default in three places
+
+v0.16.0 inverted the rescue default and said so in `agents/gemini-rescue.md:34`:
+"Do NOT add `--write` unless the user asked for edits." Two lines of
+`skills/gemini-cli-runtime/SKILL.md` and one of
+`skills/gemini-prompting/references/gemini-prompt-recipes.md` still said the
+opposite. The subagent loads both documents in the same turn, so which
+instruction won was undetermined — and an AGY `--write` run has no path boundary
+([`docs/THREAT-MODEL.md` §7.2](../../docs/THREAT-MODEL.md)). The stake was
+whether "investigate this" could edit your repository.
+
+### `--model` and `--effort` were documented as ignored on AGY
+
+Five places said AGY leaves model choice to its own configured default and that
+these flags are not translated. False since AGY 1.1.10: `buildCliArgs` in
+`lib/engine.mjs` pushes both to the AGY command line. What the flags actually
+require is now stated — an exact ID from `agy models` via `--model`, or a native
+`low`/`medium`/`high` via `--effort`, never both, and Gemini aliases are rejected
+for AGY. `--effort`'s accepted set is documented per engine rather than
+unconditionally, since `normalizeAgyEffort` throws on the other four values.
+
+### AGY was documented as returning unstructured output
+
+Two places said the response is plain text and that the on-disk transcript is
+authoritative. Since v0.11.0 the plugin reads AGY's JSON envelope and does not
+touch the transcript at or above AGY 1.1.8; transcript recovery is the fallback
+below it. The engine-routing rationale was wrong for the same reason — it claimed
+gemini wins on its JSON contract, when `detectEngine` picks gemini only when it
+is installed **and** holds a usable credential.
+
+### The alias list named three of nine
+
+`skills/gemini-cli-runtime/SKILL.md` listed `flash`, `pro`, and `lite`.
+`MODEL_ALIAS_ENTRIES` has nine.
+
+### A test now holds all four in place
+
+`tests/skills-drift.test.mjs` scans the 18 instruction documents under
+`agents/`, `commands/`, `skills/`, and `prompts/`. `CHANGELOG.md` is excluded by
+using a directory allowlist rather than an exclusion list, because a changelog
+legitimately quotes the wording a release removed — including this one.
+
+Three of the four rules are worded blacklists, which are only worth what a
+mutation proves. Each pre-fix sentence was restored, the suite run, and the
+failure checked to be an assertion in the intended rule rather than a load
+error: six mutations, six kills, one failing test each. The fourth rule is a
+positive assertion against `MODEL_ALIASES`, so adding an alias to
+`model-map.mjs` turns the documentation red until it is written down.
+
+### Notes
+
+- No runtime behavior changed. `plugins/gemini/scripts/` is untouched; it was the
+  authority this release was checked against, not the subject of it.
+- The audit and the edits were dispatched to the plugin's own AGY backend. Across
+  six runs it produced no fabricated citation, and its one review finding — a
+  `SyntaxError` claimed at confidence 1.0 in a regular expression that compiles
+  and runs — was rejected.
+
 ## 0.19.0 — 2026-08-17 — What it reached, what it wrote, which engine it used
 
 Three things a run could not tell you afterwards, and one it wrote without asking.

--- a/plugins/gemini/skills/gemini-cli-runtime/SKILL.md
+++ b/plugins/gemini/skills/gemini-cli-runtime/SKILL.md
@@ -20,15 +20,15 @@ Execution rules:
 - That prompt drafting is the only Claude-side work allowed. Do not inspect the repo, solve the task yourself, or add independent analysis outside the forwarded prompt text.
 - Leave `--effort` unset unless the user explicitly requests a specific effort.
 - Leave model unset by default. Add `--model` only when the user explicitly asks for one.
-- Model aliases: `flash` → gemini-3-flash-preview, `pro` → gemini-3.1-pro-preview, `lite` → gemini-2.5-flash-lite.
-- Default to a write-capable run by adding `--write` unless the user explicitly asks for read-only behavior.
+- Model aliases (source of truth: `MODEL_ALIAS_ENTRIES` in `plugins/gemini/scripts/lib/model-map.mjs`): `flash` / `flash3` → `gemini-3-flash-preview`, `pro` / `pro3` → `gemini-3.1-pro-preview`, `lite3` → `gemini-3.1-flash-lite`, `flash25` → `gemini-2.5-flash`, `pro25` → `gemini-2.5-pro`, `lite` / `fast` → `gemini-2.5-flash-lite`.
+- Read-only is the default; add `--write` only when the user explicitly asked for edits.
 
 Command selection:
 - Use exactly one `task` invocation per rescue handoff.
 - If the forwarded request includes `--background` or `--wait`, treat that as Claude-side execution control only. Strip it before calling `task`.
 - If the forwarded request includes `--model`, normalize aliases and pass it through.
 - If the forwarded request includes `--effort`, pass it through to `task`.
-- `--effort` accepted values: `none`, `minimal`, `low`, `medium`, `high`, `xhigh`.
+- `--effort` accepted values: Gemini engine accepts `none`, `minimal`, `low`, `medium`, `high`, `xhigh`; AGY engine accepts only `low`, `medium`, `high`.
 - `--resume`: add `--resume-last`, even if the request text is ambiguous.
 - `--fresh`: use a fresh `task` run, do not add `--resume-last`.
 - `task --resume-last`: for "keep going", "resume", "apply the top fix", or "dig deeper".
@@ -36,14 +36,14 @@ Command selection:
 Engine routing:
 - Gemini CLI and AGY are both first-class supported engines; only the selected
   engine's CLI is required.
-- Default engine: auto-detect in capability order (gemini first for its
-  JSON/model contract, then agy).
+- Default engine: credential-gated auto-detection (selects Gemini if installed
+  and authenticated with valid credentials, otherwise AGY).
 - Force AGY: add `--engine agy`.
 - Force Gemini CLI: add `--engine gemini`.
-- Note: `--model` and `--effort` are ignored when the AGY engine is active; AGY uses its configured/default model and tier.
+- Note for AGY engine: `--model` takes an exact model ID from `agy models` or `--effort` accepts `low`, `medium`, or `high`; the two cannot be combined, and Gemini model aliases are rejected for AGY.
 
 Safety rules:
-- Default to write-capable work in `gemini:gemini-rescue` unless the user explicitly asks for read-only behavior.
+- Read-only is the default in `gemini:gemini-rescue`; add `--write` only when the user explicitly asked for edits.
 - Preserve the user's task text as-is apart from stripping routing flags.
 - Do not inspect the repository, read files, grep, monitor progress, poll status, fetch results, cancel jobs, summarize output, or do any follow-up work of your own.
 - Return the stdout of the `task` command exactly as-is.

--- a/plugins/gemini/skills/gemini-prompting/SKILL.md
+++ b/plugins/gemini/skills/gemini-prompting/SKILL.md
@@ -28,7 +28,7 @@ Model selection guidance (`<model_selection>` block):
 - Debug or fix tasks → `--effort high` (→ gemini-3.1-pro-preview)
 - Research or review tasks → `--effort medium` (→ gemini-3-flash-preview)
 - Quick formatting or structure tasks → `--effort low` (→ gemini-3-flash-preview)
-- AGY engine: this plugin currently leaves model choice to AGY's configured/default behavior. `--model` and `--effort` are gemini-engine controls here and are not translated to AGY arguments.
+- AGY engine: `--model` takes an exact model id as listed by `agy models`; `--effort` takes a native `low`, `medium`, or `high`; the two are mutually exclusive; and Gemini aliases are rejected for AGY.
 
 When to add blocks:
 - Coding or debugging: add `completeness_contract`, `verification_loop`, and `missing_context_gating`.
@@ -53,4 +53,4 @@ Prompt assembly checklist:
 
 - [references/gemini-prompt-blocks.md](references/gemini-prompt-blocks.md) — the reusable XML block catalogue (including `json_output_contract` and `model_selection`).
 - [references/gemini-prompt-recipes.md](references/gemini-prompt-recipes.md) — end-to-end templates for diagnosis, narrow fix, review, research, and prompt-patching.
-- [references/gemini-prompt-antipatterns.md](references/gemini-prompt-antipatterns.md) — failure modes to avoid, including Gemini/AGY-specific ones (plugin-managed model selection is gemini-only; AGY has no pipeable stdout).
+- [references/gemini-prompt-antipatterns.md](references/gemini-prompt-antipatterns.md) — anti-patterns covering vague framing, missing contracts, follow-through defaults, reasoning misuse, job mixing, unsupported certainty, and AGY/Codex engine pitfalls.

--- a/plugins/gemini/skills/gemini-prompting/references/gemini-prompt-antipatterns.md
+++ b/plugins/gemini/skills/gemini-prompting/references/gemini-prompt-antipatterns.md
@@ -105,28 +105,29 @@ If a point is an inference, label it clearly.
 Bad:
 
 ```text
-Use --engine agy --model gemini-3.1-pro-preview --effort high to force AGY through the plugin's Gemini aliases.
+Use --engine agy --model pro --effort high or combine --model with --effort when targeting AGY.
 ```
 
 Better:
-- Use the **gemini** engine when you need this plugin to pick a specific model or effort tier — `--effort high` → `gemini-3.1-pro-preview`.
-- For AGY, treat `--model`/`--effort` as unmanaged by this plugin: it leaves model choice to AGY's configured/default behavior and prints a note when you pass those flags.
+- For AGY, pass an exact model ID from `agy models` via `--model`, or a native effort tier (`low`, `medium`, or `high`) via `--effort`, but never both.
+- Use Gemini model aliases (such as `pro` or `flash`) only with `--engine gemini`, as AGY requires exact model IDs.
 
-Explanation: AGY's own model surface can change by AGY version, and it is not the same contract as this plugin's Gemini alias / effort map. Plugin-managed capability selection is a gemini-engine concern only.
+Explanation: AGY encodes the effort tier into the model ID when `--model` is supplied, so passing `--model` together with `--effort` is refused before spawn. Additionally, Gemini engine aliases such as `pro` are rejected by `normalizeAgyRequestedModel` when targeting AGY. The correct usage is an exact ID from `agy models`, or a native `--effort` of `low`, `medium` or `high`, but not both.
 
 ## Expecting AGY to return output on stdout (AGY-specific)
 
 Bad:
 
 ```text
-Pipe `agy --print "..."` and read its stdout, or tell AGY to print only the final answer.
+Pipe legacy or unversioned `agy --print "..."` directly expecting a clean, pipeable answer stream without version checks.
 ```
 
 Better:
-- Let the plugin treat AGY's on-disk transcript as authoritative, even when AGY 1.1.2 also emits stdout.
-- Prefer the **gemini** engine (`--output-format json`) when you need clean, pipeable structured output.
+- Rely on AGY's stdout JSON envelope as authoritative on AGY 1.1.8 and up (`supportsAgyStructuredOutput` / `supportsAgyStreamJson`).
+- Treat on-disk transcript recovery as the legacy fallback mechanism for AGY versions below 1.1.8.
+- Prefer the **gemini** engine (`--output-format json`) when you need uniform, clean structured output across all environments.
 
-Explanation: older positional `agy --print` releases did not deliver responses over a pipe (upstream google-gemini/gemini-cli#27466). AGY 1.1.2's stdin auto-print path can emit stdout, but the plugin still diffs transcript dirs for the completed response, DONE status, thinking, and conversation id. The 1.1.2 path is live-verified on Windows and Ubuntu WSL2; real macOS 1.1.2 remains not run.
+Explanation: older positional `agy --print` releases did not deliver responses over a pipe (upstream google-gemini/gemini-cli#27466). Since plugin v0.11.0, the plugin reads AGY's stdout JSON envelope as authoritative on AGY 1.1.8+, while on-disk transcript recovery remains only as the fallback for AGY versions below 1.1.8. The 1.1.2 path is live-verified on Windows and Ubuntu WSL2; real macOS 1.1.2 remains not run.
 
 ## Assuming Gemini/AGY behaves like Codex (parity-specific)
 

--- a/plugins/gemini/skills/gemini-prompting/references/gemini-prompt-blocks.md
+++ b/plugins/gemini/skills/gemini-prompting/references/gemini-prompt-blocks.md
@@ -188,8 +188,7 @@ Mention only major phase changes or blockers.
 
 ### `model_selection`
 
-Drives `--effort` / `--model` for the **gemini** engine. The plugin does not translate these controls to AGY — see the
-anti-patterns file.
+Drives `--effort` / `--model` for the **gemini** engine. For AGY, pass an exact `agy models` ID via `--model` or a native `low`/`medium`/`high` via `--effort`, never both — see the anti-patterns file.
 
 ```xml
 <model_selection>
@@ -197,7 +196,7 @@ anti-patterns file.
 --effort medium → gemini-3-flash-preview  (balanced review, research)
 --effort low   → gemini-3-flash-preview   (formatting, structure)
 --effort none  → gemini-2.5-flash-lite    (cheapest, trivial transforms)
-AGY: plugin-managed --model and --effort do not apply; AGY uses its configured/default model behavior.
+AGY: takes an exact `agy models` ID via --model or a native low/medium/high via --effort, never both.
 Aliases (override anytime with --model <id>): flash/pro/lite, plus *25/*3 variants. Preview
 ids ending in -preview can drift; see model-map.mjs.
 </model_selection>

--- a/plugins/gemini/skills/gemini-prompting/references/gemini-prompt-recipes.md
+++ b/plugins/gemini/skills/gemini-prompting/references/gemini-prompt-recipes.md
@@ -2,9 +2,9 @@
 
 Use these as starting templates for Gemini task prompts or other Gemini/AGY prompt construction.
 Copy the smallest recipe that fits the task, then trim anything you do not need.
-In `gemini:gemini-rescue`, run diagnosis and fix-oriented recipes in write mode by default unless the user explicitly asked for read-only behavior.
+In `gemini:gemini-rescue`, run diagnosis and fix-oriented recipes in read-only mode by default, and add `--write` only when the user explicitly asked for edits.
 
-For the **gemini** engine, pick capability with `--effort` (or an explicit `--model`). For **AGY**, this plugin currently leaves model choice to AGY's configured/default behavior and does not translate Gemini aliases or effort tiers, so lean on a tight prompt contract instead of plugin-managed model power.
+For the **gemini** engine, pick capability with `--effort` (or an explicit `--model`). For **AGY**, pass an exact `agy models` ID via `--model` or a native effort tier (`low`, `medium`, or `high`) via `--effort` (never both), and lean on a tight prompt contract instead of Gemini engine model aliases.
 
 ## Diagnosis
 

--- a/plugins/gemini/skills/gemini-result-handling/SKILL.md
+++ b/plugins/gemini/skills/gemini-result-handling/SKILL.md
@@ -19,4 +19,4 @@ When the helper returns Gemini output:
 - CRITICAL: After presenting review findings, STOP. Do not make any code changes. Do not fix any issues. You MUST explicitly ask the user which issues, if any, they want fixed before touching a single file. Auto-applying fixes from a review is strictly forbidden, even if the fix is obvious.
 - If the helper reports malformed output or a failed run, include the most actionable stderr lines and stop there instead of guessing.
 - If the helper reports that setup or authentication is required, direct the user to `/gemini:setup` and do not improvise alternate auth flows.
-- Engine note: if AGY was used instead of Gemini CLI, the output format will be plain text without structured JSON. Present it as-is without attempting to parse structure that is not there.
+- Engine note: when AGY is used instead of Gemini CLI, AGY returns a structured JSON envelope (via `--output-format json` or `stream-json`) containing output, status, and metadata, which the plugin parses.

--- a/tests/skills-drift.test.mjs
+++ b/tests/skills-drift.test.mjs
@@ -1,0 +1,214 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  MODEL_ALIASES,
+  MODEL_ALIAS_ENTRIES
+} from "../plugins/gemini/scripts/lib/model-map.mjs";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+// The changelog (plugins/gemini/CHANGELOG.md) is excluded by using a directory
+// allowlist rather than an exclusion list because it is a historical record
+// that legitimately quotes removed wording verbatim.
+const ALLOWLIST_DIRS = [
+  "plugins/gemini/agents",
+  "plugins/gemini/commands",
+  "plugins/gemini/skills",
+  "plugins/gemini/prompts"
+];
+
+function collectMarkdownFiles(dir) {
+  const results = [];
+  if (!fs.existsSync(dir)) return results;
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...collectMarkdownFiles(fullPath));
+    } else if (entry.isFile() && entry.name.endsWith(".md")) {
+      results.push(fullPath);
+    }
+  }
+  return results;
+}
+
+const SCANNED_FILES = ALLOWLIST_DIRS.flatMap((relDir) =>
+  collectMarkdownFiles(path.join(ROOT, relDir))
+);
+
+function toRelPath(absolutePath) {
+  return path.relative(ROOT, absolutePath).replace(/\\/g, "/");
+}
+
+const sentences = (line) => line.split(/(?<=[.!?])\s+(?=[A-Z`(\-*])/);
+
+// Protects: when the user did not ask for edits, gemini:gemini-rescue does not
+// write their repository. plugins/gemini/agents/gemini-rescue.md:34 is the authority;
+// write-by-default was removed in plugin v0.16.0 and docs/THREAT-MODEL.md §7.2
+// records that an AGY --write run has no path boundary.
+//
+// Note: This pattern is narrower than searching for "--write" near "default" because
+// corrected sentences legitimately say "read-only mode by default, and add --write
+// only when the user explicitly asked for edits", and a looser pattern flags them.
+test("rule 1: no instruction may say a write-capable run is the default", () => {
+  const rule1Pattern =
+    /(write[- ](capable|mode)[^.]{0,60}by default)|(\bdefaults? to (a )?(write|--write|write-capable|write mode))|(\bdefault is (a )?(write|--write|write-capable|write mode))/i;
+
+  for (const filePath of SCANNED_FILES) {
+    const relPath = toRelPath(filePath);
+    const content = fs.readFileSync(filePath, "utf8");
+    const lines = content.split(/\r?\n/);
+
+    lines.forEach((line, lineIdx) => {
+      const lineNum = lineIdx + 1;
+      for (const sentence of sentences(line)) {
+        assert.equal(
+          rule1Pattern.test(sentence),
+          false,
+          `${relPath}:${lineNum}: "${sentence}"`
+        );
+      }
+    });
+  }
+});
+
+// Protects: the docs do not teach users to abandon a feature that works. False
+// since AGY 1.1.10; buildCliArgs in plugins/gemini/scripts/lib/engine.mjs pushes
+// both flags to the AGY command.
+//
+// Note: All three conditions must be in the same sentence. For instance,
+// plugins/gemini/commands/setup.md:27 says "read as one positional and ignored"
+// about --json, and a looser rule flags it.
+test("rule 2: no instruction may claim AGY ignores --model / --effort", () => {
+  const reAgy = /\bagy\b/i;
+  const reFlags = /--model|--effort/;
+  const reIgnored =
+    /\bignored\b|not translated|do not apply|\bunmanaged\b|leaves model choice/i;
+
+  for (const filePath of SCANNED_FILES) {
+    const relPath = toRelPath(filePath);
+    const content = fs.readFileSync(filePath, "utf8");
+    const lines = content.split(/\r?\n/);
+
+    lines.forEach((line, lineIdx) => {
+      const lineNum = lineIdx + 1;
+      for (const sentence of sentences(line)) {
+        const matchesAllThree =
+          reAgy.test(sentence) &&
+          reFlags.test(sentence) &&
+          reIgnored.test(sentence);
+
+        assert.equal(
+          matchesAllThree,
+          false,
+          `${relPath}:${lineNum}: "${sentence}"`
+        );
+      }
+    });
+  }
+});
+
+// Protects: instructions point at the JSON envelope the plugin actually parses,
+// so a subagent does not tell the user to go read transcript files.
+//
+// Note: Pattern (a) is directional on purpose (/transcript[^.]{0,60}\b(authoritative|source of truth)/i).
+// The correct sentence at plugins/gemini/skills/gemini-prompting/references/gemini-prompt-antipatterns.md:130
+// contains both "authoritative" and "transcript" in that order ("the plugin reads AGY's stdout JSON
+// envelope as authoritative ... while on-disk transcript recovery remains only as the fallback") and
+// must pass.
+test("rule 3: no instruction may describe AGY's output the pre-v0.11.0 way", () => {
+  const reShapeA = /transcript[^.]{0,60}\b(authoritative|source of truth)/i;
+  const reShapeB1 = /\bagy\b/i;
+  const reShapeB2 =
+    /plain text|without structured|no structured|not structured/i;
+
+  for (const filePath of SCANNED_FILES) {
+    const relPath = toRelPath(filePath);
+    const content = fs.readFileSync(filePath, "utf8");
+    const lines = content.split(/\r?\n/);
+
+    lines.forEach((line, lineIdx) => {
+      const lineNum = lineIdx + 1;
+      for (const sentence of sentences(line)) {
+        const matchesShapeA = reShapeA.test(sentence);
+        const matchesShapeB =
+          reShapeB1.test(sentence) && reShapeB2.test(sentence);
+
+        assert.equal(
+          matchesShapeA || matchesShapeB,
+          false,
+          `${relPath}:${lineNum}: "${sentence}"`
+        );
+      }
+    });
+  }
+});
+
+// Protects: model aliases in documentation stay in sync with their single source
+// of truth (MODEL_ALIASES and MODEL_ALIAS_ENTRIES in model-map.mjs).
+//
+// Note: Rule 4(b) is the assertion that makes the doc go red when someone adds an
+// alias to model-map.mjs without documenting it in SKILL.md.
+test("rule 4: model aliases stay in sync with single source of truth", () => {
+  const mappingPattern =
+    /`([a-z0-9]+)`(?:\s*\/\s*`([a-z0-9]+)`)*\s*(?:→|->)\s*`(gemini-[^`]+)`/g;
+
+  // 4(a) Every alias-to-model mapping written anywhere in the scanned tree must match the map.
+  for (const filePath of SCANNED_FILES) {
+    const relPath = toRelPath(filePath);
+    const content = fs.readFileSync(filePath, "utf8");
+    const lines = content.split(/\r?\n/);
+
+    lines.forEach((line, lineIdx) => {
+      const lineNum = lineIdx + 1;
+      const matches = [...line.matchAll(mappingPattern)];
+      for (const match of matches) {
+        const tokens = [...match[0].matchAll(/`([^`]+)`/g)].map((m) => m[1]);
+        const modelId = tokens.find((t) => t.startsWith("gemini-"));
+        const aliases = tokens.filter((t) => !t.startsWith("gemini-"));
+
+        for (const alias of aliases) {
+          const expectedModel = MODEL_ALIASES.get(alias);
+          assert.equal(
+            expectedModel,
+            modelId,
+            `${relPath}:${lineNum}: alias \`${alias}\` mapped to \`${modelId}\`, but MODEL_ALIASES maps to \`${expectedModel}\``
+          );
+        }
+      }
+    });
+  }
+
+  // 4(b) Completeness: in plugins/gemini/skills/gemini-cli-runtime/SKILL.md,
+  // find the line containing MODEL_ALIAS_ENTRIES and assert it mentions every
+  // alias in MODEL_ALIAS_ENTRIES as a backticked token.
+  const skillRelPath = "plugins/gemini/skills/gemini-cli-runtime/SKILL.md";
+  const skillFullPath = path.join(ROOT, skillRelPath);
+  const skillContent = fs.readFileSync(skillFullPath, "utf8");
+  const skillLines = skillContent.split(/\r?\n/);
+
+  const targetLineIdx = skillLines.findIndex((line) =>
+    line.includes("MODEL_ALIAS_ENTRIES")
+  );
+  assert.ok(
+    targetLineIdx !== -1,
+    `${skillRelPath}: expected line containing MODEL_ALIAS_ENTRIES`
+  );
+
+  const targetLine = skillLines[targetLineIdx];
+  const lineNum = targetLineIdx + 1;
+  const backtickedTokens = [...targetLine.matchAll(/`([^`]+)`/g)].map(
+    (m) => m[1]
+  );
+
+  for (const entry of MODEL_ALIAS_ENTRIES) {
+    assert.ok(
+      backtickedTokens.includes(entry.alias),
+      `${skillRelPath}:${lineNum}: missing alias \`${entry.alias}\` in MODEL_ALIAS_ENTRIES documentation line`
+    );
+  }
+});


### PR DESCRIPTION
`plugins/gemini/skills/` is loaded verbatim by the `gemini:gemini-rescue` subagent and followed. Nothing tested it, so it drifted three releases behind the code it describes.

## What was wrong

**Write-by-default, in three places.** v0.16.0 inverted the rescue default and recorded it in `agents/gemini-rescue.md:34` — "Do NOT add `--write` unless the user asked for edits". Two lines of `skills/gemini-cli-runtime/SKILL.md` and one of `references/gemini-prompt-recipes.md` still said the opposite. The subagent loads both documents in the same turn, and an AGY `--write` run has no path boundary (`docs/THREAT-MODEL.md` §7.2). The stake was whether "investigate this" could edit the repository.

**`--model` / `--effort` documented as ignored on AGY**, in five places. False since AGY 1.1.10 — `buildCliArgs` in `lib/engine.mjs` pushes both. Now stated accurately, including that `--effort`'s accepted set differs per engine because `normalizeAgyEffort` throws on the other four values.

**AGY documented as returning unstructured output**, in two places, with the on-disk transcript called authoritative. Since v0.11.0 the plugin reads the JSON envelope and does not touch the transcript at AGY ≥ 1.1.8. The engine-routing rationale was wrong for the same reason.

**The alias list named three of nine.**

## The test

`tests/skills-drift.test.mjs` scans the 18 instruction documents under `agents/`, `commands/`, `skills/`, `prompts/`. `CHANGELOG.md` is excluded via a directory allowlist rather than an exclusion list, because a changelog legitimately quotes the wording a release removed.

Three rules are worded blacklists, which are worth only what a mutation proves. Each pre-fix sentence was restored, the suite run, and the failure checked to be an assertion in the *intended* rule rather than a load error — six mutations, six kills, exactly one failing test each. The fourth rule asserts documented aliases against `MODEL_ALIASES`, so adding an alias to `model-map.mjs` turns the documentation red until it is written down.

## Verification

- `npm test` — 522 tests, 0 fail (518 before)
- `npm run check-version` — 0.19.1 consistent, changelog entry present
- `npm run verify-contracts` — passed
- `claude plugin validate --strict` — passed

## Scope

No runtime behavior changed. `plugins/gemini/scripts/` is the authority this was checked against, not the subject of it. The `model-map.mjs` AGY model-list drift and the two `docs/known-diffs.md` follow-ups are deliberately out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AkJpi4v6NseHcXpwa8yKAz
