### PR TITLE
Stop paying 20 points for saying nothing

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -119,6 +119,13 @@ Per cell, findings are matched against the case's `ground-truth.json`:
 - Each finding is assigned to its **single best** unmatched planted defect, so two
   line-adjacent defects are never double-counted.
 - `recall` = planted found / planted total. `precision` = relevant / findings.
+- **An empty review scores 0, not 20.** Precision over zero findings is undefined
+  rather than perfect, and paying for it made silence the best available wrong
+  answer: saying nothing scored 20 while naming one thing and being wrong scored 0.
+  A scorer that rewards not looking cannot be used to argue that looking helps. The
+  exception is kept: when a case plants nothing, an empty review is the correct
+  answer and earns its precision. No committed sample was ever empty (28 of 28 have
+  at least one finding), so this closes a hole rather than restating any result.
 - A finding matching none of the planted set but listed in `allowed_extras` is a
   **bonus** (a legitimate unique catch), not a false positive. Everything else
   unmatched is a **false positive**.

--- a/bench/lib/score.mjs
+++ b/bench/lib/score.mjs
@@ -118,7 +118,14 @@ export function scoreReview(findings, truth, options = {}) {
   const found = matchedPlantedIds.size;
   const recall = planted.length ? found / planted.length : 1;
   const relevant = found + bonus;
-  const precision = list.length ? relevant / list.length : 1;
+  // Precision over an empty review is not 1, it is undefined, and paying 20 points
+  // for it made silence the best available wrong answer: on this corpus, saying
+  // nothing scored 20 while naming one thing that turned out to be wrong scored 0.
+  // A scorer that rewards not looking cannot be used to argue that looking helps.
+  //
+  // The exception is real and kept: when there is nothing planted to find, an empty
+  // review is the correct answer and earns its precision.
+  const precision = list.length ? relevant / list.length : planted.length ? 0 : 1;
 
   const severity = { exact: 0, within1: 0, mismatch: 0, unknown: 0 };
   for (const p of planted) {

--- a/bench/run-bench.test.mjs
+++ b/bench/run-bench.test.mjs
@@ -333,12 +333,10 @@ test("replaying a cassette recorded with repeats averages them instead of taking
   const row = bench.replayCell({ caseId, cell: "agy.model", truth: TRUTH });
 
   assert.equal(row.status, "ok");
-  // An empty review is not 0: precision is vacuously 1 over zero findings, so
-  // saying nothing scores 20. That is what the last run alone would report here.
-  assert.notEqual(row.score.composite, 20, "20 is the last run alone — the flaw this exists to catch");
-  assert.equal(row.score.composite, 73, "(100 + 100 + 20) / 3");
+  assert.notEqual(row.score.composite, 0, "0 is the last run alone — the flaw this exists to catch");
+  assert.equal(row.score.composite, 67, "(100 + 100 + 0) / 3");
   assert.equal(row.provenance.samples, 3, "and the reader is told it is an average of three");
-  assert.equal(row.spread, 80, "and how far those three moved: 100 and 100 and 20");
+  assert.equal(row.spread, 100, "and how far those three moved: two perfect runs and one empty one");
   assert.equal(row.latencyMs, 200, "latency averages with the score, not the last run's");
 });
 
@@ -410,4 +408,27 @@ test("the source column says how many samples a number came from", () => {
     }
   ]);
   assert.doesNotMatch(single.markdown, /×1/, "one sample is the default, and saying so would be noise");
+});
+
+// --- silence must not outscore effort ----------------------------------------
+
+test("an empty review scores nothing when there was something to find", () => {
+  // Precision used to be 1 over zero findings, which paid 20 points for silence —
+  // more than naming one thing and being wrong, which pays 0. A benchmark that
+  // rewards not looking cannot be evidence that looking helps.
+  const silent = scoreReview([], TRUTH);
+  const wrong = scoreReview([finding({ file: "src/unrelated.js", title: "nothing here" })], TRUTH);
+
+  assert.equal(silent.composite, 0, "saying nothing earns nothing");
+  assert.ok(
+    silent.composite <= wrong.composite,
+    `silence (${silent.composite}) must not beat a wrong answer (${wrong.composite})`
+  );
+});
+
+test("an empty review is still correct when there is nothing planted to find", () => {
+  // The exception the rule above must not swallow: a clean diff reviewed as clean.
+  const clean = scoreReview([], { planted: [], allowed_extras: [] });
+  assert.equal(clean.precision, 1, "nothing to find, nothing wrongly claimed");
+  assert.equal(clean.composite, 90, "recall 1 and precision 1; severity has nothing to grade");
 });


### PR DESCRIPTION
`precision` was 1 over an empty finding list. That is not a perfect score, it is an undefined one, and paying 20 composite points for it made silence the best available wrong answer:

```
said nothing            -> 20
named one wrong thing   ->  0
found half, no FPs      -> 44
```

A scorer that rewards not looking cannot be used to argue that looking helps — and the harness axis exists to argue exactly that. This is the instrument, not the result, so it is worth fixing before anything else is published from it.

## The fix

```js
const precision = list.length ? relevant / list.length : planted.length ? 0 : 1;
```

The exception is deliberate and tested: a case that plants nothing is correctly reviewed as clean, and that review earns its precision. Only an empty review of a case that *had* something to find scores zero.

## No published number moves

All **28** committed samples carry at least one finding, so this hole has never once been stepped in. That is the argument for closing it now rather than after it decides something, and `bench/README.md` records the count alongside the rule so nobody later reads this as a score quietly adjusted after the fact.

One existing test moved with it: a cassette of `[perfect, perfect, empty]` now averages 67 rather than 73, and its spread is 100 rather than 80. That test was originally written expecting 67 and corrected to 73 when the old scorer contradicted it — so this is a number returning, not a new one.

## Tests

Two mutations, each killed by its own test:

| mutation | fails |
|---|---|
| restore the free precision for an empty review | "an empty review scores nothing when there was something to find" |
| score a correct clean review as though it had missed something | "an empty review is still correct when there is nothing planted to find" |

580 tests, 0 failures. `verify-contracts` passes.

## Not in scope

The composite still has no term that treats a false positive as worse than a miss, and on a review tool it plainly is — a wrong finding costs a human a trip into the code. That is a redesign of the weighting rather than a fix to an undefined value, and it would move every existing number, so it is left alone here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019G2BAczpG8DL2NiAqTYkHA
