### PR TITLE
Add three cases so one miss stops moving the score by 35 points

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -161,11 +161,31 @@ corpus/<case-id>/
 }
 ```
 
-Seeded cases:
+Cases:
 - **`auth-basic`** — five in-diff defects (the `MODEL_COMPARISON.md §A` set); probes
-  the **model axis** (everything is visible in the diff).
+  the **model axis** (everything is visible in the diff). Recorded.
 - **`repo-context`** — an undeclared dependency and a committed runtime-state file;
   invisible single-shot, so it probes the **harness axis** (`MODEL_COMPARISON.md §B`).
+  Recorded.
+- **`async-lifecycle`** — five async and resource defects in one file: a catch that
+  returns success, an unclosed handle, an uncleared interval, an unawaited promise and
+  a map nothing deletes from. Model axis. Not yet recorded.
+- **`path-and-input`** — two loud injection paths (traversal, `execSync`) and three
+  quiet ones (`parseInt` without a radix, an unbounded read, an unhandled ENOENT).
+  The quiet three are the discriminating half: a reviewer that reports only the two
+  criticals scores 0.4 recall. Model axis. Not yet recorded.
+- **`vacuous-tests`** — four green tests that constrain nothing: no assertion, an
+  `indexOf` comparison that holds when neither element is present, a permanent
+  `test.skip`, and an assertion inside `process.nextTick` that runs after the test
+  ends. The module under test sits in `base/` so the assertions can be judged against
+  real behaviour. Model axis. Not yet recorded.
+
+The three unrecorded cases exist because of the variance measured above, not because
+five cases sounded better than two. `repo-context` plants two defects, so one miss
+moves the composite by 35 points and `agy.model` swung 65 across three repeats; on
+five-defect `auth-basic` the same cell swung 13. Granularity was the dominant term in
+the noise, so every case added here plants four or five. Until they are recorded they
+print as `skipped (no cassette)` and change no number on the board.
 
 ### Adding a case
 

--- a/bench/corpus/async-lifecycle/ground-truth.json
+++ b/bench/corpus/async-lifecycle/ground-truth.json
@@ -1,0 +1,110 @@
+{
+  "title": "queue.js — five in-diff async correctness and resource defects",
+  "notes": "All defects are visible in the diff, so this case probes single-shot quality the same way auth-basic does. Five planted defects rather than two: with two, one miss moves the composite by 35 points, which is where repo-context's ±65 spread came from.",
+  "planted": [
+    {
+      "id": "swallowed-error",
+      "category": "error-handling",
+      "file": "src/queue.js",
+      "line_start": 26,
+      "line_end": 28,
+      "severity": "critical",
+      "match": {
+        "keywords": [
+          "swallow",
+          "ok: true",
+          "reports success",
+          "silently",
+          "catch block",
+          "hides the error",
+          "always returns"
+        ]
+      }
+    },
+    {
+      "id": "handle-leak",
+      "category": "resource-leak",
+      "file": "src/queue.js",
+      "line_start": 6,
+      "line_end": 10,
+      "severity": "high",
+      "match": {
+        "keywords": [
+          "file handle",
+          "not closed",
+          "leak",
+          "finally",
+          "close()",
+          "descriptor"
+        ]
+      }
+    },
+    {
+      "id": "unbounded-interval",
+      "category": "resource-leak",
+      "file": "src/queue.js",
+      "line_start": 16,
+      "line_end": 18,
+      "severity": "medium",
+      "match": {
+        "keywords": [
+          "setinterval",
+          "never cleared",
+          "clearinterval",
+          "no handle",
+          "runs forever"
+        ]
+      }
+    },
+    {
+      "id": "floating-promise",
+      "category": "error-handling",
+      "file": "src/queue.js",
+      "line_start": 17,
+      "line_end": 17,
+      "severity": "high",
+      "match": {
+        "keywords": [
+          "not awaited",
+          "floating promise",
+          "unhandled rejection",
+          "no await",
+          "no catch",
+          "promise is ignored"
+        ]
+      }
+    },
+    {
+      "id": "unbounded-map",
+      "category": "resource-leak",
+      "file": "src/queue.js",
+      "line_start": 3,
+      "line_end": 7,
+      "severity": "medium",
+      "match": {
+        "keywords": [
+          "never removed",
+          "grows",
+          "unbounded",
+          "memory",
+          "delete",
+          "map is never"
+        ]
+      }
+    }
+  ],
+  "allowed_extras": [
+    {
+      "id": "hardcoded-path",
+      "file": "src/queue.js",
+      "match": {
+        "keywords": [
+          "/var/jobs",
+          "hardcoded path",
+          "not configurable",
+          "absolute path"
+        ]
+      }
+    }
+  ]
+}

--- a/bench/corpus/async-lifecycle/head/src/queue.js
+++ b/bench/corpus/async-lifecycle/head/src/queue.js
@@ -1,0 +1,35 @@
+const fs = require("node:fs/promises");
+
+const handles = new Map();
+
+async function openJob(id) {
+  const handle = await fs.open(`/var/jobs/${id}.log`, "a");
+  handles.set(id, handle);
+  const stat = await handle.stat();
+  if (stat.size > 1_000_000) {
+    throw new Error(`job ${id} log is too large to append to`);
+  }
+  return handle;
+}
+
+function startHeartbeat(id) {
+  setInterval(() => {
+    fs.appendFile(`/var/jobs/${id}.beat`, `${Date.now()}\n`);
+  }, 1000);
+}
+
+async function runOne(id) {
+  try {
+    const handle = await openJob(id);
+    await handle.write("started\n");
+    return { id, ok: true };
+  } catch {
+    return { id, ok: true };
+  }
+}
+
+async function runAll(ids) {
+  return Promise.all(ids.map((id) => runOne(id)));
+}
+
+module.exports = { openJob, startHeartbeat, runOne, runAll };

--- a/bench/corpus/path-and-input/ground-truth.json
+++ b/bench/corpus/path-and-input/ground-truth.json
@@ -1,0 +1,113 @@
+{
+  "title": "files.js — five in-diff input-handling defects",
+  "notes": "Two critical injection paths plus three quieter validation defects. The quiet ones are the discriminating half: a reviewer that only reports the two obvious criticals scores 40 on recall, which is what separates a scan from a review.",
+  "planted": [
+    {
+      "id": "path-traversal",
+      "category": "path-traversal",
+      "file": "src/files.js",
+      "line_start": 8,
+      "line_end": 9,
+      "severity": "critical",
+      "match": {
+        "keywords": [
+          "path traversal",
+          "traversal",
+          "..",
+          "escape",
+          "outside",
+          "resolve",
+          "containment",
+          "directory traversal"
+        ]
+      }
+    },
+    {
+      "id": "command-injection",
+      "category": "injection",
+      "file": "src/files.js",
+      "line_start": 13,
+      "line_end": 13,
+      "severity": "critical",
+      "match": {
+        "keywords": [
+          "command injection",
+          "execsync",
+          "shell",
+          "interpolat",
+          "untrusted",
+          "execfile"
+        ]
+      }
+    },
+    {
+      "id": "parseint-radix",
+      "category": "validation",
+      "file": "src/files.js",
+      "line_start": 17,
+      "line_end": 18,
+      "severity": "medium",
+      "match": {
+        "keywords": [
+          "radix",
+          "parseint",
+          "nan",
+          "not validated",
+          "negative",
+          "out of range",
+          "undefined"
+        ]
+      }
+    },
+    {
+      "id": "unbounded-read",
+      "category": "resource-exhaustion",
+      "file": "src/files.js",
+      "line_start": 9,
+      "line_end": 9,
+      "severity": "medium",
+      "match": {
+        "keywords": [
+          "size limit",
+          "entire file",
+          "memory",
+          "large file",
+          "no limit",
+          "streaming"
+        ]
+      }
+    },
+    {
+      "id": "unhandled-enoent",
+      "category": "error-handling",
+      "file": "src/files.js",
+      "line_start": 7,
+      "line_end": 9,
+      "severity": "medium",
+      "match": {
+        "keywords": [
+          "enoent",
+          "missing file",
+          "throws",
+          "try/catch",
+          "does not exist",
+          "unhandled"
+        ]
+      }
+    }
+  ],
+  "allowed_extras": [
+    {
+      "id": "sync-io",
+      "file": "src/files.js",
+      "match": {
+        "keywords": [
+          "synchronous",
+          "readfilesync",
+          "blocks the event loop",
+          "blocking"
+        ]
+      }
+    }
+  ]
+}

--- a/bench/corpus/path-and-input/head/src/files.js
+++ b/bench/corpus/path-and-input/head/src/files.js
@@ -1,0 +1,21 @@
+const path = require("node:path");
+const fs = require("node:fs");
+const { execSync } = require("node:child_process");
+
+const ROOT = "/srv/uploads";
+
+function readUpload(name) {
+  const target = path.join(ROOT, name);
+  return fs.readFileSync(target, "utf8");
+}
+
+function archive(name) {
+  execSync(`tar -czf ${name}.tar.gz ${path.join(ROOT, name)}`);
+}
+
+function pickPage(body, pages) {
+  const page = parseInt(body.page);
+  return pages[page];
+}
+
+module.exports = { readUpload, archive, pickPage };

--- a/bench/corpus/vacuous-tests/base/src/session.js
+++ b/bench/corpus/vacuous-tests/base/src/session.js
@@ -1,0 +1,16 @@
+const sessions = new Map();
+
+function parseSession(raw) {
+  const parsed = JSON.parse(raw);
+  return { id: parsed.id, expiresAt: parsed.expiresAt };
+}
+
+function expire(id) {
+  return sessions.delete(id);
+}
+
+function render() {
+  return [...sessions.values()].map((s) => (s.expiresAt < Date.now() ? "expired" : "fresh"));
+}
+
+module.exports = { sessions, parseSession, expire, render };

--- a/bench/corpus/vacuous-tests/ground-truth.json
+++ b/bench/corpus/vacuous-tests/ground-truth.json
@@ -1,0 +1,94 @@
+{
+  "title": "session.test.js — four tests that pass without protecting anything",
+  "notes": "Every test here is green and none of them constrains the code. This is the case a reviewer has to read like a test, not like source: the defect is always an absent assertion rather than a present mistake. The module under test lives in base/ so the assertions can be judged against real behaviour.",
+  "planted": [
+    {
+      "id": "no-assertion",
+      "category": "test-quality",
+      "file": "test/session.test.js",
+      "line_start": 6,
+      "line_end": 7,
+      "severity": "high",
+      "match": {
+        "keywords": [
+          "no assertion",
+          "asserts nothing",
+          "does not assert",
+          "always passes",
+          "no expectation"
+        ]
+      }
+    },
+    {
+      "id": "vacuous-ordering",
+      "category": "test-quality",
+      "file": "test/session.test.js",
+      "line_start": 11,
+      "line_end": 12,
+      "severity": "high",
+      "match": {
+        "keywords": [
+          "indexof",
+          "-1",
+          "not present",
+          "absent",
+          "empty",
+          "vacuous",
+          "passes when",
+          "missing element"
+        ]
+      }
+    },
+    {
+      "id": "permanent-skip",
+      "category": "test-quality",
+      "file": "test/session.test.js",
+      "line_start": 15,
+      "line_end": 18,
+      "severity": "medium",
+      "match": {
+        "keywords": [
+          "skip",
+          "never runs",
+          "disabled",
+          "not executed",
+          "unprotected"
+        ]
+      }
+    },
+    {
+      "id": "assertion-never-runs",
+      "category": "test-quality",
+      "file": "test/session.test.js",
+      "line_start": 22,
+      "line_end": 24,
+      "severity": "high",
+      "match": {
+        "keywords": [
+          "callback",
+          "nexttick",
+          "after the test",
+          "never runs",
+          "asynchronous",
+          "not awaited",
+          "test ends"
+        ]
+      }
+    }
+  ],
+  "allowed_extras": [
+    {
+      "id": "shared-state",
+      "file": "test/session.test.js",
+      "match": {
+        "keywords": [
+          "shared state",
+          "sessions map",
+          "leaks between tests",
+          "not reset",
+          "order dependent"
+        ]
+      }
+    }
+  ]
+}

--- a/bench/corpus/vacuous-tests/head/test/session.test.js
+++ b/bench/corpus/vacuous-tests/head/test/session.test.js
@@ -1,0 +1,25 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { sessions, parseSession, expire, render } = require("../src/session");
+
+test("parseSession handles a malformed payload", () => {
+  parseSession('{"id":"abc","expiresAt":0}');
+});
+
+test("an expired session is listed before a fresh one", () => {
+  const lines = render();
+  assert.ok(lines.indexOf("expired") < lines.indexOf("fresh"));
+});
+
+test.skip("expire() removes the session", () => {
+  sessions.set("abc", { id: "abc", expiresAt: 0 });
+  assert.equal(expire("abc"), true);
+});
+
+test("deleting a session empties the store", () => {
+  sessions.set("abc", { id: "abc", expiresAt: 0 });
+  process.nextTick(() => {
+    assert.equal(sessions.size, 0);
+  });
+});


### PR DESCRIPTION
The noise on the board is mostly the corpus, not the models. `repo-context` plants two defects, so one miss is worth 35 composite points — `agy.model` swung 65 across three repeats there, against 13 on five-defect `auth-basic`. More defects per case narrows the band more cheaply than more repeats.

| case | planted | one miss costs |
|---|--:|--:|
| `async-lifecycle` | 5 | 14 |
| `path-and-input` | 5 | 14 |
| `vacuous-tests` | 4 | 18 |
| `auth-basic` (existing) | 5 | 14 |
| `repo-context` (existing) | 2 | 35 |

`vacuous-tests` is the one that is not more of the same: every other case asks the reviewer to find a mistake that is present, and this one asks it to notice an assertion that is absent. Its module under test lives in `base/`, so the assertions can be judged against real behaviour and only the test file appears in the diff.

## Verification

- Every planted anchor resolves to a real line range inside `head/` — line numbers are derived from source anchors at authoring time rather than typed.
- A synthetic perfect review scores `100` on all five cases under the merged scorer; silence and a wrong answer both score `0`.
- `npm run bench` runs clean; the three new cases print as `skipped (no cassette)`.
- `node --test bench/run-bench.test.mjs` — 30 pass.

The perfect-review check is built from the ground truth, so on its own it can only fail if the scorer is broken. The anchor check is the one that can fail on a bad case, and it is what caught nothing here only after being run.

## Not in this PR

No cassettes. Recording is 4 recordable cells × 3 cases × 3 repeats ≈ 36 live runs, and it is a separate decision from having the cases. Until then these cases change no published number.
