### PR TITLE
Say what a cut-off AGY run actually produced (v0.20.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,13 +7,13 @@
   },
   "metadata": {
     "description": "Use Gemini CLI or Antigravity CLI (agy) inside Claude Code for task delegation, code review, and adversarial review.",
-    "version": "0.19.1"
+    "version": "0.20.0"
   },
   "plugins": [
     {
       "name": "gemini",
       "description": "Gemini CLI and Antigravity CLI bridge for Claude Code task delegation and adversarial review",
-      "version": "0.19.1",
+      "version": "0.20.0",
       "author": {
         "name": "arcobaleno64",
         "email": "arcobaleno830623@gmail.com"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,8 +6,8 @@ Only the current MINOR line is supported. Update this table with every MINOR bum
 
 | Version | Supported |
 |---|---|
-| 0.19.x | :white_check_mark: |
-| < 0.19.0 | :x: |
+| 0.20.x | :white_check_mark: |
+| < 0.20.0 | :x: |
 
 ## Security Model & Trust Boundaries
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@arcobaleno64/gemini-plugin-cc",
-  "version": "0.19.1",
+  "version": "0.20.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@arcobaleno64/gemini-plugin-cc",
-      "version": "0.19.1",
+      "version": "0.20.0",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arcobaleno64/gemini-plugin-cc",
-  "version": "0.19.1",
+  "version": "0.20.0",
   "private": true,
   "type": "module",
   "description": "Use Gemini CLI or Antigravity CLI (agy) inside Claude Code for task delegation, code review, and adversarial review.",

--- a/plugins/gemini/.claude-plugin/plugin.json
+++ b/plugins/gemini/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gemini",
-  "version": "0.19.1",
+  "version": "0.20.0",
   "description": "Use Gemini/AGY from Claude Code to review code or delegate tasks.",
   "author": {
     "name": "arcobaleno64",

--- a/plugins/gemini/CHANGELOG.md
+++ b/plugins/gemini/CHANGELOG.md
@@ -1,5 +1,60 @@
 # Changelog
 
+## 0.20.0 — 2026-08-18 — What a run that was cut off hands back
+
+Two field notes from dogfooding v0.19.0, both about the same moment: AGY is
+killed by the plugin's 2-minute cap while the turn is still going. Neither was a
+crash. Both produced a confident report of something that had not happened.
+
+### The event log was relayed as the model's answer
+
+A `--output-format stream-json` run that produced no assistant text handed back
+the JSONL event stream itself, framed by the delegated-output marker as though it
+were the reply. Measured on a real run: 84 event lines, 194,226 tokens, not one
+`text_delta` among them, relayed verbatim to the caller. Every line is valid
+JSON, so nothing downstream could tell it from an answer — and on the review path
+it would have been parsed for findings.
+
+The cause was a default. `finalMessage` started as the raw stdout and was only
+overwritten when the structured result had text, so an empty result left the raw
+stream standing. A stream now always speaks through the structured result, empty
+included. Below the stream-json gate the raw-stdout fallback stays: there it is a
+malformed envelope, which is a diagnostic worth showing rather than noise.
+
+A run that returns nothing now says so, and says what it cost. The envelope
+carries the turn's token usage even when it has no response to show for it, and
+194,226 tokens spent and 2,000 call for different decisions.
+
+### A finished answer was filed as a failure
+
+The other run produced its entire deliverable — seven findings, both closing
+sections, nothing truncated — and was stored as `failed` with "Retry later,
+reduce prompt size or review scope". For that run, the advice buys a second
+identical answer at full price.
+
+Jobs now have a third terminal status, **`partial`**: text came back, and nothing
+established that it is the whole answer. It is set by the two paths that know it
+first-hand — the stream's salvaged deltas, and an unfinished transcript row — not
+inferred from the failure category. A `partial` job keeps its failure object,
+because that is where the next step lives, and `/gemini:result` reads it back
+like any other finished job.
+
+The engine's envelope is still the only thing that makes a run a success; that
+did not change. What changed is what the report says when the envelope never
+arrived. When the last stream event is an `agent_response` that reached DONE, the
+recovered text is a finished block, and the next step says to read it rather than
+to retry — a claim about the text in hand, not about the turn. The measured
+stream has an `agent_response` reach DONE at step 2 and then run tools through
+step 55, so an answered block is not an ended turn, and this does not pretend
+otherwise.
+
+If you consume job status over MCP or from `--json`, this is the change to know
+about: a comparison against `"completed"` alone will now miss runs that produced
+output. Both job-oriented MCP tools describe the state, and `/gemini:status` is
+told not to report it as a failure. The stop-time review gate treats it as
+finished work — a `--write` turn cut off partway has still edited the working
+tree, and those are exactly the edits nobody has reviewed.
+
 ## 0.19.1 — 2026-08-17 — The instructions the subagent loads, checked against the code
 
 `plugins/gemini/skills/` is not commentary. The `gemini:gemini-rescue` subagent

--- a/plugins/gemini/commands/status.md
+++ b/plugins/gemini/commands/status.md
@@ -42,6 +42,12 @@ If the user did not name a job:
 If the user named a job that appears in the output above:
 - Present that job's full entry. Do not summarize or condense it.
 
+A status of `partial` is not a failure. It means the engine was cut off after it
+had produced text: the output is stored and readable with `/gemini:result`, but
+nothing confirmed it is the whole answer. Say so rather than reporting the job as
+failed, and point at `/gemini:result` before suggesting a re-run — a re-run is
+billed from the start.
+
 If the user asked to wait, or for a job from another session (`--all`), run the
 companion again with those literal flags and the verified id, then present the
 result the same way.

--- a/plugins/gemini/scripts/gemini-companion.mjs
+++ b/plugins/gemini/scripts/gemini-companion.mjs
@@ -601,7 +601,7 @@ async function resolveLatestTrackedTaskThread(cwd, options = {}) {
     throw new Error(`Task ${activeTask.id} is still running. Use /gemini:status before continuing it.`);
   }
 
-  const trackedTask = jobs.find((job) => job.jobClass === "task" && job.status === "completed" && job.threadId);
+  const trackedTask = jobs.find((job) => job.jobClass === "task" && (job.status === "completed" || job.status === "partial") && job.threadId);
   if (trackedTask) {
     return { id: trackedTask.threadId };
   }
@@ -749,6 +749,7 @@ async function executeReviewRun(request) {
 
   return {
     exitStatus: result.status,
+    partial: Boolean(result.partial),
     threadId: null,
     turnId: null,
     engine: result.engine ?? null,
@@ -839,6 +840,7 @@ ${rendered}`
 
   return {
     exitStatus: result.status,
+    partial: Boolean(result.partial),
     threadId: result.threadId ?? null,
     turnId: null,
     engine: result.engine ?? null,
@@ -1543,7 +1545,7 @@ async function handleTaskResumeCandidate(argv) {
     );
     return;
   }
-  const candidate = jobs.find((job) => job.jobClass === "task" && job.status === "completed" && job.threadId);
+  const candidate = jobs.find((job) => job.jobClass === "task" && (job.status === "completed" || job.status === "partial") && job.threadId);
   const payload = candidate
     ? { available: true, jobId: candidate.id, threadId: candidate.threadId, title: candidate.title }
     : { available: false };

--- a/plugins/gemini/scripts/gemini-mcp.mjs
+++ b/plugins/gemini/scripts/gemini-mcp.mjs
@@ -109,7 +109,7 @@ export const TOOLS = [
   tool(
     "gemini_job_status",
     "Check a delegated job's status",
-    "Return the current state of a Gemini companion job.",
+    "Return the current state of a Gemini companion job. Terminal status is `completed`, `failed`, `cancelled`, or `partial` — `partial` means the engine was cut off after producing text, so output exists and is worth reading, but nothing confirmed it is the whole answer. Do not treat `partial` as failure: re-running it is billed from the start.",
     { readOnlyHint: true, openWorldHint: false },
     ["workspace", "jobId"],
     {
@@ -120,7 +120,7 @@ export const TOOLS = [
   tool(
     "gemini_job_result",
     "Read a finished job's output",
-    "Return the stored output of a finished Gemini companion job.",
+    "Return the stored output of a finished Gemini companion job, including one whose status is `partial` (cut off after producing text — read it before deciding to re-run).",
     { readOnlyHint: true, openWorldHint: false },
     ["workspace", "jobId"],
     {

--- a/plugins/gemini/scripts/lib/gemini.mjs
+++ b/plugins/gemini/scripts/lib/gemini.mjs
@@ -203,7 +203,11 @@ function annotateFailureWithProgress(failure, structured) {
   if (!failure || typeof failure.summary !== "string") return failure;
   const notes = [];
   if (structured.progressLabel) notes.push(`reached ${structured.progressLabel}`);
-  if (structured.salvagedText) notes.push("partial output preserved");
+  if (structured.salvagedText) {
+    notes.push(structured.salvagedBlockComplete
+      ? "the recovered response block is complete"
+      : "partial output preserved");
+  }
   // Only when the stream is what was read: on the plain-json path an absent
   // response says nothing about recovery, because there is no stream to recover
   // from. Guarded on `text` rather than on `salvagedText` so an envelope that
@@ -211,8 +215,20 @@ function annotateFailureWithProgress(failure, structured) {
   else if (structured.streamed && !structured.text) notes.push("no response text was recovered");
   const cost = describeAgyUsage(structured.usage);
   if (cost) notes.push(cost);
-  if (notes.length === 0) return failure;
-  return { ...failure, summary: `${failure.summary} (${notes.join("; ")})` };
+  const annotated = notes.length === 0
+    ? failure
+    : { ...failure, summary: `${failure.summary} (${notes.join("; ")})` };
+
+  // The default next step for a timeout is "retry later, reduce prompt size".
+  // For a run whose response block finished before the kill, that advice buys a
+  // second copy of an answer already sitting in front of the user at full price
+  // (field note gi-2026-08-17-c4a1: seven findings, both closing sections,
+  // nothing cut off, filed as failed with a retry suggestion).
+  if (!structured.salvagedBlockComplete) return annotated;
+  return {
+    ...annotated,
+    nextStep: "Read the recovered response below before retrying: its response block finished, so it may already answer the request, and a retry is billed again from the start."
+  };
 }
 
 // AGY reports the turn's token usage in its envelope even when it has no
@@ -261,6 +277,13 @@ function resolveAgyStructuredResult({ rawStdout, rawStderr, exitCode, result, en
         streamed,
         usage: null,
         text: String(recovered.response).trim(),
+        // An unfinished transcript row is the same user-visible condition the
+        // stream's salvaged deltas describe — text came back, completeness was
+        // never established — so it is reported under the same name rather than
+        // as a second vocabulary for one situation. Never a whole block: a row
+        // that was still being written is what "unfinished" means here.
+        salvagedText: recovered.done ? null : String(recovered.response).trim(),
+        salvagedBlockComplete: false,
         threadId: recovered.convDir ?? null,
         // A completed transcript row means the work finished even though the
         // envelope never made it out; an incomplete one is partial output, which
@@ -310,6 +333,17 @@ function resolveAgyStructuredResult({ rawStdout, rawStderr, exitCode, result, en
   const salvaged = envelopeText ? "" : stream.partialText().trim();
   const text = envelopeText || salvaged;
 
+  // Whether the salvaged text is a finished response block or a sentence cut in
+  // half. This is deliberately NOT a claim that the turn was over: the measured
+  // stream in gi-2026-08-17-b2d9 has an agent_response reach DONE at step 2 and
+  // then run tools through step 55, so AGY answers and keeps working. What a
+  // DONE agent_response does settle is that the text in hand is whole, which is
+  // the difference between an answer worth reading and a truncated fragment.
+  const lastStep = stream.state.lastStep;
+  const salvagedBlockComplete = Boolean(salvaged)
+    && lastStep?.type === "agent_response"
+    && lastStep?.state === "DONE";
+
   // Success still requires the envelope's own response. Salvaged text is partial
   // by definition; calling it success would let a cut-off run pass for a
   // complete one.
@@ -325,6 +359,7 @@ function resolveAgyStructuredResult({ rawStdout, rawStderr, exitCode, result, en
     // What the caller needs to say "this is partial, and here is how far it
     // got" instead of "it timed out". Null when nothing was salvaged.
     salvagedText: salvaged || null,
+    salvagedBlockComplete,
     progressLabel: streamed && !succeeded ? stream.progressLabel() : null,
     threadId:
       (typeof envelope.conversation_id === "string" && envelope.conversation_id ? envelope.conversation_id : null) ??
@@ -494,6 +529,11 @@ export async function runGeminiTurn(cwd, options = {}, { runCommandFn = runComma
   let threadId = null;
   let reasoningSummary = extractReasoningSummary(rawStderr) ?? null;
   let recoveryFailure = null;
+  // "Text came back, and nothing established that it is complete." Set only by
+  // the paths that know it first-hand — the stream's salvaged deltas and an
+  // unfinished transcript row — rather than inferred from the failure category,
+  // which would put the answer to a question neither of them was asked.
+  let partial = false;
 
   if (agyStructured) {
     const structured = resolveAgyStructuredResult({ rawStdout, rawStderr, exitCode, result, engineInfo, brainRoot: agyBrainRoot, conversationsBefore: agyBefore });
@@ -511,6 +551,7 @@ export async function runGeminiTurn(cwd, options = {}, { runCommandFn = runComma
     // it would remove information rather than noise.
     if (structured.streamed) finalMessage = structured.text ?? "";
     else if (structured.text) finalMessage = structured.text;
+    partial = Boolean(structured.salvagedText);
   } else if (engineInfo.engine === "agy") {
     // Pre-1.1.8: recover the authoritative response and conversation id by
     // diffing the transcript directories captured before/after the spawn.
@@ -537,8 +578,12 @@ export async function runGeminiTurn(cwd, options = {}, { runCommandFn = runComma
       reasoningSummary = rec.thinking ?? reasoningSummary;
       // Success is defined by a completed transcript row, not the (often killed)
       // exit code: agy frequently hangs until --print-timeout even on success.
-      if (rec.done) exitCode = 0;
-      else if (exitCode === 0) exitCode = 1; // recovered but truncated → signal partial
+      if (rec.done) {
+        exitCode = 0;
+      } else {
+        if (exitCode === 0) exitCode = 1;
+        partial = true; // recovered but truncated
+      }
     }
   } else if (useJson) {
     // For gemini engine with JSON output, extract response text and session_id
@@ -592,6 +637,10 @@ export async function runGeminiTurn(cwd, options = {}, { runCommandFn = runComma
 
   return {
     status: exitCode,
+    // Precedence against a zero exit is not decided here. runTrackedJob applies
+    // it in one place, and duplicating the rule as an unreachable guard here
+    // would mean two statements of one invariant, only one of which is tested.
+    partial,
     finalMessage,
     threadId,
     reasoningSummary,
@@ -737,6 +786,8 @@ export async function runGeminiReview(cwd, options = {}, { runCommandFn = runCom
   let reviewJson = null;
   let reviewText = rawStdout.trim();
   let recoveryFailure = null;
+  // Same meaning as on the task path: text came back, completeness unestablished.
+  let partial = false;
 
   if (agyStructured) {
     const structured = resolveAgyStructuredResult({ rawStdout, rawStderr, exitCode, result, engineInfo, brainRoot: agyBrainRoot, conversationsBefore: agyBefore });
@@ -753,6 +804,7 @@ export async function runGeminiReview(cwd, options = {}, { runCommandFn = runCom
       reviewText = structured.text;
       reviewJson = tryParseJsonFromText(reviewText);
     }
+    partial = Boolean(structured.salvagedText);
   } else if (engineInfo.engine === "agy") {
     // Pre-1.1.8: recover the authoritative review and parse JSON findings from it.
     const rec = recoverAgyResponse(agyBrainRoot, agyBefore);
@@ -777,8 +829,12 @@ export async function runGeminiReview(cwd, options = {}, { runCommandFn = runCom
       reviewText = String(rec.response).trim();
       reviewJson = tryParseJsonFromText(reviewText);
       reasoningSummary = rec.thinking ?? reasoningSummary;
-      if (rec.done) exitCode = 0;
-      else if (exitCode === 0) exitCode = 1; // recovered but truncated → signal partial
+      if (rec.done) {
+        exitCode = 0;
+      } else {
+        if (exitCode === 0) exitCode = 1;
+        partial = true; // recovered but truncated
+      }
     }
   } else if (useJson) {
     // Gemini --output-format json wraps the response in an outer JSON envelope.
@@ -827,6 +883,7 @@ export async function runGeminiReview(cwd, options = {}, { runCommandFn = runCom
 
   return {
     status: exitCode,
+    partial,
     reviewText,
     reviewJson,
     reasoningSummary,

--- a/plugins/gemini/scripts/lib/gemini.mjs
+++ b/plugins/gemini/scripts/lib/gemini.mjs
@@ -204,8 +204,32 @@ function annotateFailureWithProgress(failure, structured) {
   const notes = [];
   if (structured.progressLabel) notes.push(`reached ${structured.progressLabel}`);
   if (structured.salvagedText) notes.push("partial output preserved");
+  // Only when the stream is what was read: on the plain-json path an absent
+  // response says nothing about recovery, because there is no stream to recover
+  // from. Guarded on `text` rather than on `salvagedText` so an envelope that
+  // did carry a response is never described as having recovered nothing.
+  else if (structured.streamed && !structured.text) notes.push("no response text was recovered");
+  const cost = describeAgyUsage(structured.usage);
+  if (cost) notes.push(cost);
   if (notes.length === 0) return failure;
   return { ...failure, summary: `${failure.summary} (${notes.join("; ")})` };
+}
+
+// AGY reports the turn's token usage in its envelope even when it has no
+// response to show for it — the run was billed either way. A report that says
+// only "it timed out" leaves the user to guess whether retrying is cheap; the
+// one that cost 194,226 tokens and the one that cost 2,000 call for different
+// decisions. Shape measured on AGY 1.1.13:
+//   {input_tokens, output_tokens, thinking_tokens, cache_read_tokens, total_tokens}
+// Only the total is reported: the breakdown is not what the next decision turns
+// on, and every field is optional as far as this code is concerned.
+function describeAgyUsage(usage) {
+  if (!usage || typeof usage !== "object") return null;
+  const total = Number(usage.total_tokens);
+  if (!Number.isFinite(total) || total <= 0) return null;
+  // Fixed locale: this string is asserted in tests and read in logs, so it must
+  // not change with the machine's locale.
+  return `${total.toLocaleString("en-US")} tokens spent`;
 }
 
 function resolveAgyStructuredResult({ rawStdout, rawStderr, exitCode, result, engineInfo, brainRoot = null, conversationsBefore = null }) {
@@ -234,6 +258,8 @@ function resolveAgyStructuredResult({ rawStdout, rawStderr, exitCode, result, en
       // output. The warning it replaces went to a stderr that detached workers
       // discard, so it was invisible exactly where it mattered.
       return {
+        streamed,
+        usage: null,
         text: String(recovered.response).trim(),
         threadId: recovered.convDir ?? null,
         // A completed transcript row means the work finished even though the
@@ -256,6 +282,8 @@ function resolveAgyStructuredResult({ rawStdout, rawStderr, exitCode, result, en
     }
 
     return {
+      streamed,
+      usage: null,
       text: null,
       threadId: null,
       exitCode: failedExit,
@@ -288,6 +316,11 @@ function resolveAgyStructuredResult({ rawStdout, rawStderr, exitCode, result, en
   const succeeded = envelope.status === "SUCCESS" && Boolean(envelopeText);
 
   return {
+    // Which of the two output shapes actually arrived. The caller needs it to
+    // decide whether rawStdout may stand in for an answer: under stream-json it
+    // is a machine event log and never may.
+    streamed,
+    usage: envelope.usage ?? null,
     text,
     // What the caller needs to say "this is partial, and here is how far it
     // got" instead of "it timed out". Null when nothing was salvaged.
@@ -467,7 +500,17 @@ export async function runGeminiTurn(cwd, options = {}, { runCommandFn = runComma
     exitCode = structured.exitCode;
     recoveryFailure = annotateFailureWithProgress(structured.failure, structured);
     threadId = structured.threadId;
-    if (structured.text) finalMessage = structured.text;
+    // Under stream-json, rawStdout is a JSONL event log — not an answer, and not
+    // anything a caller should be handed behind DELEGATED_OUTPUT_MARKER. Leaving
+    // finalMessage at its rawStdout default when the run produced no text did
+    // exactly that: an 84-line event stream relayed as the delegated model's
+    // reply. So a stream always speaks through structured.text, empty included.
+    //
+    // The plain-json path keeps the fallback. There rawStdout is a malformed or
+    // unparseable envelope, which is a diagnostic worth showing, and suppressing
+    // it would remove information rather than noise.
+    if (structured.streamed) finalMessage = structured.text ?? "";
+    else if (structured.text) finalMessage = structured.text;
   } else if (engineInfo.engine === "agy") {
     // Pre-1.1.8: recover the authoritative response and conversation id by
     // diffing the transcript directories captured before/after the spawn.
@@ -699,7 +742,14 @@ export async function runGeminiReview(cwd, options = {}, { runCommandFn = runCom
     const structured = resolveAgyStructuredResult({ rawStdout, rawStderr, exitCode, result, engineInfo, brainRoot: agyBrainRoot, conversationsBefore: agyBefore });
     exitCode = structured.exitCode;
     recoveryFailure = annotateFailureWithProgress(structured.failure, structured);
-    if (structured.text) {
+    // Same rule as the task path: a stream's rawStdout is an event log, so it
+    // never stands in for review output. Parsing it for findings would be worse
+    // still — the events are valid JSON, so a JSON-shaped non-review could reach
+    // the findings renderer.
+    if (structured.streamed) {
+      reviewText = structured.text ?? "";
+      reviewJson = reviewText ? tryParseJsonFromText(reviewText) : null;
+    } else if (structured.text) {
       reviewText = structured.text;
       reviewJson = tryParseJsonFromText(reviewText);
     }

--- a/plugins/gemini/scripts/lib/job-control.mjs
+++ b/plugins/gemini/scripts/lib/job-control.mjs
@@ -159,6 +159,8 @@ function fallbackJobPhase(job) {
       return "cancelled";
     case "failed":
       return "failed";
+    case "partial":
+      return "partial";
     case "completed":
       return "done";
     default:
@@ -172,12 +174,12 @@ export function enrichJob(job, options = {}) {
     ...job,
     kindLabel: getJobTypeLabel(job),
     progressPreview:
-      job.status === "queued" || job.status === "running" || job.status === "failed"
+      job.status === "queued" || job.status === "running" || job.status === "failed" || job.status === "partial"
         ? readJobProgressPreview(job.logFile, maxProgressLines)
         : [],
     elapsed: formatElapsedDuration(job.startedAt ?? job.createdAt, job.completedAt ?? null),
     duration:
-      job.status === "completed" || job.status === "failed" || job.status === "cancelled"
+      job.status === "completed" || job.status === "failed" || job.status === "partial" || job.status === "cancelled"
         ? formatElapsedDuration(job.startedAt ?? job.createdAt, job.completedAt ?? job.updatedAt)
         : null
   };
@@ -399,7 +401,7 @@ export function resolveResultJob(cwd, reference, options = {}) {
   const selected = matchJobReference(
     jobs,
     reference,
-    (job) => job.status === "completed" || job.status === "failed" || job.status === "cancelled"
+    (job) => job.status === "completed" || job.status === "failed" || job.status === "partial" || job.status === "cancelled"
   );
 
   if (selected) {

--- a/plugins/gemini/scripts/lib/render.mjs
+++ b/plugins/gemini/scripts/lib/render.mjs
@@ -385,7 +385,7 @@ export function renderStatusReport(report) {
     lines.push("Latest finished:");
     pushJobDetails(lines, report.latestFinished, {
       showDuration: true,
-      showLog: report.latestFinished.status === "failed"
+      showLog: report.latestFinished.status === "failed" || report.latestFinished.status === "partial"
     });
     lines.push("");
   }
@@ -395,7 +395,7 @@ export function renderStatusReport(report) {
     for (const job of report.recent) {
       pushJobDetails(lines, job, {
         showDuration: true,
-        showLog: job.status === "failed"
+        showLog: job.status === "failed" || job.status === "partial"
       });
     }
     lines.push("");

--- a/plugins/gemini/scripts/lib/tracked-jobs.mjs
+++ b/plugins/gemini/scripts/lib/tracked-jobs.mjs
@@ -168,9 +168,19 @@ export async function runTrackedJob(job, runner, options = {}) {
 
   try {
     const execution = await runner();
-    const completionStatus = execution.exitStatus === 0 ? "completed" : "failed";
+    // Three terminal states, not two. A run that was cut off after producing
+    // text is neither: calling it "completed" would claim a completeness the
+    // engine never confirmed, and calling it "failed" told users to pay for a
+    // second copy of an answer already in hand (field note gi-2026-08-17-c4a1).
+    // The runner decides — see the `partial` flag in lib/gemini.mjs — because
+    // only it knows whether text was salvaged or delivered.
+    const completionStatus = execution.exitStatus === 0
+      ? "completed"
+      : (execution.partial ? "partial" : "failed");
     const completedAt = nowIso();
-    const failure = completionStatus === "failed"
+    // A partial run keeps its failure: that is where the next step lives, and it
+    // is the part that stops a user re-running work they already have.
+    const failure = completionStatus !== "completed"
       ? (execution.failure ?? classifyCliFailure({
           status: execution.exitStatus,
           stderr: execution.payload?.gemini?.stderr ?? execution.payload?.stderr ?? "",
@@ -185,7 +195,7 @@ export async function runTrackedJob(job, runner, options = {}) {
       turnId: execution.turnId ?? null,
       engine: execution.engine ?? runningRecord.engine ?? null,
       pid: null,
-      phase: completionStatus === "completed" ? "done" : "failed",
+      phase: completionStatus === "completed" ? "done" : completionStatus,
       completedAt,
       result: execution.payload,
       rendered: execution.rendered,
@@ -198,7 +208,7 @@ export async function runTrackedJob(job, runner, options = {}) {
       turnId: execution.turnId ?? null,
       engine: execution.engine ?? runningRecord.engine ?? null,
       summary: execution.summary,
-      phase: completionStatus === "completed" ? "done" : "failed",
+      phase: completionStatus === "completed" ? "done" : completionStatus,
       pid: null,
       completedAt,
       ...(failure ? { failure } : {})

--- a/plugins/gemini/scripts/stop-review-gate-hook.mjs
+++ b/plugins/gemini/scripts/stop-review-gate-hook.mjs
@@ -26,9 +26,12 @@ function emitDecision(payload) {
   process.stdout.write(`${JSON.stringify(payload)}\n`);
 }
 
-function hasCompletedWriteTask(jobs) {
+// Exported for test: this predicate decides whether a session that edited the
+// repository is reviewed before it ends, so which statuses count is a claim that
+// has to be pinned rather than read off the line.
+export function hasCompletedWriteTask(jobs) {
   return jobs.some(
-    (job) => job.write === true && job.status === "completed" && job.jobClass === "task"
+    (job) => job.write === true && (job.status === "completed" || job.status === "partial") && job.jobClass === "task"
   );
 }
 

--- a/tests/agy-stream.test.mjs
+++ b/tests/agy-stream.test.mjs
@@ -353,3 +353,69 @@ test("the plain-json path still shows output that arrived and failed to parse", 
 
   assert.equal(result.finalMessage, junk);
 });
+
+// --- a cut-off run that did produce text -------------------------------------
+//
+// gi-2026-08-17-c4a1: the run produced its entire deliverable — seven findings,
+// both closing sections, nothing truncated — and was stored as `failed` with
+// "Retry later, reduce prompt size or review scope", which for that run buys a
+// second identical answer at full price. The envelope is still the authority on
+// completeness (a SUCCESS response is what makes a run successful, and that is
+// unchanged), so this does not become a success. It stops being a bare failure.
+
+function streamCutAfter(state, text) {
+  return [
+    `{"event":"step_update","step_update":{"conversation_id":"${CONV}","step_index":56,"state":"${state}","step_type":"agent_response","text_delta":${JSON.stringify(text)}}}`,
+    `{"event":"result","result":{"conversation_id":"${CONV}","status":"ERROR","response":"","error":"timeout waiting for response","usage":{"total_tokens":1000}}}`
+  ].join("\n");
+}
+
+test("a run cut off after a finished response block is not told to retry", async () => {
+  const result = await runGeminiTurn("/repo", { prompt: "hi", write: false }, {
+    runCommandFn: stubRun({ stdout: streamCutAfter("DONE", "the whole deliverable"), status: 1 }),
+    detectEngineFn: agyEngine("1.1.13")
+  });
+
+  assert.equal(result.partial, true);
+  assert.equal(result.finalMessage, "the whole deliverable");
+  assert.match(result.failure.summary, /the recovered response block is complete/);
+  assert.doesNotMatch(result.failure.nextStep, /Retry later/);
+  assert.match(result.failure.nextStep, /Read the recovered response below/);
+});
+
+test("a run cut off mid-answer is partial but still says the text was truncated", async () => {
+  const result = await runGeminiTurn("/repo", { prompt: "hi", write: false }, {
+    runCommandFn: stubRun({ stdout: streamCutAfter("ACTIVE", "half of a sen"), status: 1 }),
+    detectEngineFn: agyEngine("1.1.13")
+  });
+
+  assert.equal(result.partial, true);
+  assert.match(result.failure.summary, /partial output preserved/);
+  assert.doesNotMatch(result.failure.summary, /response block is complete/);
+  assert.match(result.failure.nextStep, /Retry later/, "there is nothing complete to read instead");
+});
+
+test("a run with nothing to show is a failure, not a partial one", async () => {
+  const result = await timedOutTurnWithNoText();
+  assert.equal(result.partial, false, "partial promises text; there is none");
+});
+
+test("a successful run is never partial", async () => {
+  const result = await runGeminiTurn("/repo", { prompt: "hi", write: false }, {
+    runCommandFn: stubRun({ stdout: MEASURED_STREAM }),
+    detectEngineFn: agyEngine("1.1.13")
+  });
+  assert.equal(result.status, 0);
+  assert.equal(result.partial, false);
+});
+
+test("a cut-off review is partial too, and keeps the findings it produced", async () => {
+  const findings = JSON.stringify({ verdict: "needs-attention", summary: "s", findings: [], next_steps: [] });
+  const result = await runGeminiReview("/repo", { prompt: "review this", engine: "agy" }, {
+    runCommandFn: stubRun({ stdout: streamCutAfter("DONE", findings), status: 1 }),
+    detectEngineFn: agyEngine("1.1.13")
+  });
+
+  assert.equal(result.partial, true);
+  assert.equal(result.reviewJson.verdict, "needs-attention");
+});

--- a/tests/agy-stream.test.mjs
+++ b/tests/agy-stream.test.mjs
@@ -268,3 +268,88 @@ test("a SUCCESS envelope with an empty response does not let salvaged text pass 
   assert.ok(result.failure, "but completeness was never established, so this is not success");
   assert.notEqual(result.status, 0);
 });
+
+// --- what a run with no text at all hands back -------------------------------
+//
+// gi-2026-08-17-b2d9: AGY timed out after 194,226 tokens with every one of its
+// 82 step_update events carrying no text — the stream shape says nothing about
+// assistant text on tool steps. With nothing to render, the plugin relayed the
+// 84-line JSONL event log itself as the delegated model's answer, behind
+// DELEGATED_OUTPUT_MARKER. The events are valid JSON, so nothing downstream
+// could tell it apart from a reply.
+
+import { runGeminiReview } from "../plugins/gemini/scripts/lib/gemini.mjs";
+
+const NO_TEXT_STREAM = [
+  `{"event":"init","conversation_id":"${CONV}","init":{"cwd":"/repo"}}`,
+  `{"event":"step_update","step_update":{"conversation_id":"${CONV}","step_index":55,"state":"DONE","step_type":"tool","tool_name":"view_file","duration_seconds":0.028}}`,
+  `{"event":"result","result":{"conversation_id":"${CONV}","status":"ERROR","response":"","error":"timeout waiting for response","duration_seconds":103.8798991,"num_turns":1,"usage":{"input_tokens":180341,"output_tokens":13885,"thinking_tokens":11237,"cache_read_tokens":1366788,"total_tokens":194226}}}`
+].join("\n");
+
+async function timedOutTurnWithNoText() {
+  return runGeminiTurn("/repo", { prompt: "hi", write: false }, {
+    runCommandFn: stubRun({ stdout: NO_TEXT_STREAM, status: 1 }),
+    detectEngineFn: agyEngine("1.1.13")
+  });
+}
+
+test("the event log is never relayed as the delegated model's answer", async () => {
+  // Guard the fixture first: if it stopped looking like an event log, the
+  // assertion below would pass for the wrong reason.
+  assert.match(NO_TEXT_STREAM, /"event":"step_update"/, "fixture is still an event log");
+
+  const result = await timedOutTurnWithNoText();
+  assert.equal(result.finalMessage, "", "no text arrived, so there is no answer to hand over");
+});
+
+test("a run that returned nothing still reports what it cost", async () => {
+  const result = await timedOutTurnWithNoText();
+  assert.match(result.failure.summary, /194,226 tokens spent/);
+});
+
+test("a stream that recovered nothing says so rather than going quiet", async () => {
+  const result = await timedOutTurnWithNoText();
+  assert.match(result.failure.summary, /no response text was recovered/);
+});
+
+test("an envelope that did carry a response is not described as having recovered nothing", async () => {
+  // The failure here is not a timeout, and the response arrived. Saying "no
+  // response text was recovered" beside a response would be plainly false.
+  const errorWithText = [
+    `{"event":"step_update","step_update":{"step_index":0,"state":"DONE","step_type":"agent_response","text_delta":"the answer"}}`,
+    `{"event":"result","result":{"conversation_id":"${CONV}","status":"ERROR","response":"the answer","error":"tool call was denied","usage":{"total_tokens":42}}}`
+  ].join("\n");
+
+  const result = await runGeminiTurn("/repo", { prompt: "hi", write: false }, {
+    runCommandFn: stubRun({ stdout: errorWithText, status: 1 }),
+    detectEngineFn: agyEngine("1.1.13")
+  });
+
+  assert.equal(result.finalMessage, "the answer");
+  assert.doesNotMatch(result.failure.summary, /no response text was recovered/);
+});
+
+test("a review never parses the event log for findings", async () => {
+  // Worse than the task path if it leaked: every event line is valid JSON, so a
+  // JSON-shaped non-review would reach the findings renderer.
+  const result = await runGeminiReview("/repo", { prompt: "review this", engine: "agy" }, {
+    runCommandFn: stubRun({ stdout: NO_TEXT_STREAM, status: 1 }),
+    detectEngineFn: agyEngine("1.1.13")
+  });
+
+  assert.equal(result.reviewText, "");
+  assert.equal(result.reviewJson, null);
+});
+
+test("the plain-json path still shows output that arrived and failed to parse", async () => {
+  // The fence left standing on purpose. Below the stream-json gate, rawStdout is
+  // a malformed envelope rather than a machine log: it is a diagnostic, and
+  // suppressing it would remove information instead of noise.
+  const junk = "agy: something went sideways before it could print an envelope";
+  const result = await runGeminiTurn("/repo", { prompt: "hi", write: false }, {
+    runCommandFn: stubRun({ stdout: junk, status: 1 }),
+    detectEngineFn: agyEngine("1.1.11")
+  });
+
+  assert.equal(result.finalMessage, junk);
+});

--- a/tests/job-control.test.mjs
+++ b/tests/job-control.test.mjs
@@ -4,7 +4,7 @@ import fs from "node:fs";
 
 import { makeTempDir } from "./helpers.mjs";
 import { readJobFile, resolveJobFile, saveState, setConfig, writeJobFile } from "../plugins/gemini/scripts/lib/state.mjs";
-import { buildStatusSnapshot } from "../plugins/gemini/scripts/lib/job-control.mjs";
+import { buildStatusSnapshot, resolveResultJob } from "../plugins/gemini/scripts/lib/job-control.mjs";
 import { runTrackedJob } from "../plugins/gemini/scripts/lib/tracked-jobs.mjs";
 
 test("buildStatusSnapshot surfaces the stop-review-gate flag", () => {
@@ -96,4 +96,52 @@ test("runTrackedJob persists structured failure metadata when the runner throws"
   assert.equal(snapshot.latestFinished.failure.category, "rate-limit");
   assert.equal(snapshot.latestFinished.failure.retryable, true);
   assert.equal(stored.failure.category, "rate-limit");
+});
+
+// A cut-off run that produced text is a third terminal state. These pin the
+// mapping and, more importantly, that /gemini:result can still read it back —
+// the state exists so a user is not told to re-buy an answer they already have,
+// which fails if the answer becomes unreachable.
+test("runTrackedJob stores a cut-off run that produced text as partial", async () => {
+  const cwd = makeTempDir();
+  await runTrackedJob(
+    { id: "task-partial", title: "Gemini Task", workspaceRoot: cwd, jobClass: "task" },
+    () => ({
+      exitStatus: 1,
+      partial: true,
+      payload: { rawOutput: "the whole deliverable" },
+      rendered: "the whole deliverable",
+      summary: "done-ish",
+      failure: { category: "timeout", retryable: true, summary: "cut off", nextStep: "Read it first." }
+    })
+  );
+
+  const stored = readJobFile(resolveJobFile(cwd, "task-partial"));
+  assert.equal(stored.status, "partial");
+  assert.equal(stored.phase, "partial");
+  assert.equal(stored.failure.nextStep, "Read it first.", "the failure is where the next step lives");
+});
+
+test("a partial job is retrievable through the same path as a completed one", async () => {
+  const cwd = makeTempDir();
+  await runTrackedJob(
+    { id: "task-partial-read", title: "Gemini Task", workspaceRoot: cwd, jobClass: "task" },
+    () => ({ exitStatus: 1, partial: true, payload: { rawOutput: "text" }, rendered: "text", summary: "s" })
+  );
+
+  const { job } = resolveResultJob(cwd, "task-partial-read", { all: true });
+  assert.equal(job.id, "task-partial-read");
+  assert.equal(job.status, "partial");
+});
+
+test("a successful run is completed even if the runner also set partial", async () => {
+  const cwd = makeTempDir();
+  await runTrackedJob(
+    { id: "task-zero", title: "Gemini Task", workspaceRoot: cwd, jobClass: "task" },
+    () => ({ exitStatus: 0, partial: true, payload: { rawOutput: "ok" }, rendered: "ok", summary: "s" })
+  );
+
+  const stored = readJobFile(resolveJobFile(cwd, "task-zero"));
+  assert.equal(stored.status, "completed");
+  assert.equal(stored.failure ?? null, null);
 });

--- a/tests/review-gate.test.mjs
+++ b/tests/review-gate.test.mjs
@@ -56,3 +56,33 @@ test("an untruncated review reports the summary and the count", () => {
   assert.match(reason, /1 finding\b/);
   assert.doesNotMatch(reason, /too large to review in full/);
 });
+
+// ---------------------------------------------------------------------------
+// Which jobs arm the gate. The question is "did a write task finish", not "did
+// it succeed": a --write turn cut off partway through has still edited the
+// working tree, and those are exactly the edits nobody reviewed. Adding the
+// `partial` status without adding it here would have quietly opened a hole that
+// did not exist before it.
+// ---------------------------------------------------------------------------
+
+import { hasCompletedWriteTask } from "../plugins/gemini/scripts/stop-review-gate-hook.mjs";
+
+const writeTask = (status) => ({ write: true, status, jobClass: "task" });
+
+test("a completed write task arms the gate", () => {
+  assert.equal(hasCompletedWriteTask([writeTask("completed")]), true);
+});
+
+test("a partial write task arms the gate — its edits are in the tree either way", () => {
+  assert.equal(hasCompletedWriteTask([writeTask("partial")]), true);
+});
+
+test("a running or failed write task does not arm the gate", () => {
+  assert.equal(hasCompletedWriteTask([writeTask("running")]), false);
+  assert.equal(hasCompletedWriteTask([writeTask("failed")]), false);
+});
+
+test("a partial job that is not a write task leaves the gate alone", () => {
+  assert.equal(hasCompletedWriteTask([{ write: false, status: "partial", jobClass: "task" }]), false);
+  assert.equal(hasCompletedWriteTask([{ write: true, status: "partial", jobClass: "review" }]), false);
+});


### PR DESCRIPTION
Two field notes from dogfooding v0.19.0, both from the same moment: AGY is killed by the plugin's 2-minute cap while the turn is still going. Neither was a crash. Both produced a confident report of something that had not happened.

## The event log was relayed as the model's answer (`gi-2026-08-17-b2d9`)

A `--output-format stream-json` run that produced no assistant text handed back the JSONL event stream itself, behind `DELEGATED_OUTPUT_MARKER`, as though it were the reply. Measured on a real run: 84 event lines, 194,226 tokens, not one `text_delta` among them. Every line is valid JSON, so nothing downstream could tell it from an answer — and the review path would have parsed it for findings.

The cause was a default: `lib/gemini.mjs:460` starts `finalMessage` at `rawStdout.trim()`, and the `if (structured.text)` guard below never overwrites it when the structured result is empty. A stream now always speaks through `structured.text`, empty included.

**The plain-json fallback stays on purpose.** Below the stream-json gate `rawStdout` is a malformed envelope — a diagnostic worth showing, not noise. That fence has its own test, and a mutation that over-reaches and suppresses it turns red.

A run that returns nothing now says so, and says what it cost: the envelope carries the turn's usage even when it has no response to show for it, and 194,226 tokens spent and 2,000 call for different decisions.

## A finished answer was filed as a failure (`gi-2026-08-17-c4a1`)

The other run produced its entire deliverable — seven findings, both closing sections, nothing truncated — and was stored `failed` with "Retry later, reduce prompt size or review scope". For that run the advice buys a second identical answer at full price.

`partial` is a third terminal status: text came back, nothing established it is the whole answer. Set by the two paths that know it first-hand (the stream's salvaged deltas, an unfinished transcript row) rather than inferred from a failure category, which would have made the answer up. `runTrackedJob` owns precedence — `exitStatus === 0` is `completed` regardless — and a partial job keeps its failure object, because that is where the next step lives.

**`lib/gemini.mjs:288` is unchanged**: the envelope is still the only thing that makes a run a success. What changed is the advice. When the last stream event is an `agent_response` that reached DONE, the recovered text is a finished block and the next step says to read it. That is a claim about the text, not the turn — the measured b2d9 stream has an `agent_response` reach DONE at step 2 and then run tools through step 55, so an answered block is not an ended turn.

`codex-plugin-cc` 1.0.6 was checked for a precedent first: same binary `completed`/`failed` vocabulary, no partial concept anywhere. It drives Codex over the app-server protocol, so it has no envelope-versus-stream split and no external print-timeout that can discard a finished answer.

## Consumers, each changed deliberately

- `resolveResultJob` accepts it — otherwise the state hides the very output it exists to stop users paying for twice
- **the stop-time review gate accepts it**: a `--write` turn cut off partway has still edited the working tree, and those are exactly the edits nobody reviewed. Omitting this would have opened a hole that did not exist before the state was added. `hasCompletedWriteTask` is exported so the status set is pinned by test rather than read off the line
- resume candidates accept it: the conversation id is live, and resuming finishes work already paid for
- phase, duration, log preview and `showLog` follow the same reasoning
- `isActiveStatus` is a `queued`/`running` whitelist, so a new terminal state is inactive without touching it

## For anyone reading job status

A comparison against `"completed"` alone now misses runs that produced output. Both job-oriented MCP tool descriptions carry the state, and `/gemini:status` is told not to report it as a failure. Neither README enumerated job statuses, so nothing there became false. Minor version bump for this reason.

## Verification

- `npm test` — 540 tests, 532 pass, 0 fail, 8 skipped (528/520 before)
- `npm run check-version` — 0.20.0 consistent, changelog entry present
- `npm run verify-contracts` — passed
- 13 mutations, 13 kills, each landing on the intended assertion and no other

### Live AGY runs against this branch

Two real turns through the working-tree code (`spawnDetachedWorker` resolves its script from `ROOT_DIR`, so the detached worker is this branch), AGY 1.1.13, `--timeout 30`:

**Run 1 - the b2d9 shape, reproduced live.** Killed at step 28 (a tool), no assistant text ever emitted, 152,157 tokens spent:

```
Gemini did not return a final message.

Failure: timeout (retryable)
Summary: The CLI command timed out. (reached step 28 tool (DONE); no response text was recovered; 152,157 tokens spent)
```

Stored `rawOutput` is `""`, and neither it nor the rendered output matches `"event":"(init|step_update|result)"`. On `main` this run would have handed back the event log. Status `failed`, which is right: `partial` promises text, and there was none.

**Run 2 - cut mid-answer.** Status `partial`, phase `partial`, and `/gemini:result` returned the essay in full, ending mid-word. Summary: `reached step 2 agent_response (ACTIVE); partial output preserved`. The next step correctly stays "Retry later" - the block never finished, so there is nothing complete to read instead.

**Not reproduced live:** the `agent_response (DONE)` branch, where the kill lands after a finished response block. That is a narrow race and not forcible on demand; it is covered by fixture and by two mutations (removing the next-step override, and treating any salvaged text as a finished block).

## Scope

The `--timeout` flag is reachable from the CLI and from neither the slash whitelists nor the MCP schemas — the shared root cause of both incidents — and is deliberately left for its own change, as are the `model-map.mjs` AGY model-list drift and the two `docs/known-diffs.md` follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


