### PR TITLE
Make a cassette observe its engine instead of asserting it

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -128,10 +128,20 @@ What follows from it:
   the cassette says. This one could not run without the Gemini credential, which is the
   observation the cassette's `engineVersion` field cannot make.
 
-The remaining hole is that a cassette still asserts its engine rather than observing
-it: the companion's `--json` payload does not report which engine ran, so the runner
-has nothing to check the pin against. Pinning makes the cell right; it does not make
-the cassette self-describing.
+**The pin is no longer the only defence.** The companion's `--json` payload now carries
+`engine` — the engine it *resolved*, not the one it was asked for — and each companion
+cell declares what it expects. A run from the wrong engine fails the cell instead of
+being recorded, and a companion too old to report the field fails it too: reading "no
+answer" as "the right answer" is how the original defect survived every green run. New
+cassettes carry `engineObserved`, read back from the run. Cassettes recorded before
+this change do not have the field, and no number on the board depends on re-recording
+them — the cells they came from are now checked.
+
+Three tests hold it, and each was made to fail before being believed: one on a
+mismatch, one on a companion that says nothing, and one on whether anything calls the
+check at all. That third one exists because deleting the two lines at the call site
+left the helper correct, unreachable, and the suite green — the same shape as the
+defect, wearing a different hat.
 
 #### Two failure explanations that were wrong
 

--- a/bench/lib/adapters.mjs
+++ b/bench/lib/adapters.mjs
@@ -208,10 +208,36 @@ export function companionSpawnEnv(baseEnv = process.env) {
   return env;
 }
 
-function runCompanionReview(companionPath, repoDir, extraArgs) {
+// A cell may only record a run it can prove came from its own engine. Pinning
+// `--engine` on the command line stops the environment redirecting a cell; it does
+// not prove the pin was honoured, and the failure it guards against is silent —
+// every cassette stays green while carrying another engine's answers. So the
+// companion reports the engine it resolved and this compares the two.
+//
+// Absence is a failure, not a pass. A companion too old to report the field is
+// exactly the case that cannot be checked, and treating "no answer" as "the right
+// answer" is how the original defect survived.
+export function assertExpectedEngine(payload, expected) {
+  if (!expected) return null;
+  const actual = payload?.engine ?? null;
+  if (actual === null) {
+    return `companion did not report which engine ran (expected ${expected}); cannot label this cassette`;
+  }
+  if (actual !== expected) {
+    return `cell expects ${expected} but the companion ran ${actual}`;
+  }
+  return null;
+}
+
+// `spawnImpl` exists so the engine check can be tested through the function that
+// performs it rather than through the helper it calls. Without the seam, deleting
+// the two lines that invoke `assertExpectedEngine` left every test green — the
+// helper was correct and unreachable, which is the same shape as the defect this
+// whole check exists to prevent.
+export function runCompanionReview(companionPath, repoDir, extraArgs, expectEngine = null, { spawnImpl = spawnSync } = {}) {
   return timed(() => {
     if (!companionPath) return fail("companion path not configured");
-    const res = spawnSync(
+    const res = spawnImpl(
       process.execPath,
       [companionPath, "review", "--scope", "working-tree", "--json", ...extraArgs, "--cwd", repoDir],
       { cwd: repoDir, encoding: "utf8", timeout: TIMEOUT_MS, env: companionSpawnEnv() }
@@ -220,7 +246,9 @@ function runCompanionReview(companionPath, repoDir, extraArgs) {
     const payload = extractJsonObject(res.stdout);
     const review = normalizeReview(payload?.result);
     if (!review) return fail(`companion: no result in payload (${(res.stderr || "").slice(0, 200)})`);
-    return { ok: true, ...review, raw: res.stdout?.slice(0, 4000) };
+    const mismatch = assertExpectedEngine(payload, expectEngine);
+    if (mismatch) return fail(`companion: ${mismatch}`);
+    return { ok: true, ...review, engineObserved: payload?.engine ?? null, raw: res.stdout?.slice(0, 4000) };
   });
 }
 
@@ -239,14 +267,14 @@ function dispatchCell(cell, ctx) {
     case "agy.model":
       return runAgyModel(ctx.promptText);
     case "gemini.deep":
-      return runCompanionReview(GEMINI_COMPANION, ctx.repoDir, ["--deep", "--engine", "gemini"]);
+      return runCompanionReview(GEMINI_COMPANION, ctx.repoDir, ["--deep", "--engine", "gemini"], "gemini");
     case "codex.native":
       return runCompanionReview(CODEX_COMPANION, ctx.repoDir, []);
     case "agy.deep":
-      return runCompanionReview(GEMINI_COMPANION, ctx.repoDir, ["--deep", "--engine", "agy"]);
+      return runCompanionReview(GEMINI_COMPANION, ctx.repoDir, ["--deep", "--engine", "agy"], "agy");
     default:
       return fail(`unknown cell ${cell}`);
   }
 }
 
-export const _internal = { extractJsonObject, normalizeReview, geminiInnerText, companionSpawnEnv };
+export const _internal = { extractJsonObject, normalizeReview, geminiInnerText, companionSpawnEnv, assertExpectedEngine, runCompanionReview };

--- a/bench/lib/cassette.mjs
+++ b/bench/lib/cassette.mjs
@@ -58,6 +58,9 @@ export function writeCassette(caseId, cell, data, samples = null) {
     findings: Array.isArray(data.findings) ? data.findings : [],
     latencyMs: data.latencyMs ?? null,
     engineVersion: data.engineVersion ?? null,
+    // What the run reported, beside what the cell claims. When those two can
+    // disagree, only the reported one is evidence.
+    engineObserved: data.engineObserved ?? null,
     samples: runs,
     ...(data.raw !== undefined ? { raw: data.raw } : {})
   };

--- a/bench/run-bench.test.mjs
+++ b/bench/run-bench.test.mjs
@@ -447,18 +447,43 @@ test("the companion cells do not inherit an engine from the environment", () => 
   assert.equal(env.HOME, "/home/x");
 });
 
-test("each companion cell names its engine on the command line", () => {
-  // Stripping the variable leaves `auto`, which resolves by credential and would
-  // hand gemini.deep to AGY again on any machine where the gemini credential is
-  // the broken one. The engine has to be stated, not defaulted.
-  const source = fs.readFileSync(new URL("./lib/adapters.mjs", import.meta.url), "utf8");
+test("a cell refuses a run from an engine other than its own", () => {
+  // Pinning --engine stops the environment redirecting a cell; it does not prove
+  // the pin was honoured, and that failure is silent — the cassette stays green
+  // carrying another engine's answers, which is exactly what gemini.deep did for
+  // its entire life. The companion reports the engine it resolved; this compares.
+  assert.equal(adapters.assertExpectedEngine({ engine: "gemini" }, "gemini"), null, "a match passes");
 
-  for (const [cell, engine] of [["gemini.deep", "gemini"], ["agy.deep", "agy"]]) {
-    const branch = source.slice(source.indexOf(`case "${cell}":`));
-    const call = branch.slice(0, branch.indexOf(";") + 1);
-    assert.ok(
-      call.includes(`"--engine", "${engine}"`),
-      `${cell} must pin --engine ${engine}; got: ${call.trim()}`
-    );
-  }
+  const wrong = adapters.assertExpectedEngine({ engine: "agy" }, "gemini");
+  assert.match(String(wrong), /expects gemini/, "the failure names what the cell wanted");
+  assert.match(String(wrong), /ran agy/, "and what actually ran");
+});
+
+test("the cell actually calls the check — a mismatching run is rejected end to end", () => {
+  // The two tests below cover `assertExpectedEngine`; this one covers whether
+  // anything calls it. Deleting the call site left the helper correct, unreachable,
+  // and every test green, which is the defect this check exists to prevent wearing
+  // a different hat.
+  const stub = () => ({
+    status: 0,
+    stdout: JSON.stringify({ engine: "agy", result: { verdict: "needs-attention", summary: "s", findings: [] } }),
+    stderr: ""
+  });
+
+  const rejected = adapters.runCompanionReview("/companion.mjs", "/repo", ["--deep"], "gemini", { spawnImpl: stub });
+  assert.equal(rejected.ok, false, "a gemini cell must not accept an AGY run");
+  assert.match(String(rejected.error), /expects gemini.*ran agy/);
+
+  const accepted = adapters.runCompanionReview("/companion.mjs", "/repo", ["--deep"], "agy", { spawnImpl: stub });
+  assert.equal(accepted.ok, true, "the same run is fine for the cell it belongs to");
+  assert.equal(accepted.engineObserved, "agy", "and the cassette records what ran, not what was asked for");
+});
+
+test("a companion that cannot say which engine ran is a failure, not a pass", () => {
+  // Absence is the case that cannot be checked. Reading "no answer" as "the right
+  // answer" is how the original defect survived every green run.
+  const silent = adapters.assertExpectedEngine({ result: {} }, "gemini");
+  assert.match(String(silent), /did not report/, "an unreporting companion fails the cell");
+
+  assert.equal(adapters.assertExpectedEngine({ engine: null }, null), null, "a cell with no expectation is unaffected");
 });

--- a/plugins/gemini/CHANGELOG.md
+++ b/plugins/gemini/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## Unreleased
+
+- **`review --json` reports the engine that ran.** The payload carried the review, the
+  target and the engine's raw stdout, but never which engine produced them. Under
+  `--engine auto` — or `GEMINI_ENGINE`, which applies to every process a session
+  spawns — the engine that ran and the one the caller asked for are different values,
+  and only the requested one was ever recorded (on the job record, not in the payload).
+  A consumer had no way to ask.
+
+  Found from downstream: `bench`'s `gemini.deep` cell had been recording AGY for its
+  entire life, because it passed no `--engine` and this machine sets
+  `GEMINI_ENGINE=agy` in `~/.claude/settings.json`. Its cassettes were stamped
+  `gemini --version` regardless, so the harness axis was comparing AGY against AGY and
+  a README claim that "`gemini.deep` is the steadiest cell on the board" was AGY twice.
+  Pinning the flag fixes that cell; a payload that names the engine is what lets any
+  consumer detect the next one. Additive field, `engine: "gemini" | "agy" | null`.
+
 ## 0.22.2 — 2026-08-19 — Which credentials AGY actually accepts
 
 `/gemini:setup` and `--probe-agy` both told a user with a working AGY account to go

--- a/plugins/gemini/scripts/gemini-companion.mjs
+++ b/plugins/gemini/scripts/gemini-companion.mjs
@@ -764,6 +764,12 @@ async function executeReviewRun(request) {
   const payload = {
     review: reviewName,
     target: context.target,
+    // The engine that ran, resolved — not the one the caller asked for. Under
+    // `--engine auto` (or GEMINI_ENGINE) those differ, and a consumer had no way to
+    // tell them apart: the request-side value was already recorded on the job
+    // record, and this payload said nothing at all. A benchmark cell downstream
+    // spent its whole life labelling AGY runs as gemini for exactly that reason.
+    engine: result.engine ?? null,
     gemini: { status: result.status, stdout: result.reviewText, stderr: result.stderr ?? "" },
     result: parsed.parsed,
     ...(truncation ? { truncation } : {}),


### PR DESCRIPTION
Closes the hole left open by #101: pinning `--engine` stops the environment redirecting a cell, but nothing verified the pin was honoured. That failure is silent — if the flag were ignored or renamed, every cassette would stay green while carrying another engine's answers, which is the defect that started this rather than a hypothetical.

## The change

`review --json` now carries `engine`: the engine the companion **resolved**, not the one it was asked for. Those differ under `--engine auto` and under `GEMINI_ENGINE`, and only the requested value was ever recorded — on the job record, not in the payload. A consumer had no way to ask.

Each companion cell declares what it expects. A mismatching run **fails the cell** instead of being recorded. A companion too old to report the field fails it too: reading "no answer" as "the right answer" is how the original defect survived every green run. New cassettes carry `engineObserved`, read back from the run.

## The mutation that failed

Three tests, each made to fail before being believed:

| mutation | test that catches it |
|---|---|
| accept a mismatch | `a cell refuses a run from an engine other than its own` |
| accept a silent companion | `a companion that cannot say which engine ran is a failure, not a pass` |
| **delete the call site** | `the cell actually calls the check — a mismatching run is rejected end to end` |

The third exists because the first version of this work **failed that mutation**. Deleting the two lines at the call site left `assertExpectedEngine` correct, unreachable, and all 33 tests green. A helper that is right and unused is the same shape as a cassette that is labelled and unverified — so the test had to reach the wiring, which needed a `spawnImpl` seam on `runCompanionReview`.

It also replaces the source-grep test #101 shipped, which asserted on the *text* of a call. A reformat would break it while a real redirect could still pass, and a test that breaks for the wrong reason gets "fixed" by editing the test.

## Verification

- `npm test` — 592 tests, 0 fail (8 pre-existing skips).
- End-to-end: one live `agy.deep` run wrote `engineObserved: "agy"` into its cassette. (It overwrote a committed 3-sample cassette with a 1-sample one; restored from git.)
- `npm run bench` — board unchanged.
- `check-version` and `verify-contracts` pass.

## Scope

Existing cassettes predate the field and do not carry it. No number on the board depends on re-recording them — the cells they came from are now checked. Version stays 0.22.2; the payload change sits under `Unreleased` for the next cut.