### PR TITLE
Write down how this repository decides something is true

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,3 +5,4 @@
 - Documentation fixes: open a pull request directly.
 - Code changes: open an issue first, so the approach can be agreed before the work.
 - Every pull request must pass `npm test` and `npm run verify-contracts`.
+- Claims about behaviour need evidence that has been seen to fail: [docs/evidence.md](docs/evidence.md).

--- a/CONTRIBUTING.zh-TW.md
+++ b/CONTRIBUTING.zh-TW.md
@@ -3,3 +3,4 @@
 - 文件修正：直接開 pull request。
 - 程式變更：請先開 issue，讓作法在動工前先取得共識。
 - 所有 pull request 都必須通過 `npm test` 與 `npm run verify-contracts`。
+- 關於行為的主張，需要一份「曾經看它紅過」的證據：[docs/evidence.md](docs/evidence.md)。

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,7 @@ Start with the [README](../README.md). Nothing here is required reading to use t
 | [`adapter-contract.md`](adapter-contract.md) | The interface an engine adapter has to satisfy. |
 | [`version-sources.md`](version-sources.md) | Which file is authoritative for each version string, and what keeps them in lockstep. |
 | [`verifying-without-credentials.md`](verifying-without-credentials.md) | How to exercise the engine paths without a Gemini or AGY account. |
+| [`evidence.md`](evidence.md) | The rule this repository investigates by: nothing counts as evidence until it has been seen to fail. Includes the traps already paid for. |
 
 ## Dated records — never rewritten
 

--- a/docs/README.zh-TW.md
+++ b/docs/README.zh-TW.md
@@ -18,6 +18,7 @@ English: [`README.md`](README.md)
 | [`adapter-contract.md`](adapter-contract.md) | 引擎 adapter 必須滿足的介面。 |
 | [`version-sources.md`](version-sources.md) | 每個版本字串以哪個檔案為準，以及靠什麼維持一致。 |
 | [`verifying-without-credentials.md`](verifying-without-credentials.md) | 沒有 Gemini 或 AGY 帳號時，如何演練引擎路徑。 |
+| [`evidence.md`](evidence.md) | 本 repo 的調查規則：沒看過它紅過的東西，不算證據。附已經付過學費的陷阱清單。 |
 
 ## 有日期的記錄——永不重寫
 

--- a/docs/evidence.md
+++ b/docs/evidence.md
@@ -1,0 +1,47 @@
+# Evidence that has been seen to fail
+
+Most of this plugin's hard bugs are intermittent, Windows-specific, or both. The
+instruments used to investigate them — a probe, a sampler, a new assertion — fail
+silently: a broken instrument and a working system both look green. So the rule
+here is one habit, applied in four places:
+
+**Nothing counts as evidence until it has been seen to fail.**
+
+## The four places
+
+**A test.** Break the code it covers and watch it go red. If it stays green it is
+protecting nothing, however reasonable it reads. Two assertions in this repository
+passed every run while asserting nothing: one compared `indexOf(...) < indexOf(...)`
+where the first line was absent, and `-1` sorts before everything, so it passed
+most confidently in exactly the case it existed to catch.
+
+**A probe or harness.** Run it against the *unfixed* system first. If it cannot
+reproduce the failure, a clean result from it means nothing. A probe written to
+stage an orphaned process spawned its child undetached, so Windows collected it
+along with its parent; the probe reported "no survivors" and nearly became
+evidence that a real defect was absent.
+
+**A sampler.** Stage an event of known duration and confirm the sampler catches it
+before trusting a negative. A 100ms poll missed a ~700ms job-phase transition and
+produced the confident, wrong claim that the phase never appears.
+
+**A claim.** Name the observation that would falsify it, and run that observation.
+If it was never run, the claim is *inferred*, not measured, and says so in the
+commit message and the comment. A mechanism explained in a changelog entry, a
+commit and a PR description here was contradicted the next day by the first
+measurement anyone took of it.
+
+## A control comes before a conclusion
+
+A reading with no discriminating power looks exactly like a confirmed prediction.
+Chasing a leaked process, the prediction "it will report `IsProcessInJob=false`"
+was confirmed — and so were all 24 healthy processes measured alongside it. Without
+that control the investigation would have shipped the wrong mechanism.
+
+## Traps this repository has already paid for
+
+- `node:test` attributes a throw inside `t.after` to the test that hook belongs to, so cleanup failures are reported under an unrelated assertion's name.
+- A directory that is any live process's current directory cannot be deleted on Windows; `fs.rmSync` retries are not a fix for a process that outlives them.
+- Windows never clears a process's parent link, so a reused pid inherits strangers. Any decision based on "children of pid N" needs a second signal — creation time works.
+- Measuring process semantics from inside an agent harness measures the harness: its own processes may sit in a job object that collects everything they spawn.
+- Looping the full test suite is a poor way to reproduce a rare failure. Run the one file that fails, many copies in parallel: this suite yields 2 relevant samples per 3.5 minutes, where 10 parallel copies of one file yield 20 in about a minute.


### PR DESCRIPTION
Three times in one investigation a clean result came from an instrument that could not have shown a failure:

- an assertion comparing `indexOf("turn...") < indexOf("Cancelled by user")` where the first line was absent — `-1` sorts before everything, so it passed most confidently in exactly the case it existed to catch;
- a probe written to stage an orphaned process, whose child was spawned undetached and so was collected along with its parent — it reported "no survivors" and nearly became evidence that a real defect was absent;
- a 100ms sampler watching a ~700ms transition, which produced the confident, wrong claim that the transition never happens.

A broken instrument and a working system look identical from the outside, and that is worst exactly when the bug is intermittent — which describes most of the hard ones in this repository.

## What this adds

`docs/evidence.md`: one habit, four applications — **nothing counts as evidence until it has been seen to fail**, applied to a test, a probe, a sampler and a claim. Plus a control-before-conclusion note, from a case where a predicted reading was confirmed and turned out to have no discriminating power at all (all 24 healthy processes read the same as the leaked one).

It ends with the traps this repository has already paid for, because they are the ones most likely to be paid for again:

- `node:test` attributes a throw inside `t.after` to the test that hook belongs to, so a cleanup failure is reported under an unrelated assertion's name.
- A directory that is any live process's cwd cannot be deleted on Windows; `rmSync` retries do not fix a process that outlives them.
- Windows never clears a parent link, so a reused pid inherits strangers — "children of pid N" needs a second signal.
- Measuring process semantics from inside an agent harness measures the harness.
- Looping the full suite is a poor way to reproduce a rare failure: 2 relevant samples per 3.5 minutes, against 20 per minute from parallel copies of the one file.

`CONTRIBUTING.md` keeps its shape — one line pointing at `docs/`, the same as everything else there — with the mirror line in `CONTRIBUTING.zh-TW.md`, and a row in both documentation indexes.

Docs only; no code touched. `npm test` (560) and `npm run verify-contracts` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019G2BAczpG8DL2NiAqTYkHA
