### PR TITLE
Stop keeping a hand-copied roster of AGY's models (v0.21.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,13 +7,13 @@
   },
   "metadata": {
     "description": "Use Gemini CLI or Antigravity CLI (agy) inside Claude Code for task delegation, code review, and adversarial review.",
-    "version": "0.21.0"
+    "version": "0.21.1"
   },
   "plugins": [
     {
       "name": "gemini",
       "description": "Gemini CLI and Antigravity CLI bridge for Claude Code task delegation and adversarial review",
-      "version": "0.21.0",
+      "version": "0.21.1",
       "author": {
         "name": "arcobaleno64",
         "email": "arcobaleno830623@gmail.com"

--- a/docs/MODEL_COMPARISON.md
+++ b/docs/MODEL_COMPARISON.md
@@ -71,6 +71,27 @@ Probed on this machine (gemini CLI **0.44.1**, then-current on npm), 2026-06-02:
 
 - **AGY (antigravity 1.0.4)** exposed **no `--model`/`--effort`** flag in the original 2026-06-02 probe. By 2026-07-06, local AGY 1.0.16 exposed `--model` and `agy models`.
   **Superseded since — current behavior (verified on AGY 1.1.12, 2026-08-12):** the plugin forwards both. `--effort <low|medium|high>` is passed to AGY natively, and `--model` is passed through as an exact AGY model id from `agy models`. What it still does *not* do is translate Gemini aliases into AGY ids — `flash` and `pro` are Gemini aliases only — and the two flags cannot be combined, because the AGY model ids reject the pairing. See `supportsAgyModelSelection` (gated at 1.1.10, the first version that applies the selection instead of silently falling back to the persisted model).
+- **AGY's own model listing, read 2026-08-18 on AGY 1.1.13.** `agy models` returns 14 ids:
+
+  | Family | Ids |
+  |---|---|
+  | Gemini 3.7 Flash | `gemini-3.7-flash-high` · `-medium` · `-low` |
+  | Gemini 3.6 Flash | `gemini-3.6-flash-high` · `-medium` · `-low` |
+  | Gemini 3.5 Flash | `gemini-3.5-flash-high` · `-medium` · `-low` |
+  | Gemini 3.1 Pro | `gemini-3.1-pro-high` · `-low` |
+  | Other vendors | `claude-sonnet-4-6` · `claude-opus-4-6-thinking` · `gpt-oss-120b-medium` |
+
+  Against the previous reading (AGY 1.1.10, 2026-08-05, 11 ids) the 3.7 Flash
+  family is new and nothing was removed. Note the shape rather than the roster:
+  AGY encodes the effort tier into the id, which is why `--model` and `--effort`
+  cannot be combined and why no Gemini alias is ever a valid AGY model id.
+
+  There is no machine-readable form to check a copy against — `agy models` on
+  1.1.13 accepts only `-h`/`--help`. This plugin's own 0.19.0 changelog entry
+  states that AGY 1.1.12 added `--output-format json` to it; that is not true of
+  1.1.13, and the entry is left as written because a released changelog is a
+  record. `lib/model-map.mjs` no longer keeps a copy of this list and points
+  here instead.
 - The plugin therefore points `flash` at `gemini-3-flash-preview` (served) and **gracefully degrades** to the GA `gemini-2.5-flash` if a requested id 404s — see the model-not-found fallback in `lib/gemini.mjs`.
 - Heads-up: Google's consumer Gemini CLI transition took effect on **2026-06-18** — this is past, not upcoming. On a personal account gemini CLI still installs and answers `--version`, but every request returns `API key not valid` / `API_KEY_INVALID` (verified 2026-08-04); Standard/Enterprise access and API keys are unaffected. See the note at the top of the README.
 

--- a/docs/known-diffs.md
+++ b/docs/known-diffs.md
@@ -66,14 +66,22 @@ campaign matrix for the full three-way comparison.
 ## Follow-ups (adversarial-review groups, low priority)
 
 - **`/gemini:cancel <groupId>` is not group-aware.** `status` and `result`
-  accept a groupId and aggregate, but cancel matches only a job id, so an
-  adversarial-review group must be cancelled one engine job at a time. The
-  command docs never promised group cancel, so this is an asymmetry, not a
-  broken contract.
-- **Partial dispatch has no rollback.** If a later engine in an adversarial
-  dispatch fails after an earlier one already spawned, the earlier job is
-  orphaned (still queryable by its own id, but never gets its group peer). Low
-  probability; no cleanup today.
+  accept a groupId and aggregate, but `resolveCancelableJob` matches only a job
+  id, so an adversarial-review group must be cancelled one engine job at a time —
+  and a groupId is answered with "no active job found", not with a partial
+  cancel. Confirmed still true 2026-08-18. The command docs never promised group
+  cancel, so this is an asymmetry rather than a broken contract, but the
+  aggregating pattern already exists in `buildSingleJobSnapshot` and
+  `resolveResultJobs` and cancel could reuse it.
+- **Partial dispatch has no rollback — narrowed, and re-checked 2026-08-18.**
+  The original entry said any failure in a later engine could orphan an earlier
+  group member. The larger half of that is closed: `gemini-companion.mjs`
+  validates every selected engine into `preparedSelections` *before* the first
+  detached worker is spawned, with a comment saying so, so a validation error
+  now fails before anything is queued. What remains is the spawn itself failing
+  for a later engine, which leaves the earlier job orphaned as described. Lower
+  probability than the entry implied; still no cleanup, and still deliberate —
+  an orphan is queryable by its own id and costs a quota-spending job to undo.
 
 ## Upstream-blocked
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@arcobaleno64/gemini-plugin-cc",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@arcobaleno64/gemini-plugin-cc",
-      "version": "0.21.0",
+      "version": "0.21.1",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arcobaleno64/gemini-plugin-cc",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "private": true,
   "type": "module",
   "description": "Use Gemini CLI or Antigravity CLI (agy) inside Claude Code for task delegation, code review, and adversarial review.",

--- a/plugins/gemini/.claude-plugin/plugin.json
+++ b/plugins/gemini/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gemini",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "description": "Use Gemini/AGY from Claude Code to review code or delegate tasks.",
   "author": {
     "name": "arcobaleno64",

--- a/plugins/gemini/CHANGELOG.md
+++ b/plugins/gemini/CHANGELOG.md
@@ -1,5 +1,44 @@
 # Changelog
 
+## 0.21.1 — 2026-08-18 — A copy of someone else's list, kept by hand
+
+`lib/model-map.mjs` carried a comment listing what `agy models` returns, dated to
+AGY 1.1.10 on 2026-08-05. Read again on 1.1.13 the real listing has 14 ids where
+the comment named 11: the whole Gemini 3.7 Flash family arrived and nothing said
+so. Nothing was broken by this, which is the point — no code reads that list.
+`normalizeAgyRequestedModel` validates the character set and rejects Gemini
+aliases; it never compares against a roster. The comment was a copy of another
+tool's output that could only drift, and nothing could notice when it did.
+
+It cannot be kept honest automatically either. `agy models` on 1.1.13 accepts
+only `-h`/`--help`, so there is no machine-readable form to diff a copy against,
+and the probe needs AGY installed, which CI does not have. (This plugin's 0.19.0
+entry says AGY 1.1.12 added `--output-format json` to `agy models`. That is not
+true of 1.1.13. The entry stands as written — a released changelog is a record of
+what was believed, and correcting it in place would erase that.)
+
+So the comment now keeps the part that does not change — AGY encodes the effort
+tier into the id, which is why no AGY id is ever valid in this map and why
+`--model` and `--effort` cannot be combined — with one id as an illustration of
+the shape, and points at `docs/MODEL_COMPARISON.md` §D for readings. That
+document already existed to hold dated probe records; the 2026-08-18 reading on
+1.1.13 is now there in full. A test keeps the roster from coming back, and keeps
+the pointer resolving.
+
+Two follow-ups in `docs/known-diffs.md` were re-checked against the code rather
+than carried forward:
+
+- **`/gemini:cancel <groupId>`** is still not group-aware, confirmed. The entry
+  now names `resolveCancelableJob` and says what a user actually sees — "no
+  active job found", not a partial cancel — and notes that the aggregating
+  pattern cancel would reuse already exists.
+- **Partial dispatch rollback** was overstated. Every selected engine is
+  validated before the first detached worker is spawned, so a validation error
+  can no longer orphan an earlier group member. Only a failing spawn can, which
+  is narrower than the entry claimed. Still deliberate, now accurately described.
+
+Documentation and tests only; no runtime behaviour changed.
+
 ## 0.21.0 — 2026-08-18 — The timeout flag nobody could reach
 
 `--timeout <seconds>` has been parsed by the CLI since it was added, and was

--- a/plugins/gemini/scripts/lib/model-map.mjs
+++ b/plugins/gemini/scripts/lib/model-map.mjs
@@ -47,13 +47,22 @@ export const MODEL_ALIASES = new Map(MODEL_ALIAS_ENTRIES.map((entry) => [entry.a
 //
 // AGY has its own model surface and takes exact ids from `agy models`; the two
 // namespaces do not overlap, which is why normalizeAgyRequestedModel rejects
-// Gemini aliases outright. Re-confirmed on AGY 1.1.10, 2026-08-05 — `agy models`
-// returns gemini-3.6-flash-{high,medium,low} (now GA),
-// gemini-3.5-flash-{high,medium,low}, gemini-3.1-pro-{high,low},
-// claude-sonnet-4-6, claude-opus-4-6-thinking and gpt-oss-120b-medium. None of
-// those is a valid id here: AGY encodes the effort tier into the id, while this
-// map keeps model and effort separate. AGY 1.1.10+ also accepts native
-// --effort low|medium|high; see supportsAgyModelSelection in engine.mjs.
+// Gemini aliases outright. The structural reason is what matters and does not
+// change: AGY encodes the effort tier into the id (`gemini-3.7-flash-high`),
+// while this map keeps model and effort separate, so no AGY id is ever a valid
+// value here. AGY 1.1.10+ also accepts native --effort low|medium|high; see
+// supportsAgyModelSelection in engine.mjs.
+//
+// This comment used to enumerate the AGY ids as of 1.1.10, and by 1.1.13 the
+// listing had gained three that it did not mention. Nothing depended on the
+// list — normalizeAgyRequestedModel checks the character set and rejects Gemini
+// aliases, and never compares against a roster — so it was a copy that could
+// only drift. It is not re-enumerated here: `agy models` is the live answer, and
+// there is no machine-readable form of it to check a copy against (`agy models`
+// on 1.1.13 accepts only -h/--help; the plugin's own 0.19.0 changelog entry says
+// 1.1.12 added `--output-format json` to it, and that is not true of 1.1.13).
+// The dated readings live in docs/MODEL_COMPARISON.md §D, which exists to hold
+// exactly that kind of record.
 export const EFFORT_MODEL_MAP = new Map([
   ["none", "gemini-2.5-flash-lite"],
   ["minimal", "gemini-2.5-flash-lite"],

--- a/tests/model-map.test.mjs
+++ b/tests/model-map.test.mjs
@@ -87,3 +87,59 @@ test("README model alias table matches model-map.mjs exactly", () => {
     assert.equal(MODEL_ALIASES.get(alias), model, `README declares unknown alias \`${alias}\``);
   }
 });
+
+// ---------------------------------------------------------------------------
+// model-map.mjs used to carry a copy of `agy models` output as a comment, dated
+// to AGY 1.1.10. By 1.1.13 the real listing had gained three ids it did not
+// mention. No code read the list — normalizeAgyRequestedModel validates the
+// character set and rejects Gemini aliases, and never compares against a roster
+// — so it was a copy that could only ever drift, with nothing able to notice.
+//
+// It cannot be kept honest automatically either: `agy models` on 1.1.13 offers
+// only -h/--help, so there is no machine-readable form to diff a copy against,
+// and the probe needs AGY installed, which CI does not have. So the rule is that
+// the copy does not come back. One id may stay as an illustration of the shape
+// (AGY encodes the effort tier into the id); several are a roster again.
+// ---------------------------------------------------------------------------
+
+const AGY_ID_SHAPE = /gemini-\d[\d.]*-[a-z]+-(?:high|medium|low)\b/g;
+
+test("model-map does not keep its own copy of AGY's model listing", () => {
+  const source = fs.readFileSync(
+    path.join(ROOT, "plugins", "gemini", "scripts", "lib", "model-map.mjs"),
+    "utf8"
+  );
+  const ids = [...new Set(source.match(AGY_ID_SHAPE) ?? [])];
+  assert.ok(
+    ids.length <= 1,
+    `model-map.mjs names ${ids.length} AGY model ids (${ids.join(", ")}). ` +
+      "One illustrates the id shape; a list is a roster that will drift. " +
+      "Dated readings belong in docs/MODEL_COMPARISON.md §D."
+  );
+});
+
+test("the document model-map sends readers to for the listing exists", () => {
+  const source = fs.readFileSync(
+    path.join(ROOT, "plugins", "gemini", "scripts", "lib", "model-map.mjs"),
+    "utf8"
+  );
+  const referenced = source.match(/docs\/[A-Za-z0-9_.-]+\.md/g) ?? [];
+  assert.ok(referenced.length > 0, "model-map points nowhere for the AGY listing");
+  for (const relPath of new Set(referenced)) {
+    assert.ok(
+      fs.existsSync(path.join(ROOT, relPath)),
+      `model-map.mjs points at ${relPath}, which does not exist`
+    );
+  }
+});
+
+// The dated readings have to actually be there, or the pointer above sends a
+// reader to a document that answers a different question.
+test("MODEL_COMPARISON records a dated AGY model listing", () => {
+  const doc = fs.readFileSync(path.join(ROOT, "docs", "MODEL_COMPARISON.md"), "utf8");
+  assert.match(doc, /`agy models`/, "no reading of the AGY listing is recorded");
+  assert.ok(
+    (doc.match(AGY_ID_SHAPE) ?? []).length >= 3,
+    "the recorded listing names too few ids to be a listing"
+  );
+});


### PR DESCRIPTION
The last of the three documentation follow-ups #83 listed as out of scope.

## A copy that could only drift

`lib/model-map.mjs` carried a comment listing what `agy models` returns, dated to AGY 1.1.10 on 2026-08-05. Read again on 1.1.13 the real listing has **14 ids where the comment named 11** — the whole Gemini 3.7 Flash family arrived and nothing said so.

Nothing broke, which is the point. No code reads that list: `normalizeAgyRequestedModel` validates the character set and rejects Gemini aliases, and never compares against a roster. It was a copy of another tool's output, maintained by hand, with nothing able to notice when it went stale.

It cannot be kept honest automatically either. `agy models` on 1.1.13 accepts only `-h`/`--help`, so there is no machine-readable form to diff a copy against, and the probe needs AGY installed, which CI does not have.

> This plugin's 0.19.0 changelog entry states that AGY 1.1.12 added `--output-format json` to `agy models`. Measured on 1.1.13, it did not — the subcommand takes no such flag. The entry stands as written: a released changelog records what was believed at the time, and correcting it in place would erase that. The correction is in the new entry and in the code comment.

## What replaces it

The comment keeps the part that does not change — AGY encodes the effort tier into the id, which is why no AGY id is ever valid in this map and why `--model` and `--effort` cannot be combined — with one id as an illustration of the shape. Readings go to `docs/MODEL_COMPARISON.md`, which already existed to hold dated probe records and is already labelled as such in the docs index.

The 2026-08-18 reading on AGY 1.1.13 is there in full, with the delta against the 1.1.10 one: the 3.7 Flash family is new, nothing was removed.

Three tests, each mutation-checked: the roster may not come back (one id is an illustration, several are a roster), the pointer must resolve, and the document it points at must actually carry a listing — otherwise the pointer sends a reader somewhere that answers a different question.

## The two `docs/known-diffs.md` follow-ups, re-checked rather than carried forward

- **`/gemini:cancel <groupId>` is not group-aware** — still true, confirmed against `resolveCancelableJob`. The entry now says what a user actually sees ("no active job found", not a partial cancel) and notes that the aggregating pattern cancel would reuse already exists in `buildSingleJobSnapshot` and `resolveResultJobs`.
- **Partial dispatch has no rollback** — overstated. `gemini-companion.mjs` validates every selected engine into `preparedSelections` *before* the first detached worker is spawned, with a comment saying exactly why, so a validation error can no longer orphan an earlier group member. Only a failing spawn can, which is narrower than the entry claimed. Still deliberate, now accurately described.

## Verification

- `npm test` — 553 tests, 545 pass, 0 fail, 8 skipped
- `npm run check-version` — 0.21.1 consistent, changelog entry present
- `npm run verify-contracts` — passed
- 3 mutations, 3 kills: pasting a roster back into the comment, pointing at a document that does not exist, and stripping the listing out of the document that is supposed to hold it

No runtime behaviour changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
