### PR TITLE
Let the caller change the timeout they are being killed by (v0.21.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,13 +7,13 @@
   },
   "metadata": {
     "description": "Use Gemini CLI or Antigravity CLI (agy) inside Claude Code for task delegation, code review, and adversarial review.",
-    "version": "0.20.1"
+    "version": "0.21.0"
   },
   "plugins": [
     {
       "name": "gemini",
       "description": "Gemini CLI and Antigravity CLI bridge for Claude Code task delegation and adversarial review",
-      "version": "0.20.1",
+      "version": "0.21.0",
       "author": {
         "name": "arcobaleno64",
         "email": "arcobaleno830623@gmail.com"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,8 +6,8 @@ Only the current MINOR line is supported. Update this table with every MINOR bum
 
 | Version | Supported |
 |---|---|
-| 0.20.x | :white_check_mark: |
-| < 0.20.0 | :x: |
+| 0.21.x | :white_check_mark: |
+| < 0.21.0 | :x: |
 
 ## Security Model & Trust Boundaries
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@arcobaleno64/gemini-plugin-cc",
-  "version": "0.20.1",
+  "version": "0.21.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@arcobaleno64/gemini-plugin-cc",
-      "version": "0.20.1",
+      "version": "0.21.0",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arcobaleno64/gemini-plugin-cc",
-  "version": "0.20.1",
+  "version": "0.21.0",
   "private": true,
   "type": "module",
   "description": "Use Gemini CLI or Antigravity CLI (agy) inside Claude Code for task delegation, code review, and adversarial review.",

--- a/plugins/gemini/.claude-plugin/plugin.json
+++ b/plugins/gemini/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gemini",
-  "version": "0.20.1",
+  "version": "0.21.0",
   "description": "Use Gemini/AGY from Claude Code to review code or delegate tasks.",
   "author": {
     "name": "arcobaleno64",

--- a/plugins/gemini/CHANGELOG.md
+++ b/plugins/gemini/CHANGELOG.md
@@ -1,5 +1,44 @@
 # Changelog
 
+## 0.21.0 — 2026-08-18 — The timeout flag nobody could reach
+
+`--timeout <seconds>` has been parsed by the CLI since it was added, and was
+offered by neither surface a user actually drives. The slash commands assemble
+their calls from a whitelist of checked literal flags, and `--timeout` was not on
+it; the MCP tools declare `additionalProperties: false`, and none of their
+schemas had it. So the AGY default of 120 seconds was, in practice, not a default
+but a fixed limit.
+
+That limit is what both 2026-08-17 timeout incidents hit — the ones v0.20.0
+taught the plugin to *report* honestly. This is the other half: the number is now
+adjustable by whoever is paying for the run. `lib/gemini.mjs` had already
+recorded the gap in a comment; nothing had closed it.
+
+The window is also a ceiling on output size, which is the part that is easy to
+miss. A turn that cannot finish emitting its answer inside the window is killed
+with nothing to show, so a large batch or a `--deep` review over a wide diff hits
+the timeout as a size limit long before it hits it as a patience limit. Every
+place the flag is now documented says so, because "it timed out" reads as "it was
+slow" and sends people to make the prompt wait rather than make it smaller.
+
+Reachable from:
+
+- `/gemini:review`, `/gemini:adversarial-review`, `/gemini:rescue` — argument hint
+  and flag whitelist, with the same digits-and-range check the other values get
+- `gemini_rescue`, `gemini_review`, `gemini_adversarial_review` over MCP, with
+  bounds declared from the runtime constants so the schema cannot drift from what
+  is enforced
+
+`/gemini:rescue` does not call the runtime itself; it forwards to the
+`gemini:gemini-rescue` subagent, which builds the `task` call from its own
+instructions. Those now name the flag too — one preserved by the command and
+unknown to the subagent would be preserved into nothing, and a test pins both
+halves.
+
+The range check moved into a single exported function rather than being written
+twice. A caller arriving over MCP is held to the same 30–3600 rule as one typing
+the flag: a client is expected to enforce a declared schema, but nothing makes
+it, and an unchecked value becomes a `spawnSync` timeout nobody chose.
 ## 0.20.1 — 2026-08-18 — A cancel that worked, reported as a failure
 
 `/gemini:cancel` could kill the job it was aimed at, report an error, and leave

--- a/plugins/gemini/agents/gemini-rescue.md
+++ b/plugins/gemini/agents/gemini-rescue.md
@@ -30,7 +30,7 @@ Forwarding rules:
 - If the user asks for `flash`, map that to `--model flash`.
 - If the user asks for `pro` or `deep`, map that to `--model pro`.
 - If the user asks for a concrete model name such as `gemini-2.5-pro`, pass it through with `--model`.
-- Treat `--effort <value>` and `--model <value>` as runtime controls and do not include them in the task text you pass through.
+- Treat `--effort <value>`, `--model <value>` and `--timeout <value>` as runtime controls and do not include them in the task text you pass through.
 - Do NOT add `--write` unless the user asked for edits. Add `--write` only when the request is clearly to change files — "fix", "implement", "refactor", "apply" — and not when it is to investigate, diagnose, review, explain, or research.
 - Read-only is the **default intent, not an enforced boundary**. On AGY there is no read-only mode: `--write` selects how the workspace is oriented, not what the engine may do, and headless print mode auto-approves edits and shell commands either way (measured — see `docs/THREAT-MODEL.md` 7.2). A run dispatched without `--write` therefore still compares the workspace before and after and reports anything it wrote. Say so if that notice appears; do not present a modified workspace as an untouched one.
 - Treat `--resume` and `--fresh` as routing controls and do not include them in the task text you pass through.

--- a/plugins/gemini/commands/adversarial-review.md
+++ b/plugins/gemini/commands/adversarial-review.md
@@ -1,6 +1,6 @@
 ---
 description: Run an adversarial Gemini code review that challenges the implementation approach and design choices
-argument-hint: '[--wait|--background] [--deep] [--base <ref>] [--scope auto|working-tree|branch] [--engine <agy|gemini> | --engines gemini,agy] [--model <flash|pro>] [focus ...]'
+argument-hint: '[--wait|--background] [--deep] [--base <ref>] [--scope auto|working-tree|branch] [--engine <agy|gemini> | --engines gemini,agy] [--model <flash|pro>] [--timeout <seconds>] [focus ...]'
 disable-model-invocation: true
 allowed-tools: Read, Glob, Grep, Bash(node:*), Bash(git:*), AskUserQuestion
 ---
@@ -20,6 +20,7 @@ its list and then wrote out yourself — chosen, never copied:
 - `--scope <value>`: `auto`, `working-tree`, `branch`
 - `--engine <value>`: `auto`, `gemini`, `agy`
 - `--model <value>`: an alias (`flash`, `pro`, `lite`, …) or an id matching `^[A-Za-z0-9][A-Za-z0-9._-]*$`
+- `--timeout <seconds>`: only if it is entirely digits and between 30 and 3600
 - `--deep`, `--wait`, `--background`, `--json`: literal flags, no value
 Any remaining text is the review focus. It is free text, so there is no safe way
 to quote it into a command line: use the **Write** tool to put it in a file and
@@ -69,6 +70,7 @@ Argument handling:
 - Unlike `/gemini:review`, it can take extra focus text after the flags.
 - `--engines gemini,agy` queues the same blind prompt on both available engines as a background group. The jobs share a group ID but do not receive each other's identity or output. Do not combine `--engines` with `--engine` or `--wait`.
 - If one requested engine is unavailable, the runtime prints a degradation warning to stderr and queues the remaining engine as a normal single job. If neither is available, it fails without creating a job.
+- `--timeout <seconds>` is not only how long the run may take: it is also a ceiling on how much output can be produced, because a turn that cannot finish emitting inside the window is killed. Raise it for a large scope or a batch; the AGY default is 120 seconds.
 - `--deep` runs an **agentic** review: Gemini uses its read-only tools to inspect repo context beyond the diff (dependency manifests, untracked files, callers) before producing the same JSON findings. Slower and higher-token; omit it for the fast, diff-scoped default. Pair `--deep` with `--background` for larger changes.
 
 Foreground flow:

--- a/plugins/gemini/commands/rescue.md
+++ b/plugins/gemini/commands/rescue.md
@@ -1,6 +1,6 @@
 ---
 description: Delegate investigation, an explicit fix request, or follow-up rescue work to the Gemini rescue subagent
-argument-hint: "[--background|--wait] [--resume|--fresh] [--engine <agy|gemini>] [--model <flash|pro|lite>] [--effort <none|minimal|low|medium|high|xhigh>] [what Gemini should investigate, solve, or continue]"
+argument-hint: "[--background|--wait] [--resume|--fresh] [--engine <agy|gemini>] [--model <flash|pro|lite>] [--effort <none|minimal|low|medium|high|xhigh>] [--timeout <seconds>] [what Gemini should investigate, solve, or continue]"
 allowed-tools: Bash(node:*), AskUserQuestion, Agent
 ---
 
@@ -26,6 +26,7 @@ Execution mode:
 - If neither flag is present, default to foreground.
 - `--background` and `--wait` are execution flags for Claude Code. Do not forward them to `task`, and do not treat them as part of the natural-language task text.
 - `--model`, `--effort`, and `--engine` are runtime-selection flags. Preserve them for the forwarded `task` call, but do not treat them as part of the natural-language task text.
+- `--timeout <seconds>` is a runtime flag too. Preserve it the same way, and only if its value is entirely digits and between 30 and 3600.
 - If the request includes `--resume`, do not ask whether to continue. The user already chose.
 - If the request includes `--fresh`, do not ask whether to continue. The user already chose.
 - Otherwise, before starting Gemini, check for a resumable rescue thread from this Claude session by running:
@@ -51,6 +52,7 @@ Operating rules:
 - Do not paraphrase, summarize, rewrite, or add commentary before or after it.
 - Do not ask the subagent to inspect files, monitor progress, poll `/gemini:status`, fetch `/gemini:result`, call `/gemini:cancel`, summarize output, or do follow-up work of its own.
 - Leave `--effort` unset unless the user explicitly asks for a specific reasoning effort.
+- Leave `--timeout` unset unless the user asks for more time, or a previous run of the same work timed out. It caps how long the turn may run and, with it, how much output the turn can produce.
 - Leave the model and engine unset unless the user explicitly asks for one.
 - Leave `--resume` and `--fresh` in the forwarded request. The subagent handles that routing when it builds the `task` command.
 - If the helper reports that Gemini/AGY is missing or unauthenticated, stop and tell the user to run `/gemini:setup`.

--- a/plugins/gemini/commands/review.md
+++ b/plugins/gemini/commands/review.md
@@ -1,6 +1,6 @@
 ---
 description: Run a standard Gemini code review of recent git changes
-argument-hint: '[--wait|--background] [--deep] [--base <ref>] [--scope auto|working-tree|branch] [--engine <agy|gemini>] [--model <flash|pro>]'
+argument-hint: '[--wait|--background] [--deep] [--base <ref>] [--scope auto|working-tree|branch] [--engine <agy|gemini>] [--model <flash|pro>] [--timeout <seconds>]'
 disable-model-invocation: true
 allowed-tools: Read, Glob, Grep, Bash(node:*), Bash(git:*), AskUserQuestion
 ---
@@ -20,6 +20,7 @@ its list and then wrote out yourself — chosen, never copied:
 - `--scope <value>`: `auto`, `working-tree`, `branch`
 - `--engine <value>`: `auto`, `gemini`, `agy`
 - `--model <value>`: an alias (`flash`, `pro`, `lite`, …) or an id matching `^[A-Za-z0-9][A-Za-z0-9._-]*$`
+- `--timeout <seconds>`: only if it is entirely digits and between 30 and 3600
 - `--deep`, `--wait`, `--background`, `--json`: literal flags, no value
 
 If a value is not in its set, stop and say so rather than passing it through to
@@ -60,6 +61,7 @@ Argument handling:
 - The companion script handles `--background` itself: it enqueues the review and spawns a detached `review-worker`, so the result persists even if this session ends. Do not use Claude's `run_in_background: true` for it.
 - `/gemini:review` is native-review only. It does not take custom focus text.
 - For an adversarial review that challenges design decisions, use `/gemini:adversarial-review`.
+- `--timeout <seconds>` is not only how long the run may take: it is also a ceiling on how much output can be produced, because a turn that cannot finish emitting inside the window is killed. Raise it for a large scope or a batch; the AGY default is 120 seconds.
 - `--deep` runs an **agentic** review: Gemini uses its read-only tools to inspect repo context beyond the diff (dependency manifests, untracked files, callers) before producing the same JSON findings. It is slower and uses more tokens; omit it for the fast, diff-scoped default. Pair `--deep` with `--background` for larger changes.
 
 Foreground flow:

--- a/plugins/gemini/scripts/gemini-companion.mjs
+++ b/plugins/gemini/scripts/gemini-companion.mjs
@@ -64,8 +64,7 @@ import {
   getGeminiPlanTier,
   hasGeminiCredentials,
   getSessionRuntimeStatus,
-  MIN_TURN_TIMEOUT_SECONDS,
-  MAX_TURN_TIMEOUT_SECONDS
+  normalizeTurnTimeoutSeconds
 } from "./lib/gemini.mjs";
 import { MODEL_MAP_METADATA, MODEL_ALIAS_ENTRIES } from "./lib/model-map.mjs";
 
@@ -1034,14 +1033,7 @@ function enqueueBackgroundJob(cwd, job, request, workerCommand, { spawnFn = spaw
 // — advice that cannot work, because the cause is the size of the request, not a
 // transient fault. Retrying an identical batch fails identically.
 function parseTimeoutSeconds(value) {
-  if (value == null) return null;
-  const seconds = Number(value);
-  if (!Number.isInteger(seconds) || seconds < MIN_TURN_TIMEOUT_SECONDS || seconds > MAX_TURN_TIMEOUT_SECONDS) {
-    throw new Error(
-      `Invalid --timeout "${value}". Give whole seconds between ${MIN_TURN_TIMEOUT_SECONDS} and ${MAX_TURN_TIMEOUT_SECONDS}.`
-    );
-  }
-  return seconds;
+  return normalizeTurnTimeoutSeconds(value, "--timeout");
 }
 
 function validateEffortLevel(effort) {

--- a/plugins/gemini/scripts/gemini-mcp.mjs
+++ b/plugins/gemini/scripts/gemini-mcp.mjs
@@ -13,6 +13,11 @@ import {
   getJobResult,
   getJobStatus
 } from "./gemini-companion.mjs";
+import {
+  MAX_TURN_TIMEOUT_SECONDS,
+  MIN_TURN_TIMEOUT_SECONDS,
+  normalizeTurnTimeoutSeconds
+} from "./lib/gemini.mjs";
 
 const MCP_PROTOCOL_VERSION = "2025-03-26";
 const SELF_PATH = fileURLToPath(import.meta.url);
@@ -43,6 +48,20 @@ function enumSchema(values, defaultValue) {
   return { type: "string", enum: values, ...(defaultValue ? { default: defaultValue } : {}) };
 }
 
+// The AGY default is 2 minutes, and it is this plugin's number rather than AGY's
+// own (AGY defaults --print-timeout to 5m). It doubles as a ceiling on output
+// size: a turn that produces more than it can emit inside the window is killed,
+// which is what both 2026-08-17 timeout incidents actually hit. The CLI has
+// accepted `--timeout` since it was added; only the two surfaces a user reaches
+// it through did not offer it. Bounds come from the runtime constants so the
+// declared range and the enforced one cannot drift apart.
+const timeoutSchema = () => ({
+  type: "integer",
+  minimum: MIN_TURN_TIMEOUT_SECONDS,
+  maximum: MAX_TURN_TIMEOUT_SECONDS,
+  description: `Seconds this turn may run before it is killed (default 120 on AGY, 600 on Gemini CLI). Also a ceiling on how much output can be produced: raise it for large batches or deep reviews. ${MIN_TURN_TIMEOUT_SECONDS}-${MAX_TURN_TIMEOUT_SECONDS}.`
+});
+
 export const TOOLS = [
   tool(
     "gemini_rescue",
@@ -59,7 +78,8 @@ export const TOOLS = [
       write: { type: "boolean", default: false },
       model: { type: "string" },
       effort: enumSchema(["none", "minimal", "low", "medium", "high", "xhigh"]),
-      engine: enumSchema(["auto", "gemini", "agy"])
+      engine: enumSchema(["auto", "gemini", "agy"]),
+      timeout: timeoutSchema()
     }
   ),
   tool(
@@ -77,7 +97,8 @@ export const TOOLS = [
       scope: enumSchema(["auto", "working-tree", "branch"], "auto"),
       model: { type: "string" },
       engine: enumSchema(["auto", "gemini", "agy"]),
-      deep: { type: "boolean", default: false }
+      deep: { type: "boolean", default: false },
+      timeout: timeoutSchema()
     }
   ),
   // The slash surface has had /gemini:adversarial-review since it shipped, and
@@ -103,7 +124,8 @@ export const TOOLS = [
       model: { type: "string" },
       engine: enumSchema(["auto", "gemini", "agy"]),
       deep: { type: "boolean", default: false },
-      focus: { type: "string", description: "What the review should concentrate on." }
+      focus: { type: "string", description: "What the review should concentrate on." },
+      timeout: timeoutSchema()
     }
   ),
   tool(
@@ -199,7 +221,8 @@ export async function callTool(name, args = {}, { runtime = DEFAULT_RUNTIME } = 
       write: optionalBoolean(args.write, "write") ?? false,
       model: optionalString(args.model, "model"),
       effort: optionalEnum(args.effort, "effort", ["none", "minimal", "low", "medium", "high", "xhigh"]),
-      engine: optionalEnum(args.engine, "engine", ["auto", "gemini", "agy"])
+      engine: optionalEnum(args.engine, "engine", ["auto", "gemini", "agy"]),
+      timeoutSeconds: normalizeTurnTimeoutSeconds(args.timeout, "timeout")
     });
   }
   if (name === "gemini_review" || name === "gemini_adversarial_review") {
@@ -219,6 +242,10 @@ export async function callTool(name, args = {}, { runtime = DEFAULT_RUNTIME } = 
       model: optionalString(args.model, "model"),
       engine: optionalEnum(args.engine, "engine", ["auto", "gemini", "agy"]),
       deep: optionalBoolean(args.deep, "deep") ?? false,
+      // Validated here, not left to the schema: a client is expected to enforce
+      // the declared bounds but nothing makes it, and an out-of-range value
+      // reaches spawnSync as a timeout the caller never meant.
+      timeoutSeconds: normalizeTurnTimeoutSeconds(args.timeout, "timeout"),
       // Focus text is accepted only by the adversarial tool, matching the slash
       // commands: /gemini:review takes no focus argument either.
       ...(adversarial ? { focusText: optionalString(args.focus, "focus") ?? "" } : {}),

--- a/plugins/gemini/scripts/lib/gemini.mjs
+++ b/plugins/gemini/scripts/lib/gemini.mjs
@@ -33,6 +33,24 @@ const MAX_BUFFER = 50 * 1024 * 1024; // 50 MB
 export const MIN_TURN_TIMEOUT_SECONDS = 30;
 export const MAX_TURN_TIMEOUT_SECONDS = 3600;
 
+/**
+ * The one place the accepted range is enforced, so a caller reaching the runtime
+ * through MCP is held to the same rule as one typing the flag. `label` exists
+ * only so the message names what the caller actually wrote -- `--timeout` on the
+ * command line, `timeout` in a tool call -- since an error naming a spelling the
+ * caller never used is an error they cannot act on.
+ */
+export function normalizeTurnTimeoutSeconds(value, label = "--timeout") {
+  if (value == null) return null;
+  const seconds = Number(value);
+  if (!Number.isInteger(seconds) || seconds < MIN_TURN_TIMEOUT_SECONDS || seconds > MAX_TURN_TIMEOUT_SECONDS) {
+    throw new Error(
+      `Invalid ${label} "${value}". Give whole seconds between ${MIN_TURN_TIMEOUT_SECONDS} and ${MAX_TURN_TIMEOUT_SECONDS}.`
+    );
+  }
+  return seconds;
+}
+
 export function resolveSpawnTimeoutMs(engine, requestedSeconds = null) {
   if (requestedSeconds != null) {
     return Number(requestedSeconds) * 1000;

--- a/plugins/gemini/skills/gemini-cli-runtime/SKILL.md
+++ b/plugins/gemini/skills/gemini-cli-runtime/SKILL.md
@@ -28,6 +28,7 @@ Command selection:
 - If the forwarded request includes `--background` or `--wait`, treat that as Claude-side execution control only. Strip it before calling `task`.
 - If the forwarded request includes `--model`, normalize aliases and pass it through.
 - If the forwarded request includes `--effort`, pass it through to `task`.
+- If the forwarded request includes `--timeout <seconds>`, pass it through to `task`. Whole seconds, 30 to 3600. It bounds both the run's duration and the amount of output it can emit before being killed.
 - `--effort` accepted values: Gemini engine accepts `none`, `minimal`, `low`, `medium`, `high`, `xhigh`; AGY engine accepts only `low`, `medium`, `high`.
 - `--resume`: add `--resume-last`, even if the request text is ambiguous.
 - `--fresh`: use a fresh `task` run, do not add `--resume-last`.

--- a/tests/commands.test.mjs
+++ b/tests/commands.test.mjs
@@ -264,3 +264,42 @@ test("a quota-spending invocation is gated by AskUserQuestion", () => {
     );
   }
 });
+
+// A flag the runtime accepts but no user-facing surface offers is a flag that
+// does not exist. `--timeout` was in that state through both 2026-08-17 timeout
+// incidents: the CLI parsed it, and neither the slash whitelists nor the MCP
+// schemas let anyone reach it.
+//
+// The whitelist is the load-bearing half. These commands assemble their calls
+// from checked literal flags only, so a flag absent from the list is a flag the
+// command is instructed not to pass through — the argument-hint alone would
+// advertise something that then gets dropped.
+test("the three turn-spending commands offer --timeout and allow it through", () => {
+  for (const name of ["review.md", "adversarial-review.md", "rescue.md"]) {
+    const body = readCommand(name);
+    const hint = body.split(/\r?\n/).find((line) => line.startsWith("argument-hint:")) ?? "";
+    assert.match(hint, /--timeout <seconds>/, `${name}: argument-hint omits --timeout`);
+    assert.match(
+      body,
+      /`--timeout[^`]*`[^\n]*\b(30|digits)\b/,
+      `${name}: no rule tells the model when --timeout may be passed through`
+    );
+  }
+});
+
+// The rescue slash command does not call the runtime itself; it forwards to the
+// gemini:gemini-rescue subagent, which builds the `task` call from these two
+// documents. A flag preserved by the command and unknown to the subagent is
+// preserved into nothing.
+test("the rescue subagent's own instructions know the flag it is handed", () => {
+  const skill = fs.readFileSync(
+    path.join(ROOT, "plugins", "gemini", "skills", "gemini-cli-runtime", "SKILL.md"),
+    "utf8"
+  );
+  const agent = fs.readFileSync(
+    path.join(ROOT, "plugins", "gemini", "agents", "gemini-rescue.md"),
+    "utf8"
+  );
+  assert.match(skill, /--timeout/, "the runtime skill never mentions --timeout");
+  assert.match(agent, /--timeout/, "the rescue agent never mentions --timeout");
+});

--- a/tests/gemini-mcp.test.mjs
+++ b/tests/gemini-mcp.test.mjs
@@ -208,7 +208,8 @@ test("handleRequest delegates rescue and review to injected runtime dispatchers"
       write: false,
       model: undefined,
       effort: "high",
-      engine: "gemini"
+      engine: "gemini",
+      timeoutSeconds: null
     }],
     ["review", {
       cwd: path.resolve(workspace),
@@ -217,6 +218,7 @@ test("handleRequest delegates rescue and review to injected runtime dispatchers"
       model: undefined,
       engine: "agy",
       deep: true,
+      timeoutSeconds: null,
       reviewName: "Review",
       templateName: "review"
     }]
@@ -393,4 +395,70 @@ test("CLI runtime and MCP rescue dispatch persist byte-identical job prompts", a
     fs.rmSync(workspace, { recursive: true, force: true });
     fs.rmSync(dataDir, { recursive: true, force: true });
   }
+});
+
+// ---------------------------------------------------------------------------
+// `--timeout` has existed on the CLI since it was added, and reached neither
+// surface a user actually drives: not the slash whitelists, not these schemas.
+// Both 2026-08-17 timeout incidents were the 120s AGY default doing its job with
+// nobody able to change it. These pin the flag as reachable *and* bounded — an
+// out-of-range value must not become a spawnSync timeout the caller never meant.
+// ---------------------------------------------------------------------------
+
+import {
+  MAX_TURN_TIMEOUT_SECONDS,
+  MIN_TURN_TIMEOUT_SECONDS
+} from "../plugins/gemini/scripts/lib/gemini.mjs";
+
+function capturingRuntime(calls) {
+  return {
+    dispatchBackgroundTask(input) {
+      calls.push(input);
+      return { jobId: "task-1", status: "queued" };
+    },
+    dispatchBackgroundReview(input) {
+      calls.push(input);
+      return { jobId: "review-1", status: "queued" };
+    }
+  };
+}
+
+test("every tool that spends a turn accepts a timeout, and declares the runtime's own bounds", () => {
+  const spending = TOOLS.filter((tool) => tool.annotations.openWorldHint);
+  assert.equal(spending.length, 3, "rescue plus the two reviews");
+
+  for (const tool of spending) {
+    const schema = tool.inputSchema.properties.timeout;
+    assert.ok(schema, `${tool.name} has no timeout argument`);
+    assert.equal(schema.type, "integer");
+    assert.equal(schema.minimum, MIN_TURN_TIMEOUT_SECONDS);
+    assert.equal(schema.maximum, MAX_TURN_TIMEOUT_SECONDS);
+  }
+});
+
+test("a timeout given to any of the three reaches the dispatcher", async () => {
+  const workspace = makeTempDir();
+  const calls = [];
+  const runtime = capturingRuntime(calls);
+
+  await handleRequest(toolRequest("gemini_rescue", { workspace, prompt: "p", timeout: 900 }), { runtime });
+  await handleRequest(toolRequest("gemini_review", { workspace, timeout: 600 }), { runtime });
+  await handleRequest(toolRequest("gemini_adversarial_review", { workspace, timeout: 300 }), { runtime });
+
+  assert.deepEqual(calls.map((call) => call.timeoutSeconds), [900, 600, 300]);
+});
+
+test("an out-of-range or non-integer timeout is refused rather than passed on", async () => {
+  const workspace = makeTempDir();
+  const calls = [];
+  const runtime = capturingRuntime(calls);
+
+  for (const bad of [MIN_TURN_TIMEOUT_SECONDS - 1, MAX_TURN_TIMEOUT_SECONDS + 1, 45.5, "soon"]) {
+    const response = await handleRequest(
+      toolRequest("gemini_rescue", { workspace, prompt: "p", timeout: bad }),
+      { runtime }
+    );
+    assert.equal(response.isError, true, `timeout ${bad} was not refused`);
+  }
+  assert.deepEqual(calls, [], "nothing reached the dispatcher");
 });


### PR DESCRIPTION
`--timeout <seconds>` has been parsed by the CLI since it was added, and was offered by neither surface a user actually drives. The slash commands assemble their calls from a whitelist of checked literal flags and it was not on the list; the MCP tools declare `additionalProperties: false` and no schema had it. So AGY's 120-second window was not a default — it was a fixed limit.

That limit is what both 2026-08-17 timeout incidents hit, the ones #84 taught the plugin to report honestly. This is the other half: the number is now adjustable by whoever is paying for the run. `lib/gemini.mjs:24-29` already recorded the gap ("A user batching work has no way to raise it and no signal that size is what they are hitting"); nothing had closed it.

## The part that is easy to miss

The window is also a ceiling on output size. A turn that cannot finish emitting its answer inside it is killed with nothing to show, so a large batch or a `--deep` review over a wide diff meets the timeout as a size limit well before it meets it as a patience limit. Every place the flag is documented now says so — "it timed out" reads as "it was slow", which sends people to wait longer rather than to ask for less.

## Reachable from

- `/gemini:review`, `/gemini:adversarial-review`, `/gemini:rescue` — argument hint plus the flag whitelist, with the same digits-and-range check the other values get. **The whitelist is the load-bearing half**: these commands are instructed to build calls from checked literal flags only, so an argument hint alone would advertise a flag the command then drops.
- `gemini_rescue`, `gemini_review`, `gemini_adversarial_review` over MCP. Bounds are built from the runtime constants, so the declared range cannot drift from the enforced one.

`/gemini:rescue` does not call the runtime; it forwards to the `gemini:gemini-rescue` subagent, which builds the `task` call from its own instructions. Those name the flag too — one preserved by the command and unknown to the subagent would be preserved into nothing — and a test pins both halves.

## One rule, one place

The range check is now a single exported `normalizeTurnTimeoutSeconds` rather than two copies. A caller arriving over MCP meets the same 30–3600 rule as one typing the flag: a client is expected to enforce a declared schema, nothing makes it, and an unchecked value becomes a `spawnSync` timeout nobody chose. The refusal message names the spelling the caller actually used (`--timeout` or `timeout`), because an error naming a spelling they never wrote is one they cannot act on.

## Verification

- `npm test` — 545 tests, 537 pass, 0 fail, 8 skipped (540/532 before)
- `npm run check-version` — 0.21.0 consistent, changelog entry present
- `npm run verify-contracts` — passed
- 6 mutations, 6 kills, each on the intended assertion: dropping the schema entry, dropping the forwarding, accepting the value unvalidated, declaring bounds that disagree with the runtime, advertising the flag in the hint while the whitelist still forbids it, and leaving the subagent's own instructions unaware of it

## Unrelated flake found while verifying, not fixed here

`tests/reviewer-demo.test.mjs` failed twice in six local full-suite runs, always on `walkthrough never reached /# Gemini Cancel/`, and always when the machine was busy. The cause is `scripts/reviewer-demo.mjs:306`: a fixed `sleep(2000)` between starting a background job and cancelling it. Confirmed by shrinking the window to zero, which reproduces exactly that assertion. It predates this change and #84 — the demo pins `GEMINI_ENGINE: "gemini"`, so it never reaches any path either PR touched. Worth replacing with a bounded poll for the worker reaching `running`, as its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
