### PR TITLE
Cancel a group, and say which copy of the plugin is answering (v0.22.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,13 +7,13 @@
   },
   "metadata": {
     "description": "Use Gemini CLI or Antigravity CLI (agy) inside Claude Code for task delegation, code review, and adversarial review.",
-    "version": "0.21.1"
+    "version": "0.22.0"
   },
   "plugins": [
     {
       "name": "gemini",
       "description": "Gemini CLI and Antigravity CLI bridge for Claude Code task delegation and adversarial review",
-      "version": "0.21.1",
+      "version": "0.22.0",
       "author": {
         "name": "arcobaleno64",
         "email": "arcobaleno830623@gmail.com"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,8 +6,8 @@ Only the current MINOR line is supported. Update this table with every MINOR bum
 
 | Version | Supported |
 |---|---|
-| 0.21.x | :white_check_mark: |
-| < 0.21.0 | :x: |
+| 0.22.x | :white_check_mark: |
+| < 0.22.0 | :x: |
 
 ## Security Model & Trust Boundaries
 

--- a/docs/known-diffs.md
+++ b/docs/known-diffs.md
@@ -65,14 +65,9 @@ campaign matrix for the full three-way comparison.
 
 ## Follow-ups (adversarial-review groups, low priority)
 
-- **`/gemini:cancel <groupId>` is not group-aware.** `status` and `result`
-  accept a groupId and aggregate, but `resolveCancelableJob` matches only a job
-  id, so an adversarial-review group must be cancelled one engine job at a time —
-  and a groupId is answered with "no active job found", not with a partial
-  cancel. Confirmed still true 2026-08-18. The command docs never promised group
-  cancel, so this is an asymmetry rather than a broken contract, but the
-  aggregating pattern already exists in `buildSingleJobSnapshot` and
-  `resolveResultJobs` and cancel could reuse it.
+*`/gemini:cancel <groupId>` was the other entry here. Closed in v0.22.0: cancel
+reuses the same aggregating pattern as `status` and `result`.*
+
 - **Partial dispatch has no rollback — narrowed, and re-checked 2026-08-18.**
   The original entry said any failure in a later engine could orphan an earlier
   group member. The larger half of that is closed: `gemini-companion.mjs`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@arcobaleno64/gemini-plugin-cc",
-  "version": "0.21.1",
+  "version": "0.22.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@arcobaleno64/gemini-plugin-cc",
-      "version": "0.21.1",
+      "version": "0.22.0",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arcobaleno64/gemini-plugin-cc",
-  "version": "0.21.1",
+  "version": "0.22.0",
   "private": true,
   "type": "module",
   "description": "Use Gemini CLI or Antigravity CLI (agy) inside Claude Code for task delegation, code review, and adversarial review.",

--- a/plugins/gemini/.claude-plugin/plugin.json
+++ b/plugins/gemini/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gemini",
-  "version": "0.21.1",
+  "version": "0.22.0",
   "description": "Use Gemini/AGY from Claude Code to review code or delegate tasks.",
   "author": {
     "name": "arcobaleno64",

--- a/plugins/gemini/CHANGELOG.md
+++ b/plugins/gemini/CHANGELOG.md
@@ -1,5 +1,47 @@
 # Changelog
 
+## 0.22.0 — 2026-08-18 — Cancel a group; say which copy of the plugin is answering
+
+### `/gemini:cancel <group-id>`
+
+`status` and `result` have always accepted an adversarial-review group id and
+aggregated over its members. Cancel matched job ids only, so a group had to be
+cancelled one engine at a time, from ids the user first had to go and read out of
+a status listing — and a group id came back as "No active job found", which is
+the one thing it was not.
+
+Cancel now reuses the pattern the other two already use: try the group, fall back
+to a single job. Every member still queued or running is cancelled; members that
+already finished are left exactly as they are, because "cancel" has nothing to
+say about work that is done. The report lists each member and what its
+termination actually reached — one engine can have finished while the other was
+still running, and a single summary line would hide that.
+
+A group whose members have all finished now says so, with a pointer to
+`/gemini:result`, instead of reporting the id as unknown. The single-job path,
+its payload shape and its messages are unchanged: every existing caller reads
+`payload.jobId`, and that still means what it meant.
+
+### `/gemini:setup` names the plugin that is answering
+
+A session can stay wired to an older cached copy of the plugin after an update.
+Field note `gi-2026-08-17-a1c7` recorded one running 0.17.3 while the installed
+manifest said 0.19.0: fixes believed shipped were absent from both the MCP and
+the slash surface, and nothing in the session could say which version was live.
+It was found by reading the MCP server's process command line.
+
+The cache resolution is Claude Code's and `/reload-plugins` is the remedy —
+neither is this plugin's to fix. The silence is. `setup` now reports
+`pluginVersion` and `scriptPath`, both read relative to the running script, so
+they describe the code that is executing rather than what a manifest elsewhere
+claims. The version comes from the same `plugin.json` Claude Code consults first
+(see `docs/version-sources.md`). It is on the ordinary report, not only in
+`--json`: a user who has to ask for JSON to discover a stale copy will not think
+to ask.
+
+This does not detect the mismatch — it makes it visible in one command. The field
+note stays open.
+
 ## 0.21.1 — 2026-08-18 — A copy of someone else's list, kept by hand
 
 `lib/model-map.mjs` carried a comment listing what `agy models` returns, dated to

--- a/plugins/gemini/commands/cancel.md
+++ b/plugins/gemini/commands/cancel.md
@@ -1,6 +1,6 @@
 ---
 description: Cancel an active background Gemini job in this repository
-argument-hint: '[job-id] [--all]'
+argument-hint: '[job-id | group-id] [--all]'
 disable-model-invocation: true
 allowed-tools: Bash(node:*)
 ---
@@ -23,6 +23,10 @@ id has to be right for a second reason. Build the command from these pieces only
 
 - `cancel` plus a job id copied character-for-character from the listing above,
   and only from a job whose status is `queued` or `running`.
+- Or an adversarial-review group id, copied the same way, which cancels every
+  member of that group that is still active and leaves finished members alone.
+  Group ids look like `review-group-msqu22ju`; `/gemini:status <group-id>` lists
+  the members.
 - The literal flag `--all`, added only because the argument text asked to cancel
   a job from another session — never copied from that text.
 

--- a/plugins/gemini/scripts/gemini-companion.mjs
+++ b/plugins/gemini/scripts/gemini-companion.mjs
@@ -25,7 +25,7 @@ import {
   buildStatusSnapshot,
   filterJobsForCurrentSession,
   readStoredJob,
-  resolveCancelableJob,
+  resolveCancelableJobs,
   resolveResultJobs,
   sortJobsNewestFirst
 } from "./lib/job-control.mjs";
@@ -45,6 +45,7 @@ import {
   renderTaskResult,
   renderStoredJobResult,
   renderStoredJobGroupResult,
+  renderCancelGroupReport,
   renderCancelReport,
   describeTermination,
   renderJobStatusReport,
@@ -491,6 +492,21 @@ export function buildSetupReport(cwd, actionsTaken = [], options = {}) {
   return {
     ready,
     readyState,
+    // Which copy of the plugin is answering. Claude Code resolves an installed
+    // plugin through a versioned cache directory, and a session can stay wired
+    // to an older one after an update: field note gi-2026-08-17-a1c7 recorded a
+    // session running 0.17.3 while installed_plugins.json reported 0.19.0, with
+    // fixes believed shipped silently absent from both the MCP and slash
+    // surfaces. Nothing in the session could say which version was live; it was
+    // found by reading the MCP server's process command line.
+    //
+    // The resolution itself is Claude Code's, and `/reload-plugins` is the
+    // remedy — neither is this plugin's to fix. What is fixable here is the
+    // silence. Both values are read relative to the running script, so they
+    // describe the code that is actually executing rather than what a manifest
+    // elsewhere claims, and plugin.json is the same file Claude Code consults
+    // first (docs/version-sources.md).
+    ...readRunningPluginIdentity(),
     requestedEngine: requestedEngine || "auto",
     geminiReady,
     geminiCredentialSource,
@@ -525,6 +541,20 @@ export function buildSetupReport(cwd, actionsTaken = [], options = {}) {
     actionsTaken,
     nextSteps
   };
+}
+
+function readRunningPluginIdentity() {
+  const manifestPath = path.join(ROOT_DIR, ".claude-plugin", "plugin.json");
+  let pluginVersion = null;
+  try {
+    pluginVersion = JSON.parse(fs.readFileSync(manifestPath, "utf8")).version ?? null;
+  } catch {
+    // A missing or unreadable manifest is reported as unknown rather than
+    // thrown: setup exists to diagnose a broken installation, and it is no use
+    // if it cannot run on one.
+    pluginVersion = null;
+  }
+  return { pluginVersion, scriptPath: SELF_PATH };
 }
 
 function handleSetup(argv) {
@@ -1555,13 +1585,37 @@ async function handleCancel(argv) {
 
   const cwd = resolveCommandCwd(options);
   const reference = positionals[0] ?? "";
-  const { payload, job, termination } = cancelJob({ cwd, jobId: reference, all: options.all });
+  const result = cancelJob({ cwd, jobId: reference, all: options.all });
 
-  outputCommandResult(payload, renderCancelReport(job, termination), options.json);
+  outputCommandResult(
+    result.payload,
+    result.groupId
+      ? renderCancelGroupReport(result)
+      : renderCancelReport(result.job, result.termination),
+    options.json
+  );
 }
 
 export function cancelJob({ cwd = process.cwd(), jobId = "", all = false }, { terminateProcessTreeFn = terminateProcessTree } = {}) {
-  const { workspaceRoot, job } = resolveCancelableJob(path.resolve(cwd), jobId, { all });
+  const { workspaceRoot, groupId, jobs } = resolveCancelableJobs(path.resolve(cwd), jobId, { all });
+  const cancelled = jobs.map((job) => cancelOneJob(workspaceRoot, job, terminateProcessTreeFn));
+
+  if (!groupId) {
+    // Unchanged shape for the single-job case, which is every existing caller:
+    // the slash command, the MCP tool and the tests all read `payload.jobId`.
+    const [only] = cancelled;
+    return { payload: only.payload, job: only.job, termination: only.termination };
+  }
+
+  return {
+    groupId,
+    payload: { groupId, cancelled: cancelled.map((entry) => entry.payload) },
+    jobs: cancelled.map((entry) => entry.job),
+    terminations: cancelled.map((entry) => entry.termination)
+  };
+}
+
+function cancelOneJob(workspaceRoot, job, terminateProcessTreeFn) {
   const existing = readStoredJob(workspaceRoot, job.id) ?? {};
 
   // Be honest about whether a live process was actually killed: the detached

--- a/plugins/gemini/scripts/gemini-mcp.mjs
+++ b/plugins/gemini/scripts/gemini-mcp.mjs
@@ -153,7 +153,7 @@ export const TOOLS = [
   tool(
     "gemini_job_cancel",
     "Cancel a delegated job",
-    "Cancel a queued or running Gemini companion job, terminating its process tree.",
+    "Cancel a queued or running Gemini companion job, terminating its process tree. `jobId` also accepts an adversarial-review group id, which cancels every member of that group still active and leaves finished members alone.",
     // Destructive because a cancelled `write` task can leave half-applied edits
     // behind. Idempotent: cancelling an already-finished job is a no-op.
     { readOnlyHint: false, destructiveHint: true, idempotentHint: true, openWorldHint: false },

--- a/plugins/gemini/scripts/lib/job-control.mjs
+++ b/plugins/gemini/scripts/lib/job-control.mjs
@@ -428,6 +428,37 @@ export function resolveResultJobs(cwd, reference, options = {}) {
   return { workspaceRoot, groupId: selected.groupId, jobs: grouped };
 }
 
+// `/gemini:cancel <groupId>` used to answer "No active job found" — status and
+// result both accept a groupId and aggregate, and cancel alone matched job ids,
+// so an adversarial-review group had to be cancelled one engine at a time from
+// ids the user had to go and read. Same shape as buildSingleJobSnapshot and
+// resolveResultJobs: try the group first, fall back to a single job.
+//
+// Only active members are returned. A group whose other engine already finished
+// is not a reason to refuse the one still running, and "cancel" has nothing to
+// say about a job that is already done.
+export function resolveCancelableJobs(cwd, reference, options = {}) {
+  const workspaceRoot = resolveWorkspaceRoot(cwd);
+  if (reference) {
+    const scoped = options.all ? listJobs(workspaceRoot) : filterJobsForCurrentSession(listJobs(workspaceRoot));
+    const members = sortJobsNewestFirst(scoped).filter((job) => job.groupId === reference);
+    const active = members.filter((job) => isActiveStatus(job.status));
+    if (active.length > 0) {
+      return { workspaceRoot, groupId: reference, jobs: active };
+    }
+    // A group that exists and has finished is not "no job found". Falling
+    // through to the single-job path would say exactly that, and send the user
+    // looking for an id they already gave correctly.
+    if (members.length > 0) {
+      throw new Error(
+        `Review group ${reference} has no active jobs (${members.length} already finished). Read them with /gemini:result ${reference}.`
+      );
+    }
+  }
+  const { job } = resolveCancelableJob(cwd, reference, options);
+  return { workspaceRoot, groupId: null, jobs: [job] };
+}
+
 export function resolveCancelableJob(cwd, reference, options = {}) {
   const workspaceRoot = resolveWorkspaceRoot(cwd);
   // Default scope is the current Claude session so /gemini:cancel can never

--- a/plugins/gemini/scripts/lib/render.mjs
+++ b/plugins/gemini/scripts/lib/render.mjs
@@ -212,6 +212,10 @@ export function renderSetupReport(report) {
     "# Gemini Setup",
     "",
     `Status: ${statusLabel}`,
+    // Named on the report, not only in --json: the failure this answers is a
+    // session silently wired to an older cached copy, and a user who has to run
+    // a JSON command to find that out will not think to.
+    `Plugin: ${report.pluginVersion ?? "unknown"} (${report.scriptPath ?? "path unknown"})`,
     "",
     "Checks:",
     `- node: ${report.node.detail}`,
@@ -357,6 +361,24 @@ export function renderTaskResult(parsedResult, meta) {
   }
   const lines = [message, ""];
   pushFailureDetails(lines, parsedResult.failure);
+  return `${lines.join("\n").trimEnd()}\n`;
+}
+
+// A group cancel is several terminations, and which of them reached a live
+// process differs — one engine can already have finished while the other was
+// still running. Reporting a single line would hide that, so each member gets
+// its own.
+export function renderCancelGroupReport({ groupId, jobs = [], terminations = [] }) {
+  const lines = [
+    "# Gemini Cancel",
+    "",
+    `Cancelled ${jobs.length} job${jobs.length === 1 ? "" : "s"} in group ${groupId}.`,
+    ""
+  ];
+  jobs.forEach((job, index) => {
+    lines.push(`- ${job.id}${job.engine ? ` (${job.engine})` : ""}: ${describeTermination(terminations[index])}`);
+  });
+  lines.push("", "Check `/gemini:status` for the updated queue.");
   return `${lines.join("\n").trimEnd()}\n`;
 }
 

--- a/tests/job-control.test.mjs
+++ b/tests/job-control.test.mjs
@@ -3,7 +3,8 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 
 import { makeTempDir } from "./helpers.mjs";
-import { readJobFile, resolveJobFile, saveState, setConfig, writeJobFile } from "../plugins/gemini/scripts/lib/state.mjs";
+import { readJobFile, resolveJobFile, saveState, setConfig, upsertJob, writeJobFile } from "../plugins/gemini/scripts/lib/state.mjs";
+import { cancelJob } from "../plugins/gemini/scripts/gemini-companion.mjs";
 import { buildStatusSnapshot, resolveResultJob } from "../plugins/gemini/scripts/lib/job-control.mjs";
 import { runTrackedJob } from "../plugins/gemini/scripts/lib/tracked-jobs.mjs";
 
@@ -144,4 +145,92 @@ test("a successful run is completed even if the runner also set partial", async 
   const stored = readJobFile(resolveJobFile(cwd, "task-zero"));
   assert.equal(stored.status, "completed");
   assert.equal(stored.failure ?? null, null);
+});
+
+// ---------------------------------------------------------------------------
+// `/gemini:cancel <groupId>` used to answer "No active job found": status and
+// result both accept a groupId and aggregate, and cancel alone matched job ids,
+// so an adversarial-review group had to be cancelled one engine at a time from
+// ids the user had to go and read out of a status listing.
+// ---------------------------------------------------------------------------
+
+function seedGroup(cwd, groupId, members) {
+  for (const member of members) {
+    const record = { jobClass: "review", title: "Adversarial Review", groupId, ...member };
+    upsertJob(cwd, record);
+    writeJobFile(cwd, record.id, record);
+  }
+}
+
+function stubTerminate() {
+  const killed = [];
+  const fn = (pid) => {
+    killed.push(pid);
+    return { attempted: true, delivered: true, method: "taskkill" };
+  };
+  fn.killed = killed;
+  return fn;
+}
+
+test("cancelling a group cancels every active member", () => {
+  const cwd = makeTempDir();
+  seedGroup(cwd, "review-group-1", [
+    { id: "review-agy", status: "running", pid: 4001, engine: "agy" },
+    { id: "review-gemini", status: "running", pid: 4002, engine: "gemini" }
+  ]);
+
+  const terminateProcessTreeFn = stubTerminate();
+  const result = cancelJob({ cwd, jobId: "review-group-1", all: true }, { terminateProcessTreeFn });
+
+  assert.equal(result.groupId, "review-group-1");
+  assert.deepEqual(terminateProcessTreeFn.killed.sort(), [4001, 4002]);
+  for (const id of ["review-agy", "review-gemini"]) {
+    assert.equal(readJobFile(resolveJobFile(cwd, id)).status, "cancelled", `${id} was left running`);
+  }
+});
+
+test("a group cancel leaves members that already finished alone", () => {
+  const cwd = makeTempDir();
+  seedGroup(cwd, "review-group-2", [
+    { id: "review-done", status: "completed", pid: null, engine: "agy" },
+    { id: "review-live", status: "running", pid: 4003, engine: "gemini" }
+  ]);
+
+  const terminateProcessTreeFn = stubTerminate();
+  const result = cancelJob({ cwd, jobId: "review-group-2", all: true }, { terminateProcessTreeFn });
+
+  assert.deepEqual(result.payload.cancelled.map((entry) => entry.jobId), ["review-live"]);
+  assert.equal(readJobFile(resolveJobFile(cwd, "review-done")).status, "completed", "a finished job is not re-labelled");
+});
+
+test("cancelling one job of a group by its own id still cancels only that one", () => {
+  const cwd = makeTempDir();
+  seedGroup(cwd, "review-group-3", [
+    { id: "review-first", status: "running", pid: 4004, engine: "agy" },
+    { id: "review-second", status: "running", pid: 4005, engine: "gemini" }
+  ]);
+
+  const terminateProcessTreeFn = stubTerminate();
+  const result = cancelJob({ cwd, jobId: "review-first", all: true }, { terminateProcessTreeFn });
+
+  // The single-job shape is what every existing caller reads — the slash
+  // command, the MCP tool, and renderCancelReport.
+  assert.equal(result.groupId ?? null, null);
+  assert.equal(result.payload.jobId, "review-first");
+  assert.deepEqual(terminateProcessTreeFn.killed, [4004]);
+  assert.equal(readJobFile(resolveJobFile(cwd, "review-second")).status, "running", "its group peer was cancelled too");
+});
+
+test("a groupId whose members have all finished says so instead of \"no job found\"", () => {
+  const cwd = makeTempDir();
+  seedGroup(cwd, "review-group-4", [
+    { id: "review-old-a", status: "completed", pid: null },
+    { id: "review-old-b", status: "failed", pid: null }
+  ]);
+
+  assert.throws(
+    () => cancelJob({ cwd, jobId: "review-group-4", all: true }, { terminateProcessTreeFn: stubTerminate() }),
+    /group review-group-4 has no active jobs \(2 already finished\)/,
+    "the group exists; saying it was not found sends the user after an id they gave correctly"
+  );
 });

--- a/tests/setup-readiness.test.mjs
+++ b/tests/setup-readiness.test.mjs
@@ -8,7 +8,10 @@ import {
   probeAgyLogin,
   probeGeminiLogin
 } from "../plugins/gemini/scripts/lib/gemini.mjs";
+import { renderSetupReport } from "../plugins/gemini/scripts/lib/render.mjs";
 import { makeTempDir } from "./helpers.mjs";
+import fs from "node:fs";
+import path from "node:path";
 
 // ---------------------------------------------------------------------------
 // probeAgyLogin
@@ -692,4 +695,40 @@ test("the gemini probe does not spawn when the binary is absent", () => {
 
   assert.equal(status.state, "unavailable");
   assert.equal(runCommandFn.calls.length, 0);
+});
+
+// ---------------------------------------------------------------------------
+// Field note gi-2026-08-17-a1c7: a session ran plugin 0.17.3 while
+// installed_plugins.json reported 0.19.0. Fixes believed shipped were silently
+// absent from both the MCP and slash surfaces, and nothing in the session could
+// say which version was live — it was found by reading the MCP server's process
+// command line. The cache/PATH resolution is Claude Code's and `/reload-plugins`
+// is the remedy; what is fixable here is the silence.
+//
+// Both values must describe the code that is executing, not a manifest
+// elsewhere, or they would report the same thing the mismatch already reported.
+// ---------------------------------------------------------------------------
+
+test("setup names the plugin version that is actually running", () => {
+  const manifest = JSON.parse(
+    fs.readFileSync(new URL("../plugins/gemini/.claude-plugin/plugin.json", import.meta.url), "utf8")
+  );
+  const report = buildSetupReport(makeTempDir(), [], {});
+  assert.equal(report.pluginVersion, manifest.version);
+});
+
+test("setup names the script answering, so a stale copy is visible", () => {
+  const report = buildSetupReport(makeTempDir(), [], {});
+  assert.match(report.scriptPath, /gemini-companion\.mjs$/);
+  // The path has to be the running file's own, not a guess assembled from cwd:
+  // the whole failure is a session wired to a copy in a different directory.
+  assert.ok(
+    report.scriptPath.includes(`${path.sep}scripts${path.sep}`),
+    `scriptPath does not look like a resolved script path: ${report.scriptPath}`
+  );
+});
+
+test("the setup report shows the running copy without asking for --json", () => {
+  const rendered = renderSetupReport(buildSetupReport(makeTempDir(), [], {}));
+  assert.match(rendered, /^Plugin: /m);
 });


### PR DESCRIPTION
Two of the three items left from the 2026-08-17 batch. The third (`gi-2026-08-17-a1c7` itself) is not this plugin's to fix and stays open.

## `/gemini:cancel <group-id>`

`status` and `result` have always accepted an adversarial-review group id and aggregated over its members. Cancel matched job ids only — so a group had to be cancelled one engine at a time, from ids the user first had to read out of a status listing, and a group id came back as **"No active job found"**, which is the one thing it was not.

`resolveCancelableJobs` reuses the pattern the other two already use: try the group, fall back to a single job.

- Members still `queued` or `running` are cancelled. Members that already finished are left exactly as they are — cancel has nothing to say about work that is done.
- The report lists each member and what its termination actually reached. One engine can have finished while the other was still running, and a single summary line would hide that.
- A group whose members have all finished now says so, with a pointer to `/gemini:result`, instead of reporting a correct id as unknown. That was found by a test whose expectation I had written wrong — the code was reachable, the message was not the one a user needs.
- **The single-job path is unchanged** in shape, payload and messages. Every existing caller reads `payload.jobId`, and a test pins that cancelling one member of a group by its own id still cancels only that one.

Documented on both surfaces that take the reference: `commands/cancel.md` and the `gemini_job_cancel` tool description.

## `/gemini:setup` names the plugin that is answering

Field note `gi-2026-08-17-a1c7`: a session ran plugin 0.17.3 while `installed_plugins.json` reported 0.19.0. Fixes believed shipped were absent from both the MCP and the slash surface, and nothing in the session could say which version was live — it was found by reading the MCP server's process command line.

The cache/PATH resolution is Claude Code's and `/reload-plugins` is the remedy; neither is this plugin's to fix. **The silence is.** `setup` now reports `pluginVersion` and `scriptPath`, both read relative to the running script so they describe the code that is executing rather than what a manifest elsewhere claims. The version comes from the same `plugin.json` Claude Code consults first (`docs/version-sources.md`).

On the ordinary report, not only in `--json`:

```
# Gemini Setup

Status: partial (AGY selected — binary present, auth not verifiable non-interactively)
Plugin: 0.22.0 (C:\…\plugins\gemini\scripts\gemini-companion.mjs)
```

A user who has to ask for JSON to discover a stale copy will not think to ask. This makes the mismatch visible in one command; it does not detect it, and the field note stays open.

## Verification

- `npm test` — 560 tests, 552 pass, 0 fail, 8 skipped
- `npm run check-version` — 0.22.0 consistent, changelog entry present
- `npm run verify-contracts` — passed
- 5 mutations, 5 kills: cancel forgetting groups again, a group cancel sweeping finished members, the finished-group message reverting to "not found", setup dropping the identity fields, and the report dropping the `Plugin:` line

`docs/known-diffs.md` loses the cancel follow-up and keeps a line saying where it went. The remaining entry there (partial-dispatch rollback) is unchanged and still deliberate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
