### PR TITLE
Let the stop gate speak a decision the schema accepts

### DIFF
--- a/plugins/gemini/scripts/stop-review-gate-hook.mjs
+++ b/plugins/gemini/scripts/stop-review-gate-hook.mjs
@@ -22,6 +22,9 @@ function readHookInput() {
   return JSON.parse(raw);
 }
 
+// Letting the stop through means OMITTING `decision`: the Stop hook schema
+// accepts only "approve" | "block", and Claude Code rejects the whole payload
+// (running no hook output at all) if anything else appears there.
 function emitDecision(payload) {
   process.stdout.write(`${JSON.stringify(payload)}\n`);
 }
@@ -101,7 +104,7 @@ async function main() {
 
   const jobs = listJobs(workspaceRoot);
   if (!hasCompletedWriteTask(jobs)) {
-    emitDecision({ decision: "proceed" });
+    emitDecision({});
     return;
   }
 
@@ -114,7 +117,7 @@ async function main() {
     const warning =
       "Gemini review gate skipped: the adversarial review could not run (Gemini/AGY unavailable or errored). Run /gemini:adversarial-review --wait before stopping if you changed code.";
     process.stderr.write(`${warning}\n`);
-    emitDecision({ decision: "proceed", systemMessage: warning });
+    emitDecision({ systemMessage: warning });
     return;
   }
 
@@ -124,7 +127,7 @@ async function main() {
     return;
   }
 
-  emitDecision({ decision: "proceed" });
+  emitDecision({});
 }
 
 // Same guard as gemini-mcp.mjs and transfer.mjs: importing this module to test

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -2064,7 +2064,10 @@ test("stop-gate proceeds without a warning when enabled but no write task comple
   const result = runStopGate(workspace, envWithoutSession());
   assert.equal(result.status, 0, result.stderr);
   const decision = JSON.parse(result.stdout);
-  assert.equal(decision.decision, "proceed");
+  assert.ok(
+    !("decision" in decision),
+    'letting the stop through omits `decision`; the Stop schema rejects anything but "approve"/"block"'
+  );
   assert.ok(!decision.systemMessage, "no skip warning when there is nothing to review");
 });
 
@@ -2084,7 +2087,10 @@ test("stop-gate fails OPEN with a visible warning when the review cannot run", (
   const result = runStopGate(workspace, buildEnvUnavailable(binDir));
   assert.equal(result.status, 0, result.stderr);
   const decision = JSON.parse(result.stdout);
-  assert.equal(decision.decision, "proceed", "fail-open: never block on review failure");
+  assert.ok(
+    !("decision" in decision),
+    "fail-open: never block on review failure, and never emit a decision the schema rejects"
+  );
   assert.match(decision.systemMessage ?? "", /skipped/i);
   // The same warning is written to stderr as a belt-and-suspenders fallback.
   assert.match(result.stderr, /review gate skipped/i);


### PR DESCRIPTION
## What broke

The Stop hook schema accepts only `"approve" | "block"` for `decision`. Letting a stop through means **omitting** the field. Three of the gate's four exits wrote `{"decision":"proceed"}`:

| exit | before | after |
|---|---|---|
| no completed write task | `{ decision: "proceed" }` | `{}` |
| review unavailable (fail-open) | `{ decision: "proceed", systemMessage }` | `{ systemMessage }` |
| clean verdict | `{ decision: "proceed" }` | `{}` |
| `needs-attention` | `{ decision: "block", reason }` | unchanged |

Claude Code rejected the whole payload with `Hook JSON output validation failed — (root): Invalid input` and acted on none of it — including the `systemMessage` the fail-open branch exists specifically to make visible. So on those three paths the gate has never delivered anything. The `block` path uses a legal value, was not reached in the observed failure, and is unverified either way.

Observed live at the end of a turn in this repo, on the 0.22.2 install cache.

## Why the tests did not catch it

Both stop-gate tests asserted `decision.decision === "proceed"` — read straight off the implementation. They pinned the value the hook happened to write, not the contract it has to satisfy, so they stayed green while the output was being thrown away downstream. They now assert that no `decision` key is present at all.

Any hook test in this repo that checks stdout without checking it against the published schema has the same blind spot.

## Verification

- `node --test tests/runtime.test.mjs` — 97 tests, 91 pass, 0 fail, 6 skipped.
- Mutation: restoring `decision: "proceed"` at the no-write-task exit turns `stop-gate proceeds without a warning when enabled but no write task completed` red. Restored.

## Note

The same schema rule was already discovered and fixed once, in `~/.claude/hooks/unreviewed-changes-stop-hook.mjs`, which carries a comment spelling it out. It did not reach the plugin. A comment above `emitDecision` now states it here too.

Takes effect only after a version bump — the running copy is the install cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
