### PR TITLE
Release 0.22.3

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,13 +7,13 @@
   },
   "metadata": {
     "description": "Use Gemini CLI or Antigravity CLI (agy) inside Claude Code for task delegation, code review, and adversarial review.",
-    "version": "0.22.2"
+    "version": "0.22.3"
   },
   "plugins": [
     {
       "name": "gemini",
       "description": "Gemini CLI and Antigravity CLI bridge for Claude Code task delegation and adversarial review",
-      "version": "0.22.2",
+      "version": "0.22.3",
       "author": {
         "name": "arcobaleno64",
         "email": "arcobaleno830623@gmail.com"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@arcobaleno64/gemini-plugin-cc",
-  "version": "0.22.2",
+  "version": "0.22.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@arcobaleno64/gemini-plugin-cc",
-      "version": "0.22.2",
+      "version": "0.22.3",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arcobaleno64/gemini-plugin-cc",
-  "version": "0.22.2",
+  "version": "0.22.3",
   "private": true,
   "type": "module",
   "description": "Use Gemini CLI or Antigravity CLI (agy) inside Claude Code for task delegation, code review, and adversarial review.",

--- a/plugins/gemini/.claude-plugin/plugin.json
+++ b/plugins/gemini/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gemini",
-  "version": "0.22.2",
+  "version": "0.22.3",
   "description": "Use Gemini/AGY from Claude Code to review code or delegate tasks.",
   "author": {
     "name": "arcobaleno64",

--- a/plugins/gemini/CHANGELOG.md
+++ b/plugins/gemini/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 ## Unreleased
 
+## 0.22.3 — 2026-08-24 — What the plugin actually handed its caller
+
+Both entries are the same shape: the plugin produced something, a consumer needed
+it, and nobody had checked that the consumer could read it. One was a field that was
+never written; the other was a whole payload that was written and then rejected.
+
+- **The stop-review gate emitted a `decision` the Stop schema rejects.** Letting a
+  stop through means *omitting* `decision` — the schema accepts only
+  `"approve"` | `"block"` — and three of the gate's four exits wrote
+  `{"decision": "proceed"}`. Claude Code answered with
+  `Hook JSON output validation failed — (root): Invalid input` and acted on none of
+  the payload, so on those three paths the gate had never delivered anything: not the
+  silent pass, not the clean verdict, and not the `systemMessage` that the fail-open
+  branch exists specifically to make visible when the review could not run. The
+  `needs-attention` path uses a legal value, was not reached in the observed failure,
+  and is unchanged.
+
+  The two stop-gate tests read `decision.decision === "proceed"` straight off the
+  implementation, which is why they stayed green while the output was being thrown
+  away downstream — they pinned the value the hook happened to write, not the
+  contract it has to satisfy. They now assert that no `decision` key is present.
+  Mutation-confirmed. The same schema rule had already been found and fixed once in
+  `~/.claude/hooks/unreviewed-changes-stop-hook.mjs`, with a comment spelling it out;
+  it never reached the plugin, so a comment above `emitDecision` states it here too.
+
 - **`review --json` reports the engine that ran.** The payload carried the review, the
   target and the engine's raw stdout, but never which engine produced them. Under
   `--engine auto` — or `GEMINI_ENGINE`, which applies to every process a session


### PR DESCRIPTION
Version metadata moves to 0.22.3 across all four manifests, and `## Unreleased` becomes `## 0.22.3 — 2026-08-24 — What the plugin actually handed its caller`.

## What ships

- **The stop-review gate emitted a `decision` the Stop schema rejects** (#104). Three of the gate's four exits wrote `{"decision": "proceed"}`; the schema accepts only `"approve" | "block"`, and letting a stop through means omitting the field. Claude Code rejected the whole payload, so those three paths had never delivered anything — including the `systemMessage` the fail-open branch exists to make visible. Both stop-gate tests had been asserting the bug's own output shape and now assert that no `decision` key is present.
- **`review --json` reports the engine that ran.** Was already sitting in Unreleased; ships here.

## Gates

- `npm run check-version` — all four manifests agree on 0.22.3, changelog entry present.
- `npm run verify-contracts` — passed for `gemini@gemini-plugin-cc v0.22.3`.
- Full suite green on #104 across all three platforms; this branch changes only manifests and the changelog.

The annotated `v0.22.3` tag is what actually publishes, and is not pushed yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
