### PR TITLE
Name AGY's non-interactive credentials, and what the probe has not seen

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Compared with AGY-only, multi-host plugins, this project keeps the Gemini CLI pa
 
 **Install AGY** (required for `--engine agy`): `curl -fsSL https://antigravity.google/cli/install.sh | bash`
 
-**Authentication**: Each engine authenticates independently. Run `gemini` once for the Gemini engine, or run `agy` once interactively for the AGY engine. AGY 1.1.10+ also supports Application Default Credentials (ADC) and Gemini Enterprise / Workforce Identity Federation (WIF). AGY OAuth authentication cannot be verified reliably from a headless setup probe, so `/gemini:setup --engine agy` reports it as unknown until a real AGY command succeeds.
+**Authentication**: Each engine authenticates independently. Run `gemini` once for the Gemini engine, or run `agy` once interactively for the AGY engine. AGY 1.1.10+ also supports Application Default Credentials (ADC) and Gemini Enterprise / Workforce Identity Federation (WIF), and 1.1.13+ accepts `GEMINI_API_KEY` with `modelProvider: "gemini"` in its `settings.json` — a settings-file route, which is why it appears in no `agy --help` output. AGY OAuth authentication cannot be verified reliably from a headless setup probe, so `/gemini:setup --engine agy` reports it as unknown until a real AGY command succeeds. `--probe-agy` settles it for an interactive login; it has not been tested against the non-interactive credentials, so treat a `logged-out` verdict on a working account as a bug worth reporting.
 
 > **The Gemini engine now needs a Standard/Enterprise account or an API key.** Google ended consumer Gemini CLI access on 2026-06-18. On a personal account, gemini CLI 0.53.1 still installs and answers `--version`, but every request returns `API key not valid` (`API_KEY_INVALID`) — verified 2026-08-04. The AGY engine is unaffected and is the practical default; pass `--engine agy`, or set `GEMINI_ENGINE=agy`, if `auto` selects an unauthenticated gemini binary.
 
@@ -339,7 +339,7 @@ Override via `--engine` flag or the `GEMINI_ENGINE` environment variable.
 | Windows: command resolves but fails | `.cmd` wrapper / PATH | Confirm `where gemini` resolves; the plugin spawns bare names through `shell: true` to find `.cmd` shims |
 | `--engine agy` reports no brain root | AGY has not created its brain directory yet, or it lives in an unknown location | Run `agy` once so it creates the brain dir. Known roots: `~/.gemini/antigravity-cli/brain` (verified on Windows, macOS AGY 1.0.7, and Linux AGY 1.1.2) and `~/.antigravity-cli/brain` (older Linux 1.0.2, reported); if yours differs, open an issue with its location |
 
-For the Gemini engine, run **`!gemini`** once — the plugin completes OAuth by invoking `gemini` itself. There is **no** `gemini login` subcommand. For the AGY engine, run `agy` interactively once; its separate OAuth state is not inferred from Gemini's `~/.gemini/oauth_creds.json`. `setup` reports AGY as `partial` while the binary is present but auth remains unverifiable.
+For the Gemini engine, run **`!gemini`** once — the plugin completes OAuth by invoking `gemini` itself. There is **no** `gemini login` subcommand. For the AGY engine, run `agy` interactively once, or give it a non-interactive credential (ADC/WIF on 1.1.10+, `GEMINI_API_KEY` with `modelProvider: "gemini"` on 1.1.13+); its separate OAuth state is not inferred from Gemini's `~/.gemini/oauth_creds.json`. `setup` reports AGY as `partial` while the binary is present but auth remains unverifiable.
 
 ---
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -57,7 +57,7 @@
 
 **安裝 AGY**（使用 `--engine agy` 時必須安裝）：`curl -fsSL https://antigravity.google/cli/install.sh | bash`
 
-**認證**：兩個引擎各自認證。Gemini 引擎請執行一次 `gemini`；AGY 引擎請互動式執行一次 `agy`。AGY 1.1.10+ 亦支援 Application Default Credentials (ADC) 與 Gemini Enterprise / Workforce Identity Federation (WIF)。Headless setup probe 無法可靠驗證 AGY 認證，因此 `/gemini:setup --engine agy` 會將其標為 unknown，直到真實 AGY 命令成功。
+**認證**：兩個引擎各自認證。Gemini 引擎請執行一次 `gemini`；AGY 引擎請互動式執行一次 `agy`。AGY 1.1.10+ 亦支援 Application Default Credentials (ADC) 與 Gemini Enterprise / Workforce Identity Federation (WIF)；1.1.13+ 另接受在 `settings.json` 設定 `modelProvider: "gemini"` 並帶入 `GEMINI_API_KEY`——這是設定檔路徑，因此不會出現在任何 `agy --help` 輸出中。Headless setup probe 無法可靠驗證 AGY 認證，因此 `/gemini:setup --engine agy` 會將其標為 unknown，直到真實 AGY 命令成功。`--probe-agy` 可為互動式登入定案；它尚未針對上述非互動憑證測試過，因此若帳號實際可用卻被判為 `logged-out`，請視為本專案的缺陷並回報。
 
 > **Gemini 引擎現在需要 Standard／Enterprise 帳戶或 API 金鑰。** Google 已於 2026-06-18 終止消費級 Gemini CLI 存取。個人帳戶下 gemini CLI 0.53.1 仍可安裝、`--version` 也正常，但所有請求都回 `API key not valid`（`API_KEY_INVALID`）——2026-08-04 實測。AGY 引擎不受影響，實務上就是預設引擎；若 `auto` 選到未認證的 gemini binary，請改用 `--engine agy` 或設定 `GEMINI_ENGINE=agy`。
 
@@ -337,7 +337,7 @@
 | Windows：命令可解析但執行失敗 | `.cmd` wrapper／PATH | 確認 `where gemini` 可解析；外掛以 `shell: true` 啟動裸命令名以尋得 `.cmd` shim |
 | `--engine agy` 回報找不到 brain 根目錄 | AGY 尚未建立 brain 目錄，或其位於未知位置 | 先執行一次 `agy` 讓其建立 brain 目錄。已知路徑：`~/.gemini/antigravity-cli/brain`（已於 Windows、macOS AGY 1.0.7 與 Linux AGY 1.1.2 驗證）與 `~/.antigravity-cli/brain`（較舊的 Linux 1.0.2，回報）；若不同請開 issue 回報其位置 |
 
-Gemini 引擎請執行一次 **`!gemini`**——外掛即以呼叫 `gemini` 自身完成 OAuth，**並無** `gemini login` 子命令。AGY 引擎請互動式執行一次 `agy`；其獨立 OAuth 狀態不由 Gemini 的 `~/.gemini/oauth_creds.json` 推定。AGY binary 存在但 auth 無法驗證時，setup 會回報 `partial`。
+Gemini 引擎請執行一次 **`!gemini`**——外掛即以呼叫 `gemini` 自身完成 OAuth，**並無** `gemini login` 子命令。AGY 引擎請互動式執行一次 `agy`，或改用非互動憑證（1.1.10+ 的 ADC／WIF，或 1.1.13+ 在 `settings.json` 設 `modelProvider: "gemini"` 並帶 `GEMINI_API_KEY`）；其獨立 OAuth 狀態不由 Gemini 的 `~/.gemini/oauth_creds.json` 推定。AGY binary 存在但 auth 無法驗證時，setup 會回報 `partial`。
 
 ---
 

--- a/plugins/gemini/commands/setup.md
+++ b/plugins/gemini/commands/setup.md
@@ -104,7 +104,15 @@ It asks AGY a read-only question the account has to answer, so it verifies the
 login without starting a turn or spending quota (AGY 1.1.11+; below that it
 declines and says so). A verified AGY then reports `readyState: "ready"`; a probe
 that comes back `logged-out` reports `not-ready`, and the fix is to run `agy`
-once interactively.
+once interactively — or to use one of AGY's non-interactive credentials (ADC and
+Enterprise/WIF on 1.1.10+, `GEMINI_API_KEY` with `modelProvider: "gemini"` on
+1.1.13+).
+
+The probe has only been verified against an interactive login. It asks `/quota`,
+which the AGY account answers; whether an account authenticated by API key
+answers it the same way is **untested**. If your AGY turns work and `--probe-agy`
+still reports `logged-out`, that is a defect here rather than a real logout —
+please report it.
 
 There is a matching `--probe-gemini`, and **it is not free**. Gemini CLI has no
 question the account answers without generating, so the probe makes a real

--- a/plugins/gemini/scripts/lib/gemini.mjs
+++ b/plugins/gemini/scripts/lib/gemini.mjs
@@ -989,11 +989,18 @@ export function getAgyLoginStatus() {
   // evidence of AGY authentication. Keep `loggedIn` for JSON compatibility, but
   // pair it with an explicit unknown state so callers do not interpret it as a
   // verified logout.
+  //
+  // The remedy is no longer only an interactive login. AGY 1.1.10 added ADC and
+  // Enterprise/WIF, and 1.1.13 added GEMINI_API_KEY through `modelProvider:
+  // "gemini"` in settings.json — a file and an environment variable rather than a
+  // flag, which is why `agy --help` shows nothing about it. Naming only the
+  // interactive path told a user who had already authenticated to go and do it
+  // again.
   return {
     loggedIn: false,
     state: "unknown",
     verifiable: false,
-    detail: `AGY ${status.detail ?? ""} present; authentication cannot be verified non-interactively. Run \`agy\` once interactively to authenticate or refresh credentials.`.trim(),
+    detail: `AGY ${status.detail ?? ""} present; authentication cannot be verified non-interactively. Run \`agy\` once interactively, or use a non-interactive credential: ADC and Enterprise/WIF on 1.1.10+, or GEMINI_API_KEY with \`modelProvider: "gemini"\` in settings.json on 1.1.13+. \`--probe-agy\` can settle this, and has itself only been verified against an interactive login.`.trim(),
   };
 }
 
@@ -1065,7 +1072,7 @@ export function probeAgyLogin({ runCommandFn = runCommand, detectEngineFn = dete
       loggedIn: false,
       state: "logged-out",
       verifiable: true,
-      detail: `AGY ${version} rejected the \`/quota\` probe as unauthenticated. Run \`agy\` interactively once to sign in.${reason ? ` (${reason})` : ""}`
+      detail: `AGY ${version} rejected the \`/quota\` probe as unauthenticated. Run \`agy\` interactively once to sign in, or use a non-interactive credential (ADC/WIF on 1.1.10+, GEMINI_API_KEY with \`modelProvider: "gemini"\` on 1.1.13+). This probe has not been tested against those routes: if your AGY turns work and this still says unauthenticated, that is a bug here, not a logout.${reason ? ` (${reason})` : ""}`
     };
   }
   return {


### PR DESCRIPTION
`/gemini:setup` told a user with a working AGY to go and authenticate it. Its remedy for an unverified AGY named one route — run `agy` interactively — and AGY has had others for a while: ADC and Enterprise/WIF since 1.1.10, and since **1.1.13** a `GEMINI_API_KEY` read through `modelProvider: "gemini"` in `settings.json`.

That last one is easy to miss on purpose: it is a settings file plus an environment variable, so it appears in no `agy --help` output. Checking the flags and concluding the capability was absent is how this was missed here — the absence was checked on the wrong surface.

## What changed

Seven sites, all wording:

| file | what it said | what it says now |
|---|---|---|
| `lib/gemini.mjs` (unprobed status) | run `agy` once interactively | + ADC/WIF and the 1.1.13 key route, + that `--probe-agy` can settle it |
| `lib/gemini.mjs` (probe `logged-out`) | run `agy` interactively once to sign in | + the same routes, + that a working account reported as logged-out is a bug here |
| `commands/setup.md` | the fix is to run `agy` once interactively | + the non-interactive routes and what the probe has actually been tested against |
| `README.md` ×2, `README.zh-TW.md` ×2 | interactive login only | + the 1.1.13 route, and why it is invisible to `--help` |

Two sites that also say "run `agy` interactively" were deliberately **left alone**: `lib/failures.mjs:84` is about a denied tool permission, and `lib/engine.mjs:193` is about initialising the transcript brain directory below AGY 1.1.8. Neither is an authentication remedy.

## The part that is stated rather than fixed

`--probe-agy` asks AGY `/quota`, which the account answers without starting a turn. **Whether an account authenticated by API key answers it the same way is untested**, and the failure mode is not cosmetic: if that route refuses `/quota` and the refusal classifies as `auth`, the probe returns `logged-out`, and `readyState` becomes `not-ready` for a user whose turns work fine.

Testing it needs a valid Gemini API key, which was not available here, so it is not claimed either way. The new text says so at every site where a user could hit it, and asks them to report it — which is the honest version of a gap that cannot be closed today.

Verified on this machine, AGY 1.1.14, interactive login:

```
readyState: "ready"
agyAuth: { state: "verified", detail: "AGY 1.1.14 answered `/quota` from the account, so it is authenticated. No turn was spent." }
```

So the probe path itself is not broken by 1.1.14 — only its documented remedy was incomplete.

`tests/runtime.test.mjs:160` pins `/cannot be verified non-interactively/i` on that detail; the phrase is kept word for word and the sentence extended after it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019G2BAczpG8DL2NiAqTYkHA
