### PR TITLE
Stop a workspace the demo still holds from failing a passed test

### DIFF
--- a/tests/reviewer-demo.test.mjs
+++ b/tests/reviewer-demo.test.mjs
@@ -15,6 +15,24 @@ const SCRIPT = path.join(ROOT, "scripts", "reviewer-demo.mjs");
 // credential breaks with it — and nothing else in the suite would notice,
 // because it drives the commands from outside rather than importing them.
 
+// Cleanup is best effort, like the demo’s own removeWorkspace() and
+// isolate-state.mjs. The cancel step leaves a stand-in engine whose cwd is the
+// workspace; if it outlives the retries, Windows refuses the delete. The OS
+// reclaims temp either way, and throwing from an after hook fails a test whose
+// assertions all passed — which is how this surfaced, as a red "redaction
+// claim" that had nothing to do with redaction.
+const BUSY = ["EPERM", "EBUSY", "ENOTEMPTY", "EACCES"];
+
+function discardWorkspace(kept) {
+  if (!kept) return;
+  try {
+    fs.rmSync(kept, { recursive: true, force: true, maxRetries: 10, retryDelay: 300 });
+  } catch (error) {
+    if (!BUSY.includes(error?.code)) throw error;
+    process.stderr.write(`left ${kept} for the OS: ${error.code} (a demo process still holds it)\n`);
+  }
+}
+
 test("reviewer-demo lists its steps without running anything", () => {
   const result = run("node", [SCRIPT, "--list"], { cwd: ROOT });
   assert.equal(result.status, 0, result.stderr);
@@ -28,9 +46,7 @@ test("reviewer-demo runs every command end to end", (t) => {
   // rather than taken from the demo's own summary line.
   const result = run("node", [SCRIPT, "--keep"], { cwd: ROOT });
   const kept = (result.stdout.match(/^kept: (.+)$/m) ?? [])[1];
-  t.after(() => {
-    if (kept) fs.rmSync(kept, { recursive: true, force: true, maxRetries: 10, retryDelay: 300 });
-  });
+  t.after(() => discardWorkspace(kept));
 
   assert.equal(result.status, 0, result.stderr);
 
@@ -62,9 +78,7 @@ test("reviewer-demo runs every command end to end", (t) => {
 test("reviewer-demo's redaction claim holds against the files it leaves behind", (t) => {
   const result = run("node", [SCRIPT, "--keep"], { cwd: ROOT });
   const kept = (result.stdout.match(/^kept: (.+)$/m) ?? [])[1];
-  t.after(() => {
-    if (kept) fs.rmSync(kept, { recursive: true, force: true, maxRetries: 10, retryDelay: 300 });
-  });
+  t.after(() => discardWorkspace(kept));
 
   assert.equal(result.status, 0, result.stderr);
   assert.ok(kept, "--keep did not report the workspace path");


### PR DESCRIPTION
The failure looked like the redaction claim breaking:

```
✖ reviewer-demo's redaction claim holds against the files it leaves behind
  Error: EPERM, Permission denied: ...\Temp\gemini-reviewer-demo-hqCfxd
      at TestContext.<anonymous> (tests/reviewer-demo.test.mjs:66)
      at after (node:internal/test_runner/test:1076:20)
```

Every assertion in that test had passed. The throw came from the `t.after` hook, which `node:test` attributes to the test it belongs to, so the report named the one part of the suite that was never in doubt. The other `--keep` test shares the same cleanup and went red the same way in the same run — whichever copy loses the race is the one that gets blamed.

The cancel step installs a stand-in engine that blocks for 120 seconds with the demo's `sample-repo` as its working directory. Windows will not delete a directory that is any live process's cwd, and `rmSync`'s ten 300ms retries give up about 117 seconds early.

## What this does

Tolerates it, as this repository already does in the two other places that delete the same kind of directory: `removeWorkspace()` in the demo itself (`scripts/reviewer-demo.mjs:253`) and the exit hook in `tests/isolate-state.mjs`, whose comment already says failing there would fail an otherwise passing run.

- Only the busy family (`EPERM`, `EBUSY`, `ENOTEMPTY`, `EACCES`) is swallowed; anything else still throws.
- The path and errno go to stderr, because after this change a leaked process no longer turns a run red, and that line is the only thing left that would show it.

## Measured

| | red | tolerated |
|---|---|---|
| before, 8-way fan-out of this file, 120 copies | 3 (none an assertion) | — |
| after, 10-way fan-out, 50 copies | 0 | 3 |

The tolerated path was exercised, not merely unreached.

## Not in scope

Why a cancel that reports `terminated the running process` can leave that engine alive. That is #89.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019G2BAczpG8DL2NiAqTYkHA
