### PR TITLE
Make repeats reach the published number, and set the noise band from the samples

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -32,7 +32,7 @@ there joins both the ranking and its own lift without touching the report.
 
 ```bash
 npm run bench            # deterministic replay from cassettes — no auth, no network
-npm run bench:live       # run the real CLIs and re-record cassettes (needs auth)
+npm run bench:live -- --repeats 3   # re-record (needs auth; note the `--`, npm eats bare flags)
 
 # narrow it down
 node bench/run-bench.mjs --case auth-basic --cell gemini.model
@@ -55,34 +55,56 @@ The scorecard prints to stdout and is written to `bench/results/scorecard.md`
 ### Cassette provenance & live-refresh status
 
 A cassette recorded from a real run carries `recordedAt`, the `engineVersion` it was
-recorded against, and no `source`; a seeded one carries a `source` field. The
-scorecard prints this per cell, and **a seeded cell is excluded from every verdict
-and every harness lift** — it is an illustration kept so the table has a shape, not a
-result. Current committed state:
+recorded against, every repeat in `samples`, and no `source`; a seeded one carries a
+`source` field. The scorecard prints all of it per cell. Current committed state:
 
-- **`agy.model`, `agy.deep` — live-recorded** (2026-08-19, agy 1.1.14, single sample).
-  Both axes of the AGY column are real, which makes the AGY harness lift
-  (`agy.model` → `agy.deep`) the only lift on the scorecard measured end to end.
-- **`gemini.model`, `codex.model` — live-recorded** (2026-06-04, gemini 0.45 /
-  codex-cli 0.137, single sample) and predate the `engineVersion` field, so their
-  builds are recorded here rather than in the cassette. Gemini CLI's consumer tier
-  stopped serving on 2026-06-18, so re-recording `gemini.model` now needs a paid
-  Code Assist or API-key credential.
-- **`gemini.deep`, `codex.native` — still seeded.** They could not be driven
-  headlessly in this environment: `gemini --deep` exits non-zero with empty stdout
-  under headless agentic+JSON mode (tool approvals need a TTY), and the
-  `codex.native` app-server review exceeded the 180s cap. Refresh them with a longer
-  `BENCH_TIMEOUT_MS`, an interactive/approved session, or on a platform where the
-  agentic harness runs non-interactively.
+- **`agy.model`, `agy.deep`, `gemini.deep`, `codex.model` — live-recorded**
+  (2026-08-19, three samples each: agy 1.1.14, gemini 0.54.4, codex-cli 0.147.0).
+- **`gemini.deep` records headlessly after all.** The previous note here said it could
+  not — that `gemini --deep` exits non-zero with empty stdout because tool approvals
+  need a TTY. It recorded six times without complaint on gemini 0.54.4, so whatever
+  blocked it in this environment was not permanent. It is also the steadiest cell on
+  the board.
+- **`gemini.model` — still the 2026-06-04 single sample** (gemini 0.45). It now fails
+  to re-record for a reason that has nothing to do with credentials: the CLI prints
+  `Warning: True color (24-bit) support not detected` and `Ripgrep is not available`
+  ahead of its JSON, and the cell's parser gives up. Worth fixing before trusting
+  anything about the gemini model axis.
+- **`codex.native` — still seeded.** `BENCH_CODEX_COMPANION` was unset, so it was
+  skipped rather than recorded.
 
-`agy.deep` records headlessly where `gemini.deep` cannot, because AGY's print mode
-auto-approves tools and never waits for a TTY. That is a difference in permission
-model, not in capability, and `docs/THREAT-MODEL.md` 7.2 is where it is argued about
-rather than celebrated.
+### What three samples showed
+
+Enough to disqualify every single-sample number the scorecard has ever printed,
+including the ones this file used to quote. Composite, per repeat:
+
+| cell | `auth-basic` | `repo-context` | widest move |
+|---|---|---|:-:|
+| `gemini.deep` | 80, 81, 81 | 88, 88, 88 | **1** |
+| `agy.deep` | 81, 77, 93 | 88, 88, 83 | 16 |
+| `codex.model` | 96, 72, 98 | 0, 45, 0 | 45 |
+| `agy.model` | 81, 94, 81 | 0, 65, 65 | **65** |
+
+Two things fall out, and only one of them is about scores.
+
+1. **The agentic cells are an order of magnitude steadier than the model cells.**
+   `gemini.deep` moved by 1 point across six runs; `agy.model` moved by 65 on a single
+   case. Whatever a repo-exploring harness is doing, part of it is making the answer
+   repeatable — which is a more useful claim than any composite here, and the only one
+   the data currently supports.
+2. **The old ±2 noise band was calibrated against nothing.** It is now the measured
+   spread: a verdict is named only when the lead is wider than the widest move either
+   cell made between repeats. Under that rule no axis on this board is decidable, and
+   neither is AGY's harness lift. That is the honest reading of two cases at three
+   samples, not a defect in the runner.
+
+A cell recorded once has no spread. It is printed as `—`, meaning *unknown*, and it
+can neither win nor lose an axis — the same exclusion a seeded cell gets, for the same
+reason: there is nothing to compare against.
 
 Adding a cell means one entry in `lib/cells.mjs` and one `case` in `lib/adapters.mjs`;
-everything else — which cases get materialized, which cells need a repo, the axes,
-the lifts — reads the registry. It did not always: two hardcoded cell lists in
+everything else — which cases get materialized, which cells need a repo, the axes, the
+lifts, the bands — reads the registry. It did not always: two hardcoded cell lists in
 `run-bench.mjs` meant a newly added model cell ran with a null prompt, and on AGY that
 surfaced 180 seconds later as an engine timeout rather than as a missing diff.
 

--- a/bench/cassettes/auth-basic/agy.deep.json
+++ b/bench/cassettes/auth-basic/agy.deep.json
@@ -1,52 +1,245 @@
 {
   "caseId": "auth-basic",
   "cell": "agy.deep",
-  "recordedAt": "2026-08-19T02:15:34.060Z",
+  "recordedAt": "2026-08-19T03:18:29.495Z",
   "verdict": "needs-attention",
-  "summary": "Authentication module contains critical SQL injection, unhandled null reference on non-existent users, hardcoded secrets, and unsafe JSON parsing.",
+  "summary": "The authentication module contains critical security vulnerabilities including SQL injection and hardcoded secrets, as well as unhandled runtime errors and missing dependencies.",
   "findings": [
     {
       "severity": "critical",
-      "title": "SQL Injection via String Concatenation in findUser",
-      "body": "The findUser function constructs a SQL query by directly concatenating user-supplied input into the query string. This allows attackers to perform SQL injection attacks, bypass authentication, or exfiltrate database contents.",
+      "title": "SQL Injection in findUser",
+      "body": "The findUser function concatenates the username argument directly into the SQL query string without parameterization or escaping. An attacker can inject arbitrary SQL commands to manipulate queries or bypass authentication.",
       "file": "src/auth.js",
       "line_start": 7,
       "line_end": 9,
       "confidence": 1,
-      "recommendation": "Use parameterized queries or prepared statements (e.g., db.query('SELECT * FROM users WHERE name = ?', [username])) instead of raw string concatenation."
+      "recommendation": "Use parameterized queries or prepared statements (e.g. db.query('SELECT * FROM users WHERE name = $1', [username]))."
     },
     {
       "severity": "high",
-      "title": "Unhandled Null User and Insecure Plaintext Password Comparison",
-      "body": "If findUser returns null or undefined when a user is not found, accessing user.password throws an unhandled TypeError that crashes the request. Additionally, passwords are validated using plaintext comparison with loose equality (==) rather than secure password hashing.",
+      "title": "Unchecked user lookup result causes unhandled TypeError",
+      "body": "If findUser returns null, undefined, or an empty result for a non-existent user, login accesses user.password directly, throwing an unhandled TypeError that crashes the request.",
       "file": "src/auth.js",
       "line_start": 14,
-      "line_end": 18,
+      "line_end": 17,
       "confidence": 1,
-      "recommendation": "Verify that user exists before inspecting properties (e.g., if (!user) return null;), and use a secure hashing algorithm (such as bcrypt or argon2) with constant-time comparison for password verification."
+      "recommendation": "Check that the user object exists before reading properties (e.g. if (!user || !user.password) return null;)."
     },
     {
       "severity": "high",
-      "title": "Hardcoded JWT Secret Key",
-      "body": "JWT_SECRET is hardcoded in source code with a static plaintext value. If source code is compromised, any attacker can forge arbitrary JWT tokens and impersonate users.",
+      "title": "Plaintext password comparison using loose equality",
+      "body": "Passwords are evaluated using loose equality (==) against plaintext values without hashing or constant-time comparison, creating serious credential exposure and timing attack risks.",
+      "file": "src/auth.js",
+      "line_start": 15,
+      "line_end": 15,
+      "confidence": 1,
+      "recommendation": "Store passwords as salted hashes and verify them using a secure hashing library such as bcrypt (e.g. await bcrypt.compare(password, user.password))."
+    },
+    {
+      "severity": "high",
+      "title": "Hardcoded JWT secret key",
+      "body": "JWT_SECRET is hardcoded in plaintext source code, exposing signing credentials and allowing unauthorized token generation if the repository is accessible.",
       "file": "src/auth.js",
       "line_start": 4,
       "line_end": 4,
       "confidence": 1,
-      "recommendation": "Load the JWT secret from environment variables (e.g., process.env.JWT_SECRET) and throw an error at startup if the secret is not configured."
+      "recommendation": "Retrieve the JWT secret from environment variables (e.g. process.env.JWT_SECRET) or a secret manager."
+    },
+    {
+      "severity": "high",
+      "title": "Missing local database module dependency",
+      "body": "src/auth.js requires './db', but no corresponding db module or file exists in the repository, causing a runtime MODULE_NOT_FOUND error on load.",
+      "file": "src/auth.js",
+      "line_start": 2,
+      "line_end": 2,
+      "confidence": 0.95,
+      "recommendation": "Provide the database module at src/db.js or update the import path to the correct module."
     },
     {
       "severity": "medium",
-      "title": "Unhandled SyntaxError on Malformed Input in parseSession",
-      "body": "JSON.parse(raw) throws an uncaught SyntaxError when provided with invalid JSON input, and subsequent property access (session.userId) will throw a TypeError if raw parses to null.",
+      "title": "Uncaught JSON.parse exception in parseSession",
+      "body": "parseSession executes JSON.parse on raw input without error handling, throwing an unhandled SyntaxError whenever malformed or invalid JSON is passed.",
       "file": "src/auth.js",
       "line_start": 21,
       "line_end": 24,
       "confidence": 0.95,
-      "recommendation": "Wrap JSON.parse in a try/catch block and handle null or non-object results safely, returning null or undefined when parsing fails."
+      "recommendation": "Wrap JSON.parse in a try-catch block and return null or handle errors gracefully on invalid input."
     }
   ],
-  "latencyMs": 32167,
+  "latencyMs": 40058,
   "engineVersion": "1.1.14",
-  "raw": "{\n  \"review\": \"Review\",\n  \"target\": {\n    \"mode\": \"working-tree\",\n    \"label\": \"working tree diff\",\n    \"explicit\": true\n  },\n  \"gemini\": {\n    \"status\": 0,\n    \"stdout\": \"{\\n  \\\"verdict\\\": \\\"needs-attention\\\",\\n  \\\"summary\\\": \\\"Authentication module contains critical SQL injection, unhandled null reference on non-existent users, hardcoded secrets, and unsafe JSON parsing.\\\",\\n  \\\"findings\\\": [\\n    {\\n      \\\"severity\\\": \\\"critical\\\",\\n      \\\"title\\\": \\\"SQL Injection via String Concatenation in findUser\\\",\\n      \\\"body\\\": \\\"The findUser function constructs a SQL query by directly concatenating user-supplied input into the query string. This allows attackers to perform SQL injection attacks, bypass authentication, or exfiltrate database contents.\\\",\\n      \\\"file\\\": \\\"src/auth.js\\\",\\n      \\\"line_start\\\": 7,\\n      \\\"line_end\\\": 9,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Use parameterized queries or prepared statements (e.g., db.query('SELECT * FROM users WHERE name = ?', [username])) instead of raw string concatenation.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"high\\\",\\n      \\\"title\\\": \\\"Unhandled Null User and Insecure Plaintext Password Comparison\\\",\\n      \\\"body\\\": \\\"If findUser returns null or undefined when a user is not found, accessing user.password throws an unhandled TypeError that crashes the request. Additionally, passwords are validated using plaintext comparison with loose equality (==) rather than secure password hashing.\\\",\\n      \\\"file\\\": \\\"src/auth.js\\\",\\n      \\\"line_start\\\": 14,\\n      \\\"line_end\\\": 18,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Verify that user exists before inspecting properties (e.g., if (!user) return null;), and use a secure hashing algorithm (such as bcrypt or argon2) with constant-time comparison for password verification.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"high\\\",\\n      \\\"title\\\": \\\"Hardcoded JWT Secret Key\\\",\\n      \\\"body\\\": \\\"JWT_SECRET is hardcoded in source code with a static plaintext value. If source code is compromised, any attacker can forge arbitrary JWT tokens and impersonate users.\\\",\\n      \\\"file\\\": \\\"src/auth.js\\\",\\n      \\\"line_start\\\": 4,\\n      \\\"line_end\\\": 4,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Load the JWT secret from environment variables (e.g., process.env.JWT_SECRET) and throw an error at startup if the secret is not configured.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"medium\\\",\\n      \\\"title\\\": \\\"Unhandled SyntaxError on Malformed Input in parseSession\\\",\\n      \\\"body\\\": \\\"JSON.parse(raw) throws an uncaught SyntaxError when provided with invalid JSON input, and subsequent property access (session.userId) will throw a TypeError if raw parses to null.\\\",\\n      \\\"file\\\": \\\"src/auth.js\\\",\\n      \\\"line_start\\\": 21,\\n      \\\"line_end\\\": 24,\\n      \\\"confidence\\\": 0.95,\\n      \\\"recommendation\\\": \\\"Wrap JSON.parse in a try/catch block and handle null or non-object results safely, returning null or undefined when parsing fails.\\\"\\n    }\\n  ],\\n  \\\"next_steps\\\": [\\n    \\\"Refactor findUser to use parameterized SQL queries.\\\",\\n    \\\"Add null checks and hash verification in login.\\\",\\n    \\\"Move JWT_SECRET to environment variables.\\\",\\n    \\\"Add error handling around JSON.parse in parseSession.\\\"\\n  ]\\n}\",\n    \"stderr\": \"\"\n  },\n  \"result\": {\n    \"verdict\": \"needs-attention\",\n    \"summary\": \"Authentication module contains critical SQL injection, unhandled null reference on non-existent users, hardcoded secrets, and unsafe JSON parsing.\",\n    \"findings\": [\n      {\n        \"severity\": \"critical\",\n        \"title\": \"SQL Injection via String Concatenation in findUser\",\n        \"body\": \"The findUser function constructs a SQL query by directly concatenating user-supplied input into the query string. This allows attackers to perform SQL injection attacks, bypass authentication, or exfiltrate database contents.\",\n        \"file\": \"src/auth.js\",\n        \"line_start\": 7,\n        \"line_end\": 9,\n        \"confidence\": 1,\n"
+  "samples": [
+    {
+      "verdict": "needs-attention",
+      "summary": "Authentication module contains critical security vulnerabilities including SQL injection, hardcoded secrets, and unsafe password comparison.",
+      "findings": [
+        {
+          "severity": "critical",
+          "title": "SQL injection vulnerability via raw string concatenation",
+          "body": "findUser concatenates the username argument directly into the SQL query string passed to db.query, allowing arbitrary SQL injection and database compromise.",
+          "file": "src/auth.js",
+          "line_start": 7,
+          "line_end": 9,
+          "confidence": 1,
+          "recommendation": "Use parameterized queries (e.g., db.query('SELECT * FROM users WHERE name = ?', [username])) to safely pass user input."
+        },
+        {
+          "severity": "high",
+          "title": "Missing null check on user lookup and plaintext password comparison",
+          "body": "login attempts property access user.password without checking if findUser returned null/undefined, causing an unhandled TypeError crash; furthermore, passwords are evaluated in plaintext using loose equality ==.",
+          "file": "src/auth.js",
+          "line_start": 14,
+          "line_end": 17,
+          "confidence": 1,
+          "recommendation": "Check that user is non-null before accessing properties and compare hashed passwords using a secure library such as bcrypt."
+        },
+        {
+          "severity": "high",
+          "title": "Hardcoded JWT secret key in source code",
+          "body": "JWT_SECRET is defined as a static literal in source code, exposing cryptographic signing credentials and enabling token forgery.",
+          "file": "src/auth.js",
+          "line_start": 4,
+          "line_end": 4,
+          "confidence": 1,
+          "recommendation": "Read the secret from environment variables (e.g., process.env.JWT_SECRET) with runtime validation."
+        },
+        {
+          "severity": "medium",
+          "title": "Uncaught exception on invalid JSON in parseSession",
+          "body": "parseSession calls JSON.parse on raw without error handling, which will throw an unhandled SyntaxError on malformed input or a TypeError if parsed to null.",
+          "file": "src/auth.js",
+          "line_start": 21,
+          "line_end": 24,
+          "confidence": 0.95,
+          "recommendation": "Wrap JSON.parse in a try-catch block and validate the parsed output before accessing session.userId."
+        }
+      ],
+      "latencyMs": 36783
+    },
+    {
+      "verdict": "needs-attention",
+      "summary": "Authentication module contains critical SQL injection, unhandled null references, hardcoded secrets, missing error handling, and broken module imports.",
+      "findings": [
+        {
+          "severity": "critical",
+          "title": "SQL injection in findUser query",
+          "body": "The username argument is concatenated directly into the raw SQL query in findUser, allowing SQL injection. An attacker can manipulate query syntax to bypass authentication or extract sensitive data.",
+          "file": "src/auth.js",
+          "line_start": 7,
+          "line_end": 9,
+          "confidence": 1,
+          "recommendation": "Use parameterized queries or prepared statements (e.g. `db.query('SELECT * FROM users WHERE name = ?', [username])`) instead of string concatenation."
+        },
+        {
+          "severity": "high",
+          "title": "Unhandled null user in login",
+          "body": "login accesses user.password directly without verifying that findUser returned a valid user object. If a user is not found, this throws an unhandled TypeError: Cannot read properties of null/undefined.",
+          "file": "src/auth.js",
+          "line_start": 14,
+          "line_end": 18,
+          "confidence": 1,
+          "recommendation": "Check that user is non-null before accessing user.password (e.g. `if (!user || user.password !== password) return null;`) and use secure password hashing comparisons."
+        },
+        {
+          "severity": "high",
+          "title": "Hardcoded JWT secret",
+          "body": "JWT_SECRET is hardcoded in source code. If deployed, tokens can be forged by anyone with access to the codebase.",
+          "file": "src/auth.js",
+          "line_start": 4,
+          "line_end": 4,
+          "confidence": 0.95,
+          "recommendation": "Load JWT_SECRET from environment variables (e.g. `process.env.JWT_SECRET`) and fail fast if the environment variable is not defined."
+        },
+        {
+          "severity": "high",
+          "title": "Missing db module dependency and package.json manifest",
+          "body": "src/auth.js requires './db' which does not exist in the repository, and requires 'jsonwebtoken' without a package.json manifest declaring the dependency. Requiring this module will throw MODULE_NOT_FOUND at runtime.",
+          "file": "src/auth.js",
+          "line_start": 1,
+          "line_end": 2,
+          "confidence": 0.95,
+          "recommendation": "Implement the missing './db' module and add a package.json declaring required dependencies."
+        },
+        {
+          "severity": "medium",
+          "title": "Unhandled JSON parse error in parseSession",
+          "body": "parseSession calls JSON.parse(raw) without error handling and directly dereferences session.userId. Malformed JSON will throw an uncaught SyntaxError.",
+          "file": "src/auth.js",
+          "line_start": 21,
+          "line_end": 24,
+          "confidence": 0.9,
+          "recommendation": "Wrap JSON.parse in a try-catch block and validate the resulting session object before returning userId."
+        }
+      ],
+      "latencyMs": 36027
+    },
+    {
+      "verdict": "needs-attention",
+      "summary": "The authentication module contains critical security vulnerabilities including SQL injection and hardcoded secrets, as well as unhandled runtime errors and missing dependencies.",
+      "findings": [
+        {
+          "severity": "critical",
+          "title": "SQL Injection in findUser",
+          "body": "The findUser function concatenates the username argument directly into the SQL query string without parameterization or escaping. An attacker can inject arbitrary SQL commands to manipulate queries or bypass authentication.",
+          "file": "src/auth.js",
+          "line_start": 7,
+          "line_end": 9,
+          "confidence": 1,
+          "recommendation": "Use parameterized queries or prepared statements (e.g. db.query('SELECT * FROM users WHERE name = $1', [username]))."
+        },
+        {
+          "severity": "high",
+          "title": "Unchecked user lookup result causes unhandled TypeError",
+          "body": "If findUser returns null, undefined, or an empty result for a non-existent user, login accesses user.password directly, throwing an unhandled TypeError that crashes the request.",
+          "file": "src/auth.js",
+          "line_start": 14,
+          "line_end": 17,
+          "confidence": 1,
+          "recommendation": "Check that the user object exists before reading properties (e.g. if (!user || !user.password) return null;)."
+        },
+        {
+          "severity": "high",
+          "title": "Plaintext password comparison using loose equality",
+          "body": "Passwords are evaluated using loose equality (==) against plaintext values without hashing or constant-time comparison, creating serious credential exposure and timing attack risks.",
+          "file": "src/auth.js",
+          "line_start": 15,
+          "line_end": 15,
+          "confidence": 1,
+          "recommendation": "Store passwords as salted hashes and verify them using a secure hashing library such as bcrypt (e.g. await bcrypt.compare(password, user.password))."
+        },
+        {
+          "severity": "high",
+          "title": "Hardcoded JWT secret key",
+          "body": "JWT_SECRET is hardcoded in plaintext source code, exposing signing credentials and allowing unauthorized token generation if the repository is accessible.",
+          "file": "src/auth.js",
+          "line_start": 4,
+          "line_end": 4,
+          "confidence": 1,
+          "recommendation": "Retrieve the JWT secret from environment variables (e.g. process.env.JWT_SECRET) or a secret manager."
+        },
+        {
+          "severity": "high",
+          "title": "Missing local database module dependency",
+          "body": "src/auth.js requires './db', but no corresponding db module or file exists in the repository, causing a runtime MODULE_NOT_FOUND error on load.",
+          "file": "src/auth.js",
+          "line_start": 2,
+          "line_end": 2,
+          "confidence": 0.95,
+          "recommendation": "Provide the database module at src/db.js or update the import path to the correct module."
+        },
+        {
+          "severity": "medium",
+          "title": "Uncaught JSON.parse exception in parseSession",
+          "body": "parseSession executes JSON.parse on raw input without error handling, throwing an unhandled SyntaxError whenever malformed or invalid JSON is passed.",
+          "file": "src/auth.js",
+          "line_start": 21,
+          "line_end": 24,
+          "confidence": 0.95,
+          "recommendation": "Wrap JSON.parse in a try-catch block and return null or handle errors gracefully on invalid input."
+        }
+      ],
+      "latencyMs": 40058
+    }
+  ],
+  "raw": "{\n  \"review\": \"Review\",\n  \"target\": {\n    \"mode\": \"working-tree\",\n    \"label\": \"working tree diff\",\n    \"explicit\": true\n  },\n  \"gemini\": {\n    \"status\": 0,\n    \"stdout\": \"{\\n  \\\"verdict\\\": \\\"needs-attention\\\",\\n  \\\"summary\\\": \\\"The authentication module contains critical security vulnerabilities including SQL injection and hardcoded secrets, as well as unhandled runtime errors and missing dependencies.\\\",\\n  \\\"findings\\\": [\\n    {\\n      \\\"severity\\\": \\\"critical\\\",\\n      \\\"title\\\": \\\"SQL Injection in findUser\\\",\\n      \\\"body\\\": \\\"The findUser function concatenates the username argument directly into the SQL query string without parameterization or escaping. An attacker can inject arbitrary SQL commands to manipulate queries or bypass authentication.\\\",\\n      \\\"file\\\": \\\"src/auth.js\\\",\\n      \\\"line_start\\\": 7,\\n      \\\"line_end\\\": 9,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Use parameterized queries or prepared statements (e.g. db.query('SELECT * FROM users WHERE name = $1', [username])).\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"high\\\",\\n      \\\"title\\\": \\\"Unchecked user lookup result causes unhandled TypeError\\\",\\n      \\\"body\\\": \\\"If findUser returns null, undefined, or an empty result for a non-existent user, login accesses user.password directly, throwing an unhandled TypeError that crashes the request.\\\",\\n      \\\"file\\\": \\\"src/auth.js\\\",\\n      \\\"line_start\\\": 14,\\n      \\\"line_end\\\": 17,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Check that the user object exists before reading properties (e.g. if (!user || !user.password) return null;).\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"high\\\",\\n      \\\"title\\\": \\\"Plaintext password comparison using loose equality\\\",\\n      \\\"body\\\": \\\"Passwords are evaluated using loose equality (==) against plaintext values without hashing or constant-time comparison, creating serious credential exposure and timing attack risks.\\\",\\n      \\\"file\\\": \\\"src/auth.js\\\",\\n      \\\"line_start\\\": 15,\\n      \\\"line_end\\\": 15,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Store passwords as salted hashes and verify them using a secure hashing library such as bcrypt (e.g. await bcrypt.compare(password, user.password)).\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"high\\\",\\n      \\\"title\\\": \\\"Hardcoded JWT secret key\\\",\\n      \\\"body\\\": \\\"JWT_SECRET is hardcoded in plaintext source code, exposing signing credentials and allowing unauthorized token generation if the repository is accessible.\\\",\\n      \\\"file\\\": \\\"src/auth.js\\\",\\n      \\\"line_start\\\": 4,\\n      \\\"line_end\\\": 4,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Retrieve the JWT secret from environment variables (e.g. process.env.JWT_SECRET) or a secret manager.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"high\\\",\\n      \\\"title\\\": \\\"Missing local database module dependency\\\",\\n      \\\"body\\\": \\\"src/auth.js requires './db', but no corresponding db module or file exists in the repository, causing a runtime MODULE_NOT_FOUND error on load.\\\",\\n      \\\"file\\\": \\\"src/auth.js\\\",\\n      \\\"line_start\\\": 2,\\n      \\\"line_end\\\": 2,\\n      \\\"confidence\\\": 0.95,\\n      \\\"recommendation\\\": \\\"Provide the database module at src/db.js or update the import path to the correct module.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"medium\\\",\\n      \\\"title\\\": \\\"Uncaught JSON.parse exception in parseSession\\\",\\n      \\\"body\\\": \\\"parseSession executes JSON.parse on raw input without error handling, throwing an unhandled SyntaxError whenever malformed or invalid JSON is passed.\\\",\\n      \\\"file\\\": \\\"src/auth.js\\\",\\n      \\\"line_start\\\": 21,\\n      \\\"line_end\\\": 24,\\n      \\\"confidence\\\": 0.95,\\n      \\\"recommendation\\\": \\\"Wrap JSON.parse in a try-catch block and return null or handle errors gracefully on invalid input.\\\"\\n    }\\n  ],\\n  \\\"next_steps\\\": [\\n    \\\"Refactor findUser to use parameterized SQL queries.\\\",\\n    \\\"Add null checks on the user lookup in login and adopt cryptographic password hashing.\\\",\\n    \\\"Move JWT_SECRET t"
 }

--- a/bench/cassettes/auth-basic/agy.model.json
+++ b/bench/cassettes/auth-basic/agy.model.json
@@ -1,52 +1,205 @@
 {
   "caseId": "auth-basic",
   "cell": "agy.model",
-  "recordedAt": "2026-08-19T02:15:01.570Z",
+  "recordedAt": "2026-08-19T03:14:53.863Z",
   "verdict": "needs-attention",
-  "summary": "The authentication module contains critical security vulnerabilities including SQL injection, hardcoded secrets, unsafe password validation, and missing error handling.",
+  "summary": "The authentication module contains critical vulnerabilities including SQL injection, hardcoded secrets, plaintext password comparison, and missing null/exception handling.",
   "findings": [
     {
       "severity": "critical",
-      "title": "SQL injection vulnerability via concatenated query",
-      "body": "The username input is directly concatenated into the SQL query string in findUser without sanitization or parameterization, allowing an attacker to bypass authentication or extract/modify database contents.",
+      "title": "SQL Injection in findUser",
+      "body": "User input is directly concatenated into the SQL query string in findUser, allowing arbitrary SQL execution and authentication bypass.",
       "file": "src/auth.js",
       "line_start": 7,
       "line_end": 9,
       "confidence": 1,
-      "recommendation": "Use parameterized queries or prepared statements (e.g., db.query('SELECT * FROM users WHERE name = ?', [username]))."
+      "recommendation": "Use parameterized queries or prepared statements (e.g. db.query('SELECT * FROM users WHERE name = $1', [username])) instead of string concatenation."
     },
     {
       "severity": "critical",
-      "title": "Hardcoded JWT secret key",
-      "body": "A static secret key is committed directly in the source file, which exposes token signing keys and enables attackers to forge valid authentication tokens.",
-      "file": "src/auth.js",
-      "line_start": 4,
-      "line_end": 4,
-      "confidence": 1,
-      "recommendation": "Load the JWT secret from an environment variable (e.g., process.env.JWT_SECRET) and ensure a fallback error if not configured."
-    },
-    {
-      "severity": "high",
-      "title": "Unchecked null dereference and plaintext password comparison in login",
-      "body": "If findUser returns null or undefined for nonexistent users, accessing user.password throws an unhandled TypeError. Furthermore, passwords are treated as plaintext using loose equality instead of a secure cryptographic hash comparison.",
+      "title": "Plaintext Password Comparison and Potential Null Dereference",
+      "body": "Passwords are verified via loose equality against unhashed values without constant-time comparison. Additionally, if findUser returns null or undefined for non-existent users, accessing user.password will throw an unhandled TypeError.",
       "file": "src/auth.js",
       "line_start": 14,
       "line_end": 17,
       "confidence": 1,
-      "recommendation": "Verify that user exists before accessing properties (if (!user) return null;) and compare hashed passwords using a timing-safe hash library such as bcrypt or argon2."
+      "recommendation": "Check if user exists before accessing properties, store password hashes using a secure algorithm such as argon2 or bcrypt, and verify using timing-safe comparison functions."
+    },
+    {
+      "severity": "high",
+      "title": "Hardcoded JWT Secret",
+      "body": "The JWT signing secret is hardcoded in source code, exposing cryptographic keys if the repository is shared or accessed.",
+      "file": "src/auth.js",
+      "line_start": 4,
+      "line_end": 4,
+      "confidence": 1,
+      "recommendation": "Load the JWT secret from environment variables or a secure key management system (e.g. process.env.JWT_SECRET)."
     },
     {
       "severity": "medium",
-      "title": "Unhandled JSON parsing failure in parseSession",
-      "body": "Calling JSON.parse(raw) without error handling will throw an uncaught SyntaxError on malformed session input, potentially crashing the application process.",
+      "title": "Unhandled JSON.parse Exception in parseSession",
+      "body": "Calling JSON.parse directly on raw input without error handling will crash the execution context if invalid JSON is provided.",
       "file": "src/auth.js",
       "line_start": 21,
       "line_end": 24,
       "confidence": 0.95,
-      "recommendation": "Wrap JSON.parse in a try-catch block and validate the parsed object before accessing session.userId."
+      "recommendation": "Wrap JSON.parse in a try-catch block to handle malformed input gracefully and validate session object structure."
     }
   ],
-  "latencyMs": 26738,
+  "latencyMs": 33833,
   "engineVersion": "1.1.14",
-  "raw": "{\"conversation_id\":\"ee616018-1386-44d3-9d70-6b8546ddaa1e\",\"status\":\"SUCCESS\",\"response\":\"{\\n  \\\"verdict\\\": \\\"needs-attention\\\",\\n  \\\"summary\\\": \\\"The authentication module contains critical security vulnerabilities including SQL injection, hardcoded secrets, unsafe password validation, and missing error handling.\\\",\\n  \\\"findings\\\": [\\n    {\\n      \\\"severity\\\": \\\"critical\\\",\\n      \\\"title\\\": \\\"SQL injection vulnerability via concatenated query\\\",\\n      \\\"body\\\": \\\"The username input is directly concatenated into the SQL query string in findUser without sanitization or parameterization, allowing an attacker to bypass authentication or extract/modify database contents.\\\",\\n      \\\"file\\\": \\\"src/auth.js\\\",\\n      \\\"line_start\\\": 7,\\n      \\\"line_end\\\": 9,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Use parameterized queries or prepared statements (e.g., db.query('SELECT * FROM users WHERE name = ?', [username])).\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"critical\\\",\\n      \\\"title\\\": \\\"Hardcoded JWT secret key\\\",\\n      \\\"body\\\": \\\"A static secret key is committed directly in the source file, which exposes token signing keys and enables attackers to forge valid authentication tokens.\\\",\\n      \\\"file\\\": \\\"src/auth.js\\\",\\n      \\\"line_start\\\": 4,\\n      \\\"line_end\\\": 4,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Load the JWT secret from an environment variable (e.g., process.env.JWT_SECRET) and ensure a fallback error if not configured.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"high\\\",\\n      \\\"title\\\": \\\"Unchecked null dereference and plaintext password comparison in login\\\",\\n      \\\"body\\\": \\\"If findUser returns null or undefined for nonexistent users, accessing user.password throws an unhandled TypeError. Furthermore, passwords are treated as plaintext using loose equality instead of a secure cryptographic hash comparison.\\\",\\n      \\\"file\\\": \\\"src/auth.js\\\",\\n      \\\"line_start\\\": 14,\\n      \\\"line_end\\\": 17,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Verify that user exists before accessing properties (if (!user) return null;) and compare hashed passwords using a timing-safe hash library such as bcrypt or argon2.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"medium\\\",\\n      \\\"title\\\": \\\"Unhandled JSON parsing failure in parseSession\\\",\\n      \\\"body\\\": \\\"Calling JSON.parse(raw) without error handling will throw an uncaught SyntaxError on malformed session input, potentially crashing the application process.\\\",\\n      \\\"file\\\": \\\"src/auth.js\\\",\\n      \\\"line_start\\\": 21,\\n      \\\"line_end\\\": 24,\\n      \\\"confidence\\\": 0.95,\\n      \\\"recommendation\\\": \\\"Wrap JSON.parse in a try-catch block and validate the parsed object before accessing session.userId.\\\"\\n    }\\n  ],\\n  \\\"next_steps\\\": [\\n    \\\"Refactor db.query to use parameterized queries across the database layer.\\\",\\n    \\\"Move JWT_SECRET to environment configuration and validate presence at startup.\\\",\\n    \\\"Implement password hashing with bcrypt/argon2 and add null checks for user queries.\\\",\\n    \\\"Add try-catch error handling to parseSession.\\\"\\n  ]\\n}\\n\",\"duration_seconds\":22.1291657,\"num_turns\":1,\"usage\":{\"input_tokens\":19012,\"output_tokens\":2433,\"thinking_tokens\":1756,\"cache_read_tokens\":0,\"total_tokens\":21445}}\n"
+  "samples": [
+    {
+      "verdict": "needs-attention",
+      "summary": "The authentication module introduces critical SQL injection, hardcoded secrets, and unhandled null and parsing exceptions.",
+      "findings": [
+        {
+          "severity": "critical",
+          "title": "SQL Injection in findUser query",
+          "body": "The findUser function concatenates the untrusted username parameter directly into the SQL query string, allowing arbitrary SQL injection and database compromise.",
+          "file": "src/auth.js",
+          "line_start": 7,
+          "line_end": 9,
+          "confidence": 1,
+          "recommendation": "Use parameterized queries or prepared statements (e.g., db.query('SELECT * FROM users WHERE name = ?', [username]))."
+        },
+        {
+          "severity": "high",
+          "title": "Unchecked user lookup result causes unhandled TypeError",
+          "body": "If findUser returns null or undefined for nonexistent users, accessing user.password will throw an unhandled TypeError and crash the authentication flow.",
+          "file": "src/auth.js",
+          "line_start": 14,
+          "line_end": 17,
+          "confidence": 0.95,
+          "recommendation": "Check if user exists and verify password using a secure hash comparison (e.g., if (user && await bcrypt.compare(password, user.passwordHash)))."
+        },
+        {
+          "severity": "high",
+          "title": "Hardcoded JWT secret key",
+          "body": "JWT_SECRET is hardcoded in source control, allowing anyone with repository access to forge valid JWT authentication tokens.",
+          "file": "src/auth.js",
+          "line_start": 4,
+          "line_end": 4,
+          "confidence": 1,
+          "recommendation": "Retrieve the JWT secret from environment variables or a secrets manager (e.g., process.env.JWT_SECRET) and ensure it is properly validated on startup."
+        },
+        {
+          "severity": "medium",
+          "title": "Unhandled JSON.parse exception in parseSession",
+          "body": "Calling JSON.parse directly on untrusted raw input without a try/catch block will throw a SyntaxError on malformed input.",
+          "file": "src/auth.js",
+          "line_start": 21,
+          "line_end": 24,
+          "confidence": 0.9,
+          "recommendation": "Wrap JSON.parse in a try/catch block or helper to safely handle malformed input and return null or an error."
+        }
+      ],
+      "latencyMs": 34168
+    },
+    {
+      "verdict": "needs-attention",
+      "summary": "Critical security vulnerabilities including SQL injection and hardcoded secrets, alongside missing error and null checks, require remediation.",
+      "findings": [
+        {
+          "severity": "critical",
+          "title": "SQL Injection via Unsanitized Concatenation",
+          "body": "The username parameter is concatenated directly into the SQL query in findUser, enabling arbitrary SQL injection that can lead to authentication bypass or data leakage.",
+          "file": "src/auth.js",
+          "line_start": 7,
+          "line_end": 9,
+          "confidence": 1,
+          "recommendation": "Use parameterized queries (e.g. `db.query('SELECT * FROM users WHERE name = ?', [username])`)."
+        },
+        {
+          "severity": "high",
+          "title": "Unchecked User Existence Before Password Access",
+          "body": "If findUser returns null or undefined for an unknown username, accessing user.password will throw an unhandled TypeError and crash the request.",
+          "file": "src/auth.js",
+          "line_start": 14,
+          "line_end": 15,
+          "confidence": 1,
+          "recommendation": "Verify that user exists before inspecting properties (e.g., `if (user && user.password ...)`)."
+        },
+        {
+          "severity": "high",
+          "title": "Plaintext Password Comparison and Loose Equality",
+          "body": "Passwords are evaluated in plaintext using loose equality (`==`) rather than a secure, constant-time password hashing and verification function (e.g. bcrypt/argon2).",
+          "file": "src/auth.js",
+          "line_start": 15,
+          "line_end": 15,
+          "confidence": 0.95,
+          "recommendation": "Store and verify password hashes using an algorithm like bcrypt or argon2."
+        },
+        {
+          "severity": "medium",
+          "title": "Hardcoded JWT Secret",
+          "body": "JWT_SECRET is hardcoded in the source file, which exposes the signing key and prevents environment-specific rotation.",
+          "file": "src/auth.js",
+          "line_start": 4,
+          "line_end": 4,
+          "confidence": 1,
+          "recommendation": "Load the JWT secret from environment variables (e.g. `process.env.JWT_SECRET`)."
+        },
+        {
+          "severity": "low",
+          "title": "Unhandled SyntaxError in JSON Parsing",
+          "body": "parseSession calls JSON.parse on raw input without error handling, which throws an unhandled SyntaxError if invalid JSON is provided.",
+          "file": "src/auth.js",
+          "line_start": 21,
+          "line_end": 24,
+          "confidence": 0.95,
+          "recommendation": "Wrap JSON.parse in a try/catch block and handle invalid input gracefully."
+        }
+      ],
+      "latencyMs": 29552
+    },
+    {
+      "verdict": "needs-attention",
+      "summary": "The authentication module contains critical vulnerabilities including SQL injection, hardcoded secrets, plaintext password comparison, and missing null/exception handling.",
+      "findings": [
+        {
+          "severity": "critical",
+          "title": "SQL Injection in findUser",
+          "body": "User input is directly concatenated into the SQL query string in findUser, allowing arbitrary SQL execution and authentication bypass.",
+          "file": "src/auth.js",
+          "line_start": 7,
+          "line_end": 9,
+          "confidence": 1,
+          "recommendation": "Use parameterized queries or prepared statements (e.g. db.query('SELECT * FROM users WHERE name = $1', [username])) instead of string concatenation."
+        },
+        {
+          "severity": "critical",
+          "title": "Plaintext Password Comparison and Potential Null Dereference",
+          "body": "Passwords are verified via loose equality against unhashed values without constant-time comparison. Additionally, if findUser returns null or undefined for non-existent users, accessing user.password will throw an unhandled TypeError.",
+          "file": "src/auth.js",
+          "line_start": 14,
+          "line_end": 17,
+          "confidence": 1,
+          "recommendation": "Check if user exists before accessing properties, store password hashes using a secure algorithm such as argon2 or bcrypt, and verify using timing-safe comparison functions."
+        },
+        {
+          "severity": "high",
+          "title": "Hardcoded JWT Secret",
+          "body": "The JWT signing secret is hardcoded in source code, exposing cryptographic keys if the repository is shared or accessed.",
+          "file": "src/auth.js",
+          "line_start": 4,
+          "line_end": 4,
+          "confidence": 1,
+          "recommendation": "Load the JWT secret from environment variables or a secure key management system (e.g. process.env.JWT_SECRET)."
+        },
+        {
+          "severity": "medium",
+          "title": "Unhandled JSON.parse Exception in parseSession",
+          "body": "Calling JSON.parse directly on raw input without error handling will crash the execution context if invalid JSON is provided.",
+          "file": "src/auth.js",
+          "line_start": 21,
+          "line_end": 24,
+          "confidence": 0.95,
+          "recommendation": "Wrap JSON.parse in a try-catch block to handle malformed input gracefully and validate session object structure."
+        }
+      ],
+      "latencyMs": 33833
+    }
+  ],
+  "raw": "{\"conversation_id\":\"f6ac8215-8ead-4b49-8944-a0309a598137\",\"status\":\"SUCCESS\",\"response\":\"{\\n  \\\"verdict\\\": \\\"needs-attention\\\",\\n  \\\"summary\\\": \\\"The authentication module contains critical vulnerabilities including SQL injection, hardcoded secrets, plaintext password comparison, and missing null/exception handling.\\\",\\n  \\\"findings\\\": [\\n    {\\n      \\\"severity\\\": \\\"critical\\\",\\n      \\\"title\\\": \\\"SQL Injection in findUser\\\",\\n      \\\"body\\\": \\\"User input is directly concatenated into the SQL query string in findUser, allowing arbitrary SQL execution and authentication bypass.\\\",\\n      \\\"file\\\": \\\"src/auth.js\\\",\\n      \\\"line_start\\\": 7,\\n      \\\"line_end\\\": 9,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Use parameterized queries or prepared statements (e.g. db.query('SELECT * FROM users WHERE name = $1', [username])) instead of string concatenation.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"critical\\\",\\n      \\\"title\\\": \\\"Plaintext Password Comparison and Potential Null Dereference\\\",\\n      \\\"body\\\": \\\"Passwords are verified via loose equality against unhashed values without constant-time comparison. Additionally, if findUser returns null or undefined for non-existent users, accessing user.password will throw an unhandled TypeError.\\\",\\n      \\\"file\\\": \\\"src/auth.js\\\",\\n      \\\"line_start\\\": 14,\\n      \\\"line_end\\\": 17,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Check if user exists before accessing properties, store password hashes using a secure algorithm such as argon2 or bcrypt, and verify using timing-safe comparison functions.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"high\\\",\\n      \\\"title\\\": \\\"Hardcoded JWT Secret\\\",\\n      \\\"body\\\": \\\"The JWT signing secret is hardcoded in source code, exposing cryptographic keys if the repository is shared or accessed.\\\",\\n      \\\"file\\\": \\\"src/auth.js\\\",\\n      \\\"line_start\\\": 4,\\n      \\\"line_end\\\": 4,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Load the JWT secret from environment variables or a secure key management system (e.g. process.env.JWT_SECRET).\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"medium\\\",\\n      \\\"title\\\": \\\"Unhandled JSON.parse Exception in parseSession\\\",\\n      \\\"body\\\": \\\"Calling JSON.parse directly on raw input without error handling will crash the execution context if invalid JSON is provided.\\\",\\n      \\\"file\\\": \\\"src/auth.js\\\",\\n      \\\"line_start\\\": 21,\\n      \\\"line_end\\\": 24,\\n      \\\"confidence\\\": 0.95,\\n      \\\"recommendation\\\": \\\"Wrap JSON.parse in a try-catch block to handle malformed input gracefully and validate session object structure.\\\"\\n    }\\n  ],\\n  \\\"next_steps\\\": [\\n    \\\"Refactor db.query calls to use parameterized queries.\\\",\\n    \\\"Implement password hashing and timing-safe verification.\\\",\\n    \\\"Extract secrets to environment configuration.\\\",\\n    \\\"Add error handling and null-checks to parseSession and login functions.\\\"\\n  ]\\n}\\n\",\"duration_seconds\":29.3649742,\"num_turns\":1,\"usage\":{\"input_tokens\":3523,\"output_tokens\":1995,\"thinking_tokens\":1375,\"cache_read_tokens\":15489,\"total_tokens\":5518}}\n"
 }

--- a/bench/cassettes/auth-basic/codex.model.json
+++ b/bench/cassettes/auth-basic/codex.model.json
@@ -1,41 +1,225 @@
 {
   "caseId": "auth-basic",
   "cell": "codex.model",
-  "recordedAt": "2026-06-04T14:08:20.842Z",
+  "recordedAt": "2026-08-19T03:13:16.223Z",
   "verdict": "needs-attention",
-  "summary": "Authentication code introduces exploitable SQL injection and unsafe secret handling.",
+  "summary": "Authentication is vulnerable to SQL injection, credential compromise, and forged or indefinitely reusable tokens.",
   "findings": [
     {
       "severity": "critical",
       "title": "SQL injection in user lookup",
-      "body": "findUser builds the SQL statement by concatenating username directly into the WHERE clause, so crafted input can alter the query and bypass or exfiltrate user data.",
+      "body": "The username is concatenated directly into the SQL query, allowing attacker-controlled input to alter the statement and potentially bypass authentication or access/modify database data.",
       "file": "src/auth.js",
       "line_start": 6,
       "line_end": 8,
-      "confidence": 0.98,
-      "recommendation": "Use a parameterized query or the project's query builder, e.g. pass username as a bound parameter instead of interpolating it."
+      "confidence": 1,
+      "recommendation": "Use a parameterized query or prepared statement and pass username as a bound parameter."
     },
     {
       "severity": "high",
-      "title": "JWT signing secret is hardcoded",
-      "body": "JWT_SECRET is committed as a literal string, so every deployment using this code shares a known signing key; anyone with source access can forge valid tokens.",
+      "title": "Hardcoded JWT signing secret",
+      "body": "The signing key is embedded in source code, so anyone with source or artifact access can forge valid authentication tokens; rotating the compromised key also requires a code change and redeployment.",
       "file": "src/auth.js",
       "line_start": 4,
       "line_end": 4,
-      "confidence": 0.96,
-      "recommendation": "Load the signing secret from a secure environment/config secret and fail startup if it is missing or too weak."
+      "confidence": 1,
+      "recommendation": "Load a high-entropy signing key from a secret manager or protected environment variable, fail startup when it is absent, and rotate the exposed key."
+    },
+    {
+      "severity": "high",
+      "title": "Passwords are compared directly",
+      "body": "The submitted password is compared directly with the stored value, indicating plaintext or equivalently reusable password storage instead of a slow password-hash verification flow; a database disclosure would expose user credentials.",
+      "file": "src/auth.js",
+      "line_start": 11,
+      "line_end": 14,
+      "confidence": 0.98,
+      "recommendation": "Store passwords using Argon2id, bcrypt, or scrypt with per-password salts and verify them using the library's comparison function."
     },
     {
       "severity": "medium",
-      "title": "Missing user existence handling",
-      "body": "login dereferences user.password without checking whether findUser returned a user, causing an exception for unknown usernames instead of a controlled authentication failure.",
+      "title": "JWTs never expire",
+      "body": "Tokens are signed without an expiration claim, so a stolen token remains valid indefinitely unless all tokens are invalidated through signing-key rotation.",
       "file": "src/auth.js",
-      "line_start": 12,
-      "line_end": 16,
-      "confidence": 0.9,
-      "recommendation": "Return null when no user is found before reading password, and keep error behavior consistent for invalid credentials."
+      "line_start": 15,
+      "line_end": 15,
+      "confidence": 0.99,
+      "recommendation": "Set a short explicit expiresIn value and implement refresh-token rotation or another bounded session-renewal mechanism."
+    },
+    {
+      "severity": "medium",
+      "title": "Malformed session input throws uncaught exception",
+      "body": "parseSession calls JSON.parse without handling malformed input or validating the decoded shape, so attacker-controlled invalid JSON can propagate an exception through request processing and potentially cause repeated request failures.",
+      "file": "src/auth.js",
+      "line_start": 20,
+      "line_end": 23,
+      "confidence": 0.96,
+      "recommendation": "Catch JSON parsing failures, validate that the result is an object with an acceptable userId, and return or throw a controlled authentication error."
     }
   ],
-  "latencyMs": 32382,
-  "raw": "{\"verdict\":\"needs-attention\",\"summary\":\"Authentication code introduces exploitable SQL injection and unsafe secret handling.\",\"findings\":[{\"severity\":\"critical\",\"title\":\"SQL injection in user lookup\",\"body\":\"findUser builds the SQL statement by concatenating username directly into the WHERE clause, so crafted input can alter the query and bypass or exfiltrate user data.\",\"file\":\"src/auth.js\",\"line_start\":6,\"line_end\":8,\"confidence\":0.98,\"recommendation\":\"Use a parameterized query or the project's query builder, e.g. pass username as a bound parameter instead of interpolating it.\"},{\"severity\":\"high\",\"title\":\"JWT signing secret is hardcoded\",\"body\":\"JWT_SECRET is committed as a literal string, so every deployment using this code shares a known signing key; anyone with source access can forge valid tokens.\",\"file\":\"src/auth.js\",\"line_start\":4,\"line_end\":4,\"confidence\":0.96,\"recommendation\":\"Load the signing secret from a secure environment/config secret and fail startup if it is missing or too weak.\"},{\"severity\":\"medium\",\"title\":\"Missing user existence handling\",\"body\":\"login dereferences user.password without checking whether findUser returned a user, causing an exception for unknown usernames instead of a controlled authentication failure.\",\"file\":\"src/auth.js\",\"line_start\":12,\"line_end\":16,\"confidence\":0.9,\"recommendation\":\"Return null when no user is found before reading password, and keep error behavior consistent for invalid credentials.\"}],\"next_steps\":[\"Parameterize the database lookup.\",\"Move JWT_SECRET to managed secret configuration.\",\"Handle missing users before password checks.\"]}\n"
+  "latencyMs": 20209,
+  "engineVersion": "codex-cli 0.147.0",
+  "samples": [
+    {
+      "verdict": "needs-attention",
+      "summary": "Authentication is vulnerable to SQL injection, credential compromise, token forgery, and malformed-input crashes.",
+      "findings": [
+        {
+          "severity": "critical",
+          "title": "SQL injection in user lookup",
+          "body": "The username is concatenated directly into the SQL statement, allowing attacker-controlled input to alter the query and potentially bypass authentication or access database data.",
+          "file": "src/auth.js",
+          "line_start": 6,
+          "line_end": 8,
+          "confidence": 1,
+          "recommendation": "Use a parameterized query with the username supplied as a bound parameter."
+        },
+        {
+          "severity": "critical",
+          "title": "Hardcoded JWT signing secret",
+          "body": "The signing key is embedded in source code, so anyone who obtains the code can forge valid authentication tokens; the same key is also likely to be reused across deployments.",
+          "file": "src/auth.js",
+          "line_start": 4,
+          "line_end": 4,
+          "confidence": 1,
+          "recommendation": "Load a strong, deployment-specific secret from a protected secret store or environment variable, fail startup if absent, and rotate the exposed key."
+        },
+        {
+          "severity": "high",
+          "title": "Passwords compared as plaintext",
+          "body": "The supplied password is compared directly with the stored value, implying plaintext or reversibly stored credentials and exposing all accounts if the database is compromised.",
+          "file": "src/auth.js",
+          "line_start": 12,
+          "line_end": 16,
+          "confidence": 0.98,
+          "recommendation": "Store passwords using a password-hashing algorithm such as Argon2id or bcrypt and verify them with the library's constant-time comparison function."
+        },
+        {
+          "severity": "medium",
+          "title": "Unknown users can crash login",
+          "body": "The code dereferences user.password without checking whether findUser returned a user, so an unknown username can cause an exception instead of a controlled authentication failure.",
+          "file": "src/auth.js",
+          "line_start": 13,
+          "line_end": 14,
+          "confidence": 0.94,
+          "recommendation": "Validate that exactly one user was returned before accessing its fields and return a uniform authentication failure otherwise."
+        },
+        {
+          "severity": "medium",
+          "title": "Malformed session input throws uncaught exception",
+          "body": "JSON.parse is called on untrusted raw input without error handling or schema validation, so malformed JSON can propagate an exception and potentially terminate or disrupt the request path.",
+          "file": "src/auth.js",
+          "line_start": 20,
+          "line_end": 23,
+          "confidence": 0.97,
+          "recommendation": "Catch parse failures, reject non-object payloads, and validate userId before returning it."
+        }
+      ],
+      "latencyMs": 19094
+    },
+    {
+      "verdict": "needs-attention",
+      "summary": "Authentication is vulnerable to SQL injection, credential exposure, and JWT forgery.",
+      "findings": [
+        {
+          "severity": "critical",
+          "title": "Username enables SQL injection",
+          "body": "findUser concatenates attacker-controlled username directly into the SQL statement, allowing authentication bypass, data disclosure, or database modification depending on driver and account permissions.",
+          "file": "src/auth.js",
+          "line_start": 7,
+          "line_end": 9,
+          "confidence": 1,
+          "recommendation": "Use a parameterized query with a bound username value."
+        },
+        {
+          "severity": "high",
+          "title": "JWT signing secret is hardcoded",
+          "body": "The signing key is committed in source, so anyone who obtains the code can forge valid authentication tokens for arbitrary user IDs.",
+          "file": "src/auth.js",
+          "line_start": 4,
+          "line_end": 4,
+          "confidence": 1,
+          "recommendation": "Load a high-entropy secret from protected runtime configuration, fail startup if absent, and rotate the exposed key."
+        },
+        {
+          "severity": "high",
+          "title": "Passwords are compared as plaintext",
+          "body": "login directly compares the submitted password with the stored value, implying plaintext or equivalently reversible credential storage and exposing every account if the database is compromised.",
+          "file": "src/auth.js",
+          "line_start": 14,
+          "line_end": 16,
+          "confidence": 0.99,
+          "recommendation": "Store salted password hashes using a password-specific algorithm such as Argon2id or bcrypt and verify them with the library's constant-time verification function."
+        },
+        {
+          "severity": "medium",
+          "title": "Issued tokens never expire",
+          "body": "jwt.sign is called without an expiration, so stolen tokens remain usable indefinitely unless the signing key is rotated.",
+          "file": "src/auth.js",
+          "line_start": 17,
+          "line_end": 17,
+          "confidence": 0.98,
+          "recommendation": "Set a short explicit expiresIn value and implement an appropriate refresh or revocation mechanism."
+        }
+      ],
+      "latencyMs": 18171
+    },
+    {
+      "verdict": "needs-attention",
+      "summary": "Authentication is vulnerable to SQL injection, credential compromise, and forged or indefinitely reusable tokens.",
+      "findings": [
+        {
+          "severity": "critical",
+          "title": "SQL injection in user lookup",
+          "body": "The username is concatenated directly into the SQL query, allowing attacker-controlled input to alter the statement and potentially bypass authentication or access/modify database data.",
+          "file": "src/auth.js",
+          "line_start": 6,
+          "line_end": 8,
+          "confidence": 1,
+          "recommendation": "Use a parameterized query or prepared statement and pass username as a bound parameter."
+        },
+        {
+          "severity": "high",
+          "title": "Hardcoded JWT signing secret",
+          "body": "The signing key is embedded in source code, so anyone with source or artifact access can forge valid authentication tokens; rotating the compromised key also requires a code change and redeployment.",
+          "file": "src/auth.js",
+          "line_start": 4,
+          "line_end": 4,
+          "confidence": 1,
+          "recommendation": "Load a high-entropy signing key from a secret manager or protected environment variable, fail startup when it is absent, and rotate the exposed key."
+        },
+        {
+          "severity": "high",
+          "title": "Passwords are compared directly",
+          "body": "The submitted password is compared directly with the stored value, indicating plaintext or equivalently reusable password storage instead of a slow password-hash verification flow; a database disclosure would expose user credentials.",
+          "file": "src/auth.js",
+          "line_start": 11,
+          "line_end": 14,
+          "confidence": 0.98,
+          "recommendation": "Store passwords using Argon2id, bcrypt, or scrypt with per-password salts and verify them using the library's comparison function."
+        },
+        {
+          "severity": "medium",
+          "title": "JWTs never expire",
+          "body": "Tokens are signed without an expiration claim, so a stolen token remains valid indefinitely unless all tokens are invalidated through signing-key rotation.",
+          "file": "src/auth.js",
+          "line_start": 15,
+          "line_end": 15,
+          "confidence": 0.99,
+          "recommendation": "Set a short explicit expiresIn value and implement refresh-token rotation or another bounded session-renewal mechanism."
+        },
+        {
+          "severity": "medium",
+          "title": "Malformed session input throws uncaught exception",
+          "body": "parseSession calls JSON.parse without handling malformed input or validating the decoded shape, so attacker-controlled invalid JSON can propagate an exception through request processing and potentially cause repeated request failures.",
+          "file": "src/auth.js",
+          "line_start": 20,
+          "line_end": 23,
+          "confidence": 0.96,
+          "recommendation": "Catch JSON parsing failures, validate that the result is an object with an acceptable userId, and return or throw a controlled authentication error."
+        }
+      ],
+      "latencyMs": 20209
+    }
+  ],
+  "raw": "{\"verdict\":\"needs-attention\",\"summary\":\"Authentication is vulnerable to SQL injection, credential compromise, and forged or indefinitely reusable tokens.\",\"findings\":[{\"severity\":\"critical\",\"title\":\"SQL injection in user lookup\",\"body\":\"The username is concatenated directly into the SQL query, allowing attacker-controlled input to alter the statement and potentially bypass authentication or access/modify database data.\",\"file\":\"src/auth.js\",\"line_start\":6,\"line_end\":8,\"confidence\":1.0,\"recommendation\":\"Use a parameterized query or prepared statement and pass username as a bound parameter.\"},{\"severity\":\"high\",\"title\":\"Hardcoded JWT signing secret\",\"body\":\"The signing key is embedded in source code, so anyone with source or artifact access can forge valid authentication tokens; rotating the compromised key also requires a code change and redeployment.\",\"file\":\"src/auth.js\",\"line_start\":4,\"line_end\":4,\"confidence\":1.0,\"recommendation\":\"Load a high-entropy signing key from a secret manager or protected environment variable, fail startup when it is absent, and rotate the exposed key.\"},{\"severity\":\"high\",\"title\":\"Passwords are compared directly\",\"body\":\"The submitted password is compared directly with the stored value, indicating plaintext or equivalently reusable password storage instead of a slow password-hash verification flow; a database disclosure would expose user credentials.\",\"file\":\"src/auth.js\",\"line_start\":11,\"line_end\":14,\"confidence\":0.98,\"recommendation\":\"Store passwords using Argon2id, bcrypt, or scrypt with per-password salts and verify them using the library's comparison function.\"},{\"severity\":\"medium\",\"title\":\"JWTs never expire\",\"body\":\"Tokens are signed without an expiration claim, so a stolen token remains valid indefinitely unless all tokens are invalidated through signing-key rotation.\",\"file\":\"src/auth.js\",\"line_start\":15,\"line_end\":15,\"confidence\":0.99,\"recommendation\":\"Set a short explicit expiresIn value and implement refresh-token rotation or another bounded session-renewal mechanism.\"},{\"severity\":\"medium\",\"title\":\"Malformed session input throws uncaught exception\",\"body\":\"parseSession calls JSON.parse without handling malformed input or validating the decoded shape, so attacker-controlled invalid JSON can propagate an exception through request processing and potentially cause repeated request failures.\",\"file\":\"src/auth.js\",\"line_start\":20,\"line_end\":23,\"confidence\":0.96,\"recommendation\":\"Catch JSON parsing failures, validate that the result is an object with an acceptable userId, and return or throw a controlled authentication error.\"}],\"next_steps\":[\"Parameterize the database query and add SQL-injection regression tests.\",\"Replace direct password comparison with password-hash verification and migrate existing credentials safely.\",\"Move the JWT key to protected configuration, rotate it, and enforce token expiration.\",\"Validate session input and convert malformed data into a controlled authentication failure.\"]}\n"
 }

--- a/bench/cassettes/auth-basic/gemini.deep.json
+++ b/bench/cassettes/auth-basic/gemini.deep.json
@@ -1,60 +1,205 @@
 {
   "caseId": "auth-basic",
   "cell": "gemini.deep",
-  "source": "seeded illustrative (refresh with --live)",
+  "recordedAt": "2026-08-19T03:16:35.276Z",
   "verdict": "needs-attention",
-  "summary": "All five seeded defects flagged.",
-  "latencyMs": 24600,
+  "summary": "The authentication module introduces critical security vulnerabilities including SQL injection, hardcoded secrets, and unhandled null and error paths.",
   "findings": [
     {
       "severity": "critical",
-      "title": "SQL injection in findUser",
-      "body": "username concatenated into the SQL string allows injection.",
+      "title": "SQL injection in findUser via string concatenation",
+      "body": "findUser concatenates the username argument directly into the SQL query string at src/auth.js:7-9 without escaping or parameterization, allowing an attacker to execute arbitrary SQL commands and bypass authentication.",
       "file": "src/auth.js",
       "line_start": 7,
       "line_end": 9,
-      "confidence": 0.97,
-      "recommendation": "Use parameterized queries."
+      "confidence": 1,
+      "recommendation": "Use parameterized queries or prepared statements (e.g., db.query('SELECT * FROM users WHERE name = ?', [username]))."
+    },
+    {
+      "severity": "high",
+      "title": "Unhandled null user leads to TypeError in login",
+      "body": "login attempts to read user.password without checking if findUser returned a valid user record at src/auth.js:14-15. If the user does not exist (e.g., null or undefined), this throws an unhandled TypeError.",
+      "file": "src/auth.js",
+      "line_start": 14,
+      "line_end": 15,
+      "confidence": 1,
+      "recommendation": "Check if user exists before accessing properties (e.g., if (!user || user.password !== password) return null;)."
     },
     {
       "severity": "high",
       "title": "Hardcoded JWT secret",
-      "body": "JWT_SECRET is hard-coded in source.",
+      "body": "JWT_SECRET is hardcoded in source code at src/auth.js:4. Committing secrets to source control compromises signing key security and prevents secret rotation across environments.",
       "file": "src/auth.js",
       "line_start": 4,
       "line_end": 4,
-      "confidence": 0.95,
-      "recommendation": "Load from environment/secret store."
+      "confidence": 1,
+      "recommendation": "Retrieve the JWT secret from an environment variable (e.g., process.env.JWT_SECRET) or a secret manager."
     },
     {
       "severity": "medium",
-      "title": "Missing null check on user",
-      "body": "findUser may return undefined; user.password then dereferences null/undefined and throws.",
+      "title": "Uncaught exception on invalid JSON in parseSession",
+      "body": "parseSession calls JSON.parse(raw) without error handling at src/auth.js:21-24. Passing malformed JSON or null/undefined will throw an uncaught SyntaxError.",
       "file": "src/auth.js",
-      "line_start": 14,
-      "line_end": 15,
-      "confidence": 0.85,
-      "recommendation": "Guard for a missing user before accessing fields."
-    },
-    {
-      "severity": "high",
-      "title": "Plaintext password comparison",
-      "body": "Password compared with == in plaintext; hash with bcrypt and use a constant-time compare.",
-      "file": "src/auth.js",
-      "line_start": 15,
-      "line_end": 15,
-      "confidence": 0.9,
-      "recommendation": "Use hashed, constant-time comparison."
-    },
-    {
-      "severity": "high",
-      "title": "Unguarded JSON.parse",
-      "body": "JSON.parse(raw) throws on malformed input and is unguarded.",
-      "file": "src/auth.js",
-      "line_start": 22,
-      "line_end": 22,
-      "confidence": 0.88,
-      "recommendation": "Wrap in try/catch and validate."
+      "line_start": 21,
+      "line_end": 24,
+      "confidence": 0.95,
+      "recommendation": "Wrap JSON.parse in a try/catch block and handle invalid input by returning null or an explicit error."
     }
-  ]
+  ],
+  "latencyMs": 34967,
+  "engineVersion": "0.54.4",
+  "samples": [
+    {
+      "verdict": "needs-attention",
+      "summary": "Found critical SQL injection vulnerability, missing module dependency, hardcoded secret, null reference crash, and unhandled JSON parse exceptions in auth.js.",
+      "findings": [
+        {
+          "severity": "critical",
+          "title": "SQL Injection in findUser",
+          "body": "User input `username` is concatenated directly into the SQL query string in `findUser` at `src/auth.js:7-9`, allowing attackers to execute arbitrary SQL queries and bypass authentication.",
+          "file": "src/auth.js",
+          "line_start": 7,
+          "line_end": 9,
+          "confidence": 1,
+          "recommendation": "Use parameterized queries with placeholder bindings (e.g., `db.query('SELECT * FROM users WHERE name = ?', [username])`) instead of string concatenation."
+        },
+        {
+          "severity": "high",
+          "title": "Missing local database module dependency",
+          "body": "`src/auth.js:2` requires `./db`, but no `db.js` file or database module exists in the repository, which will cause a runtime `MODULE_NOT_FOUND` error upon loading.",
+          "file": "src/auth.js",
+          "line_start": 2,
+          "line_end": 2,
+          "confidence": 1,
+          "recommendation": "Implement or provide the `./db` module and define the `query` method interface."
+        },
+        {
+          "severity": "high",
+          "title": "Unhandled null user reference and plaintext password comparison in login",
+          "body": "In `login` at `src/auth.js:14-17`, `user.password` is accessed without checking if `user` exists, throwing a TypeError if the user is not found. In addition, passwords are compared directly in plaintext using loose equality rather than secure constant-time hashing.",
+          "file": "src/auth.js",
+          "line_start": 14,
+          "line_end": 17,
+          "confidence": 1,
+          "recommendation": "Verify that `user` is non-null before checking credentials, and compare password hashes using a secure hashing library such as `bcrypt.compare`."
+        },
+        {
+          "severity": "high",
+          "title": "Hardcoded JWT secret key in source code",
+          "body": "A static secret key `hardcoded-super-secret-key` is defined directly in `src/auth.js:4`, exposing signing keys in version control and preventing key rotation across environments.",
+          "file": "src/auth.js",
+          "line_start": 4,
+          "line_end": 4,
+          "confidence": 1,
+          "recommendation": "Retrieve the JWT secret from environment variables (e.g. `process.env.JWT_SECRET`) and ensure the application fails fast if it is unset."
+        },
+        {
+          "severity": "medium",
+          "title": "Uncaught JSON.parse exception in parseSession",
+          "body": "`parseSession` at `src/auth.js:21-24` calls `JSON.parse(raw)` without a try/catch block and accesses `session.userId` without verifying that `session` is an object, leading to uncaught SyntaxError or TypeError crashes on invalid input.",
+          "file": "src/auth.js",
+          "line_start": 21,
+          "line_end": 24,
+          "confidence": 0.95,
+          "recommendation": "Wrap `JSON.parse` in a try/catch block, handle parsing failures gracefully, and validate that `session` is a valid object before reading properties."
+        }
+      ],
+      "latencyMs": 34755
+    },
+    {
+      "verdict": "needs-attention",
+      "summary": "The authentication module contains critical security vulnerabilities including SQL injection, hardcoded secrets, unsafe user lookup, and unhandled parsing exceptions.",
+      "findings": [
+        {
+          "severity": "critical",
+          "title": "SQL injection in findUser",
+          "body": "The findUser function concatenates the unescaped username parameter directly into the SQL query string in src/auth.js. An attacker can supply malicious SQL payloads to bypass authentication or extract sensitive database contents.",
+          "file": "src/auth.js",
+          "line_start": 7,
+          "line_end": 9,
+          "confidence": 1,
+          "recommendation": "Use parameterized queries, such as db.query('SELECT * FROM users WHERE name = ?', [username])."
+        },
+        {
+          "severity": "high",
+          "title": "Hardcoded JWT secret key",
+          "body": "The JWT signing key is hardcoded as a static string constant. If the repository is exposed or shared, attackers can forge valid authentication tokens for any user ID.",
+          "file": "src/auth.js",
+          "line_start": 4,
+          "line_end": 4,
+          "confidence": 1,
+          "recommendation": "Retrieve the JWT secret from environment variables or a secrets manager via process.env.JWT_SECRET."
+        },
+        {
+          "severity": "high",
+          "title": "Missing null check on user lookup and plaintext password comparison",
+          "body": "In login, if findUser returns null or undefined when no user matches, accessing user.password throws an unhandled TypeError. Additionally, passwords are compared in plaintext using loose equality (==) rather than secure hashed comparison.",
+          "file": "src/auth.js",
+          "line_start": 14,
+          "line_end": 17,
+          "confidence": 0.95,
+          "recommendation": "Check that user exists before inspecting properties (e.g. if (!user) return null;) and use a secure hashing algorithm (such as bcrypt.compare) to verify passwords."
+        },
+        {
+          "severity": "medium",
+          "title": "Unhandled exception in parseSession",
+          "body": "parseSession calls JSON.parse on raw input without a try/catch block. Malformed JSON strings will throw an uncaught SyntaxError, and parsing 'null' will throw a TypeError when accessing session.userId.",
+          "file": "src/auth.js",
+          "line_start": 21,
+          "line_end": 24,
+          "confidence": 0.95,
+          "recommendation": "Wrap JSON.parse in a try/catch block, handle invalid inputs gracefully, and verify session is an object before accessing userId."
+        }
+      ],
+      "latencyMs": 29426
+    },
+    {
+      "verdict": "needs-attention",
+      "summary": "The authentication module introduces critical security vulnerabilities including SQL injection, hardcoded secrets, and unhandled null and error paths.",
+      "findings": [
+        {
+          "severity": "critical",
+          "title": "SQL injection in findUser via string concatenation",
+          "body": "findUser concatenates the username argument directly into the SQL query string at src/auth.js:7-9 without escaping or parameterization, allowing an attacker to execute arbitrary SQL commands and bypass authentication.",
+          "file": "src/auth.js",
+          "line_start": 7,
+          "line_end": 9,
+          "confidence": 1,
+          "recommendation": "Use parameterized queries or prepared statements (e.g., db.query('SELECT * FROM users WHERE name = ?', [username]))."
+        },
+        {
+          "severity": "high",
+          "title": "Unhandled null user leads to TypeError in login",
+          "body": "login attempts to read user.password without checking if findUser returned a valid user record at src/auth.js:14-15. If the user does not exist (e.g., null or undefined), this throws an unhandled TypeError.",
+          "file": "src/auth.js",
+          "line_start": 14,
+          "line_end": 15,
+          "confidence": 1,
+          "recommendation": "Check if user exists before accessing properties (e.g., if (!user || user.password !== password) return null;)."
+        },
+        {
+          "severity": "high",
+          "title": "Hardcoded JWT secret",
+          "body": "JWT_SECRET is hardcoded in source code at src/auth.js:4. Committing secrets to source control compromises signing key security and prevents secret rotation across environments.",
+          "file": "src/auth.js",
+          "line_start": 4,
+          "line_end": 4,
+          "confidence": 1,
+          "recommendation": "Retrieve the JWT secret from an environment variable (e.g., process.env.JWT_SECRET) or a secret manager."
+        },
+        {
+          "severity": "medium",
+          "title": "Uncaught exception on invalid JSON in parseSession",
+          "body": "parseSession calls JSON.parse(raw) without error handling at src/auth.js:21-24. Passing malformed JSON or null/undefined will throw an uncaught SyntaxError.",
+          "file": "src/auth.js",
+          "line_start": 21,
+          "line_end": 24,
+          "confidence": 0.95,
+          "recommendation": "Wrap JSON.parse in a try/catch block and handle invalid input by returning null or an explicit error."
+        }
+      ],
+      "latencyMs": 34967
+    }
+  ],
+  "raw": "{\n  \"review\": \"Review\",\n  \"target\": {\n    \"mode\": \"working-tree\",\n    \"label\": \"working tree diff\",\n    \"explicit\": true\n  },\n  \"gemini\": {\n    \"status\": 0,\n    \"stdout\": \"{\\n  \\\"verdict\\\": \\\"needs-attention\\\",\\n  \\\"summary\\\": \\\"The authentication module introduces critical security vulnerabilities including SQL injection, hardcoded secrets, and unhandled null and error paths.\\\",\\n  \\\"findings\\\": [\\n    {\\n      \\\"severity\\\": \\\"critical\\\",\\n      \\\"title\\\": \\\"SQL injection in findUser via string concatenation\\\",\\n      \\\"body\\\": \\\"findUser concatenates the username argument directly into the SQL query string at src/auth.js:7-9 without escaping or parameterization, allowing an attacker to execute arbitrary SQL commands and bypass authentication.\\\",\\n      \\\"file\\\": \\\"src/auth.js\\\",\\n      \\\"line_start\\\": 7,\\n      \\\"line_end\\\": 9,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Use parameterized queries or prepared statements (e.g., db.query('SELECT * FROM users WHERE name = ?', [username])).\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"high\\\",\\n      \\\"title\\\": \\\"Unhandled null user leads to TypeError in login\\\",\\n      \\\"body\\\": \\\"login attempts to read user.password without checking if findUser returned a valid user record at src/auth.js:14-15. If the user does not exist (e.g., null or undefined), this throws an unhandled TypeError.\\\",\\n      \\\"file\\\": \\\"src/auth.js\\\",\\n      \\\"line_start\\\": 14,\\n      \\\"line_end\\\": 15,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Check if user exists before accessing properties (e.g., if (!user || user.password !== password) return null;).\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"high\\\",\\n      \\\"title\\\": \\\"Hardcoded JWT secret\\\",\\n      \\\"body\\\": \\\"JWT_SECRET is hardcoded in source code at src/auth.js:4. Committing secrets to source control compromises signing key security and prevents secret rotation across environments.\\\",\\n      \\\"file\\\": \\\"src/auth.js\\\",\\n      \\\"line_start\\\": 4,\\n      \\\"line_end\\\": 4,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Retrieve the JWT secret from an environment variable (e.g., process.env.JWT_SECRET) or a secret manager.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"medium\\\",\\n      \\\"title\\\": \\\"Uncaught exception on invalid JSON in parseSession\\\",\\n      \\\"body\\\": \\\"parseSession calls JSON.parse(raw) without error handling at src/auth.js:21-24. Passing malformed JSON or null/undefined will throw an uncaught SyntaxError.\\\",\\n      \\\"file\\\": \\\"src/auth.js\\\",\\n      \\\"line_start\\\": 21,\\n      \\\"line_end\\\": 24,\\n      \\\"confidence\\\": 0.95,\\n      \\\"recommendation\\\": \\\"Wrap JSON.parse in a try/catch block and handle invalid input by returning null or an explicit error.\\\"\\n    }\\n  ],\\n  \\\"next_steps\\\": [\\n    \\\"Refactor findUser to use parameterized queries.\\\",\\n    \\\"Add null checks and secure password comparison in login.\\\",\\n    \\\"Move JWT_SECRET to environment variables.\\\",\\n    \\\"Wrap JSON parsing in parseSession with try/catch error handling.\\\"\\n  ]\\n}\",\n    \"stderr\": \"\"\n  },\n  \"result\": {\n    \"verdict\": \"needs-attention\",\n    \"summary\": \"The authentication module introduces critical security vulnerabilities including SQL injection, hardcoded secrets, and unhandled null and error paths.\",\n    \"findings\": [\n      {\n        \"severity\": \"critical\",\n        \"title\": \"SQL injection in findUser via string concatenation\",\n        \"body\": \"findUser concatenates the username argument directly into the SQL query string at src/auth.js:7-9 without escaping or parameterization, allowing an attacker to execute arbitrary SQL commands and bypass authentication.\",\n        \"file\": \"src/auth.js\",\n        \"line_start\": 7,\n        \"line_end\": 9,\n        \"confidence\": 1,\n        \"recommendation\": \"Use parameterized queries or prepared statements (e.g., db.query('SELECT * FROM users WHERE name = ?', [username])).\"\n      },\n      {\n        \"severity\": \"high\",\n        \"title\": \"Unhandled null user leads to TypeError in login\",\n        \"body\": \"login attempts"
 }

--- a/bench/cassettes/repo-context/agy.deep.json
+++ b/bench/cassettes/repo-context/agy.deep.json
@@ -1,42 +1,155 @@
 {
   "caseId": "repo-context",
   "cell": "agy.deep",
-  "recordedAt": "2026-08-19T02:16:28.914Z",
+  "recordedAt": "2026-08-19T03:23:20.325Z",
   "verdict": "needs-attention",
-  "summary": "Found undeclared dependency on jsonwebtoken, unvalidated secret configuration, and an ephemeral runtime state file added to git.",
+  "summary": "Undeclared dependency on jsonwebtoken, missing JWT_SECRET validation, and committed runtime state file require fixes.",
   "findings": [
     {
-      "severity": "high",
-      "title": "Undeclared dependency 'jsonwebtoken'",
-      "body": "src/token.js requires 'jsonwebtoken', but it is missing from dependencies in package.json, which will cause a MODULE_NOT_FOUND error in production.",
+      "severity": "critical",
+      "title": "Undeclared dependency on jsonwebtoken",
+      "body": "src/token.js requires 'jsonwebtoken', but the package is missing from dependencies in package.json, which will cause MODULE_NOT_FOUND runtime crashes in production.",
       "file": "src/token.js",
       "line_start": 1,
       "line_end": 1,
       "confidence": 1,
-      "recommendation": "Add \"jsonwebtoken\" to dependencies in package.json."
+      "recommendation": "Add 'jsonwebtoken' to dependencies in package.json."
     },
     {
-      "severity": "medium",
-      "title": "Unvalidated JWT_SECRET environment variable",
-      "body": "jwt.sign is called with process.env.JWT_SECRET without checking if it is defined; an unset secret causes jwt.sign to throw a runtime error.",
+      "severity": "high",
+      "title": "Unchecked JWT_SECRET environment variable",
+      "body": "issue() passes process.env.JWT_SECRET directly to jwt.sign() without validating that it is set. If JWT_SECRET is undefined, jwt.sign() throws a synchronous runtime exception.",
       "file": "src/token.js",
       "line_start": 3,
       "line_end": 5,
-      "confidence": 0.9,
-      "recommendation": "Validate that process.env.JWT_SECRET is present before signing or provide an explicit configuration check."
+      "confidence": 0.95,
+      "recommendation": "Validate that process.env.JWT_SECRET is defined and non-empty before attempting to sign tokens, throwing an explicit configuration error if missing."
     },
     {
-      "severity": "medium",
-      "title": "Stray runtime state file tracked in git",
-      "body": ".omc/state/job.json contains ephemeral process metadata and should not be committed to the repository.",
+      "severity": "low",
+      "title": "Committed runtime state file",
+      "body": ".omc/state/job.json contains transient process and job metadata (jobId, status, pid) that should not be tracked in version control.",
       "file": ".omc/state/job.json",
       "line_start": 1,
       "line_end": 1,
-      "confidence": 1,
-      "recommendation": "Remove .omc/state/job.json from git and add .omc/ to .gitignore."
+      "confidence": 0.95,
+      "recommendation": "Remove .omc/state/job.json from git tracking and add .omc/ to .gitignore."
     }
   ],
-  "latencyMs": 34829,
+  "latencyMs": 28459,
   "engineVersion": "1.1.14",
-  "raw": "{\n  \"review\": \"Review\",\n  \"target\": {\n    \"mode\": \"working-tree\",\n    \"label\": \"working tree diff\",\n    \"explicit\": true\n  },\n  \"gemini\": {\n    \"status\": 0,\n    \"stdout\": \"{\\n  \\\"verdict\\\": \\\"needs-attention\\\",\\n  \\\"summary\\\": \\\"Found undeclared dependency on jsonwebtoken, unvalidated secret configuration, and an ephemeral runtime state file added to git.\\\",\\n  \\\"findings\\\": [\\n    {\\n      \\\"severity\\\": \\\"high\\\",\\n      \\\"title\\\": \\\"Undeclared dependency 'jsonwebtoken'\\\",\\n      \\\"body\\\": \\\"src/token.js requires 'jsonwebtoken', but it is missing from dependencies in package.json, which will cause a MODULE_NOT_FOUND error in production.\\\",\\n      \\\"file\\\": \\\"src/token.js\\\",\\n      \\\"line_start\\\": 1,\\n      \\\"line_end\\\": 1,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Add \\\\\\\"jsonwebtoken\\\\\\\" to dependencies in package.json.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"medium\\\",\\n      \\\"title\\\": \\\"Unvalidated JWT_SECRET environment variable\\\",\\n      \\\"body\\\": \\\"jwt.sign is called with process.env.JWT_SECRET without checking if it is defined; an unset secret causes jwt.sign to throw a runtime error.\\\",\\n      \\\"file\\\": \\\"src/token.js\\\",\\n      \\\"line_start\\\": 3,\\n      \\\"line_end\\\": 5,\\n      \\\"confidence\\\": 0.9,\\n      \\\"recommendation\\\": \\\"Validate that process.env.JWT_SECRET is present before signing or provide an explicit configuration check.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"medium\\\",\\n      \\\"title\\\": \\\"Stray runtime state file tracked in git\\\",\\n      \\\"body\\\": \\\".omc/state/job.json contains ephemeral process metadata and should not be committed to the repository.\\\",\\n      \\\"file\\\": \\\".omc/state/job.json\\\",\\n      \\\"line_start\\\": 1,\\n      \\\"line_end\\\": 1,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Remove .omc/state/job.json from git and add .omc/ to .gitignore.\\\"\\n    }\\n  ],\\n  \\\"next_steps\\\": [\\n    \\\"Add jsonwebtoken to package.json dependencies\\\",\\n    \\\"Add a check for process.env.JWT_SECRET before issuing tokens in src/token.js\\\",\\n    \\\"Remove .omc/state/job.json from git and ignore .omc/ via .gitignore\\\"\\n  ]\\n}\",\n    \"stderr\": \"\"\n  },\n  \"result\": {\n    \"verdict\": \"needs-attention\",\n    \"summary\": \"Found undeclared dependency on jsonwebtoken, unvalidated secret configuration, and an ephemeral runtime state file added to git.\",\n    \"findings\": [\n      {\n        \"severity\": \"high\",\n        \"title\": \"Undeclared dependency 'jsonwebtoken'\",\n        \"body\": \"src/token.js requires 'jsonwebtoken', but it is missing from dependencies in package.json, which will cause a MODULE_NOT_FOUND error in production.\",\n        \"file\": \"src/token.js\",\n        \"line_start\": 1,\n        \"line_end\": 1,\n        \"confidence\": 1,\n        \"recommendation\": \"Add \\\"jsonwebtoken\\\" to dependencies in package.json.\"\n      },\n      {\n        \"severity\": \"medium\",\n        \"title\": \"Unvalidated JWT_SECRET environment variable\",\n        \"body\": \"jwt.sign is called with process.env.JWT_SECRET without checking if it is defined; an unset secret causes jwt.sign to throw a runtime error.\",\n        \"file\": \"src/token.js\",\n        \"line_start\": 3,\n        \"line_end\": 5,\n        \"confidence\": 0.9,\n        \"recommendation\": \"Validate that process.env.JWT_SECRET is present before signing or provide an explicit configuration check.\"\n      },\n      {\n        \"severity\": \"medium\",\n        \"title\": \"Stray runtime state file tracked in git\",\n        \"body\": \".omc/state/job.json contains ephemeral process metadata and should not be committed to the repository.\",\n        \"file\": \".omc/state/job.json\",\n        \"line_start\": 1,\n        \"line_end\": 1,\n        \"confidence\": 1,\n        \"recommendation\": \"Remove .omc/state/job.json from git and add .omc/ to .gitignore.\"\n      }\n    ],\n    \"next_steps\": [\n      \"Add jsonwebtoken to package.json dependencies\",\n      \"Add a check for process.env.JWT_SECRET before issuing tokens in src/token.js\",\n      \"Remove .omc/state/job.json from git and ignore .omc/ via .gitignore\"\n    ]\n  }\n}\n"
+  "samples": [
+    {
+      "verdict": "needs-attention",
+      "summary": "The changes introduce an undeclared dependency, unvalidated environment secret usage, and committed runtime state files.",
+      "findings": [
+        {
+          "severity": "critical",
+          "title": "Undeclared jsonwebtoken dependency",
+          "body": "src/token.js requires `jsonwebtoken`, but this package is not declared in `package.json` dependencies. This will cause `MODULE_NOT_FOUND` runtime crashes in fresh environments or production builds.",
+          "file": "src/token.js",
+          "line_start": 1,
+          "line_end": 1,
+          "confidence": 1,
+          "recommendation": "Add `jsonwebtoken` to the `dependencies` section in `package.json`."
+        },
+        {
+          "severity": "high",
+          "title": "Unvalidated JWT_SECRET environment variable",
+          "body": "In `src/token.js`, `jwt.sign()` uses `process.env.JWT_SECRET` without verifying that it is defined. If the environment variable is missing, `jwt.sign()` will throw an uncaught error at runtime or fail securely signing tokens.",
+          "file": "src/token.js",
+          "line_start": 3,
+          "line_end": 5,
+          "confidence": 0.95,
+          "recommendation": "Assert that `process.env.JWT_SECRET` is set and non-empty before calling `jwt.sign()`, throwing a clear configuration error if unset."
+        },
+        {
+          "severity": "medium",
+          "title": "Transient runtime state file added to git",
+          "body": "`.omc/state/job.json` contains transient local process metadata (job ID, pid, status) that should not be tracked in version control.",
+          "file": ".omc/state/job.json",
+          "line_start": 1,
+          "line_end": 1,
+          "confidence": 0.95,
+          "recommendation": "Remove `.omc/state/job.json` from git and add `.omc/` to `.gitignore`."
+        }
+      ],
+      "latencyMs": 27868
+    },
+    {
+      "verdict": "needs-attention",
+      "summary": "The change introduces an undeclared dependency on jsonwebtoken, unvalidated JWT secret access, and a committed ephemeral tool state file.",
+      "findings": [
+        {
+          "severity": "high",
+          "title": "Undeclared dependency on jsonwebtoken",
+          "body": "src/token.js requires jsonwebtoken, but the package is not listed in dependencies in package.json. Importing or running this module in clean or production environments will fail with a MODULE_NOT_FOUND error.",
+          "file": "src/token.js",
+          "line_start": 1,
+          "line_end": 1,
+          "confidence": 1,
+          "recommendation": "Add jsonwebtoken to dependencies in package.json by running npm install jsonwebtoken."
+        },
+        {
+          "severity": "medium",
+          "title": "Unvalidated JWT secret environment variable",
+          "body": "src/token.js passes process.env.JWT_SECRET directly to jwt.sign without verifying it is present. If the environment variable is unset, jwt.sign throws a runtime error (or generates insecure tokens depending on configuration).",
+          "file": "src/token.js",
+          "line_start": 3,
+          "line_end": 5,
+          "confidence": 0.95,
+          "recommendation": "Validate that process.env.JWT_SECRET is defined and non-empty before signing, throwing an explicit descriptive error if missing."
+        },
+        {
+          "severity": "low",
+          "title": "Transient job state file tracked in git",
+          "body": ".omc/state/job.json contains ephemeral process metadata (jobId, status, pid) from a local execution run and should not be committed to version control.",
+          "file": ".omc/state/job.json",
+          "line_start": 1,
+          "line_end": 1,
+          "confidence": 1,
+          "recommendation": "Remove .omc/state/job.json from git staging/tracking and add .omc/ to .gitignore."
+        }
+      ],
+      "latencyMs": 29434
+    },
+    {
+      "verdict": "needs-attention",
+      "summary": "Undeclared dependency on jsonwebtoken, missing JWT_SECRET validation, and committed runtime state file require fixes.",
+      "findings": [
+        {
+          "severity": "critical",
+          "title": "Undeclared dependency on jsonwebtoken",
+          "body": "src/token.js requires 'jsonwebtoken', but the package is missing from dependencies in package.json, which will cause MODULE_NOT_FOUND runtime crashes in production.",
+          "file": "src/token.js",
+          "line_start": 1,
+          "line_end": 1,
+          "confidence": 1,
+          "recommendation": "Add 'jsonwebtoken' to dependencies in package.json."
+        },
+        {
+          "severity": "high",
+          "title": "Unchecked JWT_SECRET environment variable",
+          "body": "issue() passes process.env.JWT_SECRET directly to jwt.sign() without validating that it is set. If JWT_SECRET is undefined, jwt.sign() throws a synchronous runtime exception.",
+          "file": "src/token.js",
+          "line_start": 3,
+          "line_end": 5,
+          "confidence": 0.95,
+          "recommendation": "Validate that process.env.JWT_SECRET is defined and non-empty before attempting to sign tokens, throwing an explicit configuration error if missing."
+        },
+        {
+          "severity": "low",
+          "title": "Committed runtime state file",
+          "body": ".omc/state/job.json contains transient process and job metadata (jobId, status, pid) that should not be tracked in version control.",
+          "file": ".omc/state/job.json",
+          "line_start": 1,
+          "line_end": 1,
+          "confidence": 0.95,
+          "recommendation": "Remove .omc/state/job.json from git tracking and add .omc/ to .gitignore."
+        }
+      ],
+      "latencyMs": 28459
+    }
+  ],
+  "raw": "{\n  \"review\": \"Review\",\n  \"target\": {\n    \"mode\": \"working-tree\",\n    \"label\": \"working tree diff\",\n    \"explicit\": true\n  },\n  \"gemini\": {\n    \"status\": 0,\n    \"stdout\": \"{\\n  \\\"verdict\\\": \\\"needs-attention\\\",\\n  \\\"summary\\\": \\\"Undeclared dependency on jsonwebtoken, missing JWT_SECRET validation, and committed runtime state file require fixes.\\\",\\n  \\\"findings\\\": [\\n    {\\n      \\\"severity\\\": \\\"critical\\\",\\n      \\\"title\\\": \\\"Undeclared dependency on jsonwebtoken\\\",\\n      \\\"body\\\": \\\"src/token.js requires 'jsonwebtoken', but the package is missing from dependencies in package.json, which will cause MODULE_NOT_FOUND runtime crashes in production.\\\",\\n      \\\"file\\\": \\\"src/token.js\\\",\\n      \\\"line_start\\\": 1,\\n      \\\"line_end\\\": 1,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Add 'jsonwebtoken' to dependencies in package.json.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"high\\\",\\n      \\\"title\\\": \\\"Unchecked JWT_SECRET environment variable\\\",\\n      \\\"body\\\": \\\"issue() passes process.env.JWT_SECRET directly to jwt.sign() without validating that it is set. If JWT_SECRET is undefined, jwt.sign() throws a synchronous runtime exception.\\\",\\n      \\\"file\\\": \\\"src/token.js\\\",\\n      \\\"line_start\\\": 3,\\n      \\\"line_end\\\": 5,\\n      \\\"confidence\\\": 0.95,\\n      \\\"recommendation\\\": \\\"Validate that process.env.JWT_SECRET is defined and non-empty before attempting to sign tokens, throwing an explicit configuration error if missing.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"low\\\",\\n      \\\"title\\\": \\\"Committed runtime state file\\\",\\n      \\\"body\\\": \\\".omc/state/job.json contains transient process and job metadata (jobId, status, pid) that should not be tracked in version control.\\\",\\n      \\\"file\\\": \\\".omc/state/job.json\\\",\\n      \\\"line_start\\\": 1,\\n      \\\"line_end\\\": 1,\\n      \\\"confidence\\\": 0.95,\\n      \\\"recommendation\\\": \\\"Remove .omc/state/job.json from git tracking and add .omc/ to .gitignore.\\\"\\n    }\\n  ],\\n  \\\"next_steps\\\": [\\n    \\\"Install and add jsonwebtoken to package.json dependencies.\\\",\\n    \\\"Add environment variable validation for JWT_SECRET in src/token.js.\\\",\\n    \\\"Delete .omc/state/job.json and add .omc/ to .gitignore.\\\"\\n  ]\\n}\",\n    \"stderr\": \"\"\n  },\n  \"result\": {\n    \"verdict\": \"needs-attention\",\n    \"summary\": \"Undeclared dependency on jsonwebtoken, missing JWT_SECRET validation, and committed runtime state file require fixes.\",\n    \"findings\": [\n      {\n        \"severity\": \"critical\",\n        \"title\": \"Undeclared dependency on jsonwebtoken\",\n        \"body\": \"src/token.js requires 'jsonwebtoken', but the package is missing from dependencies in package.json, which will cause MODULE_NOT_FOUND runtime crashes in production.\",\n        \"file\": \"src/token.js\",\n        \"line_start\": 1,\n        \"line_end\": 1,\n        \"confidence\": 1,\n        \"recommendation\": \"Add 'jsonwebtoken' to dependencies in package.json.\"\n      },\n      {\n        \"severity\": \"high\",\n        \"title\": \"Unchecked JWT_SECRET environment variable\",\n        \"body\": \"issue() passes process.env.JWT_SECRET directly to jwt.sign() without validating that it is set. If JWT_SECRET is undefined, jwt.sign() throws a synchronous runtime exception.\",\n        \"file\": \"src/token.js\",\n        \"line_start\": 3,\n        \"line_end\": 5,\n        \"confidence\": 0.95,\n        \"recommendation\": \"Validate that process.env.JWT_SECRET is defined and non-empty before attempting to sign tokens, throwing an explicit configuration error if missing.\"\n      },\n      {\n        \"severity\": \"low\",\n        \"title\": \"Committed runtime state file\",\n        \"body\": \".omc/state/job.json contains transient process and job metadata (jobId, status, pid) that should not be tracked in version control.\",\n        \"file\": \".omc/state/job.json\",\n        \"line_start\": 1,\n        \"line_end\": 1,\n        \"confidence\": 0.95,\n        \"recommendation\": \"Remove .omc/state/job.json from git tracking and add .omc/ to .gitignore.\"\n      }\n    ],\n    \"next_steps\": [\n      \"Install and add jsonwebtoken t"
 }

--- a/bench/cassettes/repo-context/agy.model.json
+++ b/bench/cassettes/repo-context/agy.model.json
@@ -1,22 +1,75 @@
 {
   "caseId": "repo-context",
   "cell": "agy.model",
-  "recordedAt": "2026-08-19T02:15:53.577Z",
+  "recordedAt": "2026-08-19T03:20:21.493Z",
   "verdict": "needs-attention",
-  "summary": "Missing validation for the JWT_SECRET environment variable causes unhandled runtime exceptions when signing tokens.",
+  "summary": "Token generation relies on process.env.JWT_SECRET without validation, leading to runtime failures or insecure signing if unconfigured.",
   "findings": [
     {
       "severity": "high",
       "title": "Unvalidated JWT_SECRET environment variable",
-      "body": "jwt.sign is invoked directly with process.env.JWT_SECRET without verifying that the secret is set, causing jsonwebtoken to throw a runtime error if the environment variable is missing or undefined.",
+      "body": "jwt.sign directly uses process.env.JWT_SECRET without checking if it is defined. If the environment variable is missing or empty, jsonwebtoken throws an unhandled error ('secretOrPrivateKey must have a value'), causing token generation to fail unexpectedly.",
       "file": "src/token.js",
-      "line_start": 3,
-      "line_end": 5,
+      "line_start": 4,
+      "line_end": 4,
       "confidence": 0.95,
-      "recommendation": "Validate that process.env.JWT_SECRET exists and is non-empty before signing, throwing a clear configuration error if it is not configured."
+      "recommendation": "Validate that process.env.JWT_SECRET is defined and non-empty before signing, throwing a clear error or enforcing startup environment checks, and specify an explicit signing algorithm."
     }
   ],
-  "latencyMs": 18606,
+  "latencyMs": 18495,
   "engineVersion": "1.1.14",
-  "raw": "{\"conversation_id\":\"96f624cc-31ee-44af-bf00-3ec1c797d5a2\",\"status\":\"SUCCESS\",\"response\":\"{\\n  \\\"verdict\\\": \\\"needs-attention\\\",\\n  \\\"summary\\\": \\\"Missing validation for the JWT_SECRET environment variable causes unhandled runtime exceptions when signing tokens.\\\",\\n  \\\"findings\\\": [\\n    {\\n      \\\"severity\\\": \\\"high\\\",\\n      \\\"title\\\": \\\"Unvalidated JWT_SECRET environment variable\\\",\\n      \\\"body\\\": \\\"jwt.sign is invoked directly with process.env.JWT_SECRET without verifying that the secret is set, causing jsonwebtoken to throw a runtime error if the environment variable is missing or undefined.\\\",\\n      \\\"file\\\": \\\"src/token.js\\\",\\n      \\\"line_start\\\": 3,\\n      \\\"line_end\\\": 5,\\n      \\\"confidence\\\": 0.95,\\n      \\\"recommendation\\\": \\\"Validate that process.env.JWT_SECRET exists and is non-empty before signing, throwing a clear configuration error if it is not configured.\\\"\\n    }\\n  ],\\n  \\\"next_steps\\\": [\\n    \\\"Add an explicit guard or configuration check for process.env.JWT_SECRET in src/token.js.\\\",\\n    \\\"Verify whether .omc/state/job.json is runtime state that should be added to .gitignore instead of committed.\\\"\\n  ]\\n}\\n\",\"duration_seconds\":14.9808972,\"num_turns\":1,\"usage\":{\"input_tokens\":18969,\"output_tokens\":1376,\"thinking_tokens\":1146,\"cache_read_tokens\":0,\"total_tokens\":20345}}\n"
+  "samples": [
+    {
+      "verdict": "needs-attention",
+      "summary": "The token issuance function lacks validation for the secret key environment variable, causing runtime exceptions if unset.",
+      "findings": [
+        {
+          "severity": "high",
+          "title": "Unvalidated JWT secret key",
+          "body": "process.env.JWT_SECRET is passed directly to jwt.sign without checking if it is defined. If the environment variable is missing or empty, jwt.sign throws a runtime error or risks signing tokens with an invalid key.",
+          "file": "src/token.js",
+          "line_start": 4,
+          "line_end": 4,
+          "confidence": 0.95,
+          "recommendation": "Validate that process.env.JWT_SECRET is defined and non-empty prior to signing, throwing a clear configuration error if missing."
+        }
+      ],
+      "latencyMs": 18450
+    },
+    {
+      "verdict": "needs-attention",
+      "summary": "Token signing lacks validation for the JWT_SECRET environment variable, leading to unhandled runtime errors if unset.",
+      "findings": [
+        {
+          "severity": "high",
+          "title": "Unchecked JWT_SECRET environment variable",
+          "body": "jwt.sign is called with process.env.JWT_SECRET without verifying that the secret exists. If the environment variable is missing, jsonwebtoken throws a synchronous error ('\"secretOrPrivateKey\" must have a value'), causing unhandled exceptions during token issuance.",
+          "file": "src/token.js",
+          "line_start": 3,
+          "line_end": 5,
+          "confidence": 0.95,
+          "recommendation": "Validate that process.env.JWT_SECRET is present and non-empty before signing, throwing a clear configuration error if it is not configured."
+        }
+      ],
+      "latencyMs": 19571
+    },
+    {
+      "verdict": "needs-attention",
+      "summary": "Token generation relies on process.env.JWT_SECRET without validation, leading to runtime failures or insecure signing if unconfigured.",
+      "findings": [
+        {
+          "severity": "high",
+          "title": "Unvalidated JWT_SECRET environment variable",
+          "body": "jwt.sign directly uses process.env.JWT_SECRET without checking if it is defined. If the environment variable is missing or empty, jsonwebtoken throws an unhandled error ('secretOrPrivateKey must have a value'), causing token generation to fail unexpectedly.",
+          "file": "src/token.js",
+          "line_start": 4,
+          "line_end": 4,
+          "confidence": 0.95,
+          "recommendation": "Validate that process.env.JWT_SECRET is defined and non-empty before signing, throwing a clear error or enforcing startup environment checks, and specify an explicit signing algorithm."
+        }
+      ],
+      "latencyMs": 18495
+    }
+  ],
+  "raw": "{\"conversation_id\":\"e5e7cf3a-6022-4d7e-9000-b828fb916ec3\",\"status\":\"SUCCESS\",\"response\":\"{\\n  \\\"verdict\\\": \\\"needs-attention\\\",\\n  \\\"summary\\\": \\\"Token generation relies on process.env.JWT_SECRET without validation, leading to runtime failures or insecure signing if unconfigured.\\\",\\n  \\\"findings\\\": [\\n    {\\n      \\\"severity\\\": \\\"high\\\",\\n      \\\"title\\\": \\\"Unvalidated JWT_SECRET environment variable\\\",\\n      \\\"body\\\": \\\"jwt.sign directly uses process.env.JWT_SECRET without checking if it is defined. If the environment variable is missing or empty, jsonwebtoken throws an unhandled error ('secretOrPrivateKey must have a value'), causing token generation to fail unexpectedly.\\\",\\n      \\\"file\\\": \\\"src/token.js\\\",\\n      \\\"line_start\\\": 4,\\n      \\\"line_end\\\": 4,\\n      \\\"confidence\\\": 0.95,\\n      \\\"recommendation\\\": \\\"Validate that process.env.JWT_SECRET is defined and non-empty before signing, throwing a clear error or enforcing startup environment checks, and specify an explicit signing algorithm.\\\"\\n    }\\n  ],\\n  \\\"next_steps\\\": [\\n    \\\"Add an environment variable guard check for JWT_SECRET in src/token.js or during app initialization.\\\",\\n    \\\"Explicitly set algorithm (e.g., 'HS256') in jwt.sign options to avoid relying on library defaults.\\\"\\n  ]\\n}\\n\",\"duration_seconds\":14.0636541,\"num_turns\":1,\"usage\":{\"input_tokens\":18972,\"output_tokens\":1369,\"thinking_tokens\":1108,\"cache_read_tokens\":0,\"total_tokens\":20341}}\n"
 }

--- a/bench/cassettes/repo-context/codex.model.json
+++ b/bench/cassettes/repo-context/codex.model.json
@@ -1,21 +1,115 @@
 {
   "caseId": "repo-context",
   "cell": "codex.model",
-  "recordedAt": "2026-06-04T14:12:40.990Z",
+  "recordedAt": "2026-08-19T03:19:24.977Z",
   "verdict": "needs-attention",
-  "summary": "JWT issuance can fail at runtime when required configuration is missing.",
+  "summary": "Token issuance can fail at runtime without configuration validation, and committed runtime state can misidentify an unrelated process as an active job.",
   "findings": [
     {
       "severity": "medium",
-      "title": "JWT secret is used without validation",
-      "body": "`issue` passes `process.env.JWT_SECRET` directly to `jwt.sign`; if the environment variable is missing or empty, token issuance will throw synchronously at runtime, breaking any code path that calls this helper instead of failing fast with a clear configuration error.",
+      "title": "JWT secret is used without startup validation",
+      "body": "issue() passes process.env.JWT_SECRET directly to jwt.sign; when the variable is absent, token issuance throws synchronously, leaving callers to encounter an avoidable runtime failure instead of a clear configuration error.",
       "file": "src/token.js",
       "line_start": 4,
       "line_end": 4,
-      "confidence": 0.9,
-      "recommendation": "Validate `JWT_SECRET` during module initialization or application startup and throw a clear configuration error before `issue` can be called."
+      "confidence": 0.99,
+      "recommendation": "Validate JWT_SECRET at application startup, require a non-empty suitably strong value, and fail with an explicit configuration error before serving requests."
+    },
+    {
+      "severity": "medium",
+      "title": "Ephemeral job state is committed with a live status and fixed PID",
+      "body": "The new state file declares task-123 as running under PID 4242. On another machine or later checkout, that PID may be stale or belong to an unrelated process, so consumers trusting this file could report a nonexistent job or act on the wrong process.",
+      "file": ".omc/state/job.json",
+      "line_start": 1,
+      "line_end": 1,
+      "confidence": 0.96,
+      "recommendation": "Remove the runtime state file from version control, ignore generated .omc/state data, and create state dynamically with PID identity and liveness validation."
     }
   ],
-  "latencyMs": 24330,
-  "raw": "{\"verdict\":\"needs-attention\",\"summary\":\"JWT issuance can fail at runtime when required configuration is missing.\",\"findings\":[{\"severity\":\"medium\",\"title\":\"JWT secret is used without validation\",\"body\":\"`issue` passes `process.env.JWT_SECRET` directly to `jwt.sign`; if the environment variable is missing or empty, token issuance will throw synchronously at runtime, breaking any code path that calls this helper instead of failing fast with a clear configuration error.\",\"file\":\"src/token.js\",\"line_start\":4,\"line_end\":4,\"confidence\":0.9,\"recommendation\":\"Validate `JWT_SECRET` during module initialization or application startup and throw a clear configuration error before `issue` can be called.\"}],\"next_steps\":[\"Add startup/module validation for JWT_SECRET and cover the missing-secret case with a focused test.\"]}\n"
+  "latencyMs": 17229,
+  "engineVersion": "codex-cli 0.147.0",
+  "samples": [
+    {
+      "verdict": "needs-attention",
+      "summary": "The diff commits stale runtime state and adds token issuance without explicit secret validation.",
+      "findings": [
+        {
+          "severity": "medium",
+          "title": "Runtime job state is committed as active",
+          "body": "The newly tracked state file declares task-123 as running under PID 4242, but both status and PID are ephemeral machine state. A checkout can therefore begin with a false active-job record, potentially blocking new work or causing any state consumer to target an unrelated reused PID.",
+          "file": ".omc/state/job.json",
+          "line_start": 1,
+          "line_end": 1,
+          "confidence": 0.96,
+          "recommendation": "Remove the runtime state file from version control, add the state path to the appropriate ignore file, and create job state only at runtime with stale-PID validation."
+        },
+        {
+          "severity": "medium",
+          "title": "JWT secret is used without configuration validation",
+          "body": "issue passes process.env.JWT_SECRET directly to jwt.sign. If the variable is missing or invalid, token issuance fails at runtime with a library exception and no clear configuration error at startup; this leaves an incomplete failure path in every caller relying on this function.",
+          "file": "src/token.js",
+          "line_start": 3,
+          "line_end": 4,
+          "confidence": 0.93,
+          "recommendation": "Validate JWT_SECRET once during application initialization, reject missing or insufficient configuration with a clear error, and inject the validated secret into the token issuer."
+        }
+      ],
+      "latencyMs": 17835
+    },
+    {
+      "verdict": "needs-attention",
+      "summary": "Token issuance can fail at runtime when JWT configuration is absent, and committed transient job state can become immediately stale.",
+      "findings": [
+        {
+          "severity": "medium",
+          "title": "Missing JWT secret validation",
+          "body": "issue() passes process.env.JWT_SECRET directly to jwt.sign; when the variable is missing, jsonwebtoken throws synchronously, leaving token issuance to fail with an unhandled configuration error at runtime.",
+          "file": "src/token.js",
+          "line_start": 3,
+          "line_end": 4,
+          "confidence": 0.99,
+          "recommendation": "Validate JWT_SECRET during application startup, reject empty or inadequate values, and fail with an explicit configuration error before serving requests."
+        },
+        {
+          "severity": "medium",
+          "title": "Transient running-job state is committed",
+          "body": "The repository now records a job as running with hard-coded PID 4242. After checkout or process termination this state is stale, so automation that trusts it may treat a nonexistent or unrelated process as the active job.",
+          "file": ".omc/state/job.json",
+          "line_start": 1,
+          "line_end": 1,
+          "confidence": 0.94,
+          "recommendation": "Remove the runtime state file from version control, ignore .omc/state artifacts, and generate and validate job/PID state at runtime."
+        }
+      ],
+      "latencyMs": 17946
+    },
+    {
+      "verdict": "needs-attention",
+      "summary": "Token issuance can fail at runtime without configuration validation, and committed runtime state can misidentify an unrelated process as an active job.",
+      "findings": [
+        {
+          "severity": "medium",
+          "title": "JWT secret is used without startup validation",
+          "body": "issue() passes process.env.JWT_SECRET directly to jwt.sign; when the variable is absent, token issuance throws synchronously, leaving callers to encounter an avoidable runtime failure instead of a clear configuration error.",
+          "file": "src/token.js",
+          "line_start": 4,
+          "line_end": 4,
+          "confidence": 0.99,
+          "recommendation": "Validate JWT_SECRET at application startup, require a non-empty suitably strong value, and fail with an explicit configuration error before serving requests."
+        },
+        {
+          "severity": "medium",
+          "title": "Ephemeral job state is committed with a live status and fixed PID",
+          "body": "The new state file declares task-123 as running under PID 4242. On another machine or later checkout, that PID may be stale or belong to an unrelated process, so consumers trusting this file could report a nonexistent job or act on the wrong process.",
+          "file": ".omc/state/job.json",
+          "line_start": 1,
+          "line_end": 1,
+          "confidence": 0.96,
+          "recommendation": "Remove the runtime state file from version control, ignore generated .omc/state data, and create state dynamically with PID identity and liveness validation."
+        }
+      ],
+      "latencyMs": 17229
+    }
+  ],
+  "raw": "{\"verdict\":\"needs-attention\",\"summary\":\"Token issuance can fail at runtime without configuration validation, and committed runtime state can misidentify an unrelated process as an active job.\",\"findings\":[{\"severity\":\"medium\",\"title\":\"JWT secret is used without startup validation\",\"body\":\"issue() passes process.env.JWT_SECRET directly to jwt.sign; when the variable is absent, token issuance throws synchronously, leaving callers to encounter an avoidable runtime failure instead of a clear configuration error.\",\"file\":\"src/token.js\",\"line_start\":4,\"line_end\":4,\"confidence\":0.99,\"recommendation\":\"Validate JWT_SECRET at application startup, require a non-empty suitably strong value, and fail with an explicit configuration error before serving requests.\"},{\"severity\":\"medium\",\"title\":\"Ephemeral job state is committed with a live status and fixed PID\",\"body\":\"The new state file declares task-123 as running under PID 4242. On another machine or later checkout, that PID may be stale or belong to an unrelated process, so consumers trusting this file could report a nonexistent job or act on the wrong process.\",\"file\":\".omc/state/job.json\",\"line_start\":1,\"line_end\":1,\"confidence\":0.96,\"recommendation\":\"Remove the runtime state file from version control, ignore generated .omc/state data, and create state dynamically with PID identity and liveness validation.\"}],\"next_steps\":[\"Add startup validation for JWT_SECRET and test the missing-secret path.\",\"Remove the committed job state and add the generated state path to the appropriate ignore configuration.\"]}\n"
 }

--- a/bench/cassettes/repo-context/gemini.deep.json
+++ b/bench/cassettes/repo-context/gemini.deep.json
@@ -1,20 +1,155 @@
 {
   "caseId": "repo-context",
   "cell": "gemini.deep",
-  "source": "seeded illustrative (refresh with --live)",
+  "recordedAt": "2026-08-19T03:21:52.316Z",
   "verdict": "needs-attention",
-  "summary": "src/token.js uses an undeclared dependency.",
-  "latencyMs": 27300,
+  "summary": "The change introduces an undeclared dependency on jsonwebtoken, unvalidated JWT_SECRET environment variable usage, and commits a transient runtime state file.",
   "findings": [
     {
-      "severity": "high",
-      "title": "Undeclared jsonwebtoken dependency",
-      "body": "src/token.js requires 'jsonwebtoken' but it is not declared in package.json dependencies, so a clean install will fail at runtime.",
-      "file": "package.json",
+      "severity": "critical",
+      "title": "Undeclared dependency `jsonwebtoken`",
+      "body": "src/token.js requires `jsonwebtoken`, but this package is not declared under `dependencies` in package.json. This will cause a `MODULE_NOT_FOUND` crash in fresh environments and CI/CD pipelines.",
+      "file": "src/token.js",
       "line_start": 1,
       "line_end": 1,
-      "confidence": 0.9,
-      "recommendation": "Add jsonwebtoken to package.json dependencies."
+      "confidence": 1,
+      "recommendation": "Add `jsonwebtoken` to `dependencies` in package.json (e.g., via `npm install jsonwebtoken`)."
+    },
+    {
+      "severity": "high",
+      "title": "Unvalidated `JWT_SECRET` environment variable",
+      "body": "`issue()` passes `process.env.JWT_SECRET` directly to `jwt.sign()` without verifying that it is defined. If the environment variable is missing, `jwt.sign()` will throw an uncaught exception (`\"secretOrPrivateKey\" must have a value`), failing token issuance at runtime.",
+      "file": "src/token.js",
+      "line_start": 3,
+      "line_end": 5,
+      "confidence": 0.95,
+      "recommendation": "Validate that `process.env.JWT_SECRET` is defined before signing, throwing a clear configuration error if it is missing."
+    },
+    {
+      "severity": "medium",
+      "title": "Stray runtime state file committed",
+      "body": "`.omc/state/job.json` contains transient execution metadata (PID and job status) that should not be tracked in version control.",
+      "file": ".omc/state/job.json",
+      "line_start": 1,
+      "line_end": 1,
+      "confidence": 1,
+      "recommendation": "Remove `.omc/state/job.json` from git and add `.omc/` to `.gitignore`."
     }
-  ]
+  ],
+  "latencyMs": 26885,
+  "engineVersion": "0.54.4",
+  "samples": [
+    {
+      "verdict": "needs-attention",
+      "summary": "The changes introduce an undeclared dependency, unvalidated secret access during token signing, and a stray runtime state file.",
+      "findings": [
+        {
+          "severity": "high",
+          "title": "Undeclared dependency 'jsonwebtoken'",
+          "body": "src/token.js requires 'jsonwebtoken', but the package is not listed under dependencies in package.json. In fresh environments or production deployments, importing or executing this module will throw MODULE_NOT_FOUND.",
+          "file": "src/token.js",
+          "line_start": 1,
+          "line_end": 1,
+          "confidence": 1,
+          "recommendation": "Add 'jsonwebtoken' to package.json dependencies via 'npm install jsonwebtoken'."
+        },
+        {
+          "severity": "medium",
+          "title": "Missing validation for JWT_SECRET environment variable",
+          "body": "issue() passes process.env.JWT_SECRET directly to jwt.sign without verifying it is defined. If the environment variable is missing, jsonwebtoken throws a runtime error ('secretOrPrivateKey must have a value').",
+          "file": "src/token.js",
+          "line_start": 3,
+          "line_end": 5,
+          "confidence": 0.95,
+          "recommendation": "Validate that process.env.JWT_SECRET is non-empty before signing, throwing a clear configuration error if unset."
+        },
+        {
+          "severity": "low",
+          "title": "Stray runtime state file tracked in working tree",
+          "body": "The file .omc/state/job.json contains ephemeral process state (jobId and pid) and was added to the working tree instead of being excluded from version control.",
+          "file": ".omc/state/job.json",
+          "line_start": 1,
+          "line_end": 1,
+          "confidence": 1,
+          "recommendation": "Remove .omc/state/job.json from git tracking and add .omc/ to .gitignore."
+        }
+      ],
+      "latencyMs": 30930
+    },
+    {
+      "verdict": "needs-attention",
+      "summary": "Found undeclared jsonwebtoken dependency, unvalidated JWT_SECRET environment variable, and committed transient job state file.",
+      "findings": [
+        {
+          "severity": "high",
+          "title": "Undeclared jsonwebtoken dependency",
+          "body": "src/token.js requires 'jsonwebtoken', but the package is not listed in dependencies in package.json. This will result in a MODULE_NOT_FOUND runtime failure during fresh deployments or clean installs.",
+          "file": "src/token.js",
+          "line_start": 1,
+          "line_end": 1,
+          "confidence": 1,
+          "recommendation": "Add jsonwebtoken to dependencies in package.json (e.g. `npm install jsonwebtoken`)."
+        },
+        {
+          "severity": "medium",
+          "title": "Unchecked process.env.JWT_SECRET",
+          "body": "src/token.js passes process.env.JWT_SECRET directly to jwt.sign without validating that the secret is set. If JWT_SECRET is undefined, jwt.sign throws a runtime error ('secretOrPrivateKey must have a value').",
+          "file": "src/token.js",
+          "line_start": 3,
+          "line_end": 5,
+          "confidence": 0.95,
+          "recommendation": "Validate that process.env.JWT_SECRET is defined before signing, or throw an explicit configuration error."
+        },
+        {
+          "severity": "low",
+          "title": "Ephemeral job state file tracked in git",
+          "body": ".omc/state/job.json contains runtime process state (jobId, status, pid) from local tooling that should not be committed to version control.",
+          "file": ".omc/state/job.json",
+          "line_start": 1,
+          "line_end": 1,
+          "confidence": 1,
+          "recommendation": "Remove .omc/state/job.json from git and add .omc/ to .gitignore."
+        }
+      ],
+      "latencyMs": 30552
+    },
+    {
+      "verdict": "needs-attention",
+      "summary": "The change introduces an undeclared dependency on jsonwebtoken, unvalidated JWT_SECRET environment variable usage, and commits a transient runtime state file.",
+      "findings": [
+        {
+          "severity": "critical",
+          "title": "Undeclared dependency `jsonwebtoken`",
+          "body": "src/token.js requires `jsonwebtoken`, but this package is not declared under `dependencies` in package.json. This will cause a `MODULE_NOT_FOUND` crash in fresh environments and CI/CD pipelines.",
+          "file": "src/token.js",
+          "line_start": 1,
+          "line_end": 1,
+          "confidence": 1,
+          "recommendation": "Add `jsonwebtoken` to `dependencies` in package.json (e.g., via `npm install jsonwebtoken`)."
+        },
+        {
+          "severity": "high",
+          "title": "Unvalidated `JWT_SECRET` environment variable",
+          "body": "`issue()` passes `process.env.JWT_SECRET` directly to `jwt.sign()` without verifying that it is defined. If the environment variable is missing, `jwt.sign()` will throw an uncaught exception (`\"secretOrPrivateKey\" must have a value`), failing token issuance at runtime.",
+          "file": "src/token.js",
+          "line_start": 3,
+          "line_end": 5,
+          "confidence": 0.95,
+          "recommendation": "Validate that `process.env.JWT_SECRET` is defined before signing, throwing a clear configuration error if it is missing."
+        },
+        {
+          "severity": "medium",
+          "title": "Stray runtime state file committed",
+          "body": "`.omc/state/job.json` contains transient execution metadata (PID and job status) that should not be tracked in version control.",
+          "file": ".omc/state/job.json",
+          "line_start": 1,
+          "line_end": 1,
+          "confidence": 1,
+          "recommendation": "Remove `.omc/state/job.json` from git and add `.omc/` to `.gitignore`."
+        }
+      ],
+      "latencyMs": 26885
+    }
+  ],
+  "raw": "{\n  \"review\": \"Review\",\n  \"target\": {\n    \"mode\": \"working-tree\",\n    \"label\": \"working tree diff\",\n    \"explicit\": true\n  },\n  \"gemini\": {\n    \"status\": 0,\n    \"stdout\": \"{\\n  \\\"verdict\\\": \\\"needs-attention\\\",\\n  \\\"summary\\\": \\\"The change introduces an undeclared dependency on jsonwebtoken, unvalidated JWT_SECRET environment variable usage, and commits a transient runtime state file.\\\",\\n  \\\"findings\\\": [\\n    {\\n      \\\"severity\\\": \\\"critical\\\",\\n      \\\"title\\\": \\\"Undeclared dependency `jsonwebtoken`\\\",\\n      \\\"body\\\": \\\"src/token.js requires `jsonwebtoken`, but this package is not declared under `dependencies` in package.json. This will cause a `MODULE_NOT_FOUND` crash in fresh environments and CI/CD pipelines.\\\",\\n      \\\"file\\\": \\\"src/token.js\\\",\\n      \\\"line_start\\\": 1,\\n      \\\"line_end\\\": 1,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Add `jsonwebtoken` to `dependencies` in package.json (e.g., via `npm install jsonwebtoken`).\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"high\\\",\\n      \\\"title\\\": \\\"Unvalidated `JWT_SECRET` environment variable\\\",\\n      \\\"body\\\": \\\"`issue()` passes `process.env.JWT_SECRET` directly to `jwt.sign()` without verifying that it is defined. If the environment variable is missing, `jwt.sign()` will throw an uncaught exception (`\\\\\\\"secretOrPrivateKey\\\\\\\" must have a value`), failing token issuance at runtime.\\\",\\n      \\\"file\\\": \\\"src/token.js\\\",\\n      \\\"line_start\\\": 3,\\n      \\\"line_end\\\": 5,\\n      \\\"confidence\\\": 0.95,\\n      \\\"recommendation\\\": \\\"Validate that `process.env.JWT_SECRET` is defined before signing, throwing a clear configuration error if it is missing.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"medium\\\",\\n      \\\"title\\\": \\\"Stray runtime state file committed\\\",\\n      \\\"body\\\": \\\"`.omc/state/job.json` contains transient execution metadata (PID and job status) that should not be tracked in version control.\\\",\\n      \\\"file\\\": \\\".omc/state/job.json\\\",\\n      \\\"line_start\\\": 1,\\n      \\\"line_end\\\": 1,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Remove `.omc/state/job.json` from git and add `.omc/` to `.gitignore`.\\\"\\n    }\\n  ],\\n  \\\"next_steps\\\": [\\n    \\\"Add jsonwebtoken to package.json dependencies.\\\",\\n    \\\"Add environment variable validation for JWT_SECRET in src/token.js.\\\",\\n    \\\"Untrack .omc/state/job.json and add .omc/ to .gitignore.\\\"\\n  ]\\n}\",\n    \"stderr\": \"\"\n  },\n  \"result\": {\n    \"verdict\": \"needs-attention\",\n    \"summary\": \"The change introduces an undeclared dependency on jsonwebtoken, unvalidated JWT_SECRET environment variable usage, and commits a transient runtime state file.\",\n    \"findings\": [\n      {\n        \"severity\": \"critical\",\n        \"title\": \"Undeclared dependency `jsonwebtoken`\",\n        \"body\": \"src/token.js requires `jsonwebtoken`, but this package is not declared under `dependencies` in package.json. This will cause a `MODULE_NOT_FOUND` crash in fresh environments and CI/CD pipelines.\",\n        \"file\": \"src/token.js\",\n        \"line_start\": 1,\n        \"line_end\": 1,\n        \"confidence\": 1,\n        \"recommendation\": \"Add `jsonwebtoken` to `dependencies` in package.json (e.g., via `npm install jsonwebtoken`).\"\n      },\n      {\n        \"severity\": \"high\",\n        \"title\": \"Unvalidated `JWT_SECRET` environment variable\",\n        \"body\": \"`issue()` passes `process.env.JWT_SECRET` directly to `jwt.sign()` without verifying that it is defined. If the environment variable is missing, `jwt.sign()` will throw an uncaught exception (`\\\"secretOrPrivateKey\\\" must have a value`), failing token issuance at runtime.\",\n        \"file\": \"src/token.js\",\n        \"line_start\": 3,\n        \"line_end\": 5,\n        \"confidence\": 0.95,\n        \"recommendation\": \"Validate that `process.env.JWT_SECRET` is defined before signing, throwing a clear configuration error if it is missing.\"\n      },\n      {\n        \"severity\": \"medium\",\n        \"title\": \"Stray runtime state file committed\",\n        \"body\": \"`.omc/state/job.json` contains transient execution m"
 }

--- a/bench/lib/cassette.mjs
+++ b/bench/lib/cassette.mjs
@@ -5,6 +5,15 @@ import { fileURLToPath } from "node:url";
 // Recorded tool outputs for deterministic (offline, CI-safe) replay. A cassette
 // captures the normalized review result for one (case, cell) so the scorer can
 // run without invoking any model. `--live` re-records these.
+//
+// It captures every repeat, not just the last. `--repeats N` used to average the
+// live scorecard and then store one run, so the number that got published — which
+// comes from replay — was a single sample wearing an averaged run's reputation.
+// On this corpus one cell moved 65 to 0 between two recordings minutes apart, so
+// which single sample survived was not a detail.
+//
+// The top-level verdict/summary/findings stay as the last run's, for anything
+// reading a cassette as one review; `samples` is what the scorer reads.
 const BENCH_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const CASSETTE_DIR = path.join(BENCH_DIR, "cassettes");
 
@@ -15,12 +24,31 @@ export function cassettePath(caseId, cell) {
 export function readCassette(caseId, cell) {
   const file = cassettePath(caseId, cell);
   if (!fs.existsSync(file)) return null;
-  return JSON.parse(fs.readFileSync(file, "utf8"));
+  const cassette = JSON.parse(fs.readFileSync(file, "utf8"));
+  // Cassettes recorded before `samples` existed, and every seeded one, are one
+  // run. Normalising here means the scorer never has to ask which era it is in.
+  if (!Array.isArray(cassette.samples) || cassette.samples.length === 0) {
+    cassette.samples = [
+      {
+        verdict: cassette.verdict ?? null,
+        summary: cassette.summary ?? null,
+        findings: Array.isArray(cassette.findings) ? cassette.findings : [],
+        latencyMs: cassette.latencyMs ?? null
+      }
+    ];
+  }
+  return cassette;
 }
 
-export function writeCassette(caseId, cell, data) {
+export function writeCassette(caseId, cell, data, samples = null) {
   const file = cassettePath(caseId, cell);
   fs.mkdirSync(path.dirname(file), { recursive: true });
+  const runs = (Array.isArray(samples) && samples.length > 0 ? samples : [data]).map((run) => ({
+    verdict: run.verdict ?? null,
+    summary: run.summary ?? null,
+    findings: Array.isArray(run.findings) ? run.findings : [],
+    latencyMs: run.latencyMs ?? null
+  }));
   const payload = {
     caseId,
     cell,
@@ -30,6 +58,7 @@ export function writeCassette(caseId, cell, data) {
     findings: Array.isArray(data.findings) ? data.findings : [],
     latencyMs: data.latencyMs ?? null,
     engineVersion: data.engineVersion ?? null,
+    samples: runs,
     ...(data.raw !== undefined ? { raw: data.raw } : {})
   };
   fs.writeFileSync(file, `${JSON.stringify(payload, null, 2)}\n`);

--- a/bench/lib/report.mjs
+++ b/bench/lib/report.mjs
@@ -44,7 +44,11 @@ function describeSource(p) {
   if (!p) return "—";
   if (p.seeded) return "**seeded**";
   const day = p.recordedAt ? p.recordedAt.slice(0, 10) : "?";
-  return p.engineVersion ? `live ${day} · ${p.engineVersion}` : `live ${day}`;
+  // The sample count travels with the number. A composite from one run and a
+  // composite averaged over five read identically without it, and on this corpus
+  // they are not comparable.
+  const n = Number.isFinite(p.samples) && p.samples > 1 ? ` ×${p.samples}` : "";
+  return p.engineVersion ? `live ${day} · ${p.engineVersion}${n}` : `live ${day}${n}`;
 }
 
 // A seeded cassette is an illustration, not a measurement, so it cannot win an

--- a/bench/lib/report.mjs
+++ b/bench/lib/report.mjs
@@ -35,6 +35,21 @@ function provenanceByCell(rows) {
   return out;
 }
 
+// The widest movement any one case showed, because a cell is only as trustworthy
+// as its least stable case. `null` means at least one case never repeated.
+function spreadByCell(rows) {
+  const out = {};
+  for (const cell of CELL_IDS) {
+    const own = rows.filter((r) => r.cell === cell && r.status === "ok");
+    if (own.length === 0 || own.some((r) => r.spread == null)) {
+      out[cell] = null;
+      continue;
+    }
+    out[cell] = Math.max(...own.map((r) => r.spread));
+  }
+  return out;
+}
+
 function cellsOn(axis) {
   const key = axis === "model" ? "model-isolated" : "plugin-native";
   return CELL_IDS.filter((c) => CELLS[c].track === key);
@@ -54,33 +69,70 @@ function describeSource(p) {
 // A seeded cassette is an illustration, not a measurement, so it cannot win an
 // axis and cannot anchor a lift. Scoring it anyway is how an invented number
 // reaches a reader as a result — the axis says what it has instead.
-function axisVerdict(cells, agg, prov) {
+// Two ways a number can be present and still unable to win an axis, and they are
+// the same objection: it is not evidence anyone can compare against.
+//
+//   - it was never run (seeded), or
+//   - it was run once, so how far it moves between runs is unknown.
+//
+// The second is not pedantry on this corpus. Recording `agy.model` three times
+// gave 0, 65, 65 on one case; `codex.model` gave 0, 45, 0. A single sample from
+// either could have been anything, and the hardcoded 2-point noise band that used
+// to guard these comparisons was calibrated against nothing at all.
+function axisVerdict(cells, agg, prov, spreads) {
   const scored = cells
-    .map((cell) => ({ cell, tool: CELLS[cell].tool, score: agg[cell]?.composite, seeded: Boolean(prov[cell]?.seeded) }))
+    .map((cell) => ({
+      cell,
+      tool: CELLS[cell].tool,
+      score: agg[cell]?.composite,
+      seeded: Boolean(prov[cell]?.seeded),
+      samples: prov[cell]?.samples ?? 1,
+      spread: spreads[cell]
+    }))
     .filter((e) => e.score != null);
   if (scored.length === 0) return { name: "—", note: "no data" };
+  const label = (e) =>
+    `${e.tool} ${e.score}${e.seeded ? " (seeded)" : e.spread == null ? " (1 sample)" : ` ±${e.spread}`}`;
   const detail = scored
     .slice()
     .sort((a, b) => b.score - a.score)
-    .map((e) => `${e.tool} ${e.score}${e.seeded ? " (seeded)" : ""}`)
+    .map(label)
     .join(" · ");
-  const measured = scored.filter((e) => !e.seeded);
-  if (measured.length < 2) {
-    return { name: "—", note: `not decidable: ${measured.length} of ${scored.length} cells measured · ${detail}` };
+  const comparable = scored.filter((e) => !e.seeded && e.spread != null);
+  if (comparable.length < 2) {
+    return {
+      name: "—",
+      note: `not decidable: ${comparable.length} of ${scored.length} cells carry repeated measurements · ${detail}`
+    };
   }
-  const ranked = measured.slice().sort((a, b) => b.score - a.score);
-  if (ranked[0].score - ranked[1].score < 2) return { name: "tie", note: `within noise · ${detail}` };
+  const ranked = comparable.slice().sort((a, b) => b.score - a.score);
+  const lead = ranked[0].score - ranked[1].score;
+  // Beat the movement, not a constant. If the gap is no wider than either cell's
+  // own run-to-run range, the next recording could reverse it.
+  const band = Math.max(ranked[0].spread, ranked[1].spread);
+  if (lead <= band) {
+    return {
+      name: "tie",
+      note: `lead of ${Math.round(lead * 10) / 10} does not clear the ±${band} either cell moves between runs · ${detail}`
+    };
+  }
   return { name: ranked[0].tool, note: detail };
 }
 
-function harnessLifts(agg, prov) {
+// A lift is a comparison like any other, and was the last place still exempt from
+// having to clear its own noise. `+21` between a cell that moves ±65 and one that
+// moves ±16 is not a lift anyone has measured.
+function harnessLifts(agg, prov, spreads) {
   const tools = [...new Set(CELL_IDS.map((c) => CELLS[c].tool))];
   return tools.map((tool) => {
     const from = CELL_IDS.find((c) => CELLS[c].tool === tool && CELLS[c].track === "model-isolated");
     const to = CELL_IDS.find((c) => CELLS[c].tool === tool && CELLS[c].track === "plugin-native");
     const lift = from && to ? liftOf(agg, from, to) : null;
     const seeded = Boolean(prov[from]?.seeded || prov[to]?.seeded);
-    return { tool, from, to, lift, seeded };
+    const ends = [spreads[from], spreads[to]];
+    const band = ends.some((v) => v == null) ? null : Math.max(...ends);
+    const established = lift != null && !seeded && band != null && Math.abs(lift) > band;
+    return { tool, from, to, lift, seeded, band, established };
   });
 }
 
@@ -99,9 +151,10 @@ function winner(a, b, agg) {
 export function buildScorecard(rows, meta = {}) {
   const agg = aggregateByCell(rows);
   const prov = provenanceByCell(rows);
-  const modelAxis = axisVerdict(cellsOn("model"), agg, prov);
-  const harnessAxis = axisVerdict(cellsOn("harness"), agg, prov);
-  const lifts = harnessLifts(agg, prov);
+  const spreads = spreadByCell(rows);
+  const modelAxis = axisVerdict(cellsOn("model"), agg, prov, spreads);
+  const harnessAxis = axisVerdict(cellsOn("harness"), agg, prov, spreads);
+  const lifts = harnessLifts(agg, prov, spreads);
 
   const lines = [];
   lines.push("# review benchmark scorecard — agy · gemini · codex");
@@ -116,18 +169,24 @@ export function buildScorecard(rows, meta = {}) {
   lines.push(`| **Harness** (agentic reviewers) | **${harnessAxis.name}** | ${harnessAxis.note} |`);
   for (const l of lifts) {
     if (l.lift == null) continue;
-    const note = l.seeded ? "one end is seeded — not a measurement" : `${l.from} → ${l.to} composite`;
+    const note = l.seeded
+      ? "one end is seeded — not a measurement"
+      : l.band == null
+        ? "one end was recorded once — its noise is unknown"
+        : l.established
+          ? `${l.from} → ${l.to} composite, clear of the ±${l.band} its ends move`
+          : `does not clear the ±${l.band} its ends move between runs`;
     lines.push(`| Harness lift — ${l.tool} | ${fmtLift(l.lift)} | ${note} |`);
   }
   lines.push("");
   lines.push("## Per-cell aggregate");
   lines.push("");
-  lines.push("| Cell | Source | Cases | Composite | Recall | Precision | FP | Bonus | Sev-exact | Latency |");
-  lines.push("|---|---|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|");
+  lines.push("| Cell | Source | Cases | Composite | Spread | Recall | Precision | FP | Bonus | Sev-exact | Latency |");
+  lines.push("|---|---|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|");
   for (const cell of CELL_IDS) {
     const a = agg[cell];
     lines.push(
-      `| ${CELLS[cell].label} | ${describeSource(prov[cell])} | ${a.cases} | ${fmt(a.composite)} | ${fmt(a.recall)} | ${fmt(a.precision)} | ${a.falsePositives} | ${a.bonus} | ${fmt(a.severityExactRate)} | ${a.latencyMs == null ? "—" : `${a.latencyMs}ms`} |`
+      `| ${CELLS[cell].label} | ${describeSource(prov[cell])} | ${a.cases} | ${fmt(a.composite)} | ${spreads[cell] == null ? "—" : `±${spreads[cell]}`} | ${fmt(a.recall)} | ${fmt(a.precision)} | ${a.falsePositives} | ${a.bonus} | ${fmt(a.severityExactRate)} | ${a.latencyMs == null ? "—" : `${a.latencyMs}ms`} |`
     );
   }
   lines.push("");
@@ -149,6 +208,7 @@ export function buildScorecard(rows, meta = {}) {
   lines.push("- The **model axis** isolates raw single-shot quality (diff embedded, tools forbidden); the **harness axis** is each tool's repo-exploring reviewer. Most real-world gap lives on the harness axis — see `docs/MODEL_COMPARISON.md`.");
   lines.push("- Composite = `recall*70 + precision*20 + severityExact*10` (0–100); it is a summary, not a verdict — read the columns.");
   lines.push("- In `--live` mode model output is non-deterministic; treat single-digit composite gaps as noise. Use `--repeats N` to average.");
+  lines.push("- **Spread** is the widest gap between repeats of the same recording, on the least stable case. It is the noise band: a verdict is only named when the lead is wider than it. A cell recorded once has no spread and cannot win or lose an axis — `—` there means unknown, not stable.");
   lines.push("- A cell marked **seeded** was never run: its cassette is an illustration kept so the table has a shape, and it is excluded from every verdict and lift above.");
   lines.push("- A finding outside the planted set but on the case's `allowed_extras` list counts as **bonus** (a legitimate unique catch), not a false positive.");
   lines.push("");
@@ -158,7 +218,9 @@ export function buildScorecard(rows, meta = {}) {
     caseCount: meta.caseCount ?? null,
     modelAxisWinner: modelAxis.name,
     harnessAxisWinner: harnessAxis.name,
-    harnessLifts: Object.fromEntries(lifts.map((l) => [l.tool, { lift: l.lift, seeded: l.seeded }])),
+    harnessLifts: Object.fromEntries(
+      lifts.map((l) => [l.tool, { lift: l.lift, seeded: l.seeded, band: l.band, established: l.established }])
+    ),
     provenance: prov,
     byCell: agg
   };

--- a/bench/run-bench.mjs
+++ b/bench/run-bench.mjs
@@ -51,6 +51,7 @@ function liveCell({ caseId, cell, promptText, repeats, truth }) {
   const needsRepo = CELLS[cell]?.harness === "agentic";
   try {
     const scores = [];
+    const results = [];
     let last = null;
     for (let r = 0; r < repeats; r += 1) {
       if (CELLS[cell]?.track === "model-isolated" && !promptText) {
@@ -65,14 +66,20 @@ function liveCell({ caseId, cell, promptText, repeats, truth }) {
       if (needsRepo && repoCtx) { repoCtx.cleanup(); repoCtx = null; }
       if (!result.ok) return { status: "skipped", note: result.error, latencyMs: result.latencyMs };
       last = result;
+      results.push(result);
       scores.push(scoreReview(result.findings, truth));
     }
-    writeCassette(caseId, cell, last);
+    writeCassette(caseId, cell, last, results);
     return {
       status: "ok",
       score: avgScores(scores),
       latencyMs: last.latencyMs,
-      provenance: { seeded: false, recordedAt: new Date().toISOString(), engineVersion: last.engineVersion ?? null }
+      provenance: {
+        seeded: false,
+        recordedAt: new Date().toISOString(),
+        engineVersion: last.engineVersion ?? null,
+        samples: results.length
+      }
     };
   } finally {
     if (repoCtx) repoCtx.cleanup();
@@ -82,14 +89,19 @@ function liveCell({ caseId, cell, promptText, repeats, truth }) {
 function replayCell({ caseId, cell, truth }) {
   const cassette = readCassette(caseId, cell);
   if (!cassette) return { status: "skipped", note: "no cassette" };
+  const scores = cassette.samples.map((run) => scoreReview(run.findings, truth));
+  const latencies = cassette.samples.map((run) => run.latencyMs).filter((n) => Number.isFinite(n));
   return {
     status: "ok",
-    score: scoreReview(cassette.findings, truth),
-    latencyMs: cassette.latencyMs,
+    score: avgScores(scores),
+    latencyMs: latencies.length
+      ? Math.round(latencies.reduce((a, b) => a + b, 0) / latencies.length)
+      : cassette.latencyMs,
     provenance: {
       seeded: Boolean(cassette.source),
       recordedAt: cassette.recordedAt ?? null,
-      engineVersion: cassette.engineVersion ?? null
+      engineVersion: cassette.engineVersion ?? null,
+      samples: cassette.samples.length
     }
   };
 }
@@ -144,4 +156,11 @@ function main() {
   process.stderr.write(`\nScorecard written to ${mdOut}\n`);
 }
 
-main();
+// Run only when invoked as the CLI. Importing this file used to run the whole
+// benchmark, which is why `replayCell` had no test — and replay is where the
+// published number comes from.
+const invokedDirectly =
+  process.argv[1] && path.resolve(process.argv[1]) === path.resolve(fileURLToPath(import.meta.url));
+if (invokedDirectly) main();
+
+export const _internal = { replayCell, avgScores };

--- a/bench/run-bench.mjs
+++ b/bench/run-bench.mjs
@@ -46,6 +46,16 @@ function avgScores(scores) {
   return out;
 }
 
+// How far this cell's composite moved between repeats of the same recording.
+// One sample cannot answer that, and `null` is not zero: an unknown spread must
+// not read as a perfectly stable cell.
+function spreadOf(scores) {
+  if (scores.length < 2) return null;
+  const comps = scores.map((s) => s.composite).filter((n) => Number.isFinite(n));
+  if (comps.length < 2) return null;
+  return Math.round((Math.max(...comps) - Math.min(...comps)) * 10) / 10;
+}
+
 function liveCell({ caseId, cell, promptText, repeats, truth }) {
   let repoCtx = null;
   const needsRepo = CELLS[cell]?.harness === "agentic";
@@ -73,6 +83,7 @@ function liveCell({ caseId, cell, promptText, repeats, truth }) {
     return {
       status: "ok",
       score: avgScores(scores),
+      spread: spreadOf(scores),
       latencyMs: last.latencyMs,
       provenance: {
         seeded: false,
@@ -94,6 +105,7 @@ function replayCell({ caseId, cell, truth }) {
   return {
     status: "ok",
     score: avgScores(scores),
+    spread: spreadOf(scores),
     latencyMs: latencies.length
       ? Math.round(latencies.reduce((a, b) => a + b, 0) / latencies.length)
       : cassette.latencyMs,

--- a/bench/run-bench.test.mjs
+++ b/bench/run-bench.test.mjs
@@ -171,14 +171,20 @@ function scoreOf(composite) {
   };
 }
 
-function row(cell, composite, seeded, caseId = "c1") {
+function row(cell, composite, seeded, spread = 2, caseId = "c1") {
   return {
     caseId,
     cell,
     status: "ok",
     score: scoreOf(composite),
+    spread,
     latencyMs: 1000,
-    provenance: { seeded, recordedAt: "2026-08-19T00:00:00.000Z", engineVersion: seeded ? null : "1.1.14" }
+    provenance: {
+      seeded,
+      recordedAt: "2026-08-19T00:00:00.000Z",
+      engineVersion: seeded ? null : "1.1.14",
+      samples: spread == null ? 1 : 3
+    }
   };
 }
 
@@ -190,22 +196,44 @@ test("a seeded cell cannot win an axis, however high it scores", () => {
 
   assert.notEqual(summary.harnessAxisWinner, "codex", "a cassette nobody ran must not win");
   assert.equal(summary.harnessAxisWinner, "—");
-  assert.match(markdown, /not decidable: 1 of 2 cells measured/);
+  assert.match(markdown, /not decidable: 1 of 2 cells carry repeated measurements/);
   assert.match(markdown, /codex 99 \(seeded\)/, "the seeded number is still shown, just labelled");
 });
 
-test("an axis names a winner once two measured cells disagree beyond noise", () => {
+test("an axis names a winner once the lead clears the movement behind it", () => {
   const { summary } = buildScorecard([
-    row("agy.deep", 90, false),
-    row("codex.native", 60, false)
+    row("agy.deep", 90, false, 5),
+    row("codex.native", 60, false, 5)
   ]);
-  assert.equal(summary.harnessAxisWinner, "agy");
+  assert.equal(summary.harnessAxisWinner, "agy", "a 30-point lead over cells that move ±5");
+});
+
+test("a lead inside the spread is a tie, however many points it is", () => {
+  // The old rule was a hardcoded 2-point band, which would have called this
+  // decisive. On this corpus one cell really did move 0 -> 65 between repeats.
+  const { summary, markdown } = buildScorecard([
+    row("agy.deep", 90, false, 65),
+    row("codex.native", 60, false, 5)
+  ]);
+  assert.equal(summary.harnessAxisWinner, "tie");
+  assert.match(markdown, /lead of 30 does not clear the ±65/);
+});
+
+test("a cell recorded once cannot enter a verdict, because its noise is unknown", () => {
+  const { summary, markdown } = buildScorecard([
+    row("agy.deep", 60, false, 5),
+    row("codex.native", 99, false, null)
+  ]);
+
+  assert.notEqual(summary.harnessAxisWinner, "codex", "99 from a single run must not win");
+  assert.equal(summary.harnessAxisWinner, "—");
+  assert.match(markdown, /codex 99 \(1 sample\)/, "shown, and shown to be one sample");
 });
 
 test("two measured cells within noise tie rather than crowning one", () => {
   const { summary } = buildScorecard([
-    row("agy.deep", 90, false),
-    row("codex.native", 89, false)
+    row("agy.deep", 90, false, 5),
+    row("codex.native", 89, false, 5)
   ]);
   assert.equal(summary.harnessAxisWinner, "tie");
 });
@@ -220,15 +248,38 @@ test("a harness lift with a seeded end is not reported as a measurement", () => 
   assert.match(markdown, /Harness lift — gemini \| \+20 \| one end is seeded — not a measurement/);
 });
 
-test("a harness lift measured end to end says what it is", () => {
+test("a harness lift measured end to end, and clear of its noise, says so", () => {
   const { markdown, summary } = buildScorecard([
-    row("agy.model", 73, false),
-    row("agy.deep", 90.5, false)
+    row("agy.model", 73, false, 5),
+    row("agy.deep", 90.5, false, 5)
   ]);
 
   assert.equal(summary.harnessLifts.agy.seeded, false);
   assert.equal(summary.harnessLifts.agy.lift, 17.5);
-  assert.match(markdown, /Harness lift — agy \| \+17.5 \| agy.model → agy.deep composite/);
+  assert.equal(summary.harnessLifts.agy.established, true);
+  assert.match(markdown, /Harness lift — agy \| \+17.5 \| .*clear of the ±5 its ends move/);
+});
+
+test("a lift no wider than its ends' own movement is not a lift", () => {
+  const { markdown, summary } = buildScorecard([
+    row("agy.model", 64, false, 65),
+    row("agy.deep", 85, false, 16)
+  ]);
+
+  assert.equal(summary.harnessLifts.agy.established, false);
+  assert.equal(summary.harnessLifts.agy.band, 65);
+  assert.match(markdown, /Harness lift — agy \| \+21 \| does not clear the ±65/);
+});
+
+test("a lift with a single-sample end reports that rather than a number it cannot back", () => {
+  const { markdown, summary } = buildScorecard([
+    row("gemini.model", 73, false, null),
+    row("gemini.deep", 84.5, false, 1)
+  ]);
+
+  assert.equal(summary.harnessLifts.gemini.band, null);
+  assert.equal(summary.harnessLifts.gemini.established, false);
+  assert.match(markdown, /Harness lift — gemini \| \+11.5 \| one end was recorded once/);
 });
 
 test("the per-cell table carries the build a live cell was recorded against", () => {
@@ -287,6 +338,7 @@ test("replaying a cassette recorded with repeats averages them instead of taking
   assert.notEqual(row.score.composite, 20, "20 is the last run alone — the flaw this exists to catch");
   assert.equal(row.score.composite, 73, "(100 + 100 + 20) / 3");
   assert.equal(row.provenance.samples, 3, "and the reader is told it is an average of three");
+  assert.equal(row.spread, 80, "and how far those three moved: 100 and 100 and 20");
   assert.equal(row.latencyMs, 200, "latency averages with the score, not the last run's");
 });
 
@@ -305,6 +357,7 @@ test("a cassette recorded before repeats existed still replays as a single sampl
 
   assert.equal(row.score.composite, 100, "scored from the top-level findings, exactly as before");
   assert.equal(row.provenance.samples, 1);
+  assert.equal(row.spread, null, "one run cannot show its own movement, and null is not zero");
   assert.equal(row.latencyMs, 1234);
 });
 
@@ -325,6 +378,12 @@ test("writeCassette keeps every repeat, not just the one it reports at the top",
   assert.equal(stored.samples.length, 2);
   assert.equal(stored.samples[0].findings.length, 2, "the run that was not last is still there");
   assert.equal(stored.findings.length, 0, "and the top level is still the last run");
+});
+
+test("the per-cell table shows the movement behind each number", () => {
+  const { markdown } = buildScorecard([row("agy.deep", 85, false, 16), row("gemini.deep", 84.5, false, null)]);
+  assert.match(markdown, /±16/, "a measured spread is printed");
+  assert.match(markdown, /Gemini \(--deep, agentic\) \|[^|]*\|[^|]*\|[^|]*\| — \|/, "and an unknown one is a dash, not a zero");
 });
 
 test("the source column says how many samples a number came from", () => {

--- a/bench/run-bench.test.mjs
+++ b/bench/run-bench.test.mjs
@@ -4,6 +4,10 @@ import assert from "node:assert/strict";
 import { scoreReview, findingMatchesPlanted, normalizeFile } from "./lib/score.mjs";
 import { _internal as adapters } from "./lib/adapters.mjs";
 import { buildScorecard } from "./lib/report.mjs";
+import { cassettePath, writeCassette } from "./lib/cassette.mjs";
+import { _internal as bench } from "./run-bench.mjs";
+import fs from "node:fs";
+import path from "node:path";
 
 const TRUTH = {
   planted: [
@@ -230,4 +234,121 @@ test("a harness lift measured end to end says what it is", () => {
 test("the per-cell table carries the build a live cell was recorded against", () => {
   const { markdown } = buildScorecard([row("agy.deep", 90.5, false)]);
   assert.match(markdown, /live 2026-08-19 · 1.1.14/);
+});
+
+// --- repeats have to survive into replay ------------------------------------
+// The published scorecard comes from replay, so an average that exists only in a
+// live run is an average nobody ever reads. `--repeats N` used to store the last
+// run and average nothing that lasted.
+
+const PERFECT = [
+  finding({ severity: "critical", title: "SQL injection", body: "not parameterized", line_start: 10, line_end: 12 }),
+  finding({ severity: "high", title: "Unguarded JSON.parse", body: "may throw", line_start: 40, line_end: 41 })
+];
+
+function scratchCassette(t, cell, payload) {
+  // A case id with no corpus entry, so a stray file could never join a real run.
+  const caseId = "__scratch-" + cell.replace(/\W/g, "-");
+  const file = cassettePath(caseId, cell);
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, JSON.stringify(payload, null, 2));
+  t.after(() => {
+    try {
+      fs.rmSync(path.dirname(file), { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+    } catch (error) {
+      process.stderr.write(`left ${path.dirname(file)} for the OS: ${error?.code}\n`);
+    }
+  });
+  return caseId;
+}
+
+test("replaying a cassette recorded with repeats averages them instead of taking the last", (t) => {
+  const caseId = scratchCassette(t, "agy.model", {
+    caseId: "x",
+    cell: "agy.model",
+    recordedAt: "2026-08-19T00:00:00.000Z",
+    engineVersion: "1.1.14",
+    verdict: "approve",
+    summary: "last run",
+    findings: [],
+    latencyMs: 300,
+    samples: [
+      { verdict: "needs-attention", summary: "1", findings: PERFECT, latencyMs: 100 },
+      { verdict: "needs-attention", summary: "2", findings: PERFECT, latencyMs: 200 },
+      { verdict: "approve", summary: "3", findings: [], latencyMs: 300 }
+    ]
+  });
+
+  const row = bench.replayCell({ caseId, cell: "agy.model", truth: TRUTH });
+
+  assert.equal(row.status, "ok");
+  // An empty review is not 0: precision is vacuously 1 over zero findings, so
+  // saying nothing scores 20. That is what the last run alone would report here.
+  assert.notEqual(row.score.composite, 20, "20 is the last run alone — the flaw this exists to catch");
+  assert.equal(row.score.composite, 73, "(100 + 100 + 20) / 3");
+  assert.equal(row.provenance.samples, 3, "and the reader is told it is an average of three");
+  assert.equal(row.latencyMs, 200, "latency averages with the score, not the last run's");
+});
+
+test("a cassette recorded before repeats existed still replays as a single sample", (t) => {
+  const caseId = scratchCassette(t, "agy.deep", {
+    caseId: "x",
+    cell: "agy.deep",
+    recordedAt: "2026-06-04T00:00:00.000Z",
+    verdict: "needs-attention",
+    summary: "one run",
+    findings: PERFECT,
+    latencyMs: 1234
+  });
+
+  const row = bench.replayCell({ caseId, cell: "agy.deep", truth: TRUTH });
+
+  assert.equal(row.score.composite, 100, "scored from the top-level findings, exactly as before");
+  assert.equal(row.provenance.samples, 1);
+  assert.equal(row.latencyMs, 1234);
+});
+
+test("writeCassette keeps every repeat, not just the one it reports at the top", (t) => {
+  const cell = "agy.model";
+  const caseId = scratchCassette(t, cell, { placeholder: true });
+  writeCassette(
+    caseId,
+    cell,
+    { verdict: "approve", summary: "last", findings: [], latencyMs: 300, engineVersion: "1.1.14" },
+    [
+      { verdict: "needs-attention", summary: "1", findings: PERFECT, latencyMs: 100 },
+      { verdict: "approve", summary: "last", findings: [], latencyMs: 300 }
+    ]
+  );
+
+  const stored = JSON.parse(fs.readFileSync(cassettePath(caseId, cell), "utf8"));
+  assert.equal(stored.samples.length, 2);
+  assert.equal(stored.samples[0].findings.length, 2, "the run that was not last is still there");
+  assert.equal(stored.findings.length, 0, "and the top level is still the last run");
+});
+
+test("the source column says how many samples a number came from", () => {
+  const withRepeats = buildScorecard([
+    {
+      caseId: "c1",
+      cell: "agy.deep",
+      status: "ok",
+      score: { composite: 90, recall: 1, precision: 1, falsePositives: 0, bonus: 0, severityExactRate: 1, missed: [] },
+      latencyMs: 1000,
+      provenance: { seeded: false, recordedAt: "2026-08-19T00:00:00.000Z", engineVersion: "1.1.14", samples: 5 }
+    }
+  ]);
+  assert.match(withRepeats.markdown, /live 2026-08-19 · 1.1.14 ×5/);
+
+  const single = buildScorecard([
+    {
+      caseId: "c1",
+      cell: "agy.deep",
+      status: "ok",
+      score: { composite: 90, recall: 1, precision: 1, falsePositives: 0, bonus: 0, severityExactRate: 1, missed: [] },
+      latencyMs: 1000,
+      provenance: { seeded: false, recordedAt: "2026-08-19T00:00:00.000Z", engineVersion: "1.1.14", samples: 1 }
+    }
+  ]);
+  assert.doesNotMatch(single.markdown, /×1/, "one sample is the default, and saying so would be noise");
 });


### PR DESCRIPTION
Yesterday this benchmark published `agy.model = 72` and a harness lift of `+15`. Recording the same cell three times gives 0, 65, 65 on one case. The number was never wrong so much as never meaningful, and nothing in the runner could tell the difference.

Two defects, one behind the other.

## 1. `--repeats N` never reached the published number

`liveCell` averaged N runs into the live scorecard and then called `writeCassette(caseId, cell, last)`. Everything downstream reads the cassette — the published scorecard comes from replay — so the figure that reached a reader was a single sample wearing an averaged run's reputation, and *which* sample was whichever happened to run last.

Cassettes now carry every repeat in `samples`; replay scores each and averages them; the source column prints `×N`. The top-level `verdict`/`summary`/`findings` stay as the last run's, so anything reading a cassette as one review still can. Cassettes recorded before this field — and every seeded one — normalise to a single sample on read and replay exactly the numbers they did before.

`main()` is now behind an invoked-directly guard, because importing this file used to run the whole benchmark. That is why `replayCell` had no test, and replay is where the published number comes from.

## 2. The noise band was calibrated against nothing

A lead counted as decisive at 2 composite points. Here is what three samples per cell actually do:

| cell | `auth-basic` | `repo-context` | widest move |
|---|---|---|:-:|
| `gemini.deep` | 80, 81, 81 | 88, 88, 88 | **1** |
| `agy.deep` | 81, 77, 93 | 88, 88, 83 | 16 |
| `codex.model` | 96, 72, 98 | 0, 45, 0 | 45 |
| `agy.model` | 81, 94, 81 | 0, 65, 65 | **65** |

The band is now that measured spread — the widest gap a cell's own repeats produced, on its least stable case — printed beside every number. A verdict is named only when the lead is wider than it, and harness lifts, the last comparison still exempt, are held to the same test.

A cell recorded once has no spread. It prints `—` for *unknown*, not zero, and can neither win nor lose an axis: the same exclusion a seeded cell gets, for the same reason. That closes a live hole — `gemini.model`'s single sample from 2026-06-04, recorded against a build whose consumer tier stopped serving on 2026-06-18, was beating today's three-sample averages and being crowned for it.

## What the board says now

```
| Model (single-shot)  | tie | lead of 12 does not clear the ±65 either cell moves between runs
                              · gemini 73 (1 sample) · agy 64 ±65 · codex 52 ±45 |
| Harness (agentic)    | tie | lead of 0.5 does not clear the ±16
                              · codex 93 (seeded) · agy 85 ±16 · gemini 84.5 ±1 |
| Harness lift — agy   | +21 | does not clear the ±65 its ends move between runs |
```

**Nothing on it is decidable**, including the AGY harness lift this benchmark was extended to measure. That is the honest reading of two cases at three samples, and it is the point: the runner now says so instead of printing a winner.

What the data *does* support is not a score. **The agentic cells are an order of magnitude steadier than the model cells** — `gemini.deep` moved 1 point across six runs while `agy.model` moved 65 on a single case. Part of what a repo-exploring harness buys is a repeatable answer, which is a more useful claim than any composite here and the only one currently earned.

## Cassette changes

- `agy.model`, `agy.deep`, `gemini.deep`, `codex.model` re-recorded, three samples each (agy 1.1.14, gemini 0.54.4, codex-cli 0.147.0).
- **`gemini.deep` records headlessly after all.** The README's claim that it cannot — tool approvals needing a TTY — did not survive six clean runs on gemini 0.54.4. Corrected there.
- `gemini.model` is still the 2026-06-04 single sample, and now fails to re-record for a reason unrelated to credentials: the CLI prints `Warning: True color (24-bit) support not detected` and `Ripgrep is not available` ahead of its JSON and the cell's parser gives up. Left as a known issue rather than papered over.
- `codex.native` still seeded — `BENCH_CODEX_COMPANION` was unset.

## Tests

28 in this file, 578 across the suite, 0 failures. Ten mutations, each killing exactly the test that should catch it:

| mutation | fails |
|---|---|
| replay takes the last run instead of averaging | "replaying a cassette recorded with repeats averages them" |
| replay takes the last latency | same |
| `writeCassette` discards the extra repeats | "writeCassette keeps every repeat" |
| a legacy cassette loses its normalisation | "a cassette recorded before repeats existed still replays as one sample" |
| restore the hardcoded 2-point band | "a lead inside the spread is a tie, however many points it is" |
| let a single-sample cell compete | "a cell recorded once cannot enter a verdict" |
| treat an unknown spread as zero | same, plus two others |
| call every lift established | both lift tests |
| report one sample as perfectly stable | "a cassette recorded before repeats existed…" |
| drop the sample count from the source column | "the source column says how many samples a number came from" |

One of these appeared to survive at first. It was hitting `avgScores` in the live path — `String.replace` takes the first match and both call sites read identically — so the mutation was mis-aimed rather than the test weak. Re-run against `replayCell` specifically, it kills.

## Known limits

- Two cases. Three samples. The spreads above are themselves estimated from three points and will move.
- The composite gives an empty review 20/100: precision is vacuously 1 over zero findings. A reviewer that says nothing scores 20 while one that finds half the defects cleanly scores 55. Left alone here — changing the formula shifts every existing number, and it deserves its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019G2BAczpG8DL2NiAqTYkHA
