### PR TITLE
Release 0.22.2, and re-measure 7.2 on the AGY it ships against

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,13 +7,13 @@
   },
   "metadata": {
     "description": "Use Gemini CLI or Antigravity CLI (agy) inside Claude Code for task delegation, code review, and adversarial review.",
-    "version": "0.22.1"
+    "version": "0.22.2"
   },
   "plugins": [
     {
       "name": "gemini",
       "description": "Gemini CLI and Antigravity CLI bridge for Claude Code task delegation and adversarial review",
-      "version": "0.22.1",
+      "version": "0.22.2",
       "author": {
         "name": "arcobaleno64",
         "email": "arcobaleno830623@gmail.com"

--- a/docs/THREAT-MODEL.md
+++ b/docs/THREAT-MODEL.md
@@ -132,6 +132,45 @@ Every path lived under one disposable root on `D:\`, deliberately: this machine'
 
 **Known limit of this measurement.** The machine's `settings.json` carries `"toolPermission": "always-proceed"`, and AGY offers no flag or environment variable to override a settings file, so that variable was not controlled. It does not explain the result — conclusion 2 of the 1.1.10 block already found headless print mode auto-approving without `--dangerously-skip-permissions` — but it does mean these rows describe a machine whose approval policy is permissive. Controlling it needs a temporary home directory holding a copy of `~/.gemini/oauth_creds.json` beside a minimal settings file, which is worth doing before any claim about AGY's *defaults* rather than about its behaviour here.
 
+**Re-measured on AGY 1.1.15, 2026-08-19.** The same five rows as the 1.1.14 block
+above, deliberately: changing the probe and the version in one step measures neither.
+Same disposable root on `D:\`, for the same reason — this machine's
+`trustedWorkspaces` covers all of `C:\Users\<user>`, so a probe under the home
+directory would measure that trust entry instead of AGY's workspace boundary.
+
+| Orientation | Action | Target | Outcome |
+|---|---|---|---|
+| `--new-project` | edit tool | outside the workspace | wrote, exit 0 |
+| `--new-project --sandbox` | shell command | outside the workspace | wrote, exit 0 |
+| none | edit tool | outside the workspace | wrote, exit 0 |
+| `--add-dir` (**the plugin's read-only shape**) | edit tool | outside the workspace | wrote, exit 0 |
+| `--new-project` | edit tool | in the workspace | wrote, exit 0 — positive control |
+
+1. **The residual stands, unchanged, on 1.1.15.** Four of four configurations wrote an
+   absolute path outside the workspace they were bound to, including the shape the
+   plugin uses for a read-only turn. This is the third consecutive AGY release the row
+   has survived (1.1.10, 1.1.14, 1.1.15), and
+   [antigravity-cli#749](https://github.com/google-antigravity/antigravity-cli/issues/749)
+   remains the open request.
+2. **The control wrote, so the four rows above can be read at all.** A boundary that
+   held and a prompt the model never acted on are the same observation from outside.
+
+**Seen once, not reproduced, and not a claim.** On the first pass the last two rows
+returned `status: ERROR` in the JSON envelope while writing the file and exiting 0.
+Re-run immediately with the same flags, both returned `SUCCESS` — so the cause is
+unknown and nothing here rests on it. It is written down because it points the wrong
+way for a caller: a turn that reports an error may still have changed the tree, so
+`status` cannot be read as "did this have an effect". The plugin does not read it that
+way — `lib/readonly-guard.mjs` compares the workspace after the turn and reports what
+was actually written — which is the same reason that guard exists.
+
+**The same limit as the 1.1.14 block applies and is still uncontrolled.** The machine's
+`settings.json` carries `"toolPermission": "always-proceed"`, and AGY offers no flag or
+environment variable that overrides a settings file. These rows describe this machine's
+behaviour, not AGY's defaults. Controlling it needs a temporary home holding a minimal
+settings file beside a credential, which is the next thing to do here before any claim
+about defaults.
+
 **Measured on gemini CLI 0.53.1, 2026-08-05**, against the same disposable repository and the same stdin transport, on a temporary API key. The gemini engine behaves the *opposite* way to AGY, so nothing above transfers between them.
 
 | `--yolo` | other flags | Action | Outcome |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@arcobaleno64/gemini-plugin-cc",
-  "version": "0.22.1",
+  "version": "0.22.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@arcobaleno64/gemini-plugin-cc",
-      "version": "0.22.1",
+      "version": "0.22.2",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arcobaleno64/gemini-plugin-cc",
-  "version": "0.22.1",
+  "version": "0.22.2",
   "private": true,
   "type": "module",
   "description": "Use Gemini CLI or Antigravity CLI (agy) inside Claude Code for task delegation, code review, and adversarial review.",

--- a/plugins/gemini/.claude-plugin/plugin.json
+++ b/plugins/gemini/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gemini",
-  "version": "0.22.1",
+  "version": "0.22.2",
   "description": "Use Gemini/AGY from Claude Code to review code or delegate tasks.",
   "author": {
     "name": "arcobaleno64",

--- a/plugins/gemini/CHANGELOG.md
+++ b/plugins/gemini/CHANGELOG.md
@@ -1,11 +1,17 @@
 # Changelog
 
-## Unreleased
+## 0.22.2 — 2026-08-19 — Which credentials AGY actually accepts
 
-Changes that have landed on `main` and will ship with the next version. They are
-recorded here as they land because the alternative was cutting a release for a
-sentence, and the two entries below partly cancel: the first said a route was
-untested and the second tested it.
+`/gemini:setup` and `--probe-agy` both told a user with a working AGY account to go
+and authenticate. AGY has taken non-interactive credentials since 1.1.10 (ADC,
+Enterprise/WIF) and since 1.1.13 a `GEMINI_API_KEY` routed through
+`modelProvider: "gemini"` in settings.json — a settings file plus an environment
+variable rather than a flag, which is why reading `agy --help` and concluding the
+capability was absent is exactly how it was missed. The absence was checked on the
+wrong surface.
+
+Two of the entries below partly cancel each other: the first said a route was
+untested, the second tested it.
 
 - **AGY's non-interactive credentials are named where the plugin asks for one.**
   `getAgyLoginStatus()` and the `--probe-agy` rejection both told the user to run
@@ -26,8 +32,18 @@ untested and the second tested it.
   that would have made `readyState` `not-ready` for an install whose turns work.
   ADC and Enterprise/WIF remain untested and are still marked so.
 
-- **`docs/THREAT-MODEL.md` 7.2 re-measured on AGY 1.1.14; the residual is unchanged.**
-  AGY 1.1.14's release notes say the setting that allows access outside your
+- **`docs/THREAT-MODEL.md` 7.2 re-measured on AGY 1.1.14 and 1.1.15; the residual is
+  unchanged.** 1.1.15 ran the same five rows as 1.1.14 — same probe, same disposable
+  root on `D:\`, one variable — and four of four configurations again wrote an absolute
+  path outside the workspace they were bound to, the plugin's read-only `--add-dir`
+  shape included. Three consecutive releases now. One thing the 1.1.15 pass turned up
+  and could not reproduce: two rows returned `status: ERROR` in the envelope while
+  writing the file and exiting 0, and re-run immediately both returned `SUCCESS`. No
+  mechanism is claimed; it is recorded because it points the wrong way — a turn
+  reporting an error may still have changed the tree, which is why
+  `lib/readonly-guard.mjs` compares the workspace instead of reading `status`.
+
+  On 1.1.14: its release notes say the setting that allows access outside your
   workspace "now grants only read access", which is aimed squarely at that
   residual. It does not reach headless print mode: five runs, and all five wrote an
   absolute path outside the workspace they were bound to — including `--add-dir`,


### PR DESCRIPTION
Cuts the four `Unreleased` entries into **0.22.2**, and re-measures `docs/THREAT-MODEL.md` §7.2 against the AGY release the plugin actually ships against.

## Why a release now

Two of the unreleased entries are user-visible and have been sitting on `main` since #95/#97: `getAgyLoginStatus()` and the `--probe-agy` rejection both told a user with a working AGY account to go and authenticate. They name the non-interactive routes now (ADC/WIF on 1.1.10+, `GEMINI_API_KEY` with `modelProvider: "gemini"` on 1.1.13+). Nobody installing the plugin has had that text.

Patch rather than minor: guidance strings and verification, no new surface.

## Version moves in four places, not three

`package.json` is the source of truth `scripts/verify-contracts.mjs` compares the other three against. I bumped `plugin.json` and both `marketplace.json` fields and missed it — the contract test failed on the first run, which is the whole reason it exists:

```
- .claude-plugin/marketplace.json metadata.version: expected 0.22.1, found 0.22.2
- .claude-plugin/marketplace.json plugins[gemini].version: expected 0.22.1, found 0.22.2
- plugins/gemini/.claude-plugin/plugin.json version: expected 0.22.1, found 0.22.2
```

## §7.2 re-measured on AGY 1.1.15

The same five rows as the 1.1.14 block, deliberately — same probe, same disposable root on `D:\`, one variable changed. (`D:\` because this machine's `trustedWorkspaces` covers all of `C:\Users\<user>`, so a probe under the home directory measures that trust entry instead of AGY's boundary.)

| Orientation | Action | Target | Outcome |
|---|---|---|---|
| `--new-project` | edit tool | outside the workspace | wrote, exit 0 |
| `--new-project --sandbox` | shell command | outside the workspace | wrote, exit 0 |
| none | edit tool | outside the workspace | wrote, exit 0 |
| `--add-dir` (**the plugin's read-only shape**) | edit tool | outside the workspace | wrote, exit 0 |
| `--new-project` | edit tool | in the workspace | wrote, exit 0 — positive control |

Four of four wrote an absolute path outside the workspace they were bound to. The control wrote, which is what makes the other four readable at all — a boundary that held and a prompt the model never acted on look identical from outside.

**Three consecutive releases** (1.1.10, 1.1.14, 1.1.15). [antigravity-cli#749](https://github.com/google-antigravity/antigravity-cli/issues/749) stays open; §7.2 stays High.

## Seen once, not reproduced, not a claim

On the first pass the last two rows returned `status: ERROR` in the JSON envelope **while writing the file and exiting 0**. Re-run immediately with the same flags, both returned `SUCCESS`.

No mechanism is claimed and nothing here rests on it. It is recorded because it points the wrong way for a caller: a turn that reports an error may still have changed the tree. The plugin does not read `status` that way — `lib/readonly-guard.mjs` compares the workspace after the turn — which is the same reason that guard exists.

## Known limit, unchanged and still uncontrolled

This machine's `settings.json` carries `"toolPermission": "always-proceed"` and AGY offers no flag or environment variable that overrides a settings file. These rows describe this machine, not AGY's defaults. Controlling it needs a temporary home holding a minimal settings file beside a credential — named in §7.2 as the next thing to do before any claim about defaults.

## Verification

- `npm test` — 590 tests, 0 fail (8 pre-existing skips).
- `node scripts/verify-contracts.mjs` — passes for `gemini@gemini-plugin-cc v0.22.2`.

## Not in scope

No code changes. `bench/` untouched. The `codex.model` cassettes for the three new cases still wait on the quota reset (2026-08-25).
