### PR TITLE
Cancel a job whose engine has actually started

### DIFF
--- a/scripts/reviewer-demo.mjs
+++ b/scripts/reviewer-demo.mjs
@@ -222,8 +222,8 @@ function waitForJob(env, cwd, jobId, timeoutMs = 60_000) {
 // Waiting for the phase instead means the step demonstrates what it claims,
 // rather than cancelling during engine detection whenever the machine is slow.
 // It also stops the demo aiming at the narrowest possible window: an engine
-// killed in the moment it is being created escapes the job object it was about
-// to join, which is a real defect (v0.22.1) but not what this step is for.
+// killed in the moment it is being created can outlive the cancel that reported
+// it terminated, which is a real defect (v0.22.1) but not what this step is for.
 // "engine" — the turn has started, which is what the step wants to cancel.
 // "worker" — a worker is up but its engine never reported in; cancel still has
 // something to terminate, and the step says so rather than pretending.

--- a/scripts/reviewer-demo.mjs
+++ b/scripts/reviewer-demo.mjs
@@ -204,20 +204,33 @@ function waitForJob(env, cwd, jobId, timeoutMs = 60_000) {
   return "timed-out";
 }
 
-// The cancel step needs a job whose worker is up, because what `cancel`
-// terminates is that worker's process tree. `task --background` returns as soon
-// as the worker is *spawned*, not when it has started, so the step used to wait
-// a fixed two seconds and hope. On a loaded machine two seconds is not enough:
-// the walkthrough then cancelled a job the state directory could not yet
-// describe, and the step produced no output at all -- a failure of the demo's
-// timing, reported as if the plugin could not cancel a job.
+// The cancel step needs a job whose engine is up, because the point of the step
+// is terminating a live process tree. `task --background` returns as soon as the
+// worker is *spawned*, not when it has started, so the step used to wait a fixed
+// two seconds and hope. On a loaded machine two seconds is not enough: the
+// walkthrough then cancelled a job the state directory could not yet describe,
+// and the step produced no output at all -- a failure of the demo's timing,
+// reported as if the plugin could not cancel a job.
 //
-// So wait for the state the step actually needs rather than guessing how long
-// reaching it takes. `pid` is what cancel terminates and the worker records it
-// with the running status, which makes its presence the signal that there is a
-// tree to kill.
+// So wait for the state the step actually needs. That state is not `pid`: the
+// worker records `running` with its pid *before* it starts the engine, so at
+// that instant the only thing to kill is the worker itself. Measured on this
+// machine, the engine turn begins about 900ms after that record appears, and
+// the plugin announces it by moving the job to phase `running` (`reviewing` for
+// a review) on the same event that logs "Starting <engine> turn...".
+//
+// Waiting for the phase instead means the step demonstrates what it claims,
+// rather than cancelling during engine detection whenever the machine is slow.
+// It also stops the demo aiming at the narrowest possible window: an engine
+// killed in the moment it is being created escapes the job object it was about
+// to join, which is a real defect (v0.22.1) but not what this step is for.
+// "engine" — the turn has started, which is what the step wants to cancel.
+// "worker" — a worker is up but its engine never reported in; cancel still has
+// something to terminate, and the step says so rather than pretending.
+// "none"   — nothing to go on.
 function waitForRunningJob(env, cwd, jobId, timeoutMs = 30_000) {
   const deadline = Date.now() + timeoutMs;
+  let sawWorker = false;
   while (Date.now() < deadline) {
     const probe = spawnSync(process.execPath, ["--no-deprecation", COMPANION, "status", jobId, "--json"], {
       cwd, env, encoding: "utf8", windowsHide: true
@@ -226,18 +239,22 @@ function waitForRunningJob(env, cwd, jobId, timeoutMs = 30_000) {
       const payload = JSON.parse(probe.stdout);
       const job = payload.job ?? payload.jobs?.[0] ?? payload;
       const status = String(job?.status ?? "");
-      if (status === "running" && job.pid) return true;
+      const phase = String(job?.phase ?? "");
+      if (status === "running" && job.pid) {
+        sawWorker = true;
+        if (phase === "running" || phase === "reviewing") return "engine";
+      }
       // Anything neither queued nor running has finished, and will never reach
       // running. Phrased as the complement of "still active" rather than as a
       // list of terminal states, which would need updating every time the
       // runtime gains one.
-      if (status && status !== "queued" && status !== "running") return false;
+      if (status && status !== "queued" && status !== "running") return sawWorker ? "worker" : "none";
     } catch {
       // status not written yet — keep waiting
     }
     sleep(200);
   }
-  return false;
+  return sawWorker ? "worker" : "none";
 }
 
 function sleep(ms) {
@@ -339,7 +356,10 @@ function main() {
     const toCancel = show(["task", "--background", "a job that will be cancelled"], { cwd: repo, env });
     const cancelId = (toCancel.body.match(JOB_ID) ?? [])[1];
     if (cancelId) {
-      if (!waitForRunningJob(env, repo, cancelId)) {
+      const ready = waitForRunningJob(env, repo, cancelId);
+      if (ready === "worker") {
+        note("The engine never reported its turn; cancelling the worker anyway.");
+      } else if (ready === "none") {
         note("The worker never reported a running process; cancelling anyway.");
       }
       show(["cancel", cancelId], { cwd: repo, env, allowFailure: true });

--- a/tests/reviewer-demo.test.mjs
+++ b/tests/reviewer-demo.test.mjs
@@ -33,6 +33,27 @@ function discardWorkspace(kept) {
   }
 }
 
+// The plugin writes one log per job under the workspace it was given; --keep
+// leaves them, which is how the walkthrough can be checked against what the
+// plugin recorded rather than only against what it printed.
+function findJobLog(kept, marker) {
+  const found = [];
+  const walk = (dir) => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else if (entry.name.endsWith(".log")) found.push(full);
+    }
+  };
+  const state = path.join(kept, "plugin-data");
+  if (!fs.existsSync(state)) return null;
+  walk(state);
+  for (const file of found) {
+    const body = fs.readFileSync(file, "utf8");
+    if (body.includes(marker)) return body;
+  }
+  return null;}
+
 test("reviewer-demo lists its steps without running anything", () => {
   const result = run("node", [SCRIPT, "--list"], { cwd: ROOT });
   assert.equal(result.status, 0, result.stderr);
@@ -72,6 +93,25 @@ test("reviewer-demo runs every command end to end", (t) => {
   // A reviewer must not be left believing canned text came from a model.
   assert.match(result.stdout, /stand-in engine/);
   assert.match(result.stdout, /Not verified here/);
+  // Both fallback notes mean the step cancelled a worker that had not started its
+  // turn yet, which is not what it claims to demonstrate.
+  assert.doesNotMatch(result.stdout, /never reported/, "the cancel step did not wait for a running engine");
+  // The step claims to terminate a running job’s process tree, and the job log is
+  // where that can be checked rather than assumed: the worker records `running`
+  // with its pid a beat before it starts the engine, so a cancel that arrives in
+  // that gap kills a worker with nothing under it yet. The turn must have begun
+  // first.
+  const cancelLog = findJobLog(kept, "Cancelled by user");
+  assert.ok(cancelLog, "the cancel step left no job log to check");
+  // Checked for presence before order: indexOf returns -1 for a line that never
+  // arrived, and -1 is less than everything, so the comparison alone would pass
+  // most loudly in exactly the case it is meant to catch.
+  assert.ok(cancelLog.includes("turn..."), `the engine turn never started before the cancel:\n${cancelLog}`);
+  assert.ok(
+    cancelLog.indexOf("turn...") < cancelLog.indexOf("Cancelled by user"),
+    `the cancel arrived before the engine turn started:\n${cancelLog}`
+  );
+
   assert.doesNotMatch(result.stderr, /DeprecationWarning/, "reviewer-facing output must be free of Node warnings");
 });
 


### PR DESCRIPTION
The cancel step waited for the job to report `running` with a pid. The worker writes that record **before** it starts the engine, so at the moment the wait returned there was nothing under the worker to kill.

Measured by sampling the job records every 25ms across a run:

```
12711ms  task-… queued/queued
12928ms  task-… running/starting     <- the old wait returned here
13794ms  task-… running/running      <- the engine turn actually begins
15106ms  task-… cancelled/cancelled
```

That the step usually worked anyway is luck of the clock: the cancel command's own startup happens to outlast engine detection. On a loaded machine it does not, and then the step cancels a worker mid-detection while its heading claims to terminate a running job's process tree — the failure shape this demo produced in #86, where the step printed nothing at all.

## What this does

Waits for the phase the plugin already announces. The same event that logs `Starting <engine> turn...` moves the job to phase `running` (`reviewing` for a review), so that is the state to wait for — which is what the previous fix here was reaching for when it replaced a fixed two-second sleep.

The wait now reports which state it reached, and the two fallbacks say different things: an engine that never reported its turn is not the same as a worker that never came up.

## On the test

The walkthrough now reads the job log the demo leaves behind and requires the turn to have started before the cancel arrived.

Its first form was worthless and is worth calling out: `indexOf` returns `-1` for a line that never arrived, and `-1` sorts before everything, so the ordering comparison passed most confidently in exactly the case it existed to catch. It now checks the line is present before comparing positions.

**What that test does not do:** mutating the wait to fire immediately does not fail it on an unloaded machine, because the cancel's startup still outlasts detection. It guards the loaded case, where the turn line is missing entirely. The evidence for the wait itself is the measured timeline above, not a discriminating test.

## Not in scope

The engine that escapes when it is killed in the moment it is created — that is #89. This only stops the demo aiming at that window on purpose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019G2BAczpG8DL2NiAqTYkHA
