### PR TITLE
Measure AGY on both bench axes, and stop seeded cassettes reaching verdicts

### DIFF
--- a/.github/workflows/publish-scorecard.yml
+++ b/.github/workflows/publish-scorecard.yml
@@ -1,0 +1,94 @@
+name: Publish scorecard
+# Replays the committed cassettes and publishes the scorecard to the `results`
+# branch. It holds no secrets and reaches no network, because the half of this
+# benchmark that needs credentials cannot run here at all:
+#
+#   - AGY authenticates only through its interactive OAuth flow. `agy --help`
+#     offers no key, token, or login flag, so a runner has no way to hold a
+#     credential for it.
+#   - Gemini CLI's consumer tier stopped serving on 2026-06-18; refreshing
+#     `gemini.model` now needs a paid Code Assist or API-key credential.
+#   - `codex.native` needs BENCH_CODEX_COMPANION pointing at a locally installed
+#     plugin.
+#
+# So recording is a maintainer's local `npm run bench:live`, committed as
+# cassettes. That is not a workaround — it is what keeps this workflow free of
+# the `pull_request_target` question entirely: with no secret to expose, there is
+# no exposure to reason about.
+on:
+  push:
+    branches: [main]
+    paths:
+      - "bench/**"
+  workflow_dispatch: {}
+
+# Deliberately no `schedule`. A monthly run would republish byte-identical
+# numbers under a fresh commit date, which is worse than not running: the
+# published timestamp is the credibility signal, and a schedule would turn it
+# into a claim that stale numbers were just re-measured. The scorecard's own
+# per-cell `recordedAt` and `engineVersion` are the honest timestamps, and they
+# move only when someone actually re-records.
+permissions:
+  contents: write
+
+concurrency:
+  group: publish-scorecard
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+
+      # Deterministic replay: no engine is invoked, so this cannot spend a turn
+      # or touch a credential even if one were present.
+      - run: npm run bench
+
+      - name: Publish to the results branch
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          # A worktree, so the branch is built without disturbing this checkout.
+          git fetch --depth=1 origin results || true
+          if git show-ref --verify --quiet refs/remotes/origin/results; then
+            git worktree add ../results origin/results
+          else
+            git worktree add --detach ../results
+            git -C ../results checkout --orphan results
+            git -C ../results rm -rf --cached . >/dev/null
+            find ../results -mindepth 1 -maxdepth 1 -not -name .git -exec rm -rf {} +
+          fi
+
+          cp bench/results/scorecard.md bench/results/scorecard.json ../results/
+          git -C ../results add scorecard.md scorecard.json
+
+          # Nothing changed means nothing to say. Publishing an identical
+          # scorecard would move the branch's last-updated date without moving a
+          # single measurement behind it.
+          if git -C ../results diff --cached --quiet; then
+            echo "scorecard unchanged; nothing published"
+            exit 0
+          fi
+
+          # The subject names the builds the numbers came from, so `git log` on
+          # the results branch reads as a record of what was measured against
+          # what — not of when a workflow happened to run.
+          subject=$(node -e '
+            const s = require("./bench/results/scorecard.json");
+            const live = Object.entries(s.provenance ?? {})
+              .filter(([, p]) => p && !p.seeded)
+              .map(([cell, p]) => `${cell}@${p.engineVersion ?? "unknown"}`)
+              .sort();
+            process.stdout.write(`scorecard: ${live.length ? live.join(" ") : "no measured cells"}`);
+          ')
+          git -C ../results commit -m "$subject"
+          git -C ../results push origin HEAD:results

--- a/.github/workflows/publish-scorecard.yml
+++ b/.github/workflows/publish-scorecard.yml
@@ -1,20 +1,23 @@
 name: Publish scorecard
 # Replays the committed cassettes and publishes the scorecard to the `results`
 # branch. It holds no secrets and reaches no network, because the half of this
-# benchmark that needs credentials cannot run here at all:
+# benchmark that needs credentials is deliberately not run here:
 #
-#   - AGY authenticates only through its interactive OAuth flow. `agy --help`
-#     offers no key, token, or login flag, so a runner has no way to hold a
-#     credential for it.
+#   - AGY can be given a credential non-interactively: since 1.1.13 it accepts
+#     GEMINI_API_KEY with `modelProvider: "gemini"` in settings.json. But that
+#     routes the turn to the Gemini API rather than through AGY's own sign-in,
+#     so a cassette recorded that way would measure a path no signed-in AGY user
+#     takes, and the scorecard would attribute it to AGY anyway. Possible is not
+#     the same as valid.
 #   - Gemini CLI's consumer tier stopped serving on 2026-06-18; refreshing
 #     `gemini.model` now needs a paid Code Assist or API-key credential.
 #   - `codex.native` needs BENCH_CODEX_COMPANION pointing at a locally installed
-#     plugin.
+#     plugin, and its agentic review exceeded the 180s cap when last attempted.
 #
-# So recording is a maintainer's local `npm run bench:live`, committed as
-# cassettes. That is not a workaround — it is what keeps this workflow free of
-# the `pull_request_target` question entirely: with no secret to expose, there is
-# no exposure to reason about.
+# So recording stays a maintainer's local `npm run bench:live`, committed as
+# cassettes. The benefit is not only fidelity: with no secret in this workflow
+# there is no `pull_request_target` question to get wrong, because there is
+# nothing here to expose.
 on:
   push:
     branches: [main]

--- a/.github/workflows/pull-request-ci.yml
+++ b/.github/workflows/pull-request-ci.yml
@@ -42,6 +42,16 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm test
+      # Deterministic replay of the committed cassettes. This guards the
+      # orchestrator, the scorer, and the scorecard's verdict rules — including
+      # the rule that a seeded cassette cannot win an axis.
+      #
+      # It does NOT tell you whether a change made reviews better or worse. No
+      # engine runs here: replay reads recorded outputs, so a PR that rewrites a
+      # prompt or reroutes an engine passes this untouched. Reviewing quality is
+      # measured by re-recording (`npm run bench:live`), which needs credentials
+      # and a TTY and therefore happens on a maintainer's machine.
+      - run: npm run bench
       - run: npm run check-version
       - run: npm run verify-contracts
       # verify-contracts checks version lockstep and the command surface; it does

--- a/bench/README.md
+++ b/bench/README.md
@@ -1,16 +1,16 @@
-# bench — codex vs gemini review benchmark
+# bench — agy vs gemini vs codex review benchmark
 
-A reproducible harness that pits **Codex** and **Gemini** against each other on
-code review, scored automatically against planted ground truth. It operationalizes
+A reproducible harness that pits **AGY**, **Gemini** and **Codex** against each other
+on code review, scored automatically against planted ground truth. It operationalizes
 the manual comparison in [`docs/MODEL_COMPARISON.md`](../docs/MODEL_COMPARISON.md):
 the interesting question is **model vs harness**, so the benchmark measures both.
 
-## Two axes, four cells
+## Two axes, six cells
 
-Both tools emit the **same** structured review JSON (see
+All three tools emit the **same** structured review JSON (see
 [`review-output.schema.json`](review-output.schema.json), identical to the gemini
 `prompts/review.md` contract and the codex `schemas/review-output.schema.json`), so
-one scorer grades both.
+one scorer grades all of them.
 
 | Cell | What it is | Isolates |
 |---|---|---|
@@ -18,10 +18,15 @@ one scorer grades both.
 | `codex.model` | `codex exec --output-schema …` on the same neutral prompt + diff | model (single-shot) |
 | `gemini.deep` | `gemini-companion review --deep` (agentic repo exploration) | harness |
 | `codex.native` | codex's native agentic reviewer via its companion | harness |
+| `agy.model` | `agy` on the same neutral prompt + diff, unoriented, tools forbidden | model (single-shot) |
+| `agy.deep` | `gemini-companion review --deep --engine agy` (agentic repo exploration) | harness |
 
-- **Model axis** = `gemini.model` vs `codex.model` (same prompt, no tools).
-- **Harness axis** = `gemini.deep` vs `codex.native` (each tool's repo-exploring reviewer).
+- **Model axis** = every `*.model` cell (same prompt, no tools).
+- **Harness axis** = every agentic cell (each tool's repo-exploring reviewer).
 - **Harness lift** = within a tool, `model → agentic` composite delta.
+
+The axes are read off `lib/cells.mjs`, not off a list of tool names, so a cell added
+there joins both the ranking and its own lift without touching the report.
 
 ## Running
 
@@ -49,20 +54,37 @@ The scorecard prints to stdout and is written to `bench/results/scorecard.md`
 
 ### Cassette provenance & live-refresh status
 
-A cassette recorded from a real run carries `recordedAt` and no `source`; a seeded
-one carries a `source` field. Current committed state:
+A cassette recorded from a real run carries `recordedAt`, the `engineVersion` it was
+recorded against, and no `source`; a seeded one carries a `source` field. The
+scorecard prints this per cell, and **a seeded cell is excluded from every verdict
+and every harness lift** — it is an illustration kept so the table has a shape, not a
+result. Current committed state:
 
-- **Model cells (`*.model`) — live-recorded** (2026-06-04, gemini 0.45 / codex-cli
-  0.137, single sample). On this corpus the real single-shot result was Gemini-ahead
-  on the model axis (Codex hallucinated a false positive on `repo-context` and missed
-  more in-diff defects). Single samples are noisy — re-run with `--repeats N`.
-- **Agentic cells (`gemini.deep`, `codex.native`) — still seeded.** They could not be
-  driven headlessly in this environment: `gemini --deep` exits non-zero with empty
-  stdout under headless agentic+JSON mode (tool approvals need a TTY), and the
+- **`agy.model`, `agy.deep` — live-recorded** (2026-08-19, agy 1.1.14, single sample).
+  Both axes of the AGY column are real, which makes the AGY harness lift
+  (`agy.model` → `agy.deep`) the only lift on the scorecard measured end to end.
+- **`gemini.model`, `codex.model` — live-recorded** (2026-06-04, gemini 0.45 /
+  codex-cli 0.137, single sample) and predate the `engineVersion` field, so their
+  builds are recorded here rather than in the cassette. Gemini CLI's consumer tier
+  stopped serving on 2026-06-18, so re-recording `gemini.model` now needs a paid
+  Code Assist or API-key credential.
+- **`gemini.deep`, `codex.native` — still seeded.** They could not be driven
+  headlessly in this environment: `gemini --deep` exits non-zero with empty stdout
+  under headless agentic+JSON mode (tool approvals need a TTY), and the
   `codex.native` app-server review exceeded the 180s cap. Refresh them with a longer
   `BENCH_TIMEOUT_MS`, an interactive/approved session, or on a platform where the
-  agentic harness runs non-interactively. Until then the harness-axis numbers come
-  from the `MODEL_COMPARISON.md`-grounded seeds.
+  agentic harness runs non-interactively.
+
+`agy.deep` records headlessly where `gemini.deep` cannot, because AGY's print mode
+auto-approves tools and never waits for a TTY. That is a difference in permission
+model, not in capability, and `docs/THREAT-MODEL.md` 7.2 is where it is argued about
+rather than celebrated.
+
+Adding a cell means one entry in `lib/cells.mjs` and one `case` in `lib/adapters.mjs`;
+everything else — which cases get materialized, which cells need a repo, the axes,
+the lifts — reads the registry. It did not always: two hardcoded cell lists in
+`run-bench.mjs` meant a newly added model cell ran with a null prompt, and on AGY that
+surfaced 180 seconds later as an engine timeout rather than as a missing diff.
 
 ## Scoring (`lib/score.mjs`, pure & unit-tested)
 

--- a/bench/cassettes/auth-basic/agy.deep.json
+++ b/bench/cassettes/auth-basic/agy.deep.json
@@ -1,0 +1,52 @@
+{
+  "caseId": "auth-basic",
+  "cell": "agy.deep",
+  "recordedAt": "2026-08-19T02:15:34.060Z",
+  "verdict": "needs-attention",
+  "summary": "Authentication module contains critical SQL injection, unhandled null reference on non-existent users, hardcoded secrets, and unsafe JSON parsing.",
+  "findings": [
+    {
+      "severity": "critical",
+      "title": "SQL Injection via String Concatenation in findUser",
+      "body": "The findUser function constructs a SQL query by directly concatenating user-supplied input into the query string. This allows attackers to perform SQL injection attacks, bypass authentication, or exfiltrate database contents.",
+      "file": "src/auth.js",
+      "line_start": 7,
+      "line_end": 9,
+      "confidence": 1,
+      "recommendation": "Use parameterized queries or prepared statements (e.g., db.query('SELECT * FROM users WHERE name = ?', [username])) instead of raw string concatenation."
+    },
+    {
+      "severity": "high",
+      "title": "Unhandled Null User and Insecure Plaintext Password Comparison",
+      "body": "If findUser returns null or undefined when a user is not found, accessing user.password throws an unhandled TypeError that crashes the request. Additionally, passwords are validated using plaintext comparison with loose equality (==) rather than secure password hashing.",
+      "file": "src/auth.js",
+      "line_start": 14,
+      "line_end": 18,
+      "confidence": 1,
+      "recommendation": "Verify that user exists before inspecting properties (e.g., if (!user) return null;), and use a secure hashing algorithm (such as bcrypt or argon2) with constant-time comparison for password verification."
+    },
+    {
+      "severity": "high",
+      "title": "Hardcoded JWT Secret Key",
+      "body": "JWT_SECRET is hardcoded in source code with a static plaintext value. If source code is compromised, any attacker can forge arbitrary JWT tokens and impersonate users.",
+      "file": "src/auth.js",
+      "line_start": 4,
+      "line_end": 4,
+      "confidence": 1,
+      "recommendation": "Load the JWT secret from environment variables (e.g., process.env.JWT_SECRET) and throw an error at startup if the secret is not configured."
+    },
+    {
+      "severity": "medium",
+      "title": "Unhandled SyntaxError on Malformed Input in parseSession",
+      "body": "JSON.parse(raw) throws an uncaught SyntaxError when provided with invalid JSON input, and subsequent property access (session.userId) will throw a TypeError if raw parses to null.",
+      "file": "src/auth.js",
+      "line_start": 21,
+      "line_end": 24,
+      "confidence": 0.95,
+      "recommendation": "Wrap JSON.parse in a try/catch block and handle null or non-object results safely, returning null or undefined when parsing fails."
+    }
+  ],
+  "latencyMs": 32167,
+  "engineVersion": "1.1.14",
+  "raw": "{\n  \"review\": \"Review\",\n  \"target\": {\n    \"mode\": \"working-tree\",\n    \"label\": \"working tree diff\",\n    \"explicit\": true\n  },\n  \"gemini\": {\n    \"status\": 0,\n    \"stdout\": \"{\\n  \\\"verdict\\\": \\\"needs-attention\\\",\\n  \\\"summary\\\": \\\"Authentication module contains critical SQL injection, unhandled null reference on non-existent users, hardcoded secrets, and unsafe JSON parsing.\\\",\\n  \\\"findings\\\": [\\n    {\\n      \\\"severity\\\": \\\"critical\\\",\\n      \\\"title\\\": \\\"SQL Injection via String Concatenation in findUser\\\",\\n      \\\"body\\\": \\\"The findUser function constructs a SQL query by directly concatenating user-supplied input into the query string. This allows attackers to perform SQL injection attacks, bypass authentication, or exfiltrate database contents.\\\",\\n      \\\"file\\\": \\\"src/auth.js\\\",\\n      \\\"line_start\\\": 7,\\n      \\\"line_end\\\": 9,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Use parameterized queries or prepared statements (e.g., db.query('SELECT * FROM users WHERE name = ?', [username])) instead of raw string concatenation.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"high\\\",\\n      \\\"title\\\": \\\"Unhandled Null User and Insecure Plaintext Password Comparison\\\",\\n      \\\"body\\\": \\\"If findUser returns null or undefined when a user is not found, accessing user.password throws an unhandled TypeError that crashes the request. Additionally, passwords are validated using plaintext comparison with loose equality (==) rather than secure password hashing.\\\",\\n      \\\"file\\\": \\\"src/auth.js\\\",\\n      \\\"line_start\\\": 14,\\n      \\\"line_end\\\": 18,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Verify that user exists before inspecting properties (e.g., if (!user) return null;), and use a secure hashing algorithm (such as bcrypt or argon2) with constant-time comparison for password verification.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"high\\\",\\n      \\\"title\\\": \\\"Hardcoded JWT Secret Key\\\",\\n      \\\"body\\\": \\\"JWT_SECRET is hardcoded in source code with a static plaintext value. If source code is compromised, any attacker can forge arbitrary JWT tokens and impersonate users.\\\",\\n      \\\"file\\\": \\\"src/auth.js\\\",\\n      \\\"line_start\\\": 4,\\n      \\\"line_end\\\": 4,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Load the JWT secret from environment variables (e.g., process.env.JWT_SECRET) and throw an error at startup if the secret is not configured.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"medium\\\",\\n      \\\"title\\\": \\\"Unhandled SyntaxError on Malformed Input in parseSession\\\",\\n      \\\"body\\\": \\\"JSON.parse(raw) throws an uncaught SyntaxError when provided with invalid JSON input, and subsequent property access (session.userId) will throw a TypeError if raw parses to null.\\\",\\n      \\\"file\\\": \\\"src/auth.js\\\",\\n      \\\"line_start\\\": 21,\\n      \\\"line_end\\\": 24,\\n      \\\"confidence\\\": 0.95,\\n      \\\"recommendation\\\": \\\"Wrap JSON.parse in a try/catch block and handle null or non-object results safely, returning null or undefined when parsing fails.\\\"\\n    }\\n  ],\\n  \\\"next_steps\\\": [\\n    \\\"Refactor findUser to use parameterized SQL queries.\\\",\\n    \\\"Add null checks and hash verification in login.\\\",\\n    \\\"Move JWT_SECRET to environment variables.\\\",\\n    \\\"Add error handling around JSON.parse in parseSession.\\\"\\n  ]\\n}\",\n    \"stderr\": \"\"\n  },\n  \"result\": {\n    \"verdict\": \"needs-attention\",\n    \"summary\": \"Authentication module contains critical SQL injection, unhandled null reference on non-existent users, hardcoded secrets, and unsafe JSON parsing.\",\n    \"findings\": [\n      {\n        \"severity\": \"critical\",\n        \"title\": \"SQL Injection via String Concatenation in findUser\",\n        \"body\": \"The findUser function constructs a SQL query by directly concatenating user-supplied input into the query string. This allows attackers to perform SQL injection attacks, bypass authentication, or exfiltrate database contents.\",\n        \"file\": \"src/auth.js\",\n        \"line_start\": 7,\n        \"line_end\": 9,\n        \"confidence\": 1,\n"
+}

--- a/bench/cassettes/auth-basic/agy.model.json
+++ b/bench/cassettes/auth-basic/agy.model.json
@@ -1,0 +1,52 @@
+{
+  "caseId": "auth-basic",
+  "cell": "agy.model",
+  "recordedAt": "2026-08-19T02:15:01.570Z",
+  "verdict": "needs-attention",
+  "summary": "The authentication module contains critical security vulnerabilities including SQL injection, hardcoded secrets, unsafe password validation, and missing error handling.",
+  "findings": [
+    {
+      "severity": "critical",
+      "title": "SQL injection vulnerability via concatenated query",
+      "body": "The username input is directly concatenated into the SQL query string in findUser without sanitization or parameterization, allowing an attacker to bypass authentication or extract/modify database contents.",
+      "file": "src/auth.js",
+      "line_start": 7,
+      "line_end": 9,
+      "confidence": 1,
+      "recommendation": "Use parameterized queries or prepared statements (e.g., db.query('SELECT * FROM users WHERE name = ?', [username]))."
+    },
+    {
+      "severity": "critical",
+      "title": "Hardcoded JWT secret key",
+      "body": "A static secret key is committed directly in the source file, which exposes token signing keys and enables attackers to forge valid authentication tokens.",
+      "file": "src/auth.js",
+      "line_start": 4,
+      "line_end": 4,
+      "confidence": 1,
+      "recommendation": "Load the JWT secret from an environment variable (e.g., process.env.JWT_SECRET) and ensure a fallback error if not configured."
+    },
+    {
+      "severity": "high",
+      "title": "Unchecked null dereference and plaintext password comparison in login",
+      "body": "If findUser returns null or undefined for nonexistent users, accessing user.password throws an unhandled TypeError. Furthermore, passwords are treated as plaintext using loose equality instead of a secure cryptographic hash comparison.",
+      "file": "src/auth.js",
+      "line_start": 14,
+      "line_end": 17,
+      "confidence": 1,
+      "recommendation": "Verify that user exists before accessing properties (if (!user) return null;) and compare hashed passwords using a timing-safe hash library such as bcrypt or argon2."
+    },
+    {
+      "severity": "medium",
+      "title": "Unhandled JSON parsing failure in parseSession",
+      "body": "Calling JSON.parse(raw) without error handling will throw an uncaught SyntaxError on malformed session input, potentially crashing the application process.",
+      "file": "src/auth.js",
+      "line_start": 21,
+      "line_end": 24,
+      "confidence": 0.95,
+      "recommendation": "Wrap JSON.parse in a try-catch block and validate the parsed object before accessing session.userId."
+    }
+  ],
+  "latencyMs": 26738,
+  "engineVersion": "1.1.14",
+  "raw": "{\"conversation_id\":\"ee616018-1386-44d3-9d70-6b8546ddaa1e\",\"status\":\"SUCCESS\",\"response\":\"{\\n  \\\"verdict\\\": \\\"needs-attention\\\",\\n  \\\"summary\\\": \\\"The authentication module contains critical security vulnerabilities including SQL injection, hardcoded secrets, unsafe password validation, and missing error handling.\\\",\\n  \\\"findings\\\": [\\n    {\\n      \\\"severity\\\": \\\"critical\\\",\\n      \\\"title\\\": \\\"SQL injection vulnerability via concatenated query\\\",\\n      \\\"body\\\": \\\"The username input is directly concatenated into the SQL query string in findUser without sanitization or parameterization, allowing an attacker to bypass authentication or extract/modify database contents.\\\",\\n      \\\"file\\\": \\\"src/auth.js\\\",\\n      \\\"line_start\\\": 7,\\n      \\\"line_end\\\": 9,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Use parameterized queries or prepared statements (e.g., db.query('SELECT * FROM users WHERE name = ?', [username])).\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"critical\\\",\\n      \\\"title\\\": \\\"Hardcoded JWT secret key\\\",\\n      \\\"body\\\": \\\"A static secret key is committed directly in the source file, which exposes token signing keys and enables attackers to forge valid authentication tokens.\\\",\\n      \\\"file\\\": \\\"src/auth.js\\\",\\n      \\\"line_start\\\": 4,\\n      \\\"line_end\\\": 4,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Load the JWT secret from an environment variable (e.g., process.env.JWT_SECRET) and ensure a fallback error if not configured.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"high\\\",\\n      \\\"title\\\": \\\"Unchecked null dereference and plaintext password comparison in login\\\",\\n      \\\"body\\\": \\\"If findUser returns null or undefined for nonexistent users, accessing user.password throws an unhandled TypeError. Furthermore, passwords are treated as plaintext using loose equality instead of a secure cryptographic hash comparison.\\\",\\n      \\\"file\\\": \\\"src/auth.js\\\",\\n      \\\"line_start\\\": 14,\\n      \\\"line_end\\\": 17,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Verify that user exists before accessing properties (if (!user) return null;) and compare hashed passwords using a timing-safe hash library such as bcrypt or argon2.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"medium\\\",\\n      \\\"title\\\": \\\"Unhandled JSON parsing failure in parseSession\\\",\\n      \\\"body\\\": \\\"Calling JSON.parse(raw) without error handling will throw an uncaught SyntaxError on malformed session input, potentially crashing the application process.\\\",\\n      \\\"file\\\": \\\"src/auth.js\\\",\\n      \\\"line_start\\\": 21,\\n      \\\"line_end\\\": 24,\\n      \\\"confidence\\\": 0.95,\\n      \\\"recommendation\\\": \\\"Wrap JSON.parse in a try-catch block and validate the parsed object before accessing session.userId.\\\"\\n    }\\n  ],\\n  \\\"next_steps\\\": [\\n    \\\"Refactor db.query to use parameterized queries across the database layer.\\\",\\n    \\\"Move JWT_SECRET to environment configuration and validate presence at startup.\\\",\\n    \\\"Implement password hashing with bcrypt/argon2 and add null checks for user queries.\\\",\\n    \\\"Add try-catch error handling to parseSession.\\\"\\n  ]\\n}\\n\",\"duration_seconds\":22.1291657,\"num_turns\":1,\"usage\":{\"input_tokens\":19012,\"output_tokens\":2433,\"thinking_tokens\":1756,\"cache_read_tokens\":0,\"total_tokens\":21445}}\n"
+}

--- a/bench/cassettes/repo-context/agy.deep.json
+++ b/bench/cassettes/repo-context/agy.deep.json
@@ -1,0 +1,42 @@
+{
+  "caseId": "repo-context",
+  "cell": "agy.deep",
+  "recordedAt": "2026-08-19T02:16:28.914Z",
+  "verdict": "needs-attention",
+  "summary": "Found undeclared dependency on jsonwebtoken, unvalidated secret configuration, and an ephemeral runtime state file added to git.",
+  "findings": [
+    {
+      "severity": "high",
+      "title": "Undeclared dependency 'jsonwebtoken'",
+      "body": "src/token.js requires 'jsonwebtoken', but it is missing from dependencies in package.json, which will cause a MODULE_NOT_FOUND error in production.",
+      "file": "src/token.js",
+      "line_start": 1,
+      "line_end": 1,
+      "confidence": 1,
+      "recommendation": "Add \"jsonwebtoken\" to dependencies in package.json."
+    },
+    {
+      "severity": "medium",
+      "title": "Unvalidated JWT_SECRET environment variable",
+      "body": "jwt.sign is called with process.env.JWT_SECRET without checking if it is defined; an unset secret causes jwt.sign to throw a runtime error.",
+      "file": "src/token.js",
+      "line_start": 3,
+      "line_end": 5,
+      "confidence": 0.9,
+      "recommendation": "Validate that process.env.JWT_SECRET is present before signing or provide an explicit configuration check."
+    },
+    {
+      "severity": "medium",
+      "title": "Stray runtime state file tracked in git",
+      "body": ".omc/state/job.json contains ephemeral process metadata and should not be committed to the repository.",
+      "file": ".omc/state/job.json",
+      "line_start": 1,
+      "line_end": 1,
+      "confidence": 1,
+      "recommendation": "Remove .omc/state/job.json from git and add .omc/ to .gitignore."
+    }
+  ],
+  "latencyMs": 34829,
+  "engineVersion": "1.1.14",
+  "raw": "{\n  \"review\": \"Review\",\n  \"target\": {\n    \"mode\": \"working-tree\",\n    \"label\": \"working tree diff\",\n    \"explicit\": true\n  },\n  \"gemini\": {\n    \"status\": 0,\n    \"stdout\": \"{\\n  \\\"verdict\\\": \\\"needs-attention\\\",\\n  \\\"summary\\\": \\\"Found undeclared dependency on jsonwebtoken, unvalidated secret configuration, and an ephemeral runtime state file added to git.\\\",\\n  \\\"findings\\\": [\\n    {\\n      \\\"severity\\\": \\\"high\\\",\\n      \\\"title\\\": \\\"Undeclared dependency 'jsonwebtoken'\\\",\\n      \\\"body\\\": \\\"src/token.js requires 'jsonwebtoken', but it is missing from dependencies in package.json, which will cause a MODULE_NOT_FOUND error in production.\\\",\\n      \\\"file\\\": \\\"src/token.js\\\",\\n      \\\"line_start\\\": 1,\\n      \\\"line_end\\\": 1,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Add \\\\\\\"jsonwebtoken\\\\\\\" to dependencies in package.json.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"medium\\\",\\n      \\\"title\\\": \\\"Unvalidated JWT_SECRET environment variable\\\",\\n      \\\"body\\\": \\\"jwt.sign is called with process.env.JWT_SECRET without checking if it is defined; an unset secret causes jwt.sign to throw a runtime error.\\\",\\n      \\\"file\\\": \\\"src/token.js\\\",\\n      \\\"line_start\\\": 3,\\n      \\\"line_end\\\": 5,\\n      \\\"confidence\\\": 0.9,\\n      \\\"recommendation\\\": \\\"Validate that process.env.JWT_SECRET is present before signing or provide an explicit configuration check.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"medium\\\",\\n      \\\"title\\\": \\\"Stray runtime state file tracked in git\\\",\\n      \\\"body\\\": \\\".omc/state/job.json contains ephemeral process metadata and should not be committed to the repository.\\\",\\n      \\\"file\\\": \\\".omc/state/job.json\\\",\\n      \\\"line_start\\\": 1,\\n      \\\"line_end\\\": 1,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Remove .omc/state/job.json from git and add .omc/ to .gitignore.\\\"\\n    }\\n  ],\\n  \\\"next_steps\\\": [\\n    \\\"Add jsonwebtoken to package.json dependencies\\\",\\n    \\\"Add a check for process.env.JWT_SECRET before issuing tokens in src/token.js\\\",\\n    \\\"Remove .omc/state/job.json from git and ignore .omc/ via .gitignore\\\"\\n  ]\\n}\",\n    \"stderr\": \"\"\n  },\n  \"result\": {\n    \"verdict\": \"needs-attention\",\n    \"summary\": \"Found undeclared dependency on jsonwebtoken, unvalidated secret configuration, and an ephemeral runtime state file added to git.\",\n    \"findings\": [\n      {\n        \"severity\": \"high\",\n        \"title\": \"Undeclared dependency 'jsonwebtoken'\",\n        \"body\": \"src/token.js requires 'jsonwebtoken', but it is missing from dependencies in package.json, which will cause a MODULE_NOT_FOUND error in production.\",\n        \"file\": \"src/token.js\",\n        \"line_start\": 1,\n        \"line_end\": 1,\n        \"confidence\": 1,\n        \"recommendation\": \"Add \\\"jsonwebtoken\\\" to dependencies in package.json.\"\n      },\n      {\n        \"severity\": \"medium\",\n        \"title\": \"Unvalidated JWT_SECRET environment variable\",\n        \"body\": \"jwt.sign is called with process.env.JWT_SECRET without checking if it is defined; an unset secret causes jwt.sign to throw a runtime error.\",\n        \"file\": \"src/token.js\",\n        \"line_start\": 3,\n        \"line_end\": 5,\n        \"confidence\": 0.9,\n        \"recommendation\": \"Validate that process.env.JWT_SECRET is present before signing or provide an explicit configuration check.\"\n      },\n      {\n        \"severity\": \"medium\",\n        \"title\": \"Stray runtime state file tracked in git\",\n        \"body\": \".omc/state/job.json contains ephemeral process metadata and should not be committed to the repository.\",\n        \"file\": \".omc/state/job.json\",\n        \"line_start\": 1,\n        \"line_end\": 1,\n        \"confidence\": 1,\n        \"recommendation\": \"Remove .omc/state/job.json from git and add .omc/ to .gitignore.\"\n      }\n    ],\n    \"next_steps\": [\n      \"Add jsonwebtoken to package.json dependencies\",\n      \"Add a check for process.env.JWT_SECRET before issuing tokens in src/token.js\",\n      \"Remove .omc/state/job.json from git and ignore .omc/ via .gitignore\"\n    ]\n  }\n}\n"
+}

--- a/bench/cassettes/repo-context/agy.model.json
+++ b/bench/cassettes/repo-context/agy.model.json
@@ -1,0 +1,22 @@
+{
+  "caseId": "repo-context",
+  "cell": "agy.model",
+  "recordedAt": "2026-08-19T02:15:53.577Z",
+  "verdict": "needs-attention",
+  "summary": "Missing validation for the JWT_SECRET environment variable causes unhandled runtime exceptions when signing tokens.",
+  "findings": [
+    {
+      "severity": "high",
+      "title": "Unvalidated JWT_SECRET environment variable",
+      "body": "jwt.sign is invoked directly with process.env.JWT_SECRET without verifying that the secret is set, causing jsonwebtoken to throw a runtime error if the environment variable is missing or undefined.",
+      "file": "src/token.js",
+      "line_start": 3,
+      "line_end": 5,
+      "confidence": 0.95,
+      "recommendation": "Validate that process.env.JWT_SECRET exists and is non-empty before signing, throwing a clear configuration error if it is not configured."
+    }
+  ],
+  "latencyMs": 18606,
+  "engineVersion": "1.1.14",
+  "raw": "{\"conversation_id\":\"96f624cc-31ee-44af-bf00-3ec1c797d5a2\",\"status\":\"SUCCESS\",\"response\":\"{\\n  \\\"verdict\\\": \\\"needs-attention\\\",\\n  \\\"summary\\\": \\\"Missing validation for the JWT_SECRET environment variable causes unhandled runtime exceptions when signing tokens.\\\",\\n  \\\"findings\\\": [\\n    {\\n      \\\"severity\\\": \\\"high\\\",\\n      \\\"title\\\": \\\"Unvalidated JWT_SECRET environment variable\\\",\\n      \\\"body\\\": \\\"jwt.sign is invoked directly with process.env.JWT_SECRET without verifying that the secret is set, causing jsonwebtoken to throw a runtime error if the environment variable is missing or undefined.\\\",\\n      \\\"file\\\": \\\"src/token.js\\\",\\n      \\\"line_start\\\": 3,\\n      \\\"line_end\\\": 5,\\n      \\\"confidence\\\": 0.95,\\n      \\\"recommendation\\\": \\\"Validate that process.env.JWT_SECRET exists and is non-empty before signing, throwing a clear configuration error if it is not configured.\\\"\\n    }\\n  ],\\n  \\\"next_steps\\\": [\\n    \\\"Add an explicit guard or configuration check for process.env.JWT_SECRET in src/token.js.\\\",\\n    \\\"Verify whether .omc/state/job.json is runtime state that should be added to .gitignore instead of committed.\\\"\\n  ]\\n}\\n\",\"duration_seconds\":14.9808972,\"num_turns\":1,\"usage\":{\"input_tokens\":18969,\"output_tokens\":1376,\"thinking_tokens\":1146,\"cache_read_tokens\":0,\"total_tokens\":20345}}\n"
+}

--- a/bench/lib/adapters.mjs
+++ b/bench/lib/adapters.mjs
@@ -4,6 +4,8 @@ import path from "node:path";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
+import { CELLS } from "./cells.mjs";
+
 // Live cell invocations. Each returns a normalized result; deterministic mode
 // never calls these (it replays cassettes). Cells degrade to {ok:false} with a
 // reason rather than throwing, so one unavailable tool does not sink the run.
@@ -16,6 +18,29 @@ const TIMEOUT_MS = Number(process.env.BENCH_TIMEOUT_MS ?? 180_000);
 // codex-companion lives in the installed codex plugin; its path is environment
 // specific, so it is opt-in via env. codex.model only needs the `codex` binary.
 const CODEX_COMPANION = process.env.BENCH_CODEX_COMPANION || null;
+
+// Which build produced a cassette is the thing that decides, months later,
+// whether its numbers still describe the product. A date alone cannot: the
+// engines ship faster than the benchmark reruns.
+const versionCache = new Map();
+function probeVersion(bin, useShell = false) {
+  if (versionCache.has(bin)) return versionCache.get(bin);
+  const res = spawnSync(bin, ["--version"], { encoding: "utf8", timeout: 15_000, shell: useShell });
+  const line = (res.stdout ?? "").split("\n")[0].trim();
+  const version = res.error || !line ? null : line;
+  versionCache.set(bin, version);
+  return version;
+}
+
+function engineVersionFor(tool) {
+  if (tool === "gemini") return probeVersion("gemini", process.platform === "win32");
+  if (tool === "codex") return probeVersion("codex", process.platform === "win32");
+  if (tool === "agy") {
+    const bin = resolveAgyBinary();
+    return bin ? probeVersion(bin) : null;
+  }
+  return null;
+}
 
 function extractJsonObject(text) {
   if (text == null) return null;
@@ -100,6 +125,51 @@ function runGeminiModel(promptText) {
   });
 }
 
+let agyBinaryCache;
+function resolveAgyBinary() {
+  if (agyBinaryCache !== undefined) return agyBinaryCache;
+  const finder = process.platform === "win32" ? "where" : "which";
+  const res = spawnSync(finder, ["agy"], { encoding: "utf8" });
+  const candidates = (res.stdout ?? "").split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
+  const picked = process.platform === "win32"
+    ? candidates.find((c) => path.extname(c).toLowerCase() === ".exe")
+    : candidates[0];
+  agyBinaryCache = picked && path.isAbsolute(picked) ? picked : null;
+  return agyBinaryCache;
+}
+
+function runAgyModel(promptText) {
+  return timed(() => {
+    // AGY >=1.1.2 enters print mode from a piped prompt, so --print is omitted:
+    // passing it here would make the next flag AGY's positional prompt.
+    //
+    // No --add-dir. This is the model axis, and AGY's headless print mode
+    // auto-approves tools, so leaving the turn unoriented is what keeps the cell
+    // comparable to gemini's toolless default: the prompt forbids tools in both,
+    // but only one of them is also structurally unable to find the repository.
+    const printTimeout = `${Math.max(1, Math.round((TIMEOUT_MS * 0.9) / 1000))}s`;
+    // Not `shell: true` like the neighbouring cells: routing agy through cmd.exe
+    // never delivered the piped prompt, so the turn sat until the 180s cap and the
+    // cell reported ETIMEDOUT. Spawned directly with a resolved path it answers in
+    // ~9s. That also matches what the plugin insists on for agy (engine.mjs:51):
+    // an absolute .exe, so a planted `agy.bat` on PATH cannot take the call.
+    const bin = resolveAgyBinary();
+    if (!bin) return fail("agy: no agy executable on PATH");
+    const res = spawnSync(
+      bin,
+      ["--disable-slash-commands", "--output-format", "json", "--print-timeout", printTimeout],
+      { input: promptText, encoding: "utf8", timeout: TIMEOUT_MS }
+    );
+    if (res.error) return fail(`agy spawn: ${res.error.message}`);
+    // AGY 1.1.8+ answers with one envelope: { conversation_id, status, response, ... }.
+    const envelope = extractJsonObject(res.stdout);
+    const text = envelope?.response ?? envelope?.result?.response ?? res.stdout;
+    const review = normalizeReview(extractJsonObject(text));
+    if (!review) return fail(`agy: could not parse review JSON (${(res.stderr || "").slice(0, 160)})`);
+    return { ok: true, ...review, raw: res.stdout?.slice(0, 4000) };
+  });
+}
+
 function runCodexModel(promptText) {
   return timed(() => {
     const outFile = path.join(os.tmpdir(), `bench-codex-${Date.now()}.json`);
@@ -137,15 +207,25 @@ function runCompanionReview(companionPath, repoDir, extraArgs) {
 }
 
 export function runCell(cell, ctx) {
+  const out = dispatchCell(cell, ctx);
+  if (!out.ok) return out;
+  return { ...out, engineVersion: engineVersionFor(CELLS[cell]?.tool) };
+}
+
+function dispatchCell(cell, ctx) {
   switch (cell) {
     case "gemini.model":
       return runGeminiModel(ctx.promptText);
     case "codex.model":
       return runCodexModel(ctx.promptText);
+    case "agy.model":
+      return runAgyModel(ctx.promptText);
     case "gemini.deep":
       return runCompanionReview(GEMINI_COMPANION, ctx.repoDir, ["--deep"]);
     case "codex.native":
       return runCompanionReview(CODEX_COMPANION, ctx.repoDir, []);
+    case "agy.deep":
+      return runCompanionReview(GEMINI_COMPANION, ctx.repoDir, ["--deep", "--engine", "agy"]);
     default:
       return fail(`unknown cell ${cell}`);
   }

--- a/bench/lib/cassette.mjs
+++ b/bench/lib/cassette.mjs
@@ -29,6 +29,7 @@ export function writeCassette(caseId, cell, data) {
     summary: data.summary ?? null,
     findings: Array.isArray(data.findings) ? data.findings : [],
     latencyMs: data.latencyMs ?? null,
+    engineVersion: data.engineVersion ?? null,
     ...(data.raw !== undefined ? { raw: data.raw } : {})
   };
   fs.writeFileSync(file, `${JSON.stringify(payload, null, 2)}\n`);

--- a/bench/lib/cells.mjs
+++ b/bench/lib/cells.mjs
@@ -1,12 +1,14 @@
-// The four benchmark cells. Two axes fall out of these:
+// The benchmark cells. Two axes fall out of these:
 //   model axis   = compare the two "model-isolated" cells (same neutral prompt+diff, no tools)
 //   harness axis = compare the two "agentic" cells (each tool's own repo-exploring reviewer)
 // and the within-tool "single-shot -> agentic" delta is the harness lift.
 export const CELLS = {
   "gemini.model": { tool: "gemini", track: "model-isolated", harness: "single-shot", label: "Gemini (model, single-shot)" },
   "codex.model": { tool: "codex", track: "model-isolated", harness: "single-shot", label: "Codex (model, single-shot)" },
+  "agy.model": { tool: "agy", track: "model-isolated", harness: "single-shot", label: "AGY (model, single-shot)" },
   "gemini.deep": { tool: "gemini", track: "plugin-native", harness: "agentic", label: "Gemini (--deep, agentic)" },
-  "codex.native": { tool: "codex", track: "plugin-native", harness: "agentic", label: "Codex (native review, agentic)" }
+  "codex.native": { tool: "codex", track: "plugin-native", harness: "agentic", label: "Codex (native review, agentic)" },
+  "agy.deep": { tool: "agy", track: "plugin-native", harness: "agentic", label: "AGY (--deep, agentic)" }
 };
 
 export const CELL_IDS = Object.keys(CELLS);

--- a/bench/lib/report.mjs
+++ b/bench/lib/report.mjs
@@ -27,6 +27,59 @@ function aggregateByCell(rows) {
   return out;
 }
 
+function provenanceByCell(rows) {
+  const out = {};
+  for (const cell of CELL_IDS) {
+    out[cell] = rows.find((r) => r.cell === cell && r.provenance)?.provenance ?? null;
+  }
+  return out;
+}
+
+function cellsOn(axis) {
+  const key = axis === "model" ? "model-isolated" : "plugin-native";
+  return CELL_IDS.filter((c) => CELLS[c].track === key);
+}
+
+function describeSource(p) {
+  if (!p) return "—";
+  if (p.seeded) return "**seeded**";
+  const day = p.recordedAt ? p.recordedAt.slice(0, 10) : "?";
+  return p.engineVersion ? `live ${day} · ${p.engineVersion}` : `live ${day}`;
+}
+
+// A seeded cassette is an illustration, not a measurement, so it cannot win an
+// axis and cannot anchor a lift. Scoring it anyway is how an invented number
+// reaches a reader as a result — the axis says what it has instead.
+function axisVerdict(cells, agg, prov) {
+  const scored = cells
+    .map((cell) => ({ cell, tool: CELLS[cell].tool, score: agg[cell]?.composite, seeded: Boolean(prov[cell]?.seeded) }))
+    .filter((e) => e.score != null);
+  if (scored.length === 0) return { name: "—", note: "no data" };
+  const detail = scored
+    .slice()
+    .sort((a, b) => b.score - a.score)
+    .map((e) => `${e.tool} ${e.score}${e.seeded ? " (seeded)" : ""}`)
+    .join(" · ");
+  const measured = scored.filter((e) => !e.seeded);
+  if (measured.length < 2) {
+    return { name: "—", note: `not decidable: ${measured.length} of ${scored.length} cells measured · ${detail}` };
+  }
+  const ranked = measured.slice().sort((a, b) => b.score - a.score);
+  if (ranked[0].score - ranked[1].score < 2) return { name: "tie", note: `within noise · ${detail}` };
+  return { name: ranked[0].tool, note: detail };
+}
+
+function harnessLifts(agg, prov) {
+  const tools = [...new Set(CELL_IDS.map((c) => CELLS[c].tool))];
+  return tools.map((tool) => {
+    const from = CELL_IDS.find((c) => CELLS[c].tool === tool && CELLS[c].track === "model-isolated");
+    const to = CELL_IDS.find((c) => CELLS[c].tool === tool && CELLS[c].track === "plugin-native");
+    const lift = from && to ? liftOf(agg, from, to) : null;
+    const seeded = Boolean(prov[from]?.seeded || prov[to]?.seeded);
+    return { tool, from, to, lift, seeded };
+  });
+}
+
 function winner(a, b, agg) {
   const sa = agg[a]?.composite;
   const sb = agg[b]?.composite;
@@ -41,13 +94,13 @@ function winner(a, b, agg) {
 
 export function buildScorecard(rows, meta = {}) {
   const agg = aggregateByCell(rows);
-  const modelAxis = winner("gemini.model", "codex.model", agg);
-  const harnessAxis = winner("gemini.deep", "codex.native", agg);
-  const geminiLift = liftOf(agg, "gemini.model", "gemini.deep");
-  const codexLift = liftOf(agg, "codex.model", "codex.native");
+  const prov = provenanceByCell(rows);
+  const modelAxis = axisVerdict(cellsOn("model"), agg, prov);
+  const harnessAxis = axisVerdict(cellsOn("harness"), agg, prov);
+  const lifts = harnessLifts(agg, prov);
 
   const lines = [];
-  lines.push("# codex vs gemini — review benchmark scorecard");
+  lines.push("# review benchmark scorecard — agy · gemini · codex");
   lines.push("");
   lines.push(`> Mode: **${meta.mode ?? "replay"}**${meta.repeats ? ` · repeats: ${meta.repeats}` : ""} · cases: ${meta.caseCount ?? "?"} · generated: ${new Date().toISOString()}`);
   lines.push("");
@@ -57,17 +110,20 @@ export function buildScorecard(rows, meta = {}) {
   lines.push("|---|---|---|");
   lines.push(`| **Model** (single-shot, tools off) | **${modelAxis.name}** | ${modelAxis.note} |`);
   lines.push(`| **Harness** (agentic reviewers) | **${harnessAxis.name}** | ${harnessAxis.note} |`);
-  lines.push(`| Harness lift — Gemini | ${fmtLift(geminiLift)} | model→--deep composite |`);
-  lines.push(`| Harness lift — Codex | ${fmtLift(codexLift)} | model→native composite |`);
+  for (const l of lifts) {
+    if (l.lift == null) continue;
+    const note = l.seeded ? "one end is seeded — not a measurement" : `${l.from} → ${l.to} composite`;
+    lines.push(`| Harness lift — ${l.tool} | ${fmtLift(l.lift)} | ${note} |`);
+  }
   lines.push("");
   lines.push("## Per-cell aggregate");
   lines.push("");
-  lines.push("| Cell | Cases | Composite | Recall | Precision | FP | Bonus | Sev-exact | Latency |");
-  lines.push("|---|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|");
+  lines.push("| Cell | Source | Cases | Composite | Recall | Precision | FP | Bonus | Sev-exact | Latency |");
+  lines.push("|---|---|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|");
   for (const cell of CELL_IDS) {
     const a = agg[cell];
     lines.push(
-      `| ${CELLS[cell].label} | ${a.cases} | ${fmt(a.composite)} | ${fmt(a.recall)} | ${fmt(a.precision)} | ${a.falsePositives} | ${a.bonus} | ${fmt(a.severityExactRate)} | ${a.latencyMs == null ? "—" : `${a.latencyMs}ms`} |`
+      `| ${CELLS[cell].label} | ${describeSource(prov[cell])} | ${a.cases} | ${fmt(a.composite)} | ${fmt(a.recall)} | ${fmt(a.precision)} | ${a.falsePositives} | ${a.bonus} | ${fmt(a.severityExactRate)} | ${a.latencyMs == null ? "—" : `${a.latencyMs}ms`} |`
     );
   }
   lines.push("");
@@ -89,6 +145,7 @@ export function buildScorecard(rows, meta = {}) {
   lines.push("- The **model axis** isolates raw single-shot quality (diff embedded, tools forbidden); the **harness axis** is each tool's repo-exploring reviewer. Most real-world gap lives on the harness axis — see `docs/MODEL_COMPARISON.md`.");
   lines.push("- Composite = `recall*70 + precision*20 + severityExact*10` (0–100); it is a summary, not a verdict — read the columns.");
   lines.push("- In `--live` mode model output is non-deterministic; treat single-digit composite gaps as noise. Use `--repeats N` to average.");
+  lines.push("- A cell marked **seeded** was never run: its cassette is an illustration kept so the table has a shape, and it is excluded from every verdict and lift above.");
   lines.push("- A finding outside the planted set but on the case's `allowed_extras` list counts as **bonus** (a legitimate unique catch), not a false positive.");
   lines.push("");
 
@@ -97,8 +154,8 @@ export function buildScorecard(rows, meta = {}) {
     caseCount: meta.caseCount ?? null,
     modelAxisWinner: modelAxis.name,
     harnessAxisWinner: harnessAxis.name,
-    geminiHarnessLift: geminiLift,
-    codexHarnessLift: codexLift,
+    harnessLifts: Object.fromEntries(lifts.map((l) => [l.tool, { lift: l.lift, seeded: l.seeded }])),
+    provenance: prov,
     byCell: agg
   };
   return { markdown: lines.join("\n"), summary };

--- a/bench/run-bench.mjs
+++ b/bench/run-bench.mjs
@@ -11,7 +11,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { CELL_IDS } from "./lib/cells.mjs";
+import { CELLS, CELL_IDS } from "./lib/cells.mjs";
 import { listCases, loadCase, materializeCase } from "./lib/corpus.mjs";
 import { readCassette, writeCassette } from "./lib/cassette.mjs";
 import { runCell } from "./lib/adapters.mjs";
@@ -48,11 +48,14 @@ function avgScores(scores) {
 
 function liveCell({ caseId, cell, promptText, repeats, truth }) {
   let repoCtx = null;
-  const needsRepo = cell === "gemini.deep" || cell === "codex.native";
+  const needsRepo = CELLS[cell]?.harness === "agentic";
   try {
     const scores = [];
     let last = null;
     for (let r = 0; r < repeats; r += 1) {
+      if (CELLS[cell]?.track === "model-isolated" && !promptText) {
+        return { status: "skipped", note: "no diff materialized for this case" };
+      }
       const ctx = { promptText };
       if (needsRepo) {
         repoCtx = materializeCase(caseId);
@@ -65,7 +68,12 @@ function liveCell({ caseId, cell, promptText, repeats, truth }) {
       scores.push(scoreReview(result.findings, truth));
     }
     writeCassette(caseId, cell, last);
-    return { status: "ok", score: avgScores(scores), latencyMs: last.latencyMs };
+    return {
+      status: "ok",
+      score: avgScores(scores),
+      latencyMs: last.latencyMs,
+      provenance: { seeded: false, recordedAt: new Date().toISOString(), engineVersion: last.engineVersion ?? null }
+    };
   } finally {
     if (repoCtx) repoCtx.cleanup();
   }
@@ -74,7 +82,16 @@ function liveCell({ caseId, cell, promptText, repeats, truth }) {
 function replayCell({ caseId, cell, truth }) {
   const cassette = readCassette(caseId, cell);
   if (!cassette) return { status: "skipped", note: "no cassette" };
-  return { status: "ok", score: scoreReview(cassette.findings, truth), latencyMs: cassette.latencyMs };
+  return {
+    status: "ok",
+    score: scoreReview(cassette.findings, truth),
+    latencyMs: cassette.latencyMs,
+    provenance: {
+      seeded: Boolean(cassette.source),
+      recordedAt: cassette.recordedAt ?? null,
+      engineVersion: cassette.engineVersion ?? null
+    }
+  };
 }
 
 function main() {
@@ -97,7 +114,7 @@ function main() {
   for (const caseId of cases) {
     const { truth, promptTemplate } = loadCase(caseId);
     let diffText = null;
-    if (opts.live && cells.some((c) => c === "gemini.model" || c === "codex.model")) {
+    if (opts.live && cells.some((c) => CELLS[c]?.track === "model-isolated")) {
       const mat = materializeCase(caseId);
       diffText = mat.diffText;
       mat.cleanup();

--- a/bench/run-bench.test.mjs
+++ b/bench/run-bench.test.mjs
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 
 import { scoreReview, findingMatchesPlanted, normalizeFile } from "./lib/score.mjs";
 import { _internal as adapters } from "./lib/adapters.mjs";
+import { buildScorecard } from "./lib/report.mjs";
 
 const TRUTH = {
   planted: [
@@ -148,4 +149,85 @@ test("scoreReview flags severity miscalibration without dropping the catch", () 
   assert.equal(s.found, 2);
   assert.equal(s.severity.mismatch, 1); // low vs critical
   assert.equal(s.severity.exact, 1); // high vs high
+});
+
+// --- scorecard provenance ---------------------------------------------------
+// A cassette that was never run still produces a composite, and the composite
+// looks exactly like a measured one. These pin the one thing that separates them.
+
+function scoreOf(composite) {
+  return {
+    composite,
+    recall: 1,
+    precision: 1,
+    falsePositives: 0,
+    bonus: 0,
+    severityExactRate: 1,
+    missed: []
+  };
+}
+
+function row(cell, composite, seeded, caseId = "c1") {
+  return {
+    caseId,
+    cell,
+    status: "ok",
+    score: scoreOf(composite),
+    latencyMs: 1000,
+    provenance: { seeded, recordedAt: "2026-08-19T00:00:00.000Z", engineVersion: seeded ? null : "1.1.14" }
+  };
+}
+
+test("a seeded cell cannot win an axis, however high it scores", () => {
+  const { summary, markdown } = buildScorecard([
+    row("agy.deep", 50, false),
+    row("codex.native", 99, true)
+  ]);
+
+  assert.notEqual(summary.harnessAxisWinner, "codex", "a cassette nobody ran must not win");
+  assert.equal(summary.harnessAxisWinner, "—");
+  assert.match(markdown, /not decidable: 1 of 2 cells measured/);
+  assert.match(markdown, /codex 99 \(seeded\)/, "the seeded number is still shown, just labelled");
+});
+
+test("an axis names a winner once two measured cells disagree beyond noise", () => {
+  const { summary } = buildScorecard([
+    row("agy.deep", 90, false),
+    row("codex.native", 60, false)
+  ]);
+  assert.equal(summary.harnessAxisWinner, "agy");
+});
+
+test("two measured cells within noise tie rather than crowning one", () => {
+  const { summary } = buildScorecard([
+    row("agy.deep", 90, false),
+    row("codex.native", 89, false)
+  ]);
+  assert.equal(summary.harnessAxisWinner, "tie");
+});
+
+test("a harness lift with a seeded end is not reported as a measurement", () => {
+  const { markdown, summary } = buildScorecard([
+    row("gemini.model", 70, false),
+    row("gemini.deep", 90, true)
+  ]);
+
+  assert.equal(summary.harnessLifts.gemini.seeded, true);
+  assert.match(markdown, /Harness lift — gemini \| \+20 \| one end is seeded — not a measurement/);
+});
+
+test("a harness lift measured end to end says what it is", () => {
+  const { markdown, summary } = buildScorecard([
+    row("agy.model", 73, false),
+    row("agy.deep", 90.5, false)
+  ]);
+
+  assert.equal(summary.harnessLifts.agy.seeded, false);
+  assert.equal(summary.harnessLifts.agy.lift, 17.5);
+  assert.match(markdown, /Harness lift — agy \| \+17.5 \| agy.model → agy.deep composite/);
+});
+
+test("the per-cell table carries the build a live cell was recorded against", () => {
+  const { markdown } = buildScorecard([row("agy.deep", 90.5, false)]);
+  assert.match(markdown, /live 2026-08-19 · 1.1.14/);
 });


### PR DESCRIPTION
> **Correction (after merge).** The table below originally carried 73 / 90.5 / +17.5 for AGY, with recall 1.0 on `--deep`. Those came from the first recording of these cells. The cassettes actually committed are from a second recording made minutes later to capture the `engineVersion` field, and they score 72 / 87 / +15 with recall 0.9. Only the version fields were checked after re-recording; the scores were not. The numbers below are now the ones the repository replays. The squashed commit message still carries the old figures and cannot be edited.

The scorecard's harness axis was decided by two cassettes nobody ever ran. `gemini.deep` and `codex.native` carry `source: "seeded illustrative"`, and the report scored them exactly like measurements — including the harness-lift rows, which subtracted a live number from a seeded one and so looked more like a measurement than either half.

## AGY, measured on both axes

| Cell | Source | Composite | Recall | Precision | FP | Sev-exact | Latency |
|---|---|:-:|:-:|:-:|:-:|:-:|:-:|
| AGY (model) | live 2026-08-19 · 1.1.14 | 72 | 0.65 | 1 | 0 | 0.63 | 22.7s |
| AGY (`--deep`) | live 2026-08-19 · 1.1.14 | 87 | 0.9 | 0.84 | 1 | 0.75 | 33.5s |
| Gemini (model) | live 2026-06-04 | 73 | 0.65 | 1 | 0 | 0.75 | 44.1s |
| Codex (model) | live 2026-06-04 | 36 | 0.3 | 0.5 | 1 | 0.5 | 28.4s |
| Gemini (`--deep`) | **seeded** | 82.5 | — | — | — | — | — |
| Codex (native) | **seeded** | 93 | — | — | — | — | — |

Both AGY ends are live, which makes `agy.model → agy.deep` (**+15**) the only harness lift on the scorecard measured end to end. `--deep` trades precision for reach: it finds more (recall 0.65 → 0.9) and pays one false positive for it.

**How much of that is noise is now measured rather than assumed.** The same two cells, re-recorded minutes apart against the same corpus and the same build, moved by 1 and 5.5 composite points, and `--deep`'s recall moved 1.0 → 0.9. Two cases at one sample each is not enough to separate a +15 lift from run-to-run variation; `--repeats N` is what would. The README's "single samples are noisy" caveat has a number behind it now.

`agy.deep` records headlessly where `gemini.deep` cannot: AGY's print mode auto-approves tools and never waits for a TTY, which is the same property `docs/THREAT-MODEL.md` 7.2 treats as a hazard. It is not a capability win, and the README says so where it is documented.

## Seeded cells are excluded from verdicts

An axis with fewer than two measured cells reports `not decidable` and lists the seeded numbers labelled as such, rather than crowning one:

```
| Harness (agentic) | — | not decidable: 1 of 3 cells measured
                          · codex 93 (seeded) · agy 87 · gemini 82.5 (seeded) |
| Harness lift — agy    | +15   | agy.model → agy.deep composite |
| Harness lift — gemini | +9.5  | one end is seeded — not a measurement |
```

Axes and lifts now read `lib/cells.mjs` instead of naming tools, so a cell added there joins both without touching the report. Cassettes record the `engineVersion` they ran against and the per-cell table prints it, so a reader can date a number without a hand-written staleness warning.

## A bug this uncovered

`run-bench.mjs` carried two hardcoded cell lists — one deciding which cases get materialized, one deciding which cells need a repo. A newly added model cell therefore ran with a **null prompt**. On AGY that is not a fast failure: the engine waits on stdin for a prompt that never arrives, and the cell reports `ETIMEDOUT` 180 s later, which reads like an engine problem. It cost two wrong diagnoses before the prompt was printed rather than inferred. Both lists come from the registry now, and a missing prompt fails immediately with its own reason.

## Publishing

`publish-scorecard.yml` replays the committed cassettes and publishes to a `results` branch. `bench/results/` stays gitignored; `main`'s history is unchanged.

- **No secrets, so no `pull_request_target` question to get wrong.** Recording needs credentials and a TTY and stays local (`npm run bench:live`). AGY *can* take a key non-interactively since 1.1.13 (`GEMINI_API_KEY` with `modelProvider: "gemini"`), but that routes the turn to the Gemini API rather than AGY's own sign-in — a cassette recorded that way measures a path no signed-in user takes while the scorecard credits it to AGY. Possible is not valid.
- **No `schedule`.** A monthly run would republish byte-identical numbers under a fresh commit date, turning the published timestamp — the actual credibility signal — into a claim that stale numbers were just re-measured. It runs on `bench/**` pushes and on demand, and **publishes nothing when the scorecard is unchanged**.
- The commit subject names the builds behind the numbers (`scorecard: agy.deep@1.1.14 agy.model@1.1.14 …`), so `git log` on that branch reads as a record of what was measured, not of when CI happened to fire.

The publish step's shell was extracted from the workflow file and run against a scratch origin through three states — no `results` branch, unchanged scorecard, changed scorecard — 7 assertions, all passing. It is tested text, not tested paraphrase.

`npm run bench` also joins PR CI. Its comment says what it does **not** cover: replay invokes no engine, so a PR that rewrites a prompt or reroutes an engine passes it untouched. It guards the orchestrator, the scorer and the verdict rules — not review quality.

## Tests

Six new, 577 passing. Each confirmed by a mutation that kills exactly it:

| mutation | fails |
|---|---|
| let a seeded cell compete for the axis | "a seeded cell cannot win an axis, however high it scores" |
| never flag a lift whose end is seeded | "a harness lift with a seeded end is not reported as a measurement" |
| drop the engine build from the source column | "the per-cell table carries the build a live cell was recorded against" |
| remove the noise band | "two measured cells within noise tie rather than crowning one" |

## Known limits

- Two cases, one sample per cell, and the correction above shows what that costs. `--repeats N` averages.
- `gemini.model` and `codex.model` predate the `engineVersion` field, so their builds are recorded in `bench/README.md` rather than in the cassette. Gemini CLI's consumer tier stopped serving on 2026-06-18, so re-recording that cell now needs a paid credential.
- The AGY numbers describe agy 1.1.14 on this corpus, on one machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019G2BAczpG8DL2NiAqTYkHA
