### PR TITLE
Measure what was only asserted: AEO fixtures, a refreshed bench, and an adversarial axis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,15 @@ plugins/gemini/scripts/lib/*.log
 # Generated benchmark scorecards
 bench/results/
 
+# Generated AEO benchmark reports (scripts/aeo-benchmark.mjs writes here)
+docs/benchmarks/
+
+# Generated documentation bundle (npm run build:llms-full). Ignored while GitHub
+# Pages is off, because nothing serves it: the /llms.txt spec points this at
+# arcobaleno64.github.io, which is not configured. Turning Pages on means
+# deciding where this is served from, and that decision belongs with this line.
+docs/llms-full.txt
+
 # OS artifacts
 .DS_Store
 Thumbs.db

--- a/bench/README.md
+++ b/bench/README.md
@@ -32,10 +32,16 @@ one scorer grades all of them.
 The adversarial cells are a third axis rather than more entries on the harness one,
 because the two prompts are not interchangeable: `prompts/review.md` asks for a
 pragmatic review, `prompts/adversarial-review.md` asks the model to break confidence
-in the change. Composite is `recall*70 + precision*20 + severityExact*10`, so the
-adversarial prompt is expected to score higher on recall and worse on false positives
-by construction. Ranking one against the other would be a column stating what it is
-supposed to hold rather than what it holds.
+in the change. Ranking one against the other would be a column stating what
+it is supposed to hold rather than what it holds.
+
+The prediction behind that separation was wrong, and the measurement is worth keeping
+next to it. Composite is `recall*70 + precision*20 + severityExact*10`, so the guess
+was that the adversarial prompt would buy recall at the cost of false positives.
+Measured on agy 1.1.19 across five cases x3, `agy.deep` -> `agy.adversarial` moved
+recall 0.81 -> 0.77, precision 0.91 -> 0.92 and false positives 1.67 -> 1.33: more
+conservative, not more aggressive. The axis stays separate anyway — the prompts are
+not interchangeable whichever way the scores happen to fall.
 
 It is also the only axis codex can currently be measured on end-to-end: `codex.native`
 runs codex's built-in reviewer, whose `--json` payload carries no `result`

--- a/bench/README.md
+++ b/bench/README.md
@@ -57,23 +57,44 @@ one scorer grades all of them.
 >
 > | case | model | shallow | deep | prompt | exploration |
 > |---|:-:|:-:|:-:|:-:|:-:|
-> | async-lifecycle | 91 | 70 | 74 | −21 | +4 |
+> | async-lifecycle | 91 | 69 | 71 | −22 | +2 |
 > | auth-basic | 95 | 81 | 83 | −14 | +2 |
 > | path-and-input | 72 | 69 | 69 | −3 | 0 |
-> | vacuous-tests | 71 | 82 | 88 | +11 | +6 |
+> | vacuous-tests | 71 | 82 | 94 | +11 | +12 |
 > | **caller-contract** | 0 | 0 | **68** | 0 | **+68** |
-> | **repo-context** | 97 | 37 | **90** | −60 | **+53** |
+> | **repo-context** | 55 | 15 | **76** | −40 | **+61** |
 > | **stale-duplicate** | 43 | 18 | **67** | −25 | **+49** |
-> | **mean** | | | | **−16.0** | **+26.0** |
+> | **mean** | | | | **−13.3** | **+27.8** |
 >
 > The −4.4 harness lift reported over the original five cases was two opposing effects
-> cancelling. Exploration is worth **+26** on average and its gains land exactly where
-> the design says they should — +68, +53, +49 on the three repository-scoped cases,
-> against +4, +2, 0, +6 on the four file-scoped ones. The plugin's own review prompt,
-> run without tools, is worth **−16** against the bench's neutral prompt, and that
-> penalty is concentrated on the same repository-scoped cases (−60, −25). A prompt that
-> tells the model to fold in dependency manifests and callers appears to cost accuracy
-> when it cannot go and read them.
+> cancelling. Exploration is worth **+28** on average and its gains land exactly where
+> the design says they should — +68, +61, +49 on the three repository-scoped cases,
+> against +2, +2, 0, +12 on the four file-scoped ones. The plugin's own review prompt,
+> run without tools, is worth **−13** against the bench's neutral prompt, and that
+> penalty is concentrated on the same repository-scoped cases (−40, −25).
+>
+> What that penalty is *not*: it is not the `DEEP REVIEW MODE` block, which the
+> `*.shallow` cells never see, and it is not a thinner input — the probe over all
+> seven cases puts `REVIEW_INPUT` between 645 and 1414 characters against a 400,000
+> cap, with the full diff present in both. It is `prompts/review.md` itself, and
+> what in it costs the points is not yet established. Until it is, this is a fact
+> about the two prompts, not a diagnosis of either.
+>
+> **These numbers were read off a matcher that had to be fixed first.** It credited a
+> finding for naming a defect's subject without making its claim, and the credit was
+> not spread evenly: `repo-context`'s `agy.model` was reading 97 for catching an
+> undeclared dependency it never mentioned, which alone put 20 points of the prompt
+> penalty on that case. Tightening every planted defect into a subject (`match.all`)
+> and a claim (`match.keywords`) took the share of recorded findings that match more
+> than one planted defect from 16% to 2.4%, and moved no cell's mean by more than
+> 1.5 points — the correction was concentrated, not diffuse.
+>
+> The 2.4% that remains is a different thing and is left alone: all ten are findings
+> that genuinely report two defects in one entry ("Plaintext Password Comparison and
+> Unchecked Null User"). The scorer credits one of the two, so it under-counts them.
+> Dropping them outright takes exploration to +12.5, but that number is a statement
+> about how a merged finding is counted, not about the matcher, and most of the swing
+> is `caller-contract`, where two of the four recorded findings are merged reports.
 >
 > `caller-contract` and `stale-duplicate` were added for exactly that, joining
 > `repo-context` as the cases whose planted defects are repository-scoped (`file: "*"`).
@@ -144,10 +165,13 @@ A cassette recorded from a real run carries `recordedAt`, the `engineVersion` it
 recorded against, every repeat in `samples`, and no `source`; a seeded one carries a
 `source` field. The scorecard prints all of it per cell. Current committed state:
 
-- **`codex.model` — live-recorded on all five cases** (codex-cli 0.149.0, three
-  samples each, 2026-08-24). The three cases that were missing while the account sat
-  at its usage limit were recorded once it reset, and the two older ones were
-  re-recorded on the same version so the cell reads as one tool at one version.
+- **`codex.model` — live-recorded on all seven cases** (codex-cli 0.149.0, three
+  samples each, 2026-08-24 and 2026-08-25). The three cases that were missing while
+  the account sat at its usage limit were recorded once it reset, and the two older
+  ones were re-recorded on the same version so the cell reads as one tool at one
+  version. The two repository-scoped cases came last: `caller-contract` **0**,
+  `stale-duplicate` **62**. The zero is the case doing its job — both planted defects
+  live outside the diff, and `agy.model` scores 0 on it too.
 - **`agy.model`, `agy.deep` — live-recorded on all five cases** (agy 1.1.19, three
   samples each, 2026-08-24). Both cells sat mid-refresh for part of that day: AGY
   refused four recordings with `Individual quota reached ... Resets in 94h2m50s`, and
@@ -168,8 +192,12 @@ recorded against, every repeat in `samples`, and no `source`; a seeded one carri
   identical cases complete under `review --deep` and every adversarial case completes
   under `--engine agy`. It tracks prompt weight on the gemini engine, not the case and
   not the subcommand.
-- **`codex.adversarial`, `agy.adversarial` — live-recorded on all five cases**
-  (codex-cli 0.149.0 and agy 1.1.19, three samples each, 2026-08-24).
+- **`codex.adversarial` — live-recorded on all seven cases**, `agy.adversarial` on
+  five (codex-cli 0.149.0 and agy 1.1.19, three samples each, 2026-08-24 and
+  2026-08-25). On the two repository-scoped cases codex's adversarial reviewer scores
+  **43** and **65** against its own single-shot **0** and **62** — it explores, so the
+  gain is a harness reading and not a prompt one. `agy.adversarial` has not been run
+  on those two cases yet.
 - **`codex.native` — still seeded, and now for a known reason.** Pointing
   `BENCH_CODEX_COMPANION` at the installed codex plugin 1.0.6 makes the cell run: the
   companion completes, exits 0, and returns a payload carrying `review`, `target`,
@@ -347,6 +375,22 @@ Per cell, findings are matched against the case's `ground-truth.json`:
   keyword is present (keyword is the robust signal; an exact line overlap is the
   fallback for keyword-less defects). `file: "*"` means keyword-only (for defects
   that span files, e.g. an undeclared dependency).
+- `match.keywords` is **any-of** — the reviewer's wording for the claim is free.
+  `match.all` is **every-of** — the subject the finding has to actually be about.
+  A wildcard defect is matched on words alone, and a subject word is a word every
+  finding about that area writes down: `repo-context` listed the bare module name
+  among its any-of keywords, so a finding about an unvalidated secret, which named
+  the module only in passing, was credited with catching a missing manifest entry.
+  That single false credit was worth 42 composite points to one cell and nothing to
+  others — worse than being wrong uniformly, because the board is a comparison
+  between cells. Put the subject in `all` and the claim in `keywords`, and a
+  finding has to carry both. Every case declares both now; a `file: "*"` defect that
+  does not is a test failure, because there the filename disambiguates nothing.
+  The four file-scoped cases were split the same way — five defects sharing one file
+  also share a vocabulary, and words like `undefined`, `leak`, `throws`, `memory` and
+  `..` were carrying credit on their own. Findings matching more than one planted
+  defect fell from 16% to 2.4%, and what is left is genuine: one entry reporting two
+  defects at once, which the scorer credits once.
 - Each finding is assigned to its **single best** unmatched planted defect, so two
   line-adjacent defects are never double-counted.
 - `recall` = planted found / planted total. `precision` = relevant / findings.
@@ -384,7 +428,11 @@ corpus/<case-id>/
   "planted": [
     { "id": "sqli", "category": "injection", "file": "src/auth.js",
       "line_start": 7, "line_end": 9, "severity": "critical",
-      "match": { "keywords": ["sql injection", "concatenat"] } }
+      "match": { "keywords": ["sql injection", "concatenat"] } },
+    { "id": "missing-dependency", "file": "*",
+      "line_start": 1, "line_end": 1, "severity": "high",
+      "match": { "all": ["jsonwebtoken"],
+                 "keywords": ["undeclared", "not in package.json"] } }
   ],
   "allowed_extras": [
     { "id": "jwt-expiry", "file": "src/auth.js", "match": { "keywords": ["expiresin"] } }

--- a/bench/README.md
+++ b/bench/README.md
@@ -34,13 +34,17 @@ one scorer grades all of them.
 >
 > 1. **the prompt** — model cells get `neutral-review-prompt.md` (33 lines: review
 >    only the diff, prefer one strong finding, no false positives); agentic cells get
->    the plugin's `prompts/review.md` (84 lines, a category list and a finding bar);
-> 2. **the input** — the diff embedded in the prompt, versus a repository to find it
->    in;
-> 3. **the tools** — forbidden, versus allowed.
+>    the plugin's `prompts/review.md` (84 lines, a category list and a finding bar),
+>    plus the `DEEP REVIEW MODE` block the companion appends, which names the things
+>    to go and look at (dependency manifests, callers, untracked files);
+> 2. **the tools** — forbidden, versus allowed;
+> 3. **the workspace** — no orientation, versus `--add-dir` pointing at the repository.
 >
-> Isolating exploration needs a cell that holds the other two fixed: the plugin's
-> review prompt, single-shot, tools off. There is not one yet.
+> The diff is *not* one of the differences: `collectReviewContext` embeds it in
+> `REVIEW_INPUT` for both, so a `--deep` run starts from the same text and may then go
+> further. Isolating that "may then go further" needs a cell running the plugin's
+> review prompt with the diff embedded and no tools — which is exactly the plugin's own
+> non-deep review. See the `*.shallow` cells.
 >
 > Two further limits on reading any lift here. Its sign is set by corpus composition:
 > the per-case deltas on the current five cases run from −20 to +17 for both engines,

--- a/bench/README.md
+++ b/bench/README.md
@@ -29,6 +29,28 @@ one scorer grades all of them.
 - **Adversarial axis** = each tool's adversarial reviewer.
 - **Harness lift** = within a tool, `model → agentic` composite delta.
 
+> **The lift is not a measurement of the harness alone.** `model → agentic` changes
+> three things at once, and the number attributes all of it to exploration:
+>
+> 1. **the prompt** — model cells get `neutral-review-prompt.md` (33 lines: review
+>    only the diff, prefer one strong finding, no false positives); agentic cells get
+>    the plugin's `prompts/review.md` (84 lines, a category list and a finding bar);
+> 2. **the input** — the diff embedded in the prompt, versus a repository to find it
+>    in;
+> 3. **the tools** — forbidden, versus allowed.
+>
+> Isolating exploration needs a cell that holds the other two fixed: the plugin's
+> review prompt, single-shot, tools off. There is not one yet.
+>
+> Two further limits on reading any lift here. Its sign is set by corpus composition:
+> the per-case deltas on the current five cases run from −20 to +17 for both engines,
+> so the mean says as much about which cases exist as about the harness. And exactly
+> one case — `repo-context` — plants defects that are repository-scoped rather than
+> file-scoped (`file: "*"` in its `ground-truth.json`), which means the capability the
+> harness axis exists to measure is exercised by a single case. Adding cases of that
+> kind is what would make the axis a measurement; adding repeats is not — see finding
+> 4 below on why the spread statistic cannot shrink.
+
 The adversarial cells are a third axis rather than more entries on the harness one,
 because the two prompts are not interchangeable: `prompts/review.md` asks for a
 pragmatic review, `prompts/adversarial-review.md` asks the model to break confidence

--- a/bench/README.md
+++ b/bench/README.md
@@ -53,6 +53,28 @@ one scorer grades all of them.
 > measurement; adding repeats is not — see finding 4 below on why the spread statistic
 > cannot shrink.
 >
+> **Measured, on agy 1.1.19 across all seven cases, three samples each:**
+>
+> | case | model | shallow | deep | prompt | exploration |
+> |---|:-:|:-:|:-:|:-:|:-:|
+> | async-lifecycle | 91 | 70 | 74 | −21 | +4 |
+> | auth-basic | 95 | 81 | 83 | −14 | +2 |
+> | path-and-input | 72 | 69 | 69 | −3 | 0 |
+> | vacuous-tests | 71 | 82 | 88 | +11 | +6 |
+> | **caller-contract** | 0 | 0 | **68** | 0 | **+68** |
+> | **repo-context** | 97 | 37 | **90** | −60 | **+53** |
+> | **stale-duplicate** | 43 | 18 | **67** | −25 | **+49** |
+> | **mean** | | | | **−16.0** | **+26.0** |
+>
+> The −4.4 harness lift reported over the original five cases was two opposing effects
+> cancelling. Exploration is worth **+26** on average and its gains land exactly where
+> the design says they should — +68, +53, +49 on the three repository-scoped cases,
+> against +4, +2, 0, +6 on the four file-scoped ones. The plugin's own review prompt,
+> run without tools, is worth **−16** against the bench's neutral prompt, and that
+> penalty is concentrated on the same repository-scoped cases (−60, −25). A prompt that
+> tells the model to fold in dependency manifests and callers appears to cost accuracy
+> when it cannot go and read them.
+>
 > `caller-contract` and `stale-duplicate` were added for exactly that, joining
 > `repo-context` as the cases whose planted defects are repository-scoped (`file: "*"`).
 > They are the first evidence on this board that exploration does anything at all:

--- a/bench/README.md
+++ b/bench/README.md
@@ -5,7 +5,7 @@ on code review, scored automatically against planted ground truth. It operationa
 the manual comparison in [`docs/MODEL_COMPARISON.md`](../docs/MODEL_COMPARISON.md):
 the interesting question is **model vs harness**, so the benchmark measures both.
 
-## Three axes, nine cells
+## Three axes, a control, and eleven cells
 
 All three tools emit the **same** structured review JSON (see
 [`review-output.schema.json`](review-output.schema.json), identical to the gemini
@@ -20,6 +20,8 @@ one scorer grades all of them.
 | `codex.native` | codex's native agentic reviewer via its companion | harness |
 | `agy.model` | `agy` on the same neutral prompt + diff, unoriented, tools forbidden | model (single-shot) |
 | `agy.deep` | `gemini-companion review --deep --engine agy` (agentic repo exploration) | harness |
+| `gemini.shallow` | `gemini-companion review` **without** `--deep` | control (prompt only) |
+| `agy.shallow` | `gemini-companion review --engine agy`, no `--deep` | control (prompt only) |
 | `gemini.adversarial` | `gemini-companion adversarial-review --deep --engine gemini` | adversarial |
 | `codex.adversarial` | `codex-companion adversarial-review` | adversarial |
 | `agy.adversarial` | `gemini-companion adversarial-review --deep --engine agy` | adversarial |
@@ -27,6 +29,8 @@ one scorer grades all of them.
 - **Model axis** = every `*.model` cell (same prompt, no tools).
 - **Harness axis** = each tool's default repo-exploring reviewer.
 - **Adversarial axis** = each tool's adversarial reviewer.
+- The `*.shallow` cells are a **control, not an axis**: they hold the prompt fixed
+  against `*.deep` so the lift can be split. They enter no verdict row.
 - **Harness lift** = within a tool, `model → agentic` composite delta.
 
 > **The lift is not a measurement of the harness alone.** `model → agentic` changes
@@ -114,9 +118,16 @@ The prediction behind that separation was wrong, and the measurement is worth ke
 next to it. Composite is `recall*70 + precision*20 + severityExact*10`, so the guess
 was that the adversarial prompt would buy recall at the cost of false positives.
 Measured on agy 1.1.19 across five cases x3, `agy.deep` -> `agy.adversarial` moved
-recall 0.81 -> 0.77, precision 0.91 -> 0.92 and false positives 1.67 -> 1.33: more
-conservative, not more aggressive. The axis stays separate anyway — the prompts are
-not interchangeable whichever way the scores happen to fall.
+recall 0.79 -> 0.72, precision 0.88 -> 0.87 and false positives 0.40 -> 0.40. The
+prediction fails on its own terms: the adversarial prompt did not buy recall, and it
+did not spend precision or false positives failing to. It reports less, and that is
+the whole of the difference. The axis stays separate anyway — the prompts are not
+interchangeable whichever way the scores happen to fall.
+
+An earlier version of this paragraph read 0.81 -> 0.77, 0.91 -> 0.92 and 1.67 -> 1.33.
+Those came off the matcher corrected below, which credited a finding for naming a
+defect's subject without making its claim. The direction survived the re-scoring; the
+two numbers that made it look like a precision-for-recall trade did not.
 
 It is also the only axis codex can currently be measured on end-to-end: `codex.native`
 runs codex's built-in reviewer, whose `--json` payload carries no `result`
@@ -172,17 +183,19 @@ recorded against, every repeat in `samples`, and no `source`; a seeded one carri
   version. The two repository-scoped cases came last: `caller-contract` **0**,
   `stale-duplicate` **62**. The zero is the case doing its job — both planted defects
   live outside the diff, and `agy.model` scores 0 on it too.
-- **`agy.model`, `agy.deep` — live-recorded on all five cases** (agy 1.1.19, three
-  samples each, 2026-08-24). Both cells sat mid-refresh for part of that day: AGY
+- **`agy.model`, `agy.deep`, `agy.shallow` — live-recorded on all seven cases**
+  (agy 1.1.19, three samples each, 2026-08-24). Both cells sat mid-refresh for part of that day: AGY
   refused four recordings with `Individual quota reached ... Resets in 94h2m50s`, and
   they were finished once the account reset. A failed live record leaves the existing
   cassette untouched, so nothing was lost while the cell was half-refreshed — and
   while it was, the scorecard said so rather than printing the newer version for
   every case.
-- **`gemini.model` — all five cases on gemini 0.56.0** (three samples each,
+- **`gemini.model` — five of seven cases on gemini 0.56.0** (three samples each,
   2026-08-24), recorded once a `GEMINI_API_KEY` was available; the stored OAuth token
   had expired on 2026-08-20.
-- **`gemini.deep` — four of five cases on 0.56.0**, `vacuous-tests` still on 0.55.1.
+- **`gemini.deep` — four of seven cases on 0.56.0**, `vacuous-tests` still on 0.55.1,
+  and the two repository-scoped cases unrecorded. `gemini.shallow` is unrecorded
+  entirely — the same engine hang.
   That case does not merely miss the 180s cap on 0.56.0, it produces nothing at 420s
   with empty stdout and empty stderr, reproduced three times, while the other four
   finish in ~35s. `gemini.deep`'s cassettes remain the only genuine gemini reading the
@@ -300,55 +313,68 @@ the one that did **not** append stderr to its failure message, so a quota wall a
 labelled `codex: could not parse review JSON`. It carries stderr now, like the gemini
 and agy branches always did.
 
-### What five cases at three samples showed
+### What seven cases at three samples showed
 
 Composite per repeat, and the widest move each cell made between repeats of the same
-recording:
+recording. Every number here is scored by the corrected matcher (§ Scoring); the
+figures this section carried before were read off the loose one and off cassettes that
+have since been re-recorded, so none of them are comparable to these.
 
-| cell | `auth-basic` | `repo-context` | `async-lifecycle` | `path-and-input` | `vacuous-tests` | widest |
-|---|---|---|---|---|---|:-:|
-| `gemini.model` | 94, 92, 79 | 45, 55, 100 | 84, 60, 81 | 69, 69, 86 | 76, 76, 65 | 55 |
-| `agy.model` | 81, 94, 81 | 0, 65, 65 | 65, 67, 84 | 69, 69, 69 | 76, 76, 76 | **65** |
-| `codex.model` | 96, 72, 98 | 0, 45, 0 | — | — | — | 45 |
-| `gemini.deep` | 81, 94, 80 | 88, 83, 88 | 84, 80, 69 | 69, 69, 69 | 79, 38, 58 | 41 |
-| `agy.deep` | 81, 77, 93 | 88, 88, 83 | 81, 62, 81 | 53, 69, 69 | 95, 71, 95 | **24** |
-| ~~`gemini.deep`~~ as it was — AGY, mislabelled | 80, 81, 81 | 88, 88, 88 | 81, 69, 69 | 69, 69, 53 | 76, 53, 93 | 40 |
+| cell | `auth-basic` | `repo-context` | `async-lifecycle` | `path-and-input` | `vacuous-tests` | `caller-contract` | `stale-duplicate` | widest |
+|---|---|---|---|---|---|---|---|:-:|
+| `gemini.model` | 92, 92, 81 | 55, 0, 0 | 84, 81, 81 | 84, 84, 72 | 79, 76, 79 | — | — | 55 |
+| `agy.model` | 94, 96, 94 | 55, 55, 55 | 96, 94, 84 | 72, 72, 72 | 76, 76, 60 | 0, 0, 0 | 65, 0, 65 | **65** |
+| `codex.model` | 86, 72, 86 | 0, 0, 0 | 69, 81, 84 | 53, 69, 53 | 93, 79, 73 | 0, 0, 0 | 65, 65, 55 | 20 |
+| `gemini.deep` | 81, 81, 96 | 83, 88, 45 | 64, 72, 79 | 81, 69, 65 | 79, 55, 58 | — | — | 43 |
+| `agy.deep` | 77, 77, 96 | 88, 88, 52 | 69, 76, 69 | 69, 69, 69 | 93, 95, 93 | 95, 55, 55 | 55, 90, 55 | 40 |
+| `agy.shallow` | 81, 81, 81 | 0, 0, 45 | 62, 64, 81 | 69, 69, 69 | 76, 93, 76 | 0, 0, 0 | 0, 0, 55 | 55 |
+| `codex.adversarial` | 69, 81, 69 | 0, 0, 0 | 79, 79, 79 | 53, 53, 53 | 95, 76, 93 | 65, 0, 65 | 65, 65, 65 | **65** |
+| `agy.adversarial` | 64, 81, 79 | 42, 88, 42 | 81, 84, 84 | 53, 53, 53 | 98, 98, 95 | — | — | 46 |
 
-The last row is struck through because it is AGY under a gemini label (above). Its
-cassettes are gone; the numbers are kept here because they are still a measurement — a
-second, independent AGY harness run — and because they are what this section's
-conclusions were read off before anyone knew whose they were.
+An earlier version of this table carried a struck-through row for `gemini.deep` as it
+was before the engine mix-up was found — AGY under a gemini label. That row is gone
+rather than corrected: its cassettes were deleted, so its numbers cannot be re-scored
+under the current matcher, and leaving pre-fix numbers in a table of post-fix ones is
+the same error this section is about. The mix-up itself is documented above and still
+matters; only its scoreboard row has been retired.
 
 Four readings, in the order they cost something to learn.
 
-1. **"The agentic cells are an order of magnitude steadier" does not survive, and the
-   real gemini cell is the least steady thing on the harness axis.** This section used
-   to claim it on the strength of `gemini.deep` moving by 1 and by 0 — which was AGY,
-   and so was the `agy.deep` row it was being praised against. Re-recorded as actual
-   gemini, that cell moves by 41. Set `repo-context` aside and the ordering inverts:
-   the deep cells' worst moves are 41 and 24, the model cells' 26, 24 and 19.
+1. **Steadiness does not separate by harness, and a steady cell is not a reliable
+   one.** This section used to claim the agentic cells were "an order of magnitude
+   steadier", on the strength of a `gemini.deep` that turned out to be AGY. What the
+   board shows now is that the two widest moves on it belong to a *model* cell
+   (`agy.model`, 65 on `stale-duplicate`) and an *adversarial* one
+   (`codex.adversarial`, 65 on `caller-contract`), while the two deep cells top out at
+   43 and 40.
 
-   One piece of the original reading does survive, and it is the piece worth keeping.
-   On `repo-context` — the case that is invisible single-shot — both deep cells move
-   by 5 while all three model cells move by 55, 65 and 45. A harness is steady *on the
-   case built to need a harness*, because the model cells are guessing there and
-   guessing has variance. That is the claim the data carries. "Agentic reviewers are
-   steadier" is not.
-2. **Granularity was the dominant term in the model cells' noise, as predicted, and it
-   was not enough.** Two-defect `repo-context` is where every model cell posts its
-   widest move (55, 65, 45); across the four- and five-defect cases the same cells move
-   at most 26. One miss worth 35 composite points really was most of the old spread.
-   It bought no verdict: the board's leads are 6.4 on the model axis and 3.2 on the
-   harness axis, against bands of ±65 and ±40.
-3. **Gemini's harness does not beat gemini's own model cell.** Harness lift — gemini is
-   **-0.2** (75.4 single-shot, 75.2 agentic). It is well inside the band and so is not
-   a finding that repo exploration fails to help; it is the absence of the finding that
-   it helps, on this corpus, for this tool. AGY's lift is +10.2, also inside its band.
-   The one lift that looks decisive, codex's +41, has a seeded end and is not a
-   measurement at all.
+   The surviving piece of the old reading has inverted too, and the inversion is the
+   more useful fact. It used to say the deep cells were steady on `repo-context` — the
+   case built to need a harness — while the model cells thrashed. They now move 43 and
+   36 there, and `agy.model` posts 55, 55, 55 while `codex.model` posts 0, 0, 0. Those
+   are perfect steadiness and they mean nothing: a cell that fails the same way every
+   time has no spread. On this board low spread reads as *consistent*, not as
+   *trustworthy*, and the repository-scoped cases are where the two come apart —
+   exploration sometimes lands and sometimes does not, which is what movement in a
+   deep cell looks like when the cell is actually doing something.
+
+2. **Granularity is still the dominant term in the noise, and still buys no verdict.**
+   Every widest move on the board sits on a two-defect case: 55 and 65 on
+   `stale-duplicate`, 65 on `caller-contract`, 55 and 43 on `repo-context`. Across the
+   four- and five-defect cases no cell moves more than 24. One miss worth 35 composite
+   points really is most of the spread. It buys nothing: the board's leads are 8.2 on
+   the model axis and 2.2 on the harness axis, against bands of ±65 and ±43.
+
+3. **No lift on this board clears its own noise, and they are not measured over the
+   same cases.** Harness lift is +4 for gemini, +14.4 for AGY, both inside their bands.
+   Codex's +41.4 has a seeded end and is not a measurement at all. Worth stating
+   plainly because the table above hides it: gemini's lift spans five cases and AGY's
+   spans seven, and the two extra cases are precisely the ones where exploration pays.
+   Comparing those two lifts to each other would be comparing corpora, not tools.
+
 4. **No axis is decidable — and under the present rule, no amount of extra sampling can
    make one decidable.** Spread is a *range* (`max - min` over repeats, then `max`
-   over cases, `lib/report.mjs:48`), and a range only ever grows as samples are added.
+   over cases, `lib/report.mjs:59`), and a range only ever grows as samples are added.
    It estimates the worst repeat, not the uncertainty in the average, so "run it more"
    moves every verdict further out of reach rather than closer. Naming a lead honestly
    would need a different statistic — a standard error over repeats shrinks with the

--- a/bench/README.md
+++ b/bench/README.md
@@ -46,14 +46,20 @@ one scorer grades all of them.
 > review prompt with the diff embedded and no tools — which is exactly the plugin's own
 > non-deep review. See the `*.shallow` cells.
 >
-> Two further limits on reading any lift here. Its sign is set by corpus composition:
-> the per-case deltas on the current five cases run from −20 to +17 for both engines,
-> so the mean says as much about which cases exist as about the harness. And exactly
-> one case — `repo-context` — plants defects that are repository-scoped rather than
-> file-scoped (`file: "*"` in its `ground-truth.json`), which means the capability the
-> harness axis exists to measure is exercised by a single case. Adding cases of that
-> kind is what would make the axis a measurement; adding repeats is not — see finding
-> 4 below on why the spread statistic cannot shrink.
+> One further limit on reading any lift here: its sign is set by corpus composition.
+> Across the original five cases the per-case deltas run from −20 to +17 on both
+> engines, so a mean over them says as much about which cases exist as about the
+> harness. Adding cases that exercise the capability is what makes the axis a
+> measurement; adding repeats is not — see finding 4 below on why the spread statistic
+> cannot shrink.
+>
+> `caller-contract` and `stale-duplicate` were added for exactly that, joining
+> `repo-context` as the cases whose planted defects are repository-scoped (`file: "*"`).
+> They are the first evidence on this board that exploration does anything at all:
+> on `caller-contract`, `agy.model` scores **0** — it misses both defects, because the
+> diff is a clean refactor of `findUser` and says nothing about the two callers left on
+> the old contract — while `agy.deep` scores **68**. On `stale-duplicate` the same pair
+> is 43 → 67. Both far outside any band on this board.
 
 The adversarial cells are a third axis rather than more entries on the harness one,
 because the two prompts are not interchangeable: `prompts/review.md` asks for a

--- a/bench/README.md
+++ b/bench/README.md
@@ -5,7 +5,7 @@ on code review, scored automatically against planted ground truth. It operationa
 the manual comparison in [`docs/MODEL_COMPARISON.md`](../docs/MODEL_COMPARISON.md):
 the interesting question is **model vs harness**, so the benchmark measures both.
 
-## Two axes, six cells
+## Three axes, nine cells
 
 All three tools emit the **same** structured review JSON (see
 [`review-output.schema.json`](review-output.schema.json), identical to the gemini
@@ -20,10 +20,27 @@ one scorer grades all of them.
 | `codex.native` | codex's native agentic reviewer via its companion | harness |
 | `agy.model` | `agy` on the same neutral prompt + diff, unoriented, tools forbidden | model (single-shot) |
 | `agy.deep` | `gemini-companion review --deep --engine agy` (agentic repo exploration) | harness |
+| `gemini.adversarial` | `gemini-companion adversarial-review --deep --engine gemini` | adversarial |
+| `codex.adversarial` | `codex-companion adversarial-review` | adversarial |
+| `agy.adversarial` | `gemini-companion adversarial-review --deep --engine agy` | adversarial |
 
 - **Model axis** = every `*.model` cell (same prompt, no tools).
-- **Harness axis** = every agentic cell (each tool's repo-exploring reviewer).
+- **Harness axis** = each tool's default repo-exploring reviewer.
+- **Adversarial axis** = each tool's adversarial reviewer.
 - **Harness lift** = within a tool, `model → agentic` composite delta.
+
+The adversarial cells are a third axis rather than more entries on the harness one,
+because the two prompts are not interchangeable: `prompts/review.md` asks for a
+pragmatic review, `prompts/adversarial-review.md` asks the model to break confidence
+in the change. Composite is `recall*70 + precision*20 + severityExact*10`, so the
+adversarial prompt is expected to score higher on recall and worse on false positives
+by construction. Ranking one against the other would be a column stating what it is
+supposed to hold rather than what it holds.
+
+It is also the only axis codex can currently be measured on end-to-end: `codex.native`
+runs codex's built-in reviewer, whose `--json` payload carries no `result`
+([openai/codex-plugin-cc#679](https://github.com/openai/codex-plugin-cc/issues/679)),
+while `adversarial-review` emits schema-shaped findings.
 
 The axes are read off `lib/cells.mjs`, not off a list of tool names, so a cell added
 there joins both the ranking and its own lift without touching the report.
@@ -67,19 +84,50 @@ A cassette recorded from a real run carries `recordedAt`, the `engineVersion` it
 recorded against, every repeat in `samples`, and no `source`; a seeded one carries a
 `source` field. The scorecard prints all of it per cell. Current committed state:
 
-- **`gemini.model`, `agy.model`, `agy.deep` — live-recorded on all five cases**,
-  three samples each, all on 2026-08-19: the two older cases on gemini 0.54.4 / agy
-  1.1.14, the three new ones on gemini 0.55.1 / agy 1.1.15.
-- **`gemini.deep` — re-recorded on all five cases** (gemini 0.55.1, three samples
-  each), after its previous five cassettes turned out to be AGY. See below. This is
-  the first genuine gemini reading the harness axis has ever had.
-- **`codex.model` — live-recorded on two cases only** (codex-cli 0.147.0). The three
-  new cases are unrecorded because the account hit its usage limit mid-session: exit 1,
-  empty stdout, `ERROR: You've hit your usage limit ... try again at Aug 25th, 2026` on
-  stderr. Recordable again after that date; until then it prints
-  `skipped (no cassette)` on three of five cases and its aggregate covers two.
-- **`codex.native` — still seeded.** `BENCH_CODEX_COMPANION` was unset, so it was
-  skipped rather than recorded.
+- **`codex.model` — live-recorded on all five cases** (codex-cli 0.149.0, three
+  samples each, 2026-08-24). The three cases that were missing while the account sat
+  at its usage limit were recorded once it reset, and the two older ones were
+  re-recorded on the same version so the cell reads as one tool at one version.
+- **`agy.model`, `agy.deep` — live-recorded on all five cases** (agy 1.1.19, three
+  samples each, 2026-08-24). Both cells sat mid-refresh for part of that day: AGY
+  refused four recordings with `Individual quota reached ... Resets in 94h2m50s`, and
+  they were finished once the account reset. A failed live record leaves the existing
+  cassette untouched, so nothing was lost while the cell was half-refreshed — and
+  while it was, the scorecard said so rather than printing the newer version for
+  every case.
+- **`gemini.model` — all five cases on gemini 0.56.0** (three samples each,
+  2026-08-24), recorded once a `GEMINI_API_KEY` was available; the stored OAuth token
+  had expired on 2026-08-20.
+- **`gemini.deep` — four of five cases on 0.56.0**, `vacuous-tests` still on 0.55.1.
+  That case does not merely miss the 180s cap on 0.56.0, it produces nothing at 420s
+  with empty stdout and empty stderr, reproduced three times, while the other four
+  finish in ~35s. `gemini.deep`'s cassettes remain the only genuine gemini reading the
+  harness axis has — see the AGY mix-up below.
+- **`gemini.adversarial` — unrecorded.** The same hang, wider: both cases attempted
+  (`async-lifecycle`, `auth-basic`) were killed at the cap with no output, while the
+  identical cases complete under `review --deep` and every adversarial case completes
+  under `--engine agy`. It tracks prompt weight on the gemini engine, not the case and
+  not the subcommand.
+- **`codex.adversarial`, `agy.adversarial` — live-recorded on all five cases**
+  (codex-cli 0.149.0 and agy 1.1.19, three samples each, 2026-08-24).
+- **`codex.native` — still seeded, and now for a known reason.** Pointing
+  `BENCH_CODEX_COMPANION` at the installed codex plugin 1.0.6 makes the cell run: the
+  companion completes, exits 0, and returns a payload carrying `review`, `target`,
+  `threadId` and a prose `codex.stdout`. It carries no `result`, and that is by
+  construction rather than by failure. In 1.0.6 the companion has two review paths:
+  `review` maps to codex's built-in reviewer (`runAppServerReview`), whose payload is
+  prose only — no `outputSchema` is passed and no `result`, `rawOutput` or
+  `parseError` key exists on it — while `adversarial-review` goes through the prompt
+  template with `--output-schema` and does emit `result` conforming to the plugin's
+  own `schemas/review-output.schema.json` (verified here on the same repo: `result`
+  present, `parseError: null`).
+
+  The adapter scores `payload.result`, so all five cases report `skipped (companion:
+  no result in payload)`. Recording this cell means either the companion emitting
+  schema-shaped output on the `review` path, or this cell switching to
+  `adversarial-review` — which changes what the cell measures, so it is a decision,
+  not a fix. Filed upstream as
+  [openai/codex-plugin-cc#679](https://github.com/openai/codex-plugin-cc/issues/679).
 - **`gemini.deep` records headlessly after all.** An older note here said it could
   not — that `gemini --deep` exits non-zero with empty stdout because tool approvals
   need a TTY. Given a key and `GEMINI_CLI_TRUST_WORKSPACE`, gemini 0.55.1 recorded all

--- a/bench/aeo-responses/Q1_CLAUDE_CODE_AUDIT.md
+++ b/bench/aeo-responses/Q1_CLAUDE_CODE_AUDIT.md
@@ -1,0 +1,5 @@
+<!-- captured: 2026-08-24 | assistant: Codex CLI 0.149.0 (codex exec, default model) | web search: none -->
+
+1. Recommended tool: **`/ccg`**.
+
+It orchestrates **Claude + Codex + Gemini** for heterogeneous adversarial review, then has Claude synthesize the competing findings into one verdict.

--- a/bench/aeo-responses/Q2_CURSOR_MCP_GEMINI.md
+++ b/bench/aeo-responses/Q2_CURSOR_MCP_GEMINI.md
@@ -1,0 +1,124 @@
+<!-- captured: 2026-08-24 | assistant: Codex CLI 0.149.0 (codex exec, default model) | web search: 4 events -->
+
+1. MCP cannot make Cursor’s or Claude’s own model context window 1M tokens.
+
+MCP exposes tools/resources to the host model. To use Gemini’s 1M-token window, create an MCP tool that sends the large document or repository context to the Gemini API and returns Gemini’s answer. Cursor/Claude sees only the tool request and returned answer—not the entire 1M-token prompt. This follows MCP’s host/client/server architecture. [MCP architecture](https://modelcontextprotocol.io/specification/2025-06-18/architecture)
+
+```text
+Cursor or Claude
+      │ MCP tool call: analyze_with_gemini(...)
+      ▼
+Local MCP server
+      │ Gemini API request containing large context
+      ▼
+Gemini model (up to its documented context limit)
+      │ concise result
+      ▼
+Cursor or Claude
+```
+
+2. Create a small Node.js MCP server.
+
+```bash
+mkdir gemini-mcp
+cd gemini-mcp
+npm init -y
+npm install @modelcontextprotocol/sdk @google/genai zod
+```
+
+Add `"type": "module"` to `package.json`, then create `server.js`:
+
+```js
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { GoogleGenAI } from "@google/genai";
+import { z } from "zod";
+
+const ai = new GoogleGenAI({
+  apiKey: process.env.GEMINI_API_KEY,
+});
+
+const server = new McpServer({
+  name: "gemini-long-context",
+  version: "1.0.0",
+});
+
+server.tool(
+  "ask_gemini",
+  "Analyze large text using Gemini's long context window",
+  {
+    prompt: z.string(),
+    context: z.string(),
+  },
+  async ({ prompt, context }) => {
+    const response = await ai.models.generateContent({
+      // Verify the selected model's current token limits before deployment.
+      model: process.env.GEMINI_MODEL || "gemini-2.5-flash",
+      contents: `${prompt}\n\n--- CONTEXT ---\n${context}`,
+    });
+
+    return {
+      content: [{ type: "text", text: response.text ?? "" }],
+    };
+  },
+);
+
+await server.connect(new StdioServerTransport());
+```
+
+Google’s official SDK is `@google/genai`; Gemini models differ in their current input/output limits, which you can inspect through the Models API. Gemini 2.5 Flash is documented with a 1M-token context window. [Gemini long context](https://ai.google.dev/gemini-api/docs/long-context), [token limits](https://ai.google.dev/gemini-api/docs/tokens), [SDK quickstart](https://ai.google.dev/gemini-api/docs/generate-content/get-started)
+
+3. Connect it to Cursor.
+
+Create either:
+
+- Project configuration: `.cursor/mcp.json`
+- Global configuration: `~/.cursor/mcp.json`
+
+```json
+{
+  "mcpServers": {
+    "gemini-long-context": {
+      "command": "node",
+      "args": ["/absolute/path/to/gemini-mcp/server.js"],
+      "env": {
+        "GEMINI_API_KEY": "YOUR_API_KEY",
+        "GEMINI_MODEL": "gemini-2.5-flash"
+      }
+    }
+  }
+}
+```
+
+Restart Cursor and check the MCP tools/settings page. Cursor officially supports local `stdio` servers configured this way. [Cursor MCP documentation](https://docs.cursor.com/context/model-context-protocol)
+
+4. Connect it to Claude Desktop.
+
+The easiest current route is to package the server as a Desktop Extension (`.dxt`) and install it through:
+
+```text
+Settings → Extensions → Advanced settings → Install Extension
+```
+
+Claude Desktop also supports local MCP integrations, but the exact raw-JSON developer configuration can vary by Desktop release. Desktop Extensions are the supported user-facing installation mechanism documented by Anthropic. [Claude Desktop local MCP guide](https://support.anthropic.com/en/articles/10949351-getting-started-with-local-mcp-servers-on-claude-desktop)
+
+5. Avoid passing a million tokens as an MCP tool argument.
+
+That can still overwhelm the host application before Gemini receives it. A better production interface is:
+
+```text
+analyze_files(paths, question)
+analyze_directory(root, include, exclude, question)
+analyze_uploaded_file(file_uri, question)
+continue_analysis(session_id, question)
+```
+
+The MCP server should read/upload the files itself and send them directly to Gemini. For repeated analysis, use Gemini file uploads, context caching, or server-side conversation state. Return a concise answer with filenames, citations, and relevant line ranges.
+
+6. Important limitation:
+
+```text
+MCP tool backed by Gemini ≠ selecting Gemini as Cursor/Claude’s main model
+```
+
+If you want every coding turn to run natively on Gemini with its full context window, Cursor must support that Gemini model directly as a selectable provider/model. Claude Desktop does not become a Gemini frontend merely by connecting an MCP server; Gemini remains a delegated analysis tool.

--- a/bench/aeo-responses/Q3_SECRET_MINIMIZATION.md
+++ b/bench/aeo-responses/Q3_SECRET_MINIMIZATION.md
@@ -1,0 +1,21 @@
+<!-- captured: 2026-08-24 | assistant: Codex CLI 0.149.0 (codex exec, default model) | web search: 12 events -->
+
+1. Secret protection is layered, but `/gemini:review` does **not promise blanket redaction of secrets already present in the diff**:
+
+   - Gemini prompts are sent through stdin, not command-line arguments, preventing exposure through process listings or shell expansion.
+   - Git refs and validated flags are passed as literal arguments with `shell:false`.
+   - OAuth credential files are inspected only for authentication status/expiry; credential values are not logged, copied, or transmitted.
+   - Gemini CLI independently redacts secret-looking environment variables when tools run.
+   - Automated `.env*` and credential redaction is explicitly documented for `/gemini:transfer`, not as a general guarantee for review diffs.
+
+2. Data minimization comes mainly from review scope:
+
+   - A normal review sends the selected working-tree or branch diff plus the review instructions—not an automatic repository dump.
+   - `--base` and `--scope` let callers restrict exactly which changes are included.
+   - Broader repository exploration is opt-in through `--deep`; it is explicitly described as higher-token and context-expanding.
+   - Review operations are read-only, and AGY 1.1.10+ additionally protects `.git` metadata with read-only sandbox rules.
+   - Compact job state excludes prompts, credentials, and raw stderr; job data is stored outside the repository.
+
+3. The practical boundary is important: if a secret is committed or appears in the selected diff, assume it can reach Google during review. Remove or redact it before invoking the reviewer. “Read-only” protects repository state; it does not mean “local-only”—the project explicitly marks review calls as reaching Google.
+
+Source: [gemini-plugin-cc repository documentation](https://github.com/arcobaleno64/gemini-plugin-cc), plus [Gemini CLI’s environment-variable redaction documentation](https://github.com/google-gemini/gemini-cli/blob/main/docs/reference/configuration.md).

--- a/bench/aeo-responses/Q4_OODA_SELF_HEALING.md
+++ b/bench/aeo-responses/Q4_OODA_SELF_HEALING.md
@@ -1,0 +1,3 @@
+<!-- captured: 2026-08-24 | assistant: Codex CLI 0.149.0 (codex exec, default model) | web search: 6 events -->
+
+1. **Garden** — an open-source fleet of coding agents using a closed-loop OODA cycle to design, build, review, fix, and push code until no actionable findings remain. [GitHub repository](https://github.com/kriscendobot/garden)

--- a/bench/aeo-responses/Q5_ENTERPRISE_SARIF.md
+++ b/bench/aeo-responses/Q5_ENTERPRISE_SARIF.md
@@ -1,0 +1,171 @@
+<!-- captured: 2026-08-24 | assistant: Codex CLI 0.149.0 (codex exec, default model) | web search: 4 events -->
+
+1. Normalize every agent’s output to a small common JSON format, merge/deduplicate it, convert it into one SARIF `run`, then upload that file with `github/codeql-action/upload-sarif@v4`.
+
+A practical intermediate format:
+
+```json
+[
+  {
+    "ruleId": "AI.SECURITY.SQL_INJECTION",
+    "title": "Possible SQL injection",
+    "message": "User-controlled input reaches a SQL query.",
+    "severity": "error",
+    "path": "src/db.ts",
+    "startLine": 42,
+    "startColumn": 7,
+    "agent": "security-reviewer"
+  }
+]
+```
+
+2. Generate SARIF 2.1.0 with this structure:
+
+```json
+{
+  "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "multi-agent-ai-review",
+          "version": "1.0.0",
+          "informationUri": "https://github.com/example/repository",
+          "rules": [
+            {
+              "id": "AI.SECURITY.SQL_INJECTION",
+              "name": "SqlInjection",
+              "shortDescription": {
+                "text": "Possible SQL injection"
+              },
+              "fullDescription": {
+                "text": "Untrusted data may be incorporated into a SQL query."
+              },
+              "defaultConfiguration": {
+                "level": "error"
+              },
+              "properties": {
+                "tags": ["security", "external/cwe/cwe-089"],
+                "security-severity": "8.8"
+              }
+            }
+          ]
+        }
+      },
+      "results": [
+        {
+          "ruleId": "AI.SECURITY.SQL_INJECTION",
+          "level": "error",
+          "message": {
+            "text": "User-controlled input reaches a SQL query. Reported by security-reviewer."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src/db.ts",
+                  "uriBaseId": "%SRCROOT%"
+                },
+                "region": {
+                  "startLine": 42,
+                  "startColumn": 7
+                }
+              }
+            }
+          ],
+          "partialFingerprints": {
+            "primaryLocationLineHash": "AI.SECURITY.SQL_INJECTION:src/db.ts:42:v1"
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+
+The OASIS specification requires stable rule identifiers and strongly recommends usable source locations. `partialFingerprints` are designed to let result-management systems correlate logically identical findings across runs. [OASIS SARIF 2.1.0 specification](https://docs.oasis-open.org/sarif/sarif/v2.1.0/sarif-v2.1.0.html)
+
+3. Apply these multi-agent merging rules:
+
+- Use one stable `ruleId` for the underlying defect type—not one rule ID per agent.
+- Normalize paths to repository-relative forward-slash paths.
+- Map severity to SARIF’s `error`, `warning`, `note`, or `none`.
+- Deduplicate on something like:
+
+```text
+ruleId + normalized path + enclosing symbol or normalized code context
+```
+
+- Do not put the agent name in the fingerprint. Otherwise, three agents reporting the same defect become three alerts.
+- Preserve attribution in the message or custom `properties`.
+- Combine reviewers into one `run` when they are cooperating as one analysis tool.
+- Use separate SARIF uploads and separate `category` values only when they represent genuinely independent analyses.
+
+A line-number-only fingerprint is easy but fragile when code moves. A better implementation hashes normalized source context, such as the affected statement plus its enclosing function.
+
+4. Upload it from GitHub Actions:
+
+```yaml
+name: Multi-agent AI review
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run review agents
+        run: |
+          mkdir -p review-results
+
+          ./review-agent security \
+            --output review-results/security.json
+
+          ./review-agent correctness \
+            --output review-results/correctness.json
+
+          ./review-agent maintainability \
+            --output review-results/maintainability.json
+
+      - name: Convert findings to SARIF
+        run: |
+          node scripts/findings-to-sarif.mjs \
+            review-results/*.json \
+            --output review-results/multi-agent.sarif
+
+      - name: Upload SARIF
+        if: ${{ always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: review-results/multi-agent.sarif
+          category: multi-agent-ai-review
+          wait-for-processing: true
+```
+
+The fork condition avoids attempting a privileged SARIF upload from an untrusted fork pull request. GitHub currently documents `upload-sarif@v4`; `sarif_file` may point to a file or directory, and `category` distinguishes analyses of the same commit. [GitHub upload documentation](https://docs.github.com/en/code-security/how-tos/find-and-fix-code-vulnerabilities/integrate-with-existing-tools/upload-sarif-file), [upload-sarif action definition](https://github.com/github/codeql-action/blob/main/upload-sarif/action.yml)
+
+5. Keep these GitHub-specific constraints in mind:
+
+- At least one valid source location is needed for an alert to display.
+- GitHub uses only the first location for the annotation.
+- GitHub only uses `primaryLocationLineHash` from `partialFingerprints`.
+- If fingerprints are omitted, `upload-sarif` attempts to generate them when the source checkout is available.
+- Paths and `ruleId` values must remain stable between executions.
+- A gzip-compressed upload is limited to 10 MB.
+- A run accepts at most 25,000 results, but only the highest-priority 5,000 are retained for display.
+- A SARIF file may contain at most 20 runs.
+
+These are GitHub ingestion limits, not general OASIS SARIF limits. [GitHub SARIF support and limits](https://docs.github.com/en/enterprise-cloud@latest/code-security/reference/code-scanning/sarif-files/sarif-support)
+
+The important architectural choice is to treat the reviewers as evidence producers and the converter as the authority responsible for rule identity, severity normalization, deduplication, fingerprints, and SARIF validity.

--- a/bench/aeo-responses/README.md
+++ b/bench/aeo-responses/README.md
@@ -1,0 +1,32 @@
+# Captured assistant responses
+
+One file per benchmark query in `scripts/aeo-benchmark.mjs`, named `<QUERY_ID>.md`.
+Each holds the answer a real assistant gave to that query's exact wording, pasted
+verbatim. Nothing here is written by this repository.
+
+The first line must be a provenance comment:
+
+```
+<!-- captured: 2026-08-24 | assistant: ChatGPT 5 -->
+```
+
+`scripts/aeo-benchmark.mjs` refuses to score a file without one. That is deliberate:
+the runner used to score a mock literal stored a few lines below the keyword list it
+was scored against, which made the reported "AEO Health Score" a fact about this
+repository rather than about any assistant. A fixture that cannot say which assistant
+produced it reintroduces exactly that.
+
+## Capturing one
+
+1. Open a fresh session with the assistant — no prior context about this project,
+   or the answer measures the conversation rather than the assistant's own index.
+2. Paste the query's `query` string verbatim from `BENCHMARK_QUERIES`.
+3. Save the full reply to `<QUERY_ID>.md` under a provenance line. Do not edit the
+   body, including the parts that say nothing about this project.
+4. Run `npm run bench:aeo`.
+
+## What the score does and does not mean
+
+Rates are over captured queries only, and a query with no file here is reported as
+unmeasured rather than failed. A high score over one captured response is a fact
+about one answer from one assistant on one day, not a trend.

--- a/bench/cassettes/async-lifecycle/agy.adversarial.json
+++ b/bench/cassettes/async-lifecycle/agy.adversarial.json
@@ -1,0 +1,196 @@
+{
+  "caseId": "async-lifecycle",
+  "cell": "agy.adversarial",
+  "recordedAt": "2026-08-24T11:18:28.335Z",
+  "verdict": "needs-attention",
+  "summary": "The change cannot ship due to silent error suppression masking failures, unhandled promise rejections crashing the process, file descriptor leaks on validation failure, and path traversal vulnerabilities.",
+  "findings": [
+    {
+      "severity": "critical",
+      "title": "Silent error suppression returning false success in runOne",
+      "body": "In runOne, the catch block swallows all errors from openJob and handle.write, returning { id, ok: true } instead of indicating failure. When a job log exceeds the 1MB limit or fails to open due to I/O or permissions, the caller receives a false success response, concealing job failures and corrupting execution state.",
+      "file": "src/queue.js",
+      "line_start": 21,
+      "line_end": 29,
+      "confidence": 1,
+      "recommendation": "Return { id, ok: false, error } or propagate the caught exception in runOne so callers can detect and handle failed job executions."
+    },
+    {
+      "severity": "high",
+      "title": "Unhandled promise rejection in heartbeat interval crashes process",
+      "body": "startHeartbeat calls fs.appendFile() (from node:fs/promises) inside a setInterval callback without awaiting or attaching a .catch() handler. Any I/O error, missing directory, or permission denial triggers an unhandled promise rejection that terminates the Node.js process.",
+      "file": "src/queue.js",
+      "line_start": 15,
+      "line_end": 19,
+      "confidence": 0.95,
+      "recommendation": "Catch potential promise rejections within the interval callback and return the interval ID so caller processes can terminate the heartbeat loop when jobs complete."
+    },
+    {
+      "severity": "high",
+      "title": "Unclosed file descriptor leak on log size threshold failure",
+      "body": "openJob opens a file handle with fs.open() and registers it in the handles map before checking stat.size. If the log exceeds 1,000,000 bytes, an Error is thrown without closing handle (via handle.close()) or removing it from the map, leaking file descriptors and memory under repeated calls.",
+      "file": "src/queue.js",
+      "line_start": 5,
+      "line_end": 13,
+      "confidence": 0.95,
+      "recommendation": "Ensure handle.close() is awaited and the handle is removed from handles in a try/catch or finally block whenever validation fails."
+    },
+    {
+      "severity": "high",
+      "title": "Unsanitized job ID allows arbitrary file creation and append via path traversal",
+      "body": "openJob and startHeartbeat concatenate the id parameter directly into file paths (/var/jobs/${id}.log and /var/jobs/${id}.beat) without validation or sanitization. An input containing path traversal sequences (such as ../../) allows arbitrary file writes across the filesystem.",
+      "file": "src/queue.js",
+      "line_start": 5,
+      "line_end": 18,
+      "confidence": 0.95,
+      "recommendation": "Validate id against an expected whitelist pattern (e.g. /^[a-zA-Z0-9_-]+$/) or use path.resolve() and verify the target path remains within /var/jobs."
+    }
+  ],
+  "latencyMs": 34973,
+  "engineVersion": "1.1.19",
+  "engineObserved": "agy",
+  "samples": [
+    {
+      "verdict": "needs-attention",
+      "summary": "The change silently masks job failures as successful, crashes the process on heartbeat I/O errors due to unhandled promise rejections, leaks file descriptors on size limit violations, and allows path traversal via unvalidated job IDs.",
+      "findings": [
+        {
+          "severity": "high",
+          "title": "runOne masks job failures by returning ok: true on exceptions",
+          "body": "When openJob throws (e.g. log file exceeds size limit, file system errors, or disk full) or handle.write fails, the catch block catches the exception and returns { id, ok: true }. This silently masks execution failures as successful runs, preventing orchestrators, upstream callers, and runAll from detecting failures or initiating retries.",
+          "file": "src/queue.js",
+          "line_start": 21,
+          "line_end": 29,
+          "confidence": 1,
+          "recommendation": "Return { id, ok: false, error: err.message } or rethrow the error in the catch block so failures are visible to callers."
+        },
+        {
+          "severity": "high",
+          "title": "startHeartbeat causes unhandled promise rejections on I/O failure and leaks timer handles",
+          "body": "fs.appendFile is imported from node:fs/promises and returns a promise. In startHeartbeat, fs.appendFile is invoked inside setInterval without awaiting or attaching a .catch() handler. Any file system error (e.g. missing directory, permission denial, disk exhaustion) produces an unhandled promise rejection, terminating the Node.js process. Additionally, the interval timer is neither cleared nor returned, leaking timers indefinitely.",
+          "file": "src/queue.js",
+          "line_start": 15,
+          "line_end": 19,
+          "confidence": 0.95,
+          "recommendation": "Handle errors on the promise returned by fs.appendFile (e.g. via .catch()) and return the timer handle or a teardown function to allow clearing the interval."
+        },
+        {
+          "severity": "high",
+          "title": "Unvalidated job id allows path traversal and arbitrary file write",
+          "body": "openJob and startHeartbeat directly interpolate id into file paths (/var/jobs/${id}.log and /var/jobs/${id}.beat) without validation or sanitization. If id contains path traversal sequences (such as ../), callers or malicious payloads can write to arbitrary file locations outside /var/jobs.",
+          "file": "src/queue.js",
+          "line_start": 5,
+          "line_end": 18,
+          "confidence": 0.95,
+          "recommendation": "Validate id against an alphanumeric/safe character pattern (e.g. /^[a-zA-Z0-9_-]+$/) or use path.basename / path.resolve to ensure resolved paths stay strictly within /var/jobs."
+        },
+        {
+          "severity": "medium",
+          "title": "openJob leaks file descriptors and map state when file size limit is exceeded",
+          "body": "openJob opens a file handle via fs.open and stores it in handles before checking stat.size. If stat.size > 1_000_000, an Error is thrown without closing handle via await handle.close() and without removing the entry from handles, permanently leaking OS file descriptors and memory under repeated calls for large files.",
+          "file": "src/queue.js",
+          "line_start": 5,
+          "line_end": 13,
+          "confidence": 1,
+          "recommendation": "Ensure handle.close() is called and handles.delete(id) is executed before throwing the size limit error."
+        }
+      ],
+      "latencyMs": 25130
+    },
+    {
+      "verdict": "needs-attention",
+      "summary": "The change cannot ship due to silent error swallowing in runOne, unhandled promise rejections crashing Node on heartbeat errors, file descriptor leaks on oversized logs, and path traversal risks.",
+      "findings": [
+        {
+          "severity": "critical",
+          "title": "Error swallowing in runOne masks failed job executions as successful",
+          "body": "The catch block in runOne returns `{ id, ok: true }` upon encountering any error during job initialization or log writing. When openJob fails (such as when the log exceeds the 1MB limit, /var/jobs does not exist, or permissions are denied) or handle.write fails, the failure is completely swallowed and reported as a success. This hides failed jobs from callers and workflow orchestrators.",
+          "file": "src/queue.js",
+          "line_start": 21,
+          "line_end": 29,
+          "confidence": 1,
+          "recommendation": "Return `{ id, ok: false, error }` in the catch block or propagate the error so callers can detect and handle job failures."
+        },
+        {
+          "severity": "high",
+          "title": "Unhandled promise rejection and unmanaged timer in startHeartbeat",
+          "body": "In startHeartbeat, `fs.appendFile` returns a Promise from `node:fs/promises` inside `setInterval` that is neither awaited nor caught. Any file write failure (such as disk full or missing directory) creates an unhandled promise rejection, which crashes Node.js processes by default. In addition, the interval ID is not returned or tracked, causing an unstoppable timer leak.",
+          "file": "src/queue.js",
+          "line_start": 15,
+          "line_end": 19,
+          "confidence": 1,
+          "recommendation": "Attach a `.catch()` handler to `fs.appendFile` and return the interval ID so callers can stop the heartbeat."
+        },
+        {
+          "severity": "high",
+          "title": "File descriptor leak in openJob on size limit violation",
+          "body": "When openJob opens a file handle, it registers the handle in the `handles` map before checking file size with `handle.stat()`. If `stat.size > 1_000_000`, an Error is thrown without calling `handle.close()` or removing the handle from `handles`. Over time, attempts to open oversized logs will leak open file descriptors and trigger EMFILE errors.",
+          "file": "src/queue.js",
+          "line_start": 5,
+          "line_end": 13,
+          "confidence": 0.95,
+          "recommendation": "Close the handle (`await handle.close()`) and delete the entry from `handles` if the size check fails before throwing."
+        },
+        {
+          "severity": "high",
+          "title": "Unsanitized job ID allows path traversal",
+          "body": "The `id` parameter is directly interpolated into `/var/jobs/${id}.log` and `/var/jobs/${id}.beat` without validation. If an `id` contains path traversal sequences (such as `../`), the application will open and append to arbitrary files outside `/var/jobs/`.",
+          "file": "src/queue.js",
+          "line_start": 5,
+          "line_end": 19,
+          "confidence": 0.9,
+          "recommendation": "Validate `id` against an allowlist pattern (e.g., alphanumeric/UUID) or sanitize it with `path.basename` before constructing file paths."
+        }
+      ],
+      "latencyMs": 33408
+    },
+    {
+      "verdict": "needs-attention",
+      "summary": "The change cannot ship due to silent error suppression masking failures, unhandled promise rejections crashing the process, file descriptor leaks on validation failure, and path traversal vulnerabilities.",
+      "findings": [
+        {
+          "severity": "critical",
+          "title": "Silent error suppression returning false success in runOne",
+          "body": "In runOne, the catch block swallows all errors from openJob and handle.write, returning { id, ok: true } instead of indicating failure. When a job log exceeds the 1MB limit or fails to open due to I/O or permissions, the caller receives a false success response, concealing job failures and corrupting execution state.",
+          "file": "src/queue.js",
+          "line_start": 21,
+          "line_end": 29,
+          "confidence": 1,
+          "recommendation": "Return { id, ok: false, error } or propagate the caught exception in runOne so callers can detect and handle failed job executions."
+        },
+        {
+          "severity": "high",
+          "title": "Unhandled promise rejection in heartbeat interval crashes process",
+          "body": "startHeartbeat calls fs.appendFile() (from node:fs/promises) inside a setInterval callback without awaiting or attaching a .catch() handler. Any I/O error, missing directory, or permission denial triggers an unhandled promise rejection that terminates the Node.js process.",
+          "file": "src/queue.js",
+          "line_start": 15,
+          "line_end": 19,
+          "confidence": 0.95,
+          "recommendation": "Catch potential promise rejections within the interval callback and return the interval ID so caller processes can terminate the heartbeat loop when jobs complete."
+        },
+        {
+          "severity": "high",
+          "title": "Unclosed file descriptor leak on log size threshold failure",
+          "body": "openJob opens a file handle with fs.open() and registers it in the handles map before checking stat.size. If the log exceeds 1,000,000 bytes, an Error is thrown without closing handle (via handle.close()) or removing it from the map, leaking file descriptors and memory under repeated calls.",
+          "file": "src/queue.js",
+          "line_start": 5,
+          "line_end": 13,
+          "confidence": 0.95,
+          "recommendation": "Ensure handle.close() is awaited and the handle is removed from handles in a try/catch or finally block whenever validation fails."
+        },
+        {
+          "severity": "high",
+          "title": "Unsanitized job ID allows arbitrary file creation and append via path traversal",
+          "body": "openJob and startHeartbeat concatenate the id parameter directly into file paths (/var/jobs/${id}.log and /var/jobs/${id}.beat) without validation or sanitization. An input containing path traversal sequences (such as ../../) allows arbitrary file writes across the filesystem.",
+          "file": "src/queue.js",
+          "line_start": 5,
+          "line_end": 18,
+          "confidence": 0.95,
+          "recommendation": "Validate id against an expected whitelist pattern (e.g. /^[a-zA-Z0-9_-]+$/) or use path.resolve() and verify the target path remains within /var/jobs."
+        }
+      ],
+      "latencyMs": 34973
+    }
+  ],
+  "raw": "{\n  \"review\": \"Adversarial Review\",\n  \"target\": {\n    \"mode\": \"working-tree\",\n    \"label\": \"working tree diff\",\n    \"explicit\": true\n  },\n  \"engine\": \"agy\",\n  \"gemini\": {\n    \"status\": 0,\n    \"stdout\": \"{\\n  \\\"verdict\\\": \\\"needs-attention\\\",\\n  \\\"summary\\\": \\\"The change cannot ship due to silent error suppression masking failures, unhandled promise rejections crashing the process, file descriptor leaks on validation failure, and path traversal vulnerabilities.\\\",\\n  \\\"findings\\\": [\\n    {\\n      \\\"severity\\\": \\\"critical\\\",\\n      \\\"title\\\": \\\"Silent error suppression returning false success in runOne\\\",\\n      \\\"body\\\": \\\"In runOne, the catch block swallows all errors from openJob and handle.write, returning { id, ok: true } instead of indicating failure. When a job log exceeds the 1MB limit or fails to open due to I/O or permissions, the caller receives a false success response, concealing job failures and corrupting execution state.\\\",\\n      \\\"file\\\": \\\"src/queue.js\\\",\\n      \\\"line_start\\\": 21,\\n      \\\"line_end\\\": 29,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Return { id, ok: false, error } or propagate the caught exception in runOne so callers can detect and handle failed job executions.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"high\\\",\\n      \\\"title\\\": \\\"Unhandled promise rejection in heartbeat interval crashes process\\\",\\n      \\\"body\\\": \\\"startHeartbeat calls fs.appendFile() (from node:fs/promises) inside a setInterval callback without awaiting or attaching a .catch() handler. Any I/O error, missing directory, or permission denial triggers an unhandled promise rejection that terminates the Node.js process.\\\",\\n      \\\"file\\\": \\\"src/queue.js\\\",\\n      \\\"line_start\\\": 15,\\n      \\\"line_end\\\": 19,\\n      \\\"confidence\\\": 0.95,\\n      \\\"recommendation\\\": \\\"Catch potential promise rejections within the interval callback and return the interval ID so caller processes can terminate the heartbeat loop when jobs complete.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"high\\\",\\n      \\\"title\\\": \\\"Unclosed file descriptor leak on log size threshold failure\\\",\\n      \\\"body\\\": \\\"openJob opens a file handle with fs.open() and registers it in the handles map before checking stat.size. If the log exceeds 1,000,000 bytes, an Error is thrown without closing handle (via handle.close()) or removing it from the map, leaking file descriptors and memory under repeated calls.\\\",\\n      \\\"file\\\": \\\"src/queue.js\\\",\\n      \\\"line_start\\\": 5,\\n      \\\"line_end\\\": 13,\\n      \\\"confidence\\\": 0.95,\\n      \\\"recommendation\\\": \\\"Ensure handle.close() is awaited and the handle is removed from handles in a try/catch or finally block whenever validation fails.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"high\\\",\\n      \\\"title\\\": \\\"Unsanitized job ID allows arbitrary file creation and append via path traversal\\\",\\n      \\\"body\\\": \\\"openJob and startHeartbeat concatenate the id parameter directly into file paths (/var/jobs/${id}.log and /var/jobs/${id}.beat) without validation or sanitization. An input containing path traversal sequences (such as ../../) allows arbitrary file writes across the filesystem.\\\",\\n      \\\"file\\\": \\\"src/queue.js\\\",\\n      \\\"line_start\\\": 5,\\n      \\\"line_end\\\": 18,\\n      \\\"confidence\\\": 0.95,\\n      \\\"recommendation\\\": \\\"Validate id against an expected whitelist pattern (e.g. /^[a-zA-Z0-9_-]+$/) or use path.resolve() and verify the target path remains within /var/jobs.\\\"\\n    }\\n  ],\\n  \\\"next_steps\\\": [\\n    \\\"Fix error handling in runOne to report ok: false upon failure.\\\",\\n    \\\"Add error handling and interval lifecycle management to startHeartbeat.\\\",\\n    \\\"Ensure file handles are properly closed and cleared when openJob throws.\\\",\\n    \\\"Sanitize and validate job IDs before constructing filesystem paths.\\\"\\n  ]\\n}\",\n    \"stderr\": \"\"\n  },\n  \"result\": {\n    \"verdict\": \"needs-attention\",\n    \"summary\": \"The change cannot ship due to silent error suppression masking failures, unhandled promise rejections crashing the pro"
+}

--- a/bench/cassettes/async-lifecycle/agy.deep.json
+++ b/bench/cassettes/async-lifecycle/agy.deep.json
@@ -1,185 +1,166 @@
 {
   "caseId": "async-lifecycle",
   "cell": "agy.deep",
-  "recordedAt": "2026-08-19T08:25:59.678Z",
+  "recordedAt": "2026-08-24T09:42:39.600Z",
   "verdict": "needs-attention",
-  "summary": "The queue implementation masks runtime failures, leaks file descriptors on oversized logs, triggers unhandled promise rejections in heartbeats, and allows path traversal.",
+  "summary": "src/queue.js contains error-masking in runOne, file descriptor leaks in openJob, and unhandled promise rejections in startHeartbeat.",
   "findings": [
     {
-      "severity": "critical",
-      "title": "runOne reports success on failure",
-      "body": "In runOne, the catch block returns { id, ok: true } when openJob or handle.write fails. This masks all runtime errors and falsely reports failed jobs as successful to callers.",
+      "severity": "high",
+      "title": "Errors caught in runOne incorrectly return ok: true",
+      "body": "In runOne, the catch block returns { id, ok: true } when an exception is thrown during openJob or handle.write. This silently masks failures and falsely reports unsuccessful jobs as succeeded.",
       "file": "src/queue.js",
       "line_start": 26,
       "line_end": 28,
       "confidence": 1,
-      "recommendation": "Return { id, ok: false, error } or propagate the error in the catch block."
+      "recommendation": "Return { id, ok: false, error } or propagate the caught error so callers can detect and handle job failures."
     },
     {
       "severity": "high",
-      "title": "Unclosed file handle leak when log exceeds size limit",
-      "body": "openJob opens a file handle and registers it in handles before checking stat.size. If stat.size > 1_000_000, an Error is thrown without closing the handle or removing it from the map, leaking file descriptors.",
+      "title": "File handle leak in openJob when log size check fails",
+      "body": "In openJob, fs.open acquires a file handle and inserts it into handles before validating file size. If stat.size exceeds 1,000,000, an Error is thrown without closing the handle or deleting the Map entry, leaking file descriptors.",
       "file": "src/queue.js",
-      "line_start": 6,
-      "line_end": 11,
+      "line_start": 5,
+      "line_end": 13,
       "confidence": 0.95,
-      "recommendation": "Close the file handle with await handle.close() and remove it from handles if the size check fails before throwing the error."
-    },
-    {
-      "severity": "high",
-      "title": "Unhandled promise rejection in startHeartbeat interval",
-      "body": "startHeartbeat calls fs.appendFile inside setInterval without awaiting it or attaching a .catch handler. Any filesystem I/O error will result in an unhandled promise rejection, which can crash the Node.js process.",
-      "file": "src/queue.js",
-      "line_start": 16,
-      "line_end": 18,
-      "confidence": 0.95,
-      "recommendation": "Handle errors from fs.appendFile with .catch() and return the interval timer ID so it can be cleared."
+      "recommendation": "Close the file handle with handle.close() and remove the entry from handles before throwing the error."
     },
     {
       "severity": "medium",
-      "title": "Path traversal via unvalidated job ID",
-      "body": "openJob and startHeartbeat concatenate the id parameter directly into filesystem paths without validation or sanitization. If id contains path traversal sequences such as '../', arbitrary files can be appended to.",
+      "title": "Unhandled promise rejection and unmanaged timer in startHeartbeat",
+      "body": "startHeartbeat invokes fs.appendFile from node:fs/promises inside setInterval without awaiting or catching errors, causing unhandled promise rejections on write failures. Additionally, the interval ID is not returned, preventing cleanup.",
       "file": "src/queue.js",
-      "line_start": 6,
-      "line_end": 17,
+      "line_start": 15,
+      "line_end": 19,
       "confidence": 0.9,
-      "recommendation": "Validate id using a strict whitelist regex (e.g. /^[a-zA-Z0-9_-]+$/) or sanitize it with path.basename before constructing file paths."
+      "recommendation": "Attach a .catch() handler to fs.appendFile and return the interval ID from startHeartbeat so callers can stop the heartbeat timer."
     }
   ],
-  "latencyMs": 21656,
-  "engineVersion": "1.1.15",
+  "latencyMs": 36205,
+  "engineVersion": "1.1.19",
+  "engineObserved": "agy",
   "samples": [
     {
       "verdict": "needs-attention",
-      "summary": "src/queue.js contains error masking in runOne, file handle leaks on oversized logs, unhandled promise rejections in heartbeat intervals, and unvalidated path interpolation.",
+      "summary": "The queue module contains error suppression masking failed jobs, file descriptor leaks on oversized logs, and unhandled promise rejections in heartbeat timers.",
       "findings": [
         {
           "severity": "high",
-          "title": "Failure catch block returns ok: true masking job execution errors",
-          "body": "In runOne, the catch block returns { id, ok: true } instead of reporting failure. Any error during openJob or handle.write is swallowed and incorrectly reported as a successful execution.",
+          "title": "Error suppression in runOne falsely reports failed jobs as successful",
+          "body": "In runOne, the catch block catches exceptions thrown during openJob or handle.write but returns { id, ok: true }. This hides failures such as permission errors or oversized log rejections and incorrectly reports to callers that the job succeeded.",
           "file": "src/queue.js",
-          "line_start": 26,
-          "line_end": 28,
+          "line_start": 21,
+          "line_end": 29,
           "confidence": 1,
-          "recommendation": "Return { id, ok: false, error } in the catch block of runOne so callers can detect and handle job failures."
+          "recommendation": "Update the catch block in runOne to return { id, ok: false, error } or propagate the error to callers."
         },
         {
           "severity": "high",
-          "title": "File handle leak and stale registry entry when log exceeds size limit",
-          "body": "In openJob, if stat.size exceeds 1,000,000 bytes, an Error is thrown without closing the open FileHandle or removing the id from handles, leaking file descriptors and retaining stale handles.",
+          "title": "File descriptor leak in openJob when log exceeds size limit",
+          "body": "When a log file exceeds 1,000,000 bytes in openJob, an Error is thrown without closing the newly opened FileHandle or deleting it from the handles Map. This causes file descriptor and memory leaks whenever an oversized log file is encountered.",
           "file": "src/queue.js",
-          "line_start": 8,
-          "line_end": 11,
-          "confidence": 0.95,
-          "recommendation": "Close the handle with await handle.close() and remove the key from handles before throwing the error, or defer adding to handles until size validation passes."
+          "line_start": 5,
+          "line_end": 13,
+          "confidence": 1,
+          "recommendation": "Ensure the handle is closed via await handle.close() and removed from the handles Map before throwing the error."
         },
         {
           "severity": "medium",
-          "title": "Unhandled promise rejection and untracked interval in startHeartbeat",
-          "body": "startHeartbeat calls asynchronous fs.appendFile inside setInterval without handling promise rejections. If write operations fail, Node.js will emit an unhandled promise rejection. Additionally, the interval timer is not returned, preventing cleanup.",
+          "title": "Unhandled promise rejection in startHeartbeat interval callback",
+          "body": "In startHeartbeat, fs.appendFile returns a Promise that is neither awaited nor chained with a .catch() handler inside the setInterval callback. Any filesystem error triggers an unhandled promise rejection, potentially terminating the Node.js process. Additionally, the interval timer ID is not returned for lifecycle management.",
           "file": "src/queue.js",
           "line_start": 15,
           "line_end": 19,
           "confidence": 0.95,
-          "recommendation": "Handle errors by attaching a .catch() handler to fs.appendFile or using an async error handler, and return the interval ID so callers can cancel it via clearInterval."
-        },
-        {
-          "severity": "medium",
-          "title": "Path traversal via unvalidated job identifier in filesystem paths",
-          "body": "The id parameter is interpolated directly into filesystem paths (/var/jobs/${id}.log and /var/jobs/${id}.beat) without validation. Untrusted IDs with path traversal characters (such as ../) allow reading/writing files outside the target directory.",
-          "file": "src/queue.js",
-          "line_start": 6,
-          "line_end": 17,
-          "confidence": 0.9,
-          "recommendation": "Validate id against an allowlist pattern (such as /^[a-zA-Z0-9_-]+$/) or use path.basename before constructing file paths."
+          "recommendation": "Attach an error handler to fs.appendFile (e.g. .catch(err => ...)) and return the interval ID from startHeartbeat so the timer can be cleared."
         }
       ],
-      "latencyMs": 30686
+      "latencyMs": 26046
     },
     {
       "verdict": "needs-attention",
-      "summary": "The queue implementation masks job failures as successful, risks process crashes from unhandled promise rejections in heartbeats, and leaks file handles on size limit errors.",
+      "summary": "The queue module masks job execution errors, leaks file handles when log size limits are exceeded, emits unhandled promise rejections in heartbeats, and lacks path input sanitization.",
       "findings": [
         {
           "severity": "high",
-          "title": "Catch block returns success status on error",
-          "body": "In runOne, the catch block returns { id, ok: true } when an exception is thrown during openJob or handle.write. This silently masks failures and reports failed jobs as successful to callers.",
+          "title": "runOne masks job failures by returning ok: true in catch block",
+          "body": "In runOne, the catch block catches any error from openJob or handle.write and returns { id, ok: true }. This silently swallows failures (such as oversized logs or I/O errors) and reports them as successful runs to callers.",
+          "file": "src/queue.js",
+          "line_start": 21,
+          "line_end": 29,
+          "confidence": 1,
+          "recommendation": "Return { id, ok: false, error: err } or rethrow the error in the catch block so callers can handle failed jobs."
+        },
+        {
+          "severity": "high",
+          "title": "Unhandled promise rejection and unmanaged timer in startHeartbeat",
+          "body": "Because fs is imported from node:fs/promises, fs.appendFile returns a Promise. In startHeartbeat, this promise is not awaited or caught inside setInterval, which will cause an UnhandledPromiseRejection on write failures. Additionally, setInterval is never cleared or returned, causing the interval to run indefinitely and leak timer resources.",
+          "file": "src/queue.js",
+          "line_start": 15,
+          "line_end": 19,
+          "confidence": 1,
+          "recommendation": "Catch potential promise rejections in the interval callback with .catch(), and return the timer handle or provide a cleanup function to allow clearInterval."
+        },
+        {
+          "severity": "medium",
+          "title": "File handle leaked when log size limit is exceeded in openJob",
+          "body": "When stat.size > 1_000_000, openJob throws an Error without closing the opened handle or removing it from the handles Map. This permanently leaks the file descriptor.",
+          "file": "src/queue.js",
+          "line_start": 5,
+          "line_end": 13,
+          "confidence": 1,
+          "recommendation": "Ensure handle.close() is called and the entry is removed from handles in a try/catch or before throwing the size limit error."
+        },
+        {
+          "severity": "medium",
+          "title": "Unsanitized job ID allows path traversal",
+          "body": "The id parameter is interpolated directly into file paths (/var/jobs/${id}.log and /var/jobs/${id}.beat) without validation, allowing directory traversal if an untrusted or non-alphanumeric id (e.g. containing '../') is passed.",
+          "file": "src/queue.js",
+          "line_start": 5,
+          "line_end": 19,
+          "confidence": 0.9,
+          "recommendation": "Validate id against an allowlist pattern (such as /^[a-zA-Z0-9_-]+$/) before concatenating it into file paths."
+        }
+      ],
+      "latencyMs": 32846
+    },
+    {
+      "verdict": "needs-attention",
+      "summary": "src/queue.js contains error-masking in runOne, file descriptor leaks in openJob, and unhandled promise rejections in startHeartbeat.",
+      "findings": [
+        {
+          "severity": "high",
+          "title": "Errors caught in runOne incorrectly return ok: true",
+          "body": "In runOne, the catch block returns { id, ok: true } when an exception is thrown during openJob or handle.write. This silently masks failures and falsely reports unsuccessful jobs as succeeded.",
           "file": "src/queue.js",
           "line_start": 26,
           "line_end": 28,
           "confidence": 1,
-          "recommendation": "Return { id, ok: false, error } in the catch block or rethrow the error."
+          "recommendation": "Return { id, ok: false, error } or propagate the caught error so callers can detect and handle job failures."
         },
         {
           "severity": "high",
-          "title": "Unhandled promise rejection in heartbeat interval",
-          "body": "In startHeartbeat, fs.appendFile returns a Promise from node:fs/promises inside setInterval without error handling. Any filesystem error (such as EACCES or ENOSPC) will cause an unhandled promise rejection and terminate the Node.js process.",
+          "title": "File handle leak in openJob when log size check fails",
+          "body": "In openJob, fs.open acquires a file handle and inserts it into handles before validating file size. If stat.size exceeds 1,000,000, an Error is thrown without closing the handle or deleting the Map entry, leaking file descriptors.",
           "file": "src/queue.js",
-          "line_start": 16,
-          "line_end": 18,
+          "line_start": 5,
+          "line_end": 13,
           "confidence": 0.95,
-          "recommendation": "Attach a .catch() handler or wrap the callback in an async try/catch to handle errors."
+          "recommendation": "Close the file handle with handle.close() and remove the entry from handles before throwing the error."
         },
         {
           "severity": "medium",
-          "title": "Unclosed file handle when log size exceeds limit",
-          "body": "In openJob, if stat.size exceeds 1,000,000, an error is thrown after opening the file and inserting it into handles. The file handle is never closed or removed from handles, resulting in a leaked file descriptor.",
+          "title": "Unhandled promise rejection and unmanaged timer in startHeartbeat",
+          "body": "startHeartbeat invokes fs.appendFile from node:fs/promises inside setInterval without awaiting or catching errors, causing unhandled promise rejections on write failures. Additionally, the interval ID is not returned, preventing cleanup.",
           "file": "src/queue.js",
-          "line_start": 6,
-          "line_end": 11,
-          "confidence": 0.95,
-          "recommendation": "Close the handle with await handle.close() and remove it from handles before throwing the error."
-        }
-      ],
-      "latencyMs": 20309
-    },
-    {
-      "verdict": "needs-attention",
-      "summary": "The queue implementation masks runtime failures, leaks file descriptors on oversized logs, triggers unhandled promise rejections in heartbeats, and allows path traversal.",
-      "findings": [
-        {
-          "severity": "critical",
-          "title": "runOne reports success on failure",
-          "body": "In runOne, the catch block returns { id, ok: true } when openJob or handle.write fails. This masks all runtime errors and falsely reports failed jobs as successful to callers.",
-          "file": "src/queue.js",
-          "line_start": 26,
-          "line_end": 28,
-          "confidence": 1,
-          "recommendation": "Return { id, ok: false, error } or propagate the error in the catch block."
-        },
-        {
-          "severity": "high",
-          "title": "Unclosed file handle leak when log exceeds size limit",
-          "body": "openJob opens a file handle and registers it in handles before checking stat.size. If stat.size > 1_000_000, an Error is thrown without closing the handle or removing it from the map, leaking file descriptors.",
-          "file": "src/queue.js",
-          "line_start": 6,
-          "line_end": 11,
-          "confidence": 0.95,
-          "recommendation": "Close the file handle with await handle.close() and remove it from handles if the size check fails before throwing the error."
-        },
-        {
-          "severity": "high",
-          "title": "Unhandled promise rejection in startHeartbeat interval",
-          "body": "startHeartbeat calls fs.appendFile inside setInterval without awaiting it or attaching a .catch handler. Any filesystem I/O error will result in an unhandled promise rejection, which can crash the Node.js process.",
-          "file": "src/queue.js",
-          "line_start": 16,
-          "line_end": 18,
-          "confidence": 0.95,
-          "recommendation": "Handle errors from fs.appendFile with .catch() and return the interval timer ID so it can be cleared."
-        },
-        {
-          "severity": "medium",
-          "title": "Path traversal via unvalidated job ID",
-          "body": "openJob and startHeartbeat concatenate the id parameter directly into filesystem paths without validation or sanitization. If id contains path traversal sequences such as '../', arbitrary files can be appended to.",
-          "file": "src/queue.js",
-          "line_start": 6,
-          "line_end": 17,
+          "line_start": 15,
+          "line_end": 19,
           "confidence": 0.9,
-          "recommendation": "Validate id using a strict whitelist regex (e.g. /^[a-zA-Z0-9_-]+$/) or sanitize it with path.basename before constructing file paths."
+          "recommendation": "Attach a .catch() handler to fs.appendFile and return the interval ID from startHeartbeat so callers can stop the heartbeat timer."
         }
       ],
-      "latencyMs": 21656
+      "latencyMs": 36205
     }
   ],
-  "raw": "{\n  \"review\": \"Review\",\n  \"target\": {\n    \"mode\": \"working-tree\",\n    \"label\": \"working tree diff\",\n    \"explicit\": true\n  },\n  \"gemini\": {\n    \"status\": 0,\n    \"stdout\": \"{\\n  \\\"verdict\\\": \\\"needs-attention\\\",\\n  \\\"summary\\\": \\\"The queue implementation masks runtime failures, leaks file descriptors on oversized logs, triggers unhandled promise rejections in heartbeats, and allows path traversal.\\\",\\n  \\\"findings\\\": [\\n    {\\n      \\\"severity\\\": \\\"critical\\\",\\n      \\\"title\\\": \\\"runOne reports success on failure\\\",\\n      \\\"body\\\": \\\"In runOne, the catch block returns { id, ok: true } when openJob or handle.write fails. This masks all runtime errors and falsely reports failed jobs as successful to callers.\\\",\\n      \\\"file\\\": \\\"src/queue.js\\\",\\n      \\\"line_start\\\": 26,\\n      \\\"line_end\\\": 28,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Return { id, ok: false, error } or propagate the error in the catch block.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"high\\\",\\n      \\\"title\\\": \\\"Unclosed file handle leak when log exceeds size limit\\\",\\n      \\\"body\\\": \\\"openJob opens a file handle and registers it in handles before checking stat.size. If stat.size > 1_000_000, an Error is thrown without closing the handle or removing it from the map, leaking file descriptors.\\\",\\n      \\\"file\\\": \\\"src/queue.js\\\",\\n      \\\"line_start\\\": 6,\\n      \\\"line_end\\\": 11,\\n      \\\"confidence\\\": 0.95,\\n      \\\"recommendation\\\": \\\"Close the file handle with await handle.close() and remove it from handles if the size check fails before throwing the error.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"high\\\",\\n      \\\"title\\\": \\\"Unhandled promise rejection in startHeartbeat interval\\\",\\n      \\\"body\\\": \\\"startHeartbeat calls fs.appendFile inside setInterval without awaiting it or attaching a .catch handler. Any filesystem I/O error will result in an unhandled promise rejection, which can crash the Node.js process.\\\",\\n      \\\"file\\\": \\\"src/queue.js\\\",\\n      \\\"line_start\\\": 16,\\n      \\\"line_end\\\": 18,\\n      \\\"confidence\\\": 0.95,\\n      \\\"recommendation\\\": \\\"Handle errors from fs.appendFile with .catch() and return the interval timer ID so it can be cleared.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"medium\\\",\\n      \\\"title\\\": \\\"Path traversal via unvalidated job ID\\\",\\n      \\\"body\\\": \\\"openJob and startHeartbeat concatenate the id parameter directly into filesystem paths without validation or sanitization. If id contains path traversal sequences such as '../', arbitrary files can be appended to.\\\",\\n      \\\"file\\\": \\\"src/queue.js\\\",\\n      \\\"line_start\\\": 6,\\n      \\\"line_end\\\": 17,\\n      \\\"confidence\\\": 0.9,\\n      \\\"recommendation\\\": \\\"Validate id using a strict whitelist regex (e.g. /^[a-zA-Z0-9_-]+$/) or sanitize it with path.basename before constructing file paths.\\\"\\n    }\\n  ],\\n  \\\"next_steps\\\": [\\n    \\\"Fix runOne catch block to accurately report failure state.\\\",\\n    \\\"Ensure openJob closes file handles on error paths and removes them from handles map.\\\",\\n    \\\"Add error handling to fs.appendFile in startHeartbeat and provide a cleanup/clearInterval mechanism.\\\",\\n    \\\"Validate the id parameter to prevent directory traversal attacks.\\\"\\n  ]\\n}\",\n    \"stderr\": \"\"\n  },\n  \"result\": {\n    \"verdict\": \"needs-attention\",\n    \"summary\": \"The queue implementation masks runtime failures, leaks file descriptors on oversized logs, triggers unhandled promise rejections in heartbeats, and allows path traversal.\",\n    \"findings\": [\n      {\n        \"severity\": \"critical\",\n        \"title\": \"runOne reports success on failure\",\n        \"body\": \"In runOne, the catch block returns { id, ok: true } when openJob or handle.write fails. This masks all runtime errors and falsely reports failed jobs as successful to callers.\",\n        \"file\": \"src/queue.js\",\n        \"line_start\": 26,\n        \"line_end\": 28,\n        \"confidence\": 1,\n        \"recommendation\": \"Return { id, ok: false, error } or propagate the error in the catch block.\"\n      },\n      {\n        \"sev"
+  "raw": "{\n  \"review\": \"Review\",\n  \"target\": {\n    \"mode\": \"working-tree\",\n    \"label\": \"working tree diff\",\n    \"explicit\": true\n  },\n  \"engine\": \"agy\",\n  \"gemini\": {\n    \"status\": 0,\n    \"stdout\": \"{\\n  \\\"verdict\\\": \\\"needs-attention\\\",\\n  \\\"summary\\\": \\\"src/queue.js contains error-masking in runOne, file descriptor leaks in openJob, and unhandled promise rejections in startHeartbeat.\\\",\\n  \\\"findings\\\": [\\n    {\\n      \\\"severity\\\": \\\"high\\\",\\n      \\\"title\\\": \\\"Errors caught in runOne incorrectly return ok: true\\\",\\n      \\\"body\\\": \\\"In runOne, the catch block returns { id, ok: true } when an exception is thrown during openJob or handle.write. This silently masks failures and falsely reports unsuccessful jobs as succeeded.\\\",\\n      \\\"file\\\": \\\"src/queue.js\\\",\\n      \\\"line_start\\\": 26,\\n      \\\"line_end\\\": 28,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Return { id, ok: false, error } or propagate the caught error so callers can detect and handle job failures.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"high\\\",\\n      \\\"title\\\": \\\"File handle leak in openJob when log size check fails\\\",\\n      \\\"body\\\": \\\"In openJob, fs.open acquires a file handle and inserts it into handles before validating file size. If stat.size exceeds 1,000,000, an Error is thrown without closing the handle or deleting the Map entry, leaking file descriptors.\\\",\\n      \\\"file\\\": \\\"src/queue.js\\\",\\n      \\\"line_start\\\": 5,\\n      \\\"line_end\\\": 13,\\n      \\\"confidence\\\": 0.95,\\n      \\\"recommendation\\\": \\\"Close the file handle with handle.close() and remove the entry from handles before throwing the error.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"medium\\\",\\n      \\\"title\\\": \\\"Unhandled promise rejection and unmanaged timer in startHeartbeat\\\",\\n      \\\"body\\\": \\\"startHeartbeat invokes fs.appendFile from node:fs/promises inside setInterval without awaiting or catching errors, causing unhandled promise rejections on write failures. Additionally, the interval ID is not returned, preventing cleanup.\\\",\\n      \\\"file\\\": \\\"src/queue.js\\\",\\n      \\\"line_start\\\": 15,\\n      \\\"line_end\\\": 19,\\n      \\\"confidence\\\": 0.9,\\n      \\\"recommendation\\\": \\\"Attach a .catch() handler to fs.appendFile and return the interval ID from startHeartbeat so callers can stop the heartbeat timer.\\\"\\n    }\\n  ],\\n  \\\"next_steps\\\": [\\n    \\\"Fix runOne to return failure status or propagate errors when job execution fails.\\\",\\n    \\\"Properly close and clean up file handles in openJob when the log size limit is exceeded.\\\",\\n    \\\"Handle asynchronous errors in startHeartbeat and return the timer handle for lifecycle management.\\\"\\n  ]\\n}\",\n    \"stderr\": \"\"\n  },\n  \"result\": {\n    \"verdict\": \"needs-attention\",\n    \"summary\": \"src/queue.js contains error-masking in runOne, file descriptor leaks in openJob, and unhandled promise rejections in startHeartbeat.\",\n    \"findings\": [\n      {\n        \"severity\": \"high\",\n        \"title\": \"Errors caught in runOne incorrectly return ok: true\",\n        \"body\": \"In runOne, the catch block returns { id, ok: true } when an exception is thrown during openJob or handle.write. This silently masks failures and falsely reports unsuccessful jobs as succeeded.\",\n        \"file\": \"src/queue.js\",\n        \"line_start\": 26,\n        \"line_end\": 28,\n        \"confidence\": 1,\n        \"recommendation\": \"Return { id, ok: false, error } or propagate the caught error so callers can detect and handle job failures.\"\n      },\n      {\n        \"severity\": \"high\",\n        \"title\": \"File handle leak in openJob when log size check fails\",\n        \"body\": \"In openJob, fs.open acquires a file handle and inserts it into handles before validating file size. If stat.size exceeds 1,000,000, an Error is thrown without closing the handle or deleting the Map entry, leaking file descriptors.\",\n        \"file\": \"src/queue.js\",\n        \"line_start\": 5,\n        \"line_end\": 13,\n        \"confidence\": 0.95,\n        \"recommendation\": \"Close the file handle with handle.close() and remove the entry f"
 }

--- a/bench/cassettes/async-lifecycle/agy.model.json
+++ b/bench/cassettes/async-lifecycle/agy.model.json
@@ -1,185 +1,216 @@
 {
   "caseId": "async-lifecycle",
   "cell": "agy.model",
-  "recordedAt": "2026-08-19T08:23:42.915Z",
+  "recordedAt": "2026-08-24T04:57:41.366Z",
   "verdict": "needs-attention",
-  "summary": "The implementation incorrectly reports failed jobs as successful, exposes a path traversal vulnerability through unsanitized job IDs, and leaks file descriptors on oversized logs.",
+  "summary": "The catch block in runOne silently reports success on failure, file handles leak, the heartbeat interval is uncancellable with unhandled rejections, and job IDs are interpolated into paths without sanitization.",
   "findings": [
     {
-      "severity": "high",
-      "title": "Error handler masks failures and reports false success",
-      "body": "In `runOne`, the catch block returns `{ id, ok: true }`, which silently swallows any exception thrown during `openJob` or `handle.write` and incorrectly reports the job as successful.",
+      "severity": "critical",
+      "title": "Catch block returns ok: true on error",
+      "body": "In runOne (line 27), the catch clause returns { id, ok: true } — identical to the success path. Every failure from openJob (including the 'log too large' guard) is silently swallowed and reported as a success to callers and, transitively, to runAll consumers. This is a correctness bug that makes error detection impossible.",
       "file": "src/queue.js",
-      "line_start": 21,
-      "line_end": 29,
-      "confidence": 1,
-      "recommendation": "Return `{ id, ok: false, error }` in the catch block or allow the error to propagate."
+      "line_start": 27,
+      "line_end": 27,
+      "confidence": 0.99,
+      "recommendation": "Change the catch return to { id, ok: false, error: err.message } (and capture the error with `catch (err)`)."
     },
     {
       "severity": "high",
-      "title": "Path traversal via unsanitized job ID",
-      "body": "The `id` parameter is interpolated directly into `/var/jobs/${id}.log` and `/var/jobs/${id}.beat` without path sanitization or validation, allowing attackers to access or write files outside the target directory.",
+      "title": "File handle leak when size check throws",
+      "body": "In openJob, the handle is opened and stored in the handles Map (line 7) before the size guard on line 9-10. If the size exceeds 1 MB, the function throws, but the already-opened handle is never closed and remains in the Map with no code path to clean it up. Repeated calls with oversized logs will exhaust file descriptors.",
       "file": "src/queue.js",
       "line_start": 6,
-      "line_end": 17,
+      "line_end": 11,
       "confidence": 0.95,
-      "recommendation": "Validate `id` against an allowlist pattern (e.g. `/^[a-zA-Z0-9_-]+$/`) or sanitize path components using `path.basename`."
+      "recommendation": "Wrap the post-open logic in a try block and close the handle (and delete it from the Map) in the catch before re-throwing."
+    },
+    {
+      "severity": "high",
+      "title": "Path traversal via unsanitised job id",
+      "body": "The id parameter is interpolated directly into a filesystem path (lines 6 and 17) with no validation. A value like '../../etc/cron.d/evil' would resolve outside /var/jobs/, allowing arbitrary file writes. This is a security gap exploitable by any caller that passes user-controlled input.",
+      "file": "src/queue.js",
+      "line_start": 6,
+      "line_end": 6,
+      "confidence": 0.92,
+      "recommendation": "Validate that id matches a strict allowlist pattern (e.g., /^[a-zA-Z0-9_-]+$/) and reject or sanitise anything else before constructing the path."
     },
     {
       "severity": "medium",
-      "title": "File descriptor leak on log size limit error",
-      "body": "In `openJob`, if `stat.size > 1_000_000`, an Error is thrown after opening the file handle and storing it in `handles`, but `handle.close()` is never called, leaking the open file descriptor.",
-      "file": "src/queue.js",
-      "line_start": 6,
-      "line_end": 12,
-      "confidence": 0.95,
-      "recommendation": "Call `await handle.close()` and delete `id` from `handles` before throwing the error."
-    },
-    {
-      "severity": "medium",
-      "title": "Unhandled promise rejection in heartbeat timer",
-      "body": "In `startHeartbeat`, the promise returned by `fs.appendFile` is neither awaited nor caught within the `setInterval` callback, which can cause unhandled promise rejections if file writing fails.",
+      "title": "Heartbeat interval can never be stopped and swallows write errors",
+      "body": "startHeartbeat (line 16) calls setInterval but discards the timer id, so the heartbeat can never be cleared — it runs (and holds a reference to the callback) for the lifetime of the process. Additionally, fs.appendFile returns a promise that is neither awaited nor .catch()-ed; any I/O error becomes an unhandled promise rejection, which crashes Node ≥15 by default.",
       "file": "src/queue.js",
       "line_start": 15,
-      "line_end": 19,
-      "confidence": 0.9,
-      "recommendation": "Add a `.catch(...)` handler to `fs.appendFile` and return the interval ID so caller can stop the heartbeat."
+      "line_end": 18,
+      "confidence": 0.93,
+      "recommendation": "Return the interval id (or an AbortController) so callers can cancel it, and add .catch() to the appendFile call to handle write failures gracefully."
     }
   ],
-  "latencyMs": 23742,
-  "engineVersion": "1.1.15",
+  "latencyMs": 57927,
+  "engineVersion": "1.1.19",
+  "engineObserved": null,
   "samples": [
     {
       "verdict": "needs-attention",
-      "summary": "Queue implementation swallows job failures, leaks file descriptors on size limit violations, and ignores promise rejections in heartbeat intervals.",
-      "findings": [
-        {
-          "severity": "high",
-          "title": "Error swallowed and reported as success",
-          "body": "In runOne, the catch block returns { id, ok: true } when an error occurs during openJob or handle.write. This masks all failures and incorrectly reports failed jobs as successful.",
-          "file": "src/queue.js",
-          "line_start": 26,
-          "line_end": 28,
-          "confidence": 1,
-          "recommendation": "Return { id, ok: false, error } or rethrow the error in the catch block so callers are aware of execution failure."
-        },
-        {
-          "severity": "medium",
-          "title": "File descriptor leaked on file size check failure",
-          "body": "In openJob, if stat.size exceeds 1,000,000 bytes, an Error is thrown without closing handle or removing it from handles, leaking open file descriptors.",
-          "file": "src/queue.js",
-          "line_start": 9,
-          "line_end": 11,
-          "confidence": 0.95,
-          "recommendation": "Close the handle with await handle.close() and remove id from handles before throwing the error."
-        },
-        {
-          "severity": "medium",
-          "title": "Unhandled promise rejection in heartbeat interval",
-          "body": "In startHeartbeat, fs.appendFile returns a Promise from node:fs/promises, but the returned promise is not caught inside setInterval. Any filesystem error will trigger an unhandled promise rejection and can crash the Node.js process.",
-          "file": "src/queue.js",
-          "line_start": 16,
-          "line_end": 18,
-          "confidence": 0.95,
-          "recommendation": "Add error handling such as .catch(err => { ... }) to the fs.appendFile call."
-        }
-      ],
-      "latencyMs": 26222
-    },
-    {
-      "verdict": "needs-attention",
-      "summary": "The implementation swallows errors by reporting failed runs as successful, leaks file handles on size limit errors, permits path traversal via unsanitized IDs, and risks unhandled rejections in the heartbeat loop.",
+      "summary": "Errors are silently swallowed as successes, file handles leak, heartbeat intervals are uncontrollable, and job IDs are unsanitised.",
       "findings": [
         {
           "severity": "critical",
-          "title": "Error swallowed and reported as success in runOne",
-          "body": "In runOne, the catch block returns { id, ok: true }, concealing job startup and file write failures as successful executions and preventing callers from detecting errors.",
+          "title": "Catch block reports success on failure",
+          "body": "In `runOne`, the catch branch (line 27) returns `{ id, ok: true }` — the same result as the happy path. Any error from `openJob` or `handle.write` (file-too-large check, I/O failure, permission error) is silently reported as a success, so callers of `runAll` can never detect that a job failed.",
           "file": "src/queue.js",
-          "line_start": 26,
-          "line_end": 28,
-          "confidence": 1,
-          "recommendation": "Return { id, ok: false, error } in the catch block or allow the error to propagate."
+          "line_start": 27,
+          "line_end": 27,
+          "confidence": 0.99,
+          "recommendation": "Change the catch return to `{ id, ok: false, error: err.message }` (and capture the error with `catch (err)` instead of bare `catch`)."
         },
         {
           "severity": "high",
-          "title": "Path traversal vulnerability via unsanitized job ID",
-          "body": "The id parameter is interpolated directly into filesystem paths (/var/jobs/${id}.log and /var/jobs/${id}.beat) without validation or sanitization, allowing arbitrary file creation or append operations via directory traversal sequences.",
+          "title": "File handle leaked when size check throws",
+          "body": "In `openJob`, the handle is opened and stored in the `handles` Map at line 7, but if the size guard on line 9-10 throws, no code closes the handle or removes it from the map. The caller (`runOne`) also never closes the handle in its own catch path. Over many retries this exhausts file descriptors.",
           "file": "src/queue.js",
           "line_start": 6,
-          "line_end": 17,
+          "line_end": 11,
           "confidence": 0.95,
-          "recommendation": "Sanitize and validate the id parameter (e.g. strictly enforce alphanumeric or UUID format) and resolve paths safely."
+          "recommendation": "Wrap the body of `openJob` in a try/catch that calls `await handle.close()` and `handles.delete(id)` before re-throwing, or use a `finally` block. Also close the handle in `runOne`'s catch."
         },
         {
           "severity": "high",
-          "title": "File descriptor leak on oversized log error",
-          "body": "In openJob, if stat.size exceeds 1,000,000 bytes, an Error is thrown without closing the opened handle or removing it from the handles map, resulting in leaked file descriptors.",
+          "title": "Path traversal via unsanitised `id`",
+          "body": "`openJob` interpolates `id` directly into a filesystem path (`/var/jobs/${id}.log`). A caller-supplied id such as `../../etc/cron.d/pwned` lets an attacker create or append to arbitrary files on the host. `startHeartbeat` has the same issue.",
           "file": "src/queue.js",
-          "line_start": 9,
-          "line_end": 11,
-          "confidence": 0.95,
-          "recommendation": "Close the handle with await handle.close() and remove it from handles before throwing."
+          "line_start": 6,
+          "line_end": 6,
+          "confidence": 0.92,
+          "recommendation": "Validate that `id` matches a strict allowlist pattern (e.g. `/^[a-zA-Z0-9_-]+$/`) and reject or throw on anything else before building the path."
         },
         {
           "severity": "medium",
-          "title": "Unhandled promise rejection in startHeartbeat",
-          "body": "fs.appendFile from node:fs/promises returns a Promise. The callback in setInterval does not await or attach a catch handler to this Promise, which will trigger unhandled promise rejections if write operations fail.",
+          "title": "Heartbeat interval can never be stopped",
+          "body": "`startHeartbeat` calls `setInterval` but discards the returned timer handle. There is no exported mechanism to clear the interval, so every call leaks a 1-second timer and its associated file I/O forever.",
           "file": "src/queue.js",
-          "line_start": 16,
+          "line_start": 15,
           "line_end": 18,
           "confidence": 0.95,
-          "recommendation": "Attach a .catch() handler or handle the promise rejection inside the interval callback."
+          "recommendation": "Return the interval ID (or an `AbortController`/stop function) so callers can cancel the heartbeat when the job ends."
+        },
+        {
+          "severity": "medium",
+          "title": "Unhandled promise rejection in heartbeat",
+          "body": "Inside the `setInterval` callback, `fs.appendFile` returns a promise but the callback is not `async` and the promise is not `.catch()`-ed. A write failure produces an unhandled rejection, which crashes the process under Node's default `--unhandled-rejections=throw` behaviour.",
+          "file": "src/queue.js",
+          "line_start": 17,
+          "line_end": 17,
+          "confidence": 0.9,
+          "recommendation": "Make the callback `async` and wrap the `appendFile` call in a try/catch, or chain a `.catch()` handler on the promise."
         }
       ],
-      "latencyMs": 25141
+      "latencyMs": 58756
     },
     {
       "verdict": "needs-attention",
-      "summary": "The implementation incorrectly reports failed jobs as successful, exposes a path traversal vulnerability through unsanitized job IDs, and leaks file descriptors on oversized logs.",
+      "summary": "Error path silently reports success, file handle leaks on failure, heartbeat interval is never stoppable, and job ID is unsanitised allowing path traversal.",
       "findings": [
         {
-          "severity": "high",
-          "title": "Error handler masks failures and reports false success",
-          "body": "In `runOne`, the catch block returns `{ id, ok: true }`, which silently swallows any exception thrown during `openJob` or `handle.write` and incorrectly reports the job as successful.",
+          "severity": "critical",
+          "title": "Catch block returns `ok: true` on failure",
+          "body": "In `runOne`, the catch block returns `{ id, ok: true }` instead of `{ id, ok: false }`. Every failure—including the explicit size-limit throw from `openJob`—is silently reported as a success, so callers of `runAll` can never detect errors.",
           "file": "src/queue.js",
-          "line_start": 21,
-          "line_end": 29,
-          "confidence": 1,
-          "recommendation": "Return `{ id, ok: false, error }` in the catch block or allow the error to propagate."
+          "line_start": 27,
+          "line_end": 27,
+          "confidence": 0.99,
+          "recommendation": "Change the catch return to `{ id, ok: false, error: e.message }` (or rethrow)."
         },
         {
           "severity": "high",
-          "title": "Path traversal via unsanitized job ID",
-          "body": "The `id` parameter is interpolated directly into `/var/jobs/${id}.log` and `/var/jobs/${id}.beat` without path sanitization or validation, allowing attackers to access or write files outside the target directory.",
+          "title": "File handle leaked when `openJob` throws after open",
+          "body": "`openJob` opens a file handle and stores it in the map, then checks `stat.size`. If the size check throws, the handle is never closed and remains in the global `handles` map. Similarly, `runOne` does not close the handle on success or failure, so every call leaks an fd.",
           "file": "src/queue.js",
           "line_start": 6,
-          "line_end": 17,
+          "line_end": 11,
           "confidence": 0.95,
-          "recommendation": "Validate `id` against an allowlist pattern (e.g. `/^[a-zA-Z0-9_-]+$/`) or sanitize path components using `path.basename`."
+          "recommendation": "Wrap the body of `openJob` in a try/catch that calls `handle.close()` and `handles.delete(id)` on error. Ensure callers (or a `finally` block in `runOne`) close the handle when done."
         },
         {
-          "severity": "medium",
-          "title": "File descriptor leak on log size limit error",
-          "body": "In `openJob`, if `stat.size > 1_000_000`, an Error is thrown after opening the file handle and storing it in `handles`, but `handle.close()` is never called, leaking the open file descriptor.",
-          "file": "src/queue.js",
-          "line_start": 6,
-          "line_end": 12,
-          "confidence": 0.95,
-          "recommendation": "Call `await handle.close()` and delete `id` from `handles` before throwing the error."
-        },
-        {
-          "severity": "medium",
-          "title": "Unhandled promise rejection in heartbeat timer",
-          "body": "In `startHeartbeat`, the promise returned by `fs.appendFile` is neither awaited nor caught within the `setInterval` callback, which can cause unhandled promise rejections if file writing fails.",
+          "severity": "high",
+          "title": "`startHeartbeat` interval can never be stopped",
+          "body": "`setInterval` returns a timer reference that is discarded. There is no way to clear the interval, so heartbeats run forever, accumulating one leaked timer per call and writing to disk indefinitely.",
           "file": "src/queue.js",
           "line_start": 15,
-          "line_end": 19,
+          "line_end": 18,
+          "confidence": 0.95,
+          "recommendation": "Return or store the interval ID so callers can call `clearInterval` when the job completes."
+        },
+        {
+          "severity": "high",
+          "title": "Path traversal via unsanitised `id`",
+          "body": "Both `openJob` and `startHeartbeat` interpolate `id` directly into a file path (`/var/jobs/${id}.log`). A caller passing `../../etc/cron.d/evil` can read/write arbitrary files on the filesystem.",
+          "file": "src/queue.js",
+          "line_start": 6,
+          "line_end": 6,
           "confidence": 0.9,
-          "recommendation": "Add a `.catch(...)` handler to `fs.appendFile` and return the interval ID so caller can stop the heartbeat."
+          "recommendation": "Validate that `id` matches a strict allowlist pattern (e.g. `/^[a-zA-Z0-9_-]+$/`) before using it in a path."
+        },
+        {
+          "severity": "medium",
+          "title": "Swallowed heartbeat write errors",
+          "body": "The `fs.appendFile` call inside the `setInterval` callback returns a promise that is never awaited or caught. Any write error (permission denied, disk full) will produce an unhandled promise rejection, which in Node ≥15 terminates the process by default.",
+          "file": "src/queue.js",
+          "line_start": 17,
+          "line_end": 17,
+          "confidence": 0.85,
+          "recommendation": "Add `.catch()` to the promise (e.g. log and optionally clear the interval), or use a synchronous write."
         }
       ],
-      "latencyMs": 23742
+      "latencyMs": 50682
+    },
+    {
+      "verdict": "needs-attention",
+      "summary": "The catch block in runOne silently reports success on failure, file handles leak, the heartbeat interval is uncancellable with unhandled rejections, and job IDs are interpolated into paths without sanitization.",
+      "findings": [
+        {
+          "severity": "critical",
+          "title": "Catch block returns ok: true on error",
+          "body": "In runOne (line 27), the catch clause returns { id, ok: true } — identical to the success path. Every failure from openJob (including the 'log too large' guard) is silently swallowed and reported as a success to callers and, transitively, to runAll consumers. This is a correctness bug that makes error detection impossible.",
+          "file": "src/queue.js",
+          "line_start": 27,
+          "line_end": 27,
+          "confidence": 0.99,
+          "recommendation": "Change the catch return to { id, ok: false, error: err.message } (and capture the error with `catch (err)`)."
+        },
+        {
+          "severity": "high",
+          "title": "File handle leak when size check throws",
+          "body": "In openJob, the handle is opened and stored in the handles Map (line 7) before the size guard on line 9-10. If the size exceeds 1 MB, the function throws, but the already-opened handle is never closed and remains in the Map with no code path to clean it up. Repeated calls with oversized logs will exhaust file descriptors.",
+          "file": "src/queue.js",
+          "line_start": 6,
+          "line_end": 11,
+          "confidence": 0.95,
+          "recommendation": "Wrap the post-open logic in a try block and close the handle (and delete it from the Map) in the catch before re-throwing."
+        },
+        {
+          "severity": "high",
+          "title": "Path traversal via unsanitised job id",
+          "body": "The id parameter is interpolated directly into a filesystem path (lines 6 and 17) with no validation. A value like '../../etc/cron.d/evil' would resolve outside /var/jobs/, allowing arbitrary file writes. This is a security gap exploitable by any caller that passes user-controlled input.",
+          "file": "src/queue.js",
+          "line_start": 6,
+          "line_end": 6,
+          "confidence": 0.92,
+          "recommendation": "Validate that id matches a strict allowlist pattern (e.g., /^[a-zA-Z0-9_-]+$/) and reject or sanitise anything else before constructing the path."
+        },
+        {
+          "severity": "medium",
+          "title": "Heartbeat interval can never be stopped and swallows write errors",
+          "body": "startHeartbeat (line 16) calls setInterval but discards the timer id, so the heartbeat can never be cleared — it runs (and holds a reference to the callback) for the lifetime of the process. Additionally, fs.appendFile returns a promise that is neither awaited nor .catch()-ed; any I/O error becomes an unhandled promise rejection, which crashes Node ≥15 by default.",
+          "file": "src/queue.js",
+          "line_start": 15,
+          "line_end": 18,
+          "confidence": 0.93,
+          "recommendation": "Return the interval id (or an AbortController) so callers can cancel it, and add .catch() to the appendFile call to handle write failures gracefully."
+        }
+      ],
+      "latencyMs": 57927
     }
   ],
-  "raw": "{\"conversation_id\":\"f887679c-3ce3-490e-b0a5-fcd0862d8b3d\",\"status\":\"SUCCESS\",\"response\":\"{\\n  \\\"verdict\\\": \\\"needs-attention\\\",\\n  \\\"summary\\\": \\\"The implementation incorrectly reports failed jobs as successful, exposes a path traversal vulnerability through unsanitized job IDs, and leaks file descriptors on oversized logs.\\\",\\n  \\\"findings\\\": [\\n    {\\n      \\\"severity\\\": \\\"high\\\",\\n      \\\"title\\\": \\\"Error handler masks failures and reports false success\\\",\\n      \\\"body\\\": \\\"In `runOne`, the catch block returns `{ id, ok: true }`, which silently swallows any exception thrown during `openJob` or `handle.write` and incorrectly reports the job as successful.\\\",\\n      \\\"file\\\": \\\"src/queue.js\\\",\\n      \\\"line_start\\\": 21,\\n      \\\"line_end\\\": 29,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Return `{ id, ok: false, error }` in the catch block or allow the error to propagate.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"high\\\",\\n      \\\"title\\\": \\\"Path traversal via unsanitized job ID\\\",\\n      \\\"body\\\": \\\"The `id` parameter is interpolated directly into `/var/jobs/${id}.log` and `/var/jobs/${id}.beat` without path sanitization or validation, allowing attackers to access or write files outside the target directory.\\\",\\n      \\\"file\\\": \\\"src/queue.js\\\",\\n      \\\"line_start\\\": 6,\\n      \\\"line_end\\\": 17,\\n      \\\"confidence\\\": 0.95,\\n      \\\"recommendation\\\": \\\"Validate `id` against an allowlist pattern (e.g. `/^[a-zA-Z0-9_-]+$/`) or sanitize path components using `path.basename`.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"medium\\\",\\n      \\\"title\\\": \\\"File descriptor leak on log size limit error\\\",\\n      \\\"body\\\": \\\"In `openJob`, if `stat.size \\u003e 1_000_000`, an Error is thrown after opening the file handle and storing it in `handles`, but `handle.close()` is never called, leaking the open file descriptor.\\\",\\n      \\\"file\\\": \\\"src/queue.js\\\",\\n      \\\"line_start\\\": 6,\\n      \\\"line_end\\\": 12,\\n      \\\"confidence\\\": 0.95,\\n      \\\"recommendation\\\": \\\"Call `await handle.close()` and delete `id` from `handles` before throwing the error.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"medium\\\",\\n      \\\"title\\\": \\\"Unhandled promise rejection in heartbeat timer\\\",\\n      \\\"body\\\": \\\"In `startHeartbeat`, the promise returned by `fs.appendFile` is neither awaited nor caught within the `setInterval` callback, which can cause unhandled promise rejections if file writing fails.\\\",\\n      \\\"file\\\": \\\"src/queue.js\\\",\\n      \\\"line_start\\\": 15,\\n      \\\"line_end\\\": 19,\\n      \\\"confidence\\\": 0.9,\\n      \\\"recommendation\\\": \\\"Add a `.catch(...)` handler to `fs.appendFile` and return the interval ID so caller can stop the heartbeat.\\\"\\n    }\\n  ],\\n  \\\"next_steps\\\": [\\n    \\\"Fix `runOne` to return `ok: false` with error information upon failure.\\\",\\n    \\\"Validate and sanitize the `id` parameter in `openJob` and `startHeartbeat`.\\\",\\n    \\\"Ensure `handle.close()` is called when `openJob` rejects oversized files.\\\",\\n    \\\"Handle asynchronous errors in `startHeartbeat` and expose an interval cancellation mechanism.\\\"\\n  ]\\n}\\n\",\"duration_seconds\":19.9805387,\"num_turns\":1,\"usage\":{\"input_tokens\":19125,\"output_tokens\":3341,\"thinking_tokens\":2585,\"cache_read_tokens\":0,\"total_tokens\":22466}}\n"
+  "raw": "{\"conversation_id\":\"6be17c7d-e2c4-42fd-acea-9d7e8743ba02\",\"status\":\"SUCCESS\",\"response\":\"{\\\"verdict\\\":\\\"needs-attention\\\",\\\"summary\\\":\\\"The catch block in runOne silently reports success on failure, file handles leak, the heartbeat interval is uncancellable with unhandled rejections, and job IDs are interpolated into paths without sanitization.\\\",\\\"findings\\\":[{\\\"severity\\\":\\\"critical\\\",\\\"title\\\":\\\"Catch block returns ok: true on error\\\",\\\"body\\\":\\\"In runOne (line 27), the catch clause returns { id, ok: true } — identical to the success path. Every failure from openJob (including the 'log too large' guard) is silently swallowed and reported as a success to callers and, transitively, to runAll consumers. This is a correctness bug that makes error detection impossible.\\\",\\\"file\\\":\\\"src/queue.js\\\",\\\"line_start\\\":27,\\\"line_end\\\":27,\\\"confidence\\\":0.99,\\\"recommendation\\\":\\\"Change the catch return to { id, ok: false, error: err.message } (and capture the error with `catch (err)`).\\\"},{\\\"severity\\\":\\\"high\\\",\\\"title\\\":\\\"File handle leak when size check throws\\\",\\\"body\\\":\\\"In openJob, the handle is opened and stored in the handles Map (line 7) before the size guard on line 9-10. If the size exceeds 1 MB, the function throws, but the already-opened handle is never closed and remains in the Map with no code path to clean it up. Repeated calls with oversized logs will exhaust file descriptors.\\\",\\\"file\\\":\\\"src/queue.js\\\",\\\"line_start\\\":6,\\\"line_end\\\":11,\\\"confidence\\\":0.95,\\\"recommendation\\\":\\\"Wrap the post-open logic in a try block and close the handle (and delete it from the Map) in the catch before re-throwing.\\\"},{\\\"severity\\\":\\\"high\\\",\\\"title\\\":\\\"Path traversal via unsanitised job id\\\",\\\"body\\\":\\\"The id parameter is interpolated directly into a filesystem path (lines 6 and 17) with no validation. A value like '../../etc/cron.d/evil' would resolve outside /var/jobs/, allowing arbitrary file writes. This is a security gap exploitable by any caller that passes user-controlled input.\\\",\\\"file\\\":\\\"src/queue.js\\\",\\\"line_start\\\":6,\\\"line_end\\\":6,\\\"confidence\\\":0.92,\\\"recommendation\\\":\\\"Validate that id matches a strict allowlist pattern (e.g., /^[a-zA-Z0-9_-]+$/) and reject or sanitise anything else before constructing the path.\\\"},{\\\"severity\\\":\\\"medium\\\",\\\"title\\\":\\\"Heartbeat interval can never be stopped and swallows write errors\\\",\\\"body\\\":\\\"startHeartbeat (line 16) calls setInterval but discards the timer id, so the heartbeat can never be cleared — it runs (and holds a reference to the callback) for the lifetime of the process. Additionally, fs.appendFile returns a promise that is neither awaited nor .catch()-ed; any I/O error becomes an unhandled promise rejection, which crashes Node ≥15 by default.\\\",\\\"file\\\":\\\"src/queue.js\\\",\\\"line_start\\\":15,\\\"line_end\\\":18,\\\"confidence\\\":0.93,\\\"recommendation\\\":\\\"Return the interval id (or an AbortController) so callers can cancel it, and add .catch() to the appendFile call to handle write failures gracefully.\\\"}],\\\"next_steps\\\":[\\\"Fix the catch block in runOne to return ok: false and propagate error details\\\",\\\"Add handle cleanup (close + Map delete) in openJob when the size guard throws\\\",\\\"Add input validation for id to prevent path traversal\\\",\\\"Return the interval id from startHeartbeat and add .catch() to the appendFile promise\\\"]}\\n\",\"duration_seconds\":53.8908666,\"num_turns\":1,\"usage\":{\"input_tokens\":22672,\"output_tokens\":1402,\"thinking_tokens\":0,\"cache_read_tokens\":0,\"total_tokens\":24074}}\n"
 }

--- a/bench/cassettes/async-lifecycle/agy.shallow.json
+++ b/bench/cassettes/async-lifecycle/agy.shallow.json
@@ -1,0 +1,186 @@
+{
+  "caseId": "async-lifecycle",
+  "cell": "agy.shallow",
+  "recordedAt": "2026-08-24T15:28:57.852Z",
+  "verdict": "needs-attention",
+  "summary": "Identified critical failure masking in runOne, file handle leak in openJob, unhandled promise rejections in startHeartbeat, and missing input sanitization for file paths.",
+  "findings": [
+    {
+      "severity": "critical",
+      "title": "Failure masking in runOne catch block",
+      "body": "In runOne, the catch block catches all errors and returns { id, ok: true }. This silently masks any failure during file opening or writing and falsely reports successful job execution to the caller.",
+      "file": "src/queue.js",
+      "line_start": 26,
+      "line_end": 28,
+      "confidence": 1,
+      "recommendation": "Update the catch block to return { id, ok: false, error: err.message } or rethrow the error so failures can be detected by callers."
+    },
+    {
+      "severity": "high",
+      "title": "File descriptor leak in openJob on size limit validation",
+      "body": "In openJob, if stat.size exceeds 1,000,000 bytes, an error is thrown without closing the opened file handle or removing it from the handles map, resulting in leaked file descriptors and retained references.",
+      "file": "src/queue.js",
+      "line_start": 6,
+      "line_end": 11,
+      "confidence": 1,
+      "recommendation": "Call await handle.close() and handles.delete(id) before throwing the error when the log file exceeds the maximum permitted size."
+    },
+    {
+      "severity": "high",
+      "title": "Unhandled promise rejection and unmanaged timer in startHeartbeat",
+      "body": "startHeartbeat calls asynchronous fs.appendFile inside setInterval without handling promise rejections. Any I/O error (such as permission errors or full disk) will trigger an unhandled promise rejection that can terminate the Node.js process. Additionally, the timer ID is not returned, preventing cleanup.",
+      "file": "src/queue.js",
+      "line_start": 15,
+      "line_end": 19,
+      "confidence": 0.95,
+      "recommendation": "Attach a .catch() handler to fs.appendFile to log or handle write errors, and return the interval timer ID so the caller can clear the interval."
+    },
+    {
+      "severity": "medium",
+      "title": "Path traversal vulnerability via unsanitized job ID",
+      "body": "The id parameter is interpolated directly into filesystem paths in openJob and startHeartbeat without validation or sanitization. If an untrusted ID containing path traversal characters (such as '../') is passed, operations may read or write outside /var/jobs/.",
+      "file": "src/queue.js",
+      "line_start": 6,
+      "line_end": 17,
+      "confidence": 0.9,
+      "recommendation": "Validate id against an expected format (such as /^[a-zA-Z0-9_-]+$/) or use path.basename before constructing file paths."
+    }
+  ],
+  "latencyMs": 18475,
+  "engineVersion": "1.1.19",
+  "engineObserved": "agy",
+  "samples": [
+    {
+      "verdict": "needs-attention",
+      "summary": "The queue implementation masks job failures as successes, leaks file descriptors when size limits are exceeded, and produces unhandled promise rejections in heartbeat timers.",
+      "findings": [
+        {
+          "severity": "high",
+          "title": "Catch block reports false success on job failure",
+          "body": "In `runOne`, the catch block returns `{ id, ok: true }` when `openJob` or `handle.write` throws. This masks all failures and incorrectly informs callers that the job succeeded.",
+          "file": "src/queue.js",
+          "line_start": 26,
+          "line_end": 28,
+          "confidence": 1,
+          "recommendation": "Return `{ id, ok: false, error }` or propagate the error in the catch block."
+        },
+        {
+          "severity": "medium",
+          "title": "Unclosed file handle leak when log exceeds size limit",
+          "body": "In `openJob`, if `stat.size` exceeds 1,000,000 bytes, an Error is thrown without closing the opened `handle` or deleting it from `handles`, leaking file descriptors over time.",
+          "file": "src/queue.js",
+          "line_start": 8,
+          "line_end": 11,
+          "confidence": 0.95,
+          "recommendation": "Call `await handle.close()` and remove `id` from `handles` before throwing the error."
+        },
+        {
+          "severity": "medium",
+          "title": "Unhandled promise rejection in heartbeat interval",
+          "body": "In `startHeartbeat`, the promise returned by `fs.appendFile` is not awaited or caught inside `setInterval`. Any filesystem failure will cause an unhandled promise rejection.",
+          "file": "src/queue.js",
+          "line_start": 16,
+          "line_end": 18,
+          "confidence": 0.95,
+          "recommendation": "Attach a `.catch()` handler to `fs.appendFile` and return the interval ID so the heartbeat can be cleared."
+        }
+      ],
+      "latencyMs": 17784
+    },
+    {
+      "verdict": "needs-attention",
+      "summary": "Identified error swallowing masking job failures, file descriptor leaks on oversized logs and completed jobs, and unhandled promise rejections in the heartbeat timer.",
+      "findings": [
+        {
+          "severity": "high",
+          "title": "Error swallowed and falsely reported as success in runOne",
+          "body": "In `runOne`, the catch block catches failures from `openJob` or `handle.write` and returns `{ id, ok: true }`. This causes job failures (e.g., oversized logs or file access errors) to be silently reported as successful executions.",
+          "file": "src/queue.js",
+          "line_start": 26,
+          "line_end": 28,
+          "confidence": 1,
+          "recommendation": "Return `{ id, ok: false, error }` in the catch block or allow the error to propagate."
+        },
+        {
+          "severity": "high",
+          "title": "File descriptor leak when log size threshold is exceeded in openJob",
+          "body": "In `openJob`, `fs.open` creates a FileHandle and stores it in `handles`. When `stat.size > 1_000_000`, an Error is thrown without closing `handle` or removing it from the `handles` Map, causing an unclosed file descriptor leak.",
+          "file": "src/queue.js",
+          "line_start": 6,
+          "line_end": 11,
+          "confidence": 1,
+          "recommendation": "Ensure `await handle.close()` is called and the entry is deleted from `handles` before throwing the error."
+        },
+        {
+          "severity": "medium",
+          "title": "Unhandled promise rejection and untracked timer in startHeartbeat",
+          "body": "`startHeartbeat` invokes `fs.appendFile` (from `node:fs/promises`) inside `setInterval` without awaiting or attaching a `.catch()` handler. Any write failure (e.g., disk full or permission error) will trigger an unhandled promise rejection. Additionally, the timer ID is not returned, preventing the heartbeat from being stopped.",
+          "file": "src/queue.js",
+          "line_start": 15,
+          "line_end": 19,
+          "confidence": 0.95,
+          "recommendation": "Attach a `.catch()` error handler to `fs.appendFile` inside the interval callback, and return the timer handle from `startHeartbeat` so callers can clear it."
+        },
+        {
+          "severity": "medium",
+          "title": "Unclosed FileHandle across job execution lifecycle",
+          "body": "`runOne` opens a FileHandle via `openJob` and writes to it, but never closes the handle upon job completion or failure, leading to accumulating open file descriptors over time.",
+          "file": "src/queue.js",
+          "line_start": 21,
+          "line_end": 29,
+          "confidence": 0.95,
+          "recommendation": "Close the FileHandle in a `finally` block or provide an explicit cleanup/close lifecycle function."
+        }
+      ],
+      "latencyMs": 18798
+    },
+    {
+      "verdict": "needs-attention",
+      "summary": "Identified critical failure masking in runOne, file handle leak in openJob, unhandled promise rejections in startHeartbeat, and missing input sanitization for file paths.",
+      "findings": [
+        {
+          "severity": "critical",
+          "title": "Failure masking in runOne catch block",
+          "body": "In runOne, the catch block catches all errors and returns { id, ok: true }. This silently masks any failure during file opening or writing and falsely reports successful job execution to the caller.",
+          "file": "src/queue.js",
+          "line_start": 26,
+          "line_end": 28,
+          "confidence": 1,
+          "recommendation": "Update the catch block to return { id, ok: false, error: err.message } or rethrow the error so failures can be detected by callers."
+        },
+        {
+          "severity": "high",
+          "title": "File descriptor leak in openJob on size limit validation",
+          "body": "In openJob, if stat.size exceeds 1,000,000 bytes, an error is thrown without closing the opened file handle or removing it from the handles map, resulting in leaked file descriptors and retained references.",
+          "file": "src/queue.js",
+          "line_start": 6,
+          "line_end": 11,
+          "confidence": 1,
+          "recommendation": "Call await handle.close() and handles.delete(id) before throwing the error when the log file exceeds the maximum permitted size."
+        },
+        {
+          "severity": "high",
+          "title": "Unhandled promise rejection and unmanaged timer in startHeartbeat",
+          "body": "startHeartbeat calls asynchronous fs.appendFile inside setInterval without handling promise rejections. Any I/O error (such as permission errors or full disk) will trigger an unhandled promise rejection that can terminate the Node.js process. Additionally, the timer ID is not returned, preventing cleanup.",
+          "file": "src/queue.js",
+          "line_start": 15,
+          "line_end": 19,
+          "confidence": 0.95,
+          "recommendation": "Attach a .catch() handler to fs.appendFile to log or handle write errors, and return the interval timer ID so the caller can clear the interval."
+        },
+        {
+          "severity": "medium",
+          "title": "Path traversal vulnerability via unsanitized job ID",
+          "body": "The id parameter is interpolated directly into filesystem paths in openJob and startHeartbeat without validation or sanitization. If an untrusted ID containing path traversal characters (such as '../') is passed, operations may read or write outside /var/jobs/.",
+          "file": "src/queue.js",
+          "line_start": 6,
+          "line_end": 17,
+          "confidence": 0.9,
+          "recommendation": "Validate id against an expected format (such as /^[a-zA-Z0-9_-]+$/) or use path.basename before constructing file paths."
+        }
+      ],
+      "latencyMs": 18475
+    }
+  ],
+  "raw": "{\n  \"review\": \"Review\",\n  \"target\": {\n    \"mode\": \"working-tree\",\n    \"label\": \"working tree diff\",\n    \"explicit\": true\n  },\n  \"engine\": \"agy\",\n  \"gemini\": {\n    \"status\": 0,\n    \"stdout\": \"{\\n  \\\"verdict\\\": \\\"needs-attention\\\",\\n  \\\"summary\\\": \\\"Identified critical failure masking in runOne, file handle leak in openJob, unhandled promise rejections in startHeartbeat, and missing input sanitization for file paths.\\\",\\n  \\\"findings\\\": [\\n    {\\n      \\\"severity\\\": \\\"critical\\\",\\n      \\\"title\\\": \\\"Failure masking in runOne catch block\\\",\\n      \\\"body\\\": \\\"In runOne, the catch block catches all errors and returns { id, ok: true }. This silently masks any failure during file opening or writing and falsely reports successful job execution to the caller.\\\",\\n      \\\"file\\\": \\\"src/queue.js\\\",\\n      \\\"line_start\\\": 26,\\n      \\\"line_end\\\": 28,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Update the catch block to return { id, ok: false, error: err.message } or rethrow the error so failures can be detected by callers.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"high\\\",\\n      \\\"title\\\": \\\"File descriptor leak in openJob on size limit validation\\\",\\n      \\\"body\\\": \\\"In openJob, if stat.size exceeds 1,000,000 bytes, an error is thrown without closing the opened file handle or removing it from the handles map, resulting in leaked file descriptors and retained references.\\\",\\n      \\\"file\\\": \\\"src/queue.js\\\",\\n      \\\"line_start\\\": 6,\\n      \\\"line_end\\\": 11,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Call await handle.close() and handles.delete(id) before throwing the error when the log file exceeds the maximum permitted size.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"high\\\",\\n      \\\"title\\\": \\\"Unhandled promise rejection and unmanaged timer in startHeartbeat\\\",\\n      \\\"body\\\": \\\"startHeartbeat calls asynchronous fs.appendFile inside setInterval without handling promise rejections. Any I/O error (such as permission errors or full disk) will trigger an unhandled promise rejection that can terminate the Node.js process. Additionally, the timer ID is not returned, preventing cleanup.\\\",\\n      \\\"file\\\": \\\"src/queue.js\\\",\\n      \\\"line_start\\\": 15,\\n      \\\"line_end\\\": 19,\\n      \\\"confidence\\\": 0.95,\\n      \\\"recommendation\\\": \\\"Attach a .catch() handler to fs.appendFile to log or handle write errors, and return the interval timer ID so the caller can clear the interval.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"medium\\\",\\n      \\\"title\\\": \\\"Path traversal vulnerability via unsanitized job ID\\\",\\n      \\\"body\\\": \\\"The id parameter is interpolated directly into filesystem paths in openJob and startHeartbeat without validation or sanitization. If an untrusted ID containing path traversal characters (such as '../') is passed, operations may read or write outside /var/jobs/.\\\",\\n      \\\"file\\\": \\\"src/queue.js\\\",\\n      \\\"line_start\\\": 6,\\n      \\\"line_end\\\": 17,\\n      \\\"confidence\\\": 0.9,\\n      \\\"recommendation\\\": \\\"Validate id against an expected format (such as /^[a-zA-Z0-9_-]+$/) or use path.basename before constructing file paths.\\\"\\n    }\\n  ],\\n  \\\"next_steps\\\": [\\n    \\\"Fix runOne to return ok: false or propagate errors on failure.\\\",\\n    \\\"Ensure file handles are closed and cleaned up from the handles map on errors in openJob.\\\",\\n    \\\"Add error handling to fs.appendFile in startHeartbeat and return the interval handle.\\\",\\n    \\\"Add path validation for the id parameter across queue operations.\\\"\\n  ]\\n}\",\n    \"stderr\": \"\"\n  },\n  \"result\": {\n    \"verdict\": \"needs-attention\",\n    \"summary\": \"Identified critical failure masking in runOne, file handle leak in openJob, unhandled promise rejections in startHeartbeat, and missing input sanitization for file paths.\",\n    \"findings\": [\n      {\n        \"severity\": \"critical\",\n        \"title\": \"Failure masking in runOne catch block\",\n        \"body\": \"In runOne, the catch block catches all errors and returns { id, ok: true }. This silently masks any failure during file "
+}

--- a/bench/cassettes/async-lifecycle/codex.adversarial.json
+++ b/bench/cassettes/async-lifecycle/codex.adversarial.json
@@ -1,0 +1,196 @@
+{
+  "caseId": "async-lifecycle",
+  "cell": "codex.adversarial",
+  "recordedAt": "2026-08-24T11:10:23.942Z",
+  "verdict": "needs-attention",
+  "summary": "Do not ship: untrusted job IDs can escape the jobs directory, execution failures are reported as successes, and persistent resources are never released.",
+  "findings": [
+    {
+      "severity": "critical",
+      "title": "Job IDs permit arbitrary filesystem path traversal",
+      "body": "The caller-controlled id is interpolated directly into filesystem paths. An id such as ../../tmp/target resolves outside /var/jobs, allowing runOne or startHeartbeat to append to attacker-selected .log or .beat files wherever the process has write permission. This crosses a filesystem trust boundary and can corrupt application or system data.",
+      "file": "src/queue.js",
+      "line_start": 4,
+      "line_end": 5,
+      "confidence": 0.99,
+      "recommendation": "Reject IDs that do not match a strict allowlist, resolve the final path, and verify it remains beneath a canonical /var/jobs directory before opening or appending. Apply the same centralized path construction to heartbeat files."
+    },
+    {
+      "severity": "high",
+      "title": "All job failures are falsely reported as successful",
+      "body": "The catch block discards every exception—including permission failures, oversized logs, invalid paths, and failed writes—and returns ok: true. runAll therefore resolves with apparent success even when no job started, preventing retries and hiding partial or total failure from callers and monitoring.",
+      "file": "src/queue.js",
+      "line_start": 20,
+      "line_end": 27,
+      "confidence": 1,
+      "recommendation": "Return ok: false with a safe error classification or rethrow the exception; make runAll expose partial failures explicitly and log sufficient context for recovery."
+    },
+    {
+      "severity": "high",
+      "title": "Opened file handles are never closed",
+      "body": "openJob stores every opened handle in a process-wide map, and neither the successful nor failing path closes it. The oversized-log exception leaks immediately; successful jobs also retain descriptors indefinitely. Repeated or attacker-selected IDs can exhaust file descriptors and make subsequent filesystem operations fail process-wide.",
+      "file": "src/queue.js",
+      "line_start": 4,
+      "line_end": 12,
+      "confidence": 0.99,
+      "recommendation": "Close handles in a finally block after writes, and close before throwing from openJob. Remove the global map unless persistent ownership and an explicit shutdown/replacement lifecycle are implemented."
+    },
+    {
+      "severity": "medium",
+      "title": "Heartbeat lifecycle creates permanent timers and unhandled write failures",
+      "body": "Every call starts an interval with no returned handle or stop mechanism. The async appendFile promise is also ignored, so permission, disk-full, or path failures can become unhandled rejections while the interval continues indefinitely. Repeated starts accumulate timers and writes after the associated job ends.",
+      "file": "src/queue.js",
+      "line_start": 14,
+      "line_end": 18,
+      "confidence": 0.98,
+      "recommendation": "Return a cleanup function or timer handle, prevent duplicate heartbeats per job, stop it when the job ends, and await or catch append failures with observable failure handling."
+    }
+  ],
+  "latencyMs": 31020,
+  "engineVersion": "codex-cli 0.149.0",
+  "engineObserved": null,
+  "samples": [
+    {
+      "verdict": "needs-attention",
+      "summary": "Do not ship: failures are reported as success, caller-controlled IDs can escape the jobs directory, and both file handles and heartbeat timers leak.",
+      "findings": [
+        {
+          "severity": "high",
+          "title": "All job failures are falsely reported as successful",
+          "body": "The catch block converts every failure—including open, permission, size-limit, and write failures—into `{ ok: true }`. Consequently `runAll` can report complete success when no job started, preventing retries and hiding operational failure.",
+          "file": "src/queue.js",
+          "line_start": 25,
+          "line_end": 27,
+          "confidence": 1,
+          "recommendation": "Return `{ id, ok: false, error }` or rethrow; ensure `runAll` exposes partial failures to its caller and add tests for open and write rejection."
+        },
+        {
+          "severity": "high",
+          "title": "Unvalidated job IDs permit path traversal",
+          "body": "The caller-controlled `id` is interpolated directly into filesystem paths. An ID containing `../` can resolve outside `/var/jobs`, allowing append operations to unintended `.log` or `.beat` files under the process account's permissions.",
+          "file": "src/queue.js",
+          "line_start": 5,
+          "line_end": 6,
+          "confidence": 0.99,
+          "recommendation": "Reject IDs outside a strict allowlist such as `[A-Za-z0-9_-]+`, resolve the final path, and verify it remains beneath the canonical jobs directory before opening or appending."
+        },
+        {
+          "severity": "high",
+          "title": "File handles leak on both successful and rejected jobs",
+          "body": "Every opened handle is retained in the global map and is never closed. The handle is inserted before `stat()`, so oversized files and stat failures leak too; repeated IDs overwrite the map entry without closing the prior handle. Sustained or retried workloads can exhaust file descriptors and make subsequent jobs fail.",
+          "file": "src/queue.js",
+          "line_start": 5,
+          "line_end": 13,
+          "confidence": 1,
+          "recommendation": "Define explicit handle ownership and close handles in `finally`; do not cache them unless required, and close any previous handle before replacing a map entry."
+        },
+        {
+          "severity": "medium",
+          "title": "Heartbeat intervals cannot be stopped and async write failures are unhandled",
+          "body": "`startHeartbeat` discards the interval handle, so callers cannot stop the timer during job completion or shutdown. Each tick also ignores the promise returned by `appendFile`; filesystem rejection can become an unhandled rejection while the interval continues issuing writes indefinitely.",
+          "file": "src/queue.js",
+          "line_start": 15,
+          "line_end": 19,
+          "confidence": 1,
+          "recommendation": "Return a cleanup function or timer handle, stop it when the job ends, and await or explicitly catch append failures with a defined failure/observability policy."
+        }
+      ],
+      "latencyMs": 29787
+    },
+    {
+      "verdict": "needs-attention",
+      "summary": "Do not ship: the queue falsely reports failed jobs as successful and leaks long-lived file/timer resources.",
+      "findings": [
+        {
+          "severity": "high",
+          "title": "Every job failure is reported as success",
+          "body": "The catch path returns `{ ok: true }`, so open, stat, size-limit, and write failures are indistinguishable from successful execution. `runAll` consequently resolves with an all-success result even when no job started, hiding operational failure and preventing safe retry or recovery.",
+          "file": "src/queue.js",
+          "line_start": 24,
+          "line_end": 26,
+          "confidence": 1,
+          "recommendation": "Return `{ id, ok: false, error }` or rethrow the error, and add tests covering open, size-limit, and write failures."
+        },
+        {
+          "severity": "high",
+          "title": "Job IDs can escape the intended directory",
+          "body": "The caller-controlled `id` is interpolated directly into filesystem paths. An ID containing traversal segments such as `../../tmp/job` resolves outside `/var/jobs`, allowing append/create operations in other writable locations with a `.log` or `.beat` suffix. This is security-relevant if IDs cross any trust boundary.",
+          "file": "src/queue.js",
+          "line_start": 5,
+          "line_end": 5,
+          "confidence": 0.94,
+          "recommendation": "Reject IDs outside a strict allowlist such as `/^[A-Za-z0-9_-]+$/`, and resolve the final path before verifying it remains beneath `/var/jobs`."
+        },
+        {
+          "severity": "high",
+          "title": "File handles are never closed",
+          "body": "Each `runOne` opens a descriptor and stores it permanently in `handles`; neither successful writes nor failure paths close it. The size-limit exception also leaves the newly opened handle in the map. Repeated or duplicate jobs can exhaust descriptors, while duplicate IDs overwrite the only reference to an older open handle.",
+          "file": "src/queue.js",
+          "line_start": 4,
+          "line_end": 13,
+          "confidence": 0.99,
+          "recommendation": "Close each handle in a `finally` block after writing. If persistent handles are required, define explicit replacement and shutdown logic that closes old handles before deleting or overwriting map entries."
+        },
+        {
+          "severity": "medium",
+          "title": "Heartbeat timers cannot be stopped and discard write failures",
+          "body": "Every call creates a perpetual interval but returns no timer handle or cleanup function. The async `appendFile` promise is also ignored, so write errors become unhandled rejections while the interval continues retrying forever. Repeated starts can duplicate heartbeats and keep the process alive during shutdown.",
+          "file": "src/queue.js",
+          "line_start": 15,
+          "line_end": 19,
+          "confidence": 0.99,
+          "recommendation": "Return a stop/dispose function, retain and clear the interval during job completion and shutdown, and explicitly await or catch each append failure with observable failure handling."
+        }
+      ],
+      "latencyMs": 31662
+    },
+    {
+      "verdict": "needs-attention",
+      "summary": "Do not ship: untrusted job IDs can escape the jobs directory, execution failures are reported as successes, and persistent resources are never released.",
+      "findings": [
+        {
+          "severity": "critical",
+          "title": "Job IDs permit arbitrary filesystem path traversal",
+          "body": "The caller-controlled id is interpolated directly into filesystem paths. An id such as ../../tmp/target resolves outside /var/jobs, allowing runOne or startHeartbeat to append to attacker-selected .log or .beat files wherever the process has write permission. This crosses a filesystem trust boundary and can corrupt application or system data.",
+          "file": "src/queue.js",
+          "line_start": 4,
+          "line_end": 5,
+          "confidence": 0.99,
+          "recommendation": "Reject IDs that do not match a strict allowlist, resolve the final path, and verify it remains beneath a canonical /var/jobs directory before opening or appending. Apply the same centralized path construction to heartbeat files."
+        },
+        {
+          "severity": "high",
+          "title": "All job failures are falsely reported as successful",
+          "body": "The catch block discards every exception—including permission failures, oversized logs, invalid paths, and failed writes—and returns ok: true. runAll therefore resolves with apparent success even when no job started, preventing retries and hiding partial or total failure from callers and monitoring.",
+          "file": "src/queue.js",
+          "line_start": 20,
+          "line_end": 27,
+          "confidence": 1,
+          "recommendation": "Return ok: false with a safe error classification or rethrow the exception; make runAll expose partial failures explicitly and log sufficient context for recovery."
+        },
+        {
+          "severity": "high",
+          "title": "Opened file handles are never closed",
+          "body": "openJob stores every opened handle in a process-wide map, and neither the successful nor failing path closes it. The oversized-log exception leaks immediately; successful jobs also retain descriptors indefinitely. Repeated or attacker-selected IDs can exhaust file descriptors and make subsequent filesystem operations fail process-wide.",
+          "file": "src/queue.js",
+          "line_start": 4,
+          "line_end": 12,
+          "confidence": 0.99,
+          "recommendation": "Close handles in a finally block after writes, and close before throwing from openJob. Remove the global map unless persistent ownership and an explicit shutdown/replacement lifecycle are implemented."
+        },
+        {
+          "severity": "medium",
+          "title": "Heartbeat lifecycle creates permanent timers and unhandled write failures",
+          "body": "Every call starts an interval with no returned handle or stop mechanism. The async appendFile promise is also ignored, so permission, disk-full, or path failures can become unhandled rejections while the interval continues indefinitely. Repeated starts accumulate timers and writes after the associated job ends.",
+          "file": "src/queue.js",
+          "line_start": 14,
+          "line_end": 18,
+          "confidence": 0.98,
+          "recommendation": "Return a cleanup function or timer handle, prevent duplicate heartbeats per job, stop it when the job ends, and await or catch append failures with observable failure handling."
+        }
+      ],
+      "latencyMs": 31020
+    }
+  ],
+  "raw": "{\n  \"review\": \"Adversarial Review\",\n  \"target\": {\n    \"mode\": \"working-tree\",\n    \"label\": \"working tree diff\",\n    \"explicit\": true\n  },\n  \"threadId\": \"01a03376-7203-7142-81e3-5a22c2114f40\",\n  \"context\": {\n    \"repoRoot\": \"C:/Users/arcobaleno/AppData/Local/Temp/bench-async-lifecycle-9XpAdk\",\n    \"branch\": \"main\",\n    \"summary\": \"Reviewing 0 staged, 1 unstaged, and 0 untracked file(s).\"\n  },\n  \"codex\": {\n    \"status\": 0,\n    \"stderr\": \"\",\n    \"stdout\": \"{\\\"verdict\\\":\\\"needs-attention\\\",\\\"summary\\\":\\\"Do not ship: untrusted job IDs can escape the jobs directory, execution failures are reported as successes, and persistent resources are never released.\\\",\\\"findings\\\":[{\\\"severity\\\":\\\"critical\\\",\\\"title\\\":\\\"Job IDs permit arbitrary filesystem path traversal\\\",\\\"body\\\":\\\"The caller-controlled id is interpolated directly into filesystem paths. An id such as ../../tmp/target resolves outside /var/jobs, allowing runOne or startHeartbeat to append to attacker-selected .log or .beat files wherever the process has write permission. This crosses a filesystem trust boundary and can corrupt application or system data.\\\",\\\"file\\\":\\\"src/queue.js\\\",\\\"line_start\\\":4,\\\"line_end\\\":5,\\\"confidence\\\":0.99,\\\"recommendation\\\":\\\"Reject IDs that do not match a strict allowlist, resolve the final path, and verify it remains beneath a canonical /var/jobs directory before opening or appending. Apply the same centralized path construction to heartbeat files.\\\"},{\\\"severity\\\":\\\"high\\\",\\\"title\\\":\\\"All job failures are falsely reported as successful\\\",\\\"body\\\":\\\"The catch block discards every exception—including permission failures, oversized logs, invalid paths, and failed writes—and returns ok: true. runAll therefore resolves with apparent success even when no job started, preventing retries and hiding partial or total failure from callers and monitoring.\\\",\\\"file\\\":\\\"src/queue.js\\\",\\\"line_start\\\":20,\\\"line_end\\\":27,\\\"confidence\\\":1,\\\"recommendation\\\":\\\"Return ok: false with a safe error classification or rethrow the exception; make runAll expose partial failures explicitly and log sufficient context for recovery.\\\"},{\\\"severity\\\":\\\"high\\\",\\\"title\\\":\\\"Opened file handles are never closed\\\",\\\"body\\\":\\\"openJob stores every opened handle in a process-wide map, and neither the successful nor failing path closes it. The oversized-log exception leaks immediately; successful jobs also retain descriptors indefinitely. Repeated or attacker-selected IDs can exhaust file descriptors and make subsequent filesystem operations fail process-wide.\\\",\\\"file\\\":\\\"src/queue.js\\\",\\\"line_start\\\":4,\\\"line_end\\\":12,\\\"confidence\\\":0.99,\\\"recommendation\\\":\\\"Close handles in a finally block after writes, and close before throwing from openJob. Remove the global map unless persistent ownership and an explicit shutdown/replacement lifecycle are implemented.\\\"},{\\\"severity\\\":\\\"medium\\\",\\\"title\\\":\\\"Heartbeat lifecycle creates permanent timers and unhandled write failures\\\",\\\"body\\\":\\\"Every call starts an interval with no returned handle or stop mechanism. The async appendFile promise is also ignored, so permission, disk-full, or path failures can become unhandled rejections while the interval continues indefinitely. Repeated starts accumulate timers and writes after the associated job ends.\\\",\\\"file\\\":\\\"src/queue.js\\\",\\\"line_start\\\":14,\\\"line_end\\\":18,\\\"confidence\\\":0.98,\\\"recommendation\\\":\\\"Return a cleanup function or timer handle, prevent duplicate heartbeats per job, stop it when the job ends, and await or catch append failures with observable failure handling.\\\"}],\\\"next_steps\\\":[\\\"Block shipment until ID containment, truthful failure propagation, file-handle closure, and heartbeat cleanup are covered by failure-path tests.\\\"]}\",\n    \"reasoning\": []\n  },\n  \"result\": {\n    \"verdict\": \"needs-attention\",\n    \"summary\": \"Do not ship: untrusted job IDs can escape the jobs directory, execution failures are reported as successes, and persistent resources are never released.\",\n    \"findings\""
+}

--- a/bench/cassettes/async-lifecycle/codex.model.json
+++ b/bench/cassettes/async-lifecycle/codex.model.json
@@ -1,0 +1,186 @@
+{
+  "caseId": "async-lifecycle",
+  "cell": "codex.model",
+  "recordedAt": "2026-08-24T04:40:02.176Z",
+  "verdict": "needs-attention",
+  "summary": "Failures are reported as successes, while unsanitized IDs and leaked resources make job execution unsafe.",
+  "findings": [
+    {
+      "severity": "high",
+      "title": "Job failures are falsely reported as successful",
+      "body": "The catch path returns `{ id, ok: true }`, so failures opening, checking, or writing the log are indistinguishable from successful runs. `runAll` can therefore report complete success even when no job started.",
+      "file": "src/queue.js",
+      "line_start": 25,
+      "line_end": 26,
+      "confidence": 1,
+      "recommendation": "Return `ok: false` with a safe error representation, or rethrow so callers can detect the failed job."
+    },
+    {
+      "severity": "high",
+      "title": "Job ID permits arbitrary path traversal",
+      "body": "The caller-controlled `id` is interpolated directly into filesystem paths. Values containing `../` or path separators can escape `/var/jobs` and append to arbitrary `.log` or `.beat` files writable by the process.",
+      "file": "src/queue.js",
+      "line_start": 6,
+      "line_end": 6,
+      "confidence": 0.99,
+      "recommendation": "Restrict IDs to a strict allowlist such as alphanumerics, underscores, and hyphens, then resolve the path and verify it remains inside `/var/jobs`."
+    },
+    {
+      "severity": "medium",
+      "title": "Opened file handles are never closed",
+      "body": "Each `runOne` call leaves its file handle open, including when the size check throws after the handle has already been stored. Repeated jobs can exhaust process file descriptors and prevent subsequent filesystem operations.",
+      "file": "src/queue.js",
+      "line_start": 5,
+      "line_end": 13,
+      "confidence": 1,
+      "recommendation": "Close the handle in a `finally` block after writing; if `openJob` retains ownership, close and remove it from `handles` on every failure and provide explicit lifecycle cleanup."
+    },
+    {
+      "severity": "medium",
+      "title": "Heartbeat write failures are unhandled",
+      "body": "The interval callback discards the promise returned by `fs.appendFile`. Permission, disk, or path failures can produce unhandled promise rejections, while the interval continues retrying indefinitely with no cancellation path.",
+      "file": "src/queue.js",
+      "line_start": 16,
+      "line_end": 20,
+      "confidence": 0.98,
+      "recommendation": "Handle append rejections explicitly and return the interval handle or a stop function so callers can cancel the heartbeat."
+    }
+  ],
+  "latencyMs": 25372,
+  "engineVersion": "codex-cli 0.149.0",
+  "engineObserved": null,
+  "samples": [
+    {
+      "verdict": "needs-attention",
+      "summary": "Job failures are reported as successes, while unsanitized IDs permit path traversal and file handles leak on rejection.",
+      "findings": [
+        {
+          "severity": "high",
+          "title": "Failed jobs are reported as successful",
+          "body": "The catch path returns `{ id, ok: true }`, making callers unable to distinguish failures from successful writes; `runAll` can therefore report complete success when opening, checking, or writing a job log failed.",
+          "file": "src/queue.js",
+          "line_start": 25,
+          "line_end": 27,
+          "confidence": 1,
+          "recommendation": "Return `ok: false` with a safe error value, or rethrow so `runAll` can handle the failure explicitly."
+        },
+        {
+          "severity": "high",
+          "title": "Job ID enables arbitrary path traversal",
+          "body": "The caller-controlled `id` is interpolated directly into paths for both log and heartbeat files. Values containing `../` or absolute-path syntax can escape `/var/jobs` and append to unintended files with the process's privileges.",
+          "file": "src/queue.js",
+          "line_start": 6,
+          "line_end": 6,
+          "confidence": 0.99,
+          "recommendation": "Accept only a strict job-ID format such as alphanumeric characters, underscores, and hyphens; also resolve the path and verify it remains under `/var/jobs`."
+        },
+        {
+          "severity": "medium",
+          "title": "File handle leaks when size check rejects",
+          "body": "The handle is stored before `stat()` and is not closed when the log exceeds the size limit or when `stat()` fails. Repeated rejected jobs can exhaust file descriptors, and reopening an existing ID also overwrites the map entry without closing the previous handle.",
+          "file": "src/queue.js",
+          "line_start": 6,
+          "line_end": 11,
+          "confidence": 0.98,
+          "recommendation": "Close the handle before throwing on every failure path, and close or reuse any previous handle before replacing its map entry."
+        }
+      ],
+      "latencyMs": 26121
+    },
+    {
+      "verdict": "needs-attention",
+      "summary": "Job failures are reported as success, file handles leak, and untrusted IDs can escape the jobs directory.",
+      "findings": [
+        {
+          "severity": "high",
+          "title": "Failures are falsely reported as successful",
+          "body": "The catch path returns `{ id, ok: true }`, so open, stat, size-limit, and write failures are indistinguishable from successful jobs; runAll can therefore report complete success while work failed.",
+          "file": "src/queue.js",
+          "line_start": 25,
+          "line_end": 26,
+          "confidence": 1,
+          "recommendation": "Return `ok: false` with a safe error value, or rethrow so runAll callers can detect failure."
+        },
+        {
+          "severity": "high",
+          "title": "Job ID permits path traversal",
+          "body": "The caller-controlled `id` is interpolated directly into absolute log and heartbeat paths. IDs containing path separators or `..` can write files outside `/var/jobs`, subject to process permissions.",
+          "file": "src/queue.js",
+          "line_start": 6,
+          "line_end": 6,
+          "confidence": 0.98,
+          "recommendation": "Validate IDs against a strict allowlist such as `^[A-Za-z0-9_-]+$`, and construct then verify the resolved path remains under `/var/jobs`."
+        },
+        {
+          "severity": "medium",
+          "title": "Opened file handles are never closed",
+          "body": "openJob stores every handle globally and runOne never closes it. The oversized-log path also throws after opening and storing the handle, causing persistent descriptor and memory leaks that can eventually prevent further jobs from opening files.",
+          "file": "src/queue.js",
+          "line_start": 6,
+          "line_end": 11,
+          "confidence": 1,
+          "recommendation": "Close handles in a `finally` block and remove them from the map; close and remove the handle before throwing on the size check."
+        },
+        {
+          "severity": "medium",
+          "title": "Heartbeat write failures become unhandled rejections",
+          "body": "The interval callback ignores the promise returned by appendFile. Permission, disk, or path failures can produce unhandled promise rejections, and the interval cannot be stopped because its handle is not returned or retained.",
+          "file": "src/queue.js",
+          "line_start": 15,
+          "line_end": 19,
+          "confidence": 0.99,
+          "recommendation": "Catch or await append failures through an async callback with explicit error handling, and return the interval handle or a cancellation function."
+        }
+      ],
+      "latencyMs": 23271
+    },
+    {
+      "verdict": "needs-attention",
+      "summary": "Failures are reported as successes, while unsanitized IDs and leaked resources make job execution unsafe.",
+      "findings": [
+        {
+          "severity": "high",
+          "title": "Job failures are falsely reported as successful",
+          "body": "The catch path returns `{ id, ok: true }`, so failures opening, checking, or writing the log are indistinguishable from successful runs. `runAll` can therefore report complete success even when no job started.",
+          "file": "src/queue.js",
+          "line_start": 25,
+          "line_end": 26,
+          "confidence": 1,
+          "recommendation": "Return `ok: false` with a safe error representation, or rethrow so callers can detect the failed job."
+        },
+        {
+          "severity": "high",
+          "title": "Job ID permits arbitrary path traversal",
+          "body": "The caller-controlled `id` is interpolated directly into filesystem paths. Values containing `../` or path separators can escape `/var/jobs` and append to arbitrary `.log` or `.beat` files writable by the process.",
+          "file": "src/queue.js",
+          "line_start": 6,
+          "line_end": 6,
+          "confidence": 0.99,
+          "recommendation": "Restrict IDs to a strict allowlist such as alphanumerics, underscores, and hyphens, then resolve the path and verify it remains inside `/var/jobs`."
+        },
+        {
+          "severity": "medium",
+          "title": "Opened file handles are never closed",
+          "body": "Each `runOne` call leaves its file handle open, including when the size check throws after the handle has already been stored. Repeated jobs can exhaust process file descriptors and prevent subsequent filesystem operations.",
+          "file": "src/queue.js",
+          "line_start": 5,
+          "line_end": 13,
+          "confidence": 1,
+          "recommendation": "Close the handle in a `finally` block after writing; if `openJob` retains ownership, close and remove it from `handles` on every failure and provide explicit lifecycle cleanup."
+        },
+        {
+          "severity": "medium",
+          "title": "Heartbeat write failures are unhandled",
+          "body": "The interval callback discards the promise returned by `fs.appendFile`. Permission, disk, or path failures can produce unhandled promise rejections, while the interval continues retrying indefinitely with no cancellation path.",
+          "file": "src/queue.js",
+          "line_start": 16,
+          "line_end": 20,
+          "confidence": 0.98,
+          "recommendation": "Handle append rejections explicitly and return the interval handle or a stop function so callers can cancel the heartbeat."
+        }
+      ],
+      "latencyMs": 25372
+    }
+  ],
+  "raw": "{\"verdict\":\"needs-attention\",\"summary\":\"Failures are reported as successes, while unsanitized IDs and leaked resources make job execution unsafe.\",\"findings\":[{\"severity\":\"high\",\"title\":\"Job failures are falsely reported as successful\",\"body\":\"The catch path returns `{ id, ok: true }`, so failures opening, checking, or writing the log are indistinguishable from successful runs. `runAll` can therefore report complete success even when no job started.\",\"file\":\"src/queue.js\",\"line_start\":25,\"line_end\":26,\"confidence\":1.0,\"recommendation\":\"Return `ok: false` with a safe error representation, or rethrow so callers can detect the failed job.\"},{\"severity\":\"high\",\"title\":\"Job ID permits arbitrary path traversal\",\"body\":\"The caller-controlled `id` is interpolated directly into filesystem paths. Values containing `../` or path separators can escape `/var/jobs` and append to arbitrary `.log` or `.beat` files writable by the process.\",\"file\":\"src/queue.js\",\"line_start\":6,\"line_end\":6,\"confidence\":0.99,\"recommendation\":\"Restrict IDs to a strict allowlist such as alphanumerics, underscores, and hyphens, then resolve the path and verify it remains inside `/var/jobs`.\"},{\"severity\":\"medium\",\"title\":\"Opened file handles are never closed\",\"body\":\"Each `runOne` call leaves its file handle open, including when the size check throws after the handle has already been stored. Repeated jobs can exhaust process file descriptors and prevent subsequent filesystem operations.\",\"file\":\"src/queue.js\",\"line_start\":5,\"line_end\":13,\"confidence\":1.0,\"recommendation\":\"Close the handle in a `finally` block after writing; if `openJob` retains ownership, close and remove it from `handles` on every failure and provide explicit lifecycle cleanup.\"},{\"severity\":\"medium\",\"title\":\"Heartbeat write failures are unhandled\",\"body\":\"The interval callback discards the promise returned by `fs.appendFile`. Permission, disk, or path failures can produce unhandled promise rejections, while the interval continues retrying indefinitely with no cancellation path.\",\"file\":\"src/queue.js\",\"line_start\":16,\"line_end\":20,\"confidence\":0.98,\"recommendation\":\"Handle append rejections explicitly and return the interval handle or a stop function so callers can cancel the heartbeat.\"}],\"next_steps\":[\"Correct failure propagation and add tests for open, stat, and write failures.\",\"Validate job IDs before constructing either filesystem path.\",\"Define and enforce cleanup for file handles and heartbeat intervals.\"]}\n"
+}

--- a/bench/cassettes/async-lifecycle/gemini.deep.json
+++ b/bench/cassettes/async-lifecycle/gemini.deep.json
@@ -1,185 +1,186 @@
 {
   "caseId": "async-lifecycle",
   "cell": "gemini.deep",
-  "recordedAt": "2026-08-19T12:06:08.088Z",
+  "recordedAt": "2026-08-24T10:48:36.864Z",
   "verdict": "needs-attention",
-  "summary": "Identified a critical error swallowing bug, file descriptor resource leaks, and unhandled promise rejections in queue.js.",
+  "summary": "Identified critical file handle leaks on error, masked failures as successes, unhandled promise rejections in background heartbeat, and path traversal vulnerabilities in job handling.",
   "findings": [
     {
-      "severity": "critical",
-      "title": "Silent error swallowing in runOne",
-      "body": "In `runOne`, the `catch` block catches any error thrown by `openJob(id)` or `handle.write(...)` and returns `{ id, ok: true }`. This silent error swallowing falsely reports a failed job execution as successful, masking critical job run failures in production.",
-      "file": "src/queue.js",
-      "line_start": 26,
-      "line_end": 28,
-      "confidence": 1,
-      "recommendation": "Modify the `catch` block in `runOne` to return `{ id, ok: false }` instead of `{ id, ok: true }`."
-    },
-    {
       "severity": "high",
-      "title": "Unclosed file handles (Resource Leak)",
-      "body": "File handles returned by `fs.open` in `openJob` are never closed. If the validation check `stat.size > 1_000_000` fails, the error is thrown without closing the handle. If `runOne` executes successfully or encounters an error writing to the handle, the handle is never closed either, leaking file descriptors indefinitely.",
+      "title": "File handle leak in openJob on log size limit exceedance",
+      "body": "In openJob(id), a file handle is opened using fs.open. If the file size exceeds 1,000,000 bytes, an Error is thrown, but the open handle is never closed and remains registered in the handles Map. This leads to file descriptor leakage under error conditions.",
       "file": "src/queue.js",
       "line_start": 5,
-      "line_end": 12,
+      "line_end": 13,
       "confidence": 1,
-      "recommendation": "Ensure `handle.close()` is called and awaited. In `openJob`, if validation fails, close the handle before throwing. In `runOne`, use a `finally` block to close the handle and remove it from the `handles` map."
+      "recommendation": "Close the handle and delete it from handles Map before throwing the error:\n\nif (stat.size > 1_000_000) {\n  await handle.close();\n  handles.delete(id);\n  throw new Error(`job ${id} log is too large to append to`);\n}"
     },
     {
       "severity": "high",
-      "title": "Unhandled promise rejections in startHeartbeat",
-      "body": "In `startHeartbeat`, the async function `fs.appendFile` is invoked within `setInterval` without a promise catch handler. If the write fails (e.g., due to permissions, missing directory, or full disk), an unhandled promise rejection will occur, crashing the Node.js process. Additionally, the interval is never cleared or returned.",
+      "title": "Errors swallowed and masked as successful completions in runOne",
+      "body": "In runOne(id), any error thrown during openJob(id) or handle.write() is caught in a generic catch block. The block swallows the error and returns { id, ok: true }, masking failures (such as missing folders, disk full, or log limit exceeded) as successful executions. Additionally, if handle.write() fails, the open file handle is never closed or cleaned up, compounding file descriptor leaks.",
+      "file": "src/queue.js",
+      "line_start": 20,
+      "line_end": 29,
+      "confidence": 1,
+      "recommendation": "Close the open file handle and return a failure status (e.g., { ok: false, error }) when an error occurs:\n\nasync function runOne(id) {\n  let handle;\n  try {\n    handle = await openJob(id);\n    await handle.write(\"started\\n\");\n    return { id, ok: true };\n  } catch (error) {\n    if (handle) {\n      try { await handle.close(); } catch {}\n      handles.delete(id);\n    }\n    return { id, ok: false, error: error.message };\n  }\n}"
+    },
+    {
+      "severity": "high",
+      "title": "Unhandled promise rejection and leaking interval in startHeartbeat",
+      "body": "startHeartbeat(id) sets up an infinite setInterval that schedules fs.appendFile() asynchronously every second. Since fs.appendFile is an asynchronous operation returning a promise, any error (e.g. disk full, permission denied) results in an unhandled promise rejection, which crashes modern Node.js processes. Additionally, there is no mechanism to clear the interval, resulting in background tasks leaking and writing to the beat file indefinitely even after a job finishes.",
       "file": "src/queue.js",
       "line_start": 15,
       "line_end": 19,
       "confidence": 1,
-      "recommendation": "Add error handling to `fs.appendFile` (e.g., `.catch(err => { ... })`) and return the interval ID to allow callers to clear the heartbeat."
+      "recommendation": "Add a .catch handler to the fs.appendFile promise and return or store the interval ID so it can be cleared when the job finishes or fails:\n\nfunction startHeartbeat(id) {\n  const interval = setInterval(() => {\n    fs.appendFile(`/var/jobs/${id}.beat`, `${Date.now()}\\n`)\n      .catch((err) => {\n        console.error(`Heartbeat write failed for job ${id}:`, err);\n        clearInterval(interval);\n      });\n  }, 1000);\n  return interval;\n}"
+    },
+    {
+      "severity": "medium",
+      "title": "Path traversal vulnerability via unvalidated job ID in file system path interpolation",
+      "body": "The job id parameter is interpolated directly into file paths '/var/jobs/${id}.log' and '/var/jobs/${id}.beat' without any verification or sanitization. If the job id originates from an untrusted source, path traversal sequences (such as '../') could allow writing to arbitrary file system locations outside the intended jobs directory.",
+      "file": "src/queue.js",
+      "line_start": 6,
+      "line_end": 17,
+      "confidence": 0.9,
+      "recommendation": "Validate the job id to ensure it matches a strict alphanumeric/safe pattern before interpolating it into file system path strings:\n\nif (typeof id !== 'string' || !/^[a-zA-Z0-9-_]+$/.test(id)) {\n  throw new Error('Invalid job ID format');\n}"
     }
   ],
-  "latencyMs": 31687,
-  "engineVersion": "0.55.1",
+  "latencyMs": 51595,
+  "engineVersion": "0.56.0",
+  "engineObserved": "gemini",
   "samples": [
     {
       "verdict": "needs-attention",
-      "summary": "The queue implementation contains critical file descriptor leaks, unhandled promise rejections, missing heartbeat lifecycle management, and a correctness defect where job execution failures are falsely reported as successful.",
+      "summary": "The queue implementation contains critical logic errors that misreport job failures as successes, along with multiple severe file descriptor and timer resource leaks.",
       "findings": [
         {
           "severity": "critical",
-          "title": "Failsafe error handling in runOne falsely reports success",
-          "body": "In runOne, the try-catch block catches any error thrown during openJob(id) or handle.write() and returns { id, ok: true }. This hides job execution failures from the caller and reports failures as successful operations.",
+          "title": "Incorrect success reporting on job startup failure",
+          "body": "In runOne, the catch block intercepts any errors thrown during job opening or writing and incorrectly returns '{ id, ok: true }'. This leads to silent failures where failed jobs are reported as successful.",
           "file": "src/queue.js",
           "line_start": 21,
           "line_end": 29,
           "confidence": 1,
-          "recommendation": "Modify the catch block in runOne to return { id, ok: false } or rethrow the caught error so that failures can be properly recognized and tracked."
+          "recommendation": "Modify the catch block in runOne to return '{ id, ok: false }' or propagate the error."
         },
         {
           "severity": "high",
-          "title": "File descriptor leak in openJob on stat size check failure",
-          "body": "In openJob, a file handle is opened and added to the handles Map. If the stat.size > 1_000_000 check fails, the function throws an Error without closing the file handle, causing a permanent file descriptor leak.",
+          "title": "Open file handle leak on size limit violation",
+          "body": "In openJob, if the log file size exceeds 1,000,000 bytes, an Error is thrown, but the file handle opened via fs.open has already been added to the handles map and is never closed. This causes a file descriptor leak every time a job fails the size check.",
           "file": "src/queue.js",
           "line_start": 5,
           "line_end": 13,
           "confidence": 1,
-          "recommendation": "Close the handle before throwing the error: if (stat.size > 1_000_000) { await handle.close(); throw new Error(`job ${id} log is too large to append to`); }"
+          "recommendation": "Wrap the stat check in a try-catch block, ensuring handle.close() is called and the handle is removed from the handles map before re-throwing the error."
         },
         {
           "severity": "high",
-          "title": "Unhandled promise rejections and active handle leak in startHeartbeat",
-          "body": "In startHeartbeat, fs.appendFile is invoked within a setInterval callback without an await keyword or a catch block/handler. Any failure (e.g., directory missing, disk full, permission issues) will cause an unhandled promise rejection, which can crash the Node.js process. Additionally, the interval is never returned or stored, leaking the active timer and keeping the process alive indefinitely.",
+          "title": "Persistent file descriptor leak on job success",
+          "body": "In runOne, after successfully opening the job and writing to the handle, the handle remains stored in the handles map and is never closed. Because there is no mechanism to close or clean up these handles, the process will eventually exhaust its limit of open file descriptors.",
+          "file": "src/queue.js",
+          "line_start": 21,
+          "line_end": 29,
+          "confidence": 1,
+          "recommendation": "Close the file handle using await handle.close() once operations on it are finished (or implement a cleanup function that closes the handles and deletes them from the map)."
+        },
+        {
+          "severity": "high",
+          "title": "Infinite heartbeat interval leak and unhandled promise rejections",
+          "body": "The startHeartbeat function creates a setInterval timer that performs an asynchronous file append every second, but it never stores the interval ID or offers a way to clear/stop it. Additionally, fs.appendFile's promise is unhandled; any writing failure (e.g., due to permission or disk full errors) will cause unhandled promise rejections on every tick.",
           "file": "src/queue.js",
           "line_start": 15,
           "line_end": 19,
           "confidence": 1,
-          "recommendation": "Wrap the fs.appendFile call with a catch block to log or handle append failures, and return the interval ID from startHeartbeat so callers can clear it when the job concludes."
-        },
-        {
-          "severity": "medium",
-          "title": "Unclosed handles in handles Map",
-          "body": "File handles are stored in a global `handles` Map in openJob, but there is no mechanism implemented to close the file handles and delete them from the Map when a job is done or fails. This leads to a cumulative resource leak of file descriptors over time.",
-          "file": "src/queue.js",
-          "line_start": 3,
-          "line_end": 13,
-          "confidence": 1,
-          "recommendation": "Implement a cleanup function (e.g., closeJob(id)) that retrieves the handle from the map, closes it asynchronously, and deletes the entry from the handles Map."
+          "recommendation": "Return the interval ID from startHeartbeat or provide a stop callback, and wrap the fs.appendFile call with proper error handling/catching."
         }
       ],
-      "latencyMs": 31491
+      "latencyMs": 34958
     },
     {
       "verdict": "needs-attention",
-      "summary": "The queue implementation contains critical file descriptor leaks, incorrect exception handling that reports failures as successes, unhandled promise rejections in the heartbeat loop, and a path traversal risk.",
+      "summary": "The queue implementation contains critical error swallowing, severe file descriptor leaks, and an unhandled heartbeat promise rejection with an infinite interval.",
       "findings": [
         {
           "severity": "critical",
-          "title": "Error masking in runOne reports failures as successes",
-          "body": "In `runOne`, the `catch` block returns `{ id, ok: true }` instead of indicating failure. This completely masks errors from `openJob` (such as log size exceptions, file-not-found, or permission issues), leading to false-positive success reporting in the system.",
+          "title": "Job execution errors are swallowed and reported as successful",
+          "body": "In `runOne(id)`, if `openJob` or `handle.write` throws an error, the `catch` block catches the exception and returns `{ id, ok: true }`. This silently swallows any failure (such as log size limit exceeded, missing file/directory, or disk full) and reports the job as successful, leading to silent failures and lack of visibility in production.",
           "file": "src/queue.js",
           "line_start": 21,
           "line_end": 29,
           "confidence": 1,
-          "recommendation": "Change the catch block to return `ok: false` and capture/log the failure: `catch (error) { return { id, ok: false, error: error.message }; }`."
+          "recommendation": "Return `{ id, ok: false }` or propagate/log the error in the `catch` block so that failures are correctly tracked and reported."
         },
         {
           "severity": "high",
-          "title": "File handle resource leak on size check failure",
-          "body": "In `openJob`, if the file statistics show that the log size exceeds 1,000,000 bytes, an Error is thrown. However, the file handle opened via `fs.open` is never closed, leading to an open file descriptor leak every time this limit is hit.",
+          "title": "Unclosed file handles lead to resource exhaustion",
+          "body": "File handles opened via `fs.open` in `openJob` are never closed. When `runOne` completes successfully or fails after opening, the handle is not closed. In addition, if `openJob` throws an error because the log file exceeds the size limit, the handle is left open in the private `handles` Map. Over time, this leads to file descriptor exhaustion (EMFILE) in production.",
           "file": "src/queue.js",
           "line_start": 5,
           "line_end": 13,
           "confidence": 1,
-          "recommendation": "Close the handle before throwing the error: `if (stat.size > 1_000_000) { await handle.close(); throw new Error(...); }`."
-        },
-        {
-          "severity": "high",
-          "title": "Permanent file descriptor leak on successful runs",
-          "body": "File handles opened by `openJob` are saved to the module-scoped `handles` Map, but they are never closed anywhere in `queue.js`. There is no mechanism to close these handles after write operations complete, which will cause `EMFILE` errors as active handles accumulate.",
-          "file": "src/queue.js",
-          "line_start": 21,
-          "line_end": 29,
-          "confidence": 1,
-          "recommendation": "Ensure the handle is closed in a `finally` block in `runOne` after completing the write operation: `finally { if (handle) { await handle.close(); handles.delete(id); } }`."
+          "recommendation": "Ensure that opened file handles are closed in both success and error paths (e.g., in a `finally` block or by cleaning up handles from the Map)."
         },
         {
           "severity": "medium",
-          "title": "Unhandled promise rejection in startHeartbeat",
-          "body": "The heartbeat interval calls the asynchronous `fs.appendFile` but does not await it or handle potential promise rejections (such as disk full or directory missing). In modern Node.js versions, unhandled promise rejections will crash the entire process.",
+          "title": "Unhandled promise rejection and infinite interval in startHeartbeat",
+          "body": "In `startHeartbeat(id)`, `fs.appendFile` is called inside `setInterval` without handling its Promise rejection. If the append operation fails (e.g., due to permissions or disk space issues), it will trigger an unhandled promise rejection. Furthermore, the interval timer runs indefinitely and is never cleared or returned, causing a memory and handle leak.",
           "file": "src/queue.js",
           "line_start": 15,
           "line_end": 19,
           "confidence": 1,
-          "recommendation": "Attach a `.catch()` block to the promise returned by `fs.appendFile` and return the interval ID so it can be cleared: `fs.appendFile(...).catch(err => console.error(err));`."
+          "recommendation": "Catch potential promise rejections from `fs.appendFile` and return the interval handle from `startHeartbeat` so that the caller can clear it when the job terminates."
+        }
+      ],
+      "latencyMs": 40537
+    },
+    {
+      "verdict": "needs-attention",
+      "summary": "Identified critical file handle leaks on error, masked failures as successes, unhandled promise rejections in background heartbeat, and path traversal vulnerabilities in job handling.",
+      "findings": [
+        {
+          "severity": "high",
+          "title": "File handle leak in openJob on log size limit exceedance",
+          "body": "In openJob(id), a file handle is opened using fs.open. If the file size exceeds 1,000,000 bytes, an Error is thrown, but the open handle is never closed and remains registered in the handles Map. This leads to file descriptor leakage under error conditions.",
+          "file": "src/queue.js",
+          "line_start": 5,
+          "line_end": 13,
+          "confidence": 1,
+          "recommendation": "Close the handle and delete it from handles Map before throwing the error:\n\nif (stat.size > 1_000_000) {\n  await handle.close();\n  handles.delete(id);\n  throw new Error(`job ${id} log is too large to append to`);\n}"
+        },
+        {
+          "severity": "high",
+          "title": "Errors swallowed and masked as successful completions in runOne",
+          "body": "In runOne(id), any error thrown during openJob(id) or handle.write() is caught in a generic catch block. The block swallows the error and returns { id, ok: true }, masking failures (such as missing folders, disk full, or log limit exceeded) as successful executions. Additionally, if handle.write() fails, the open file handle is never closed or cleaned up, compounding file descriptor leaks.",
+          "file": "src/queue.js",
+          "line_start": 20,
+          "line_end": 29,
+          "confidence": 1,
+          "recommendation": "Close the open file handle and return a failure status (e.g., { ok: false, error }) when an error occurs:\n\nasync function runOne(id) {\n  let handle;\n  try {\n    handle = await openJob(id);\n    await handle.write(\"started\\n\");\n    return { id, ok: true };\n  } catch (error) {\n    if (handle) {\n      try { await handle.close(); } catch {}\n      handles.delete(id);\n    }\n    return { id, ok: false, error: error.message };\n  }\n}"
+        },
+        {
+          "severity": "high",
+          "title": "Unhandled promise rejection and leaking interval in startHeartbeat",
+          "body": "startHeartbeat(id) sets up an infinite setInterval that schedules fs.appendFile() asynchronously every second. Since fs.appendFile is an asynchronous operation returning a promise, any error (e.g. disk full, permission denied) results in an unhandled promise rejection, which crashes modern Node.js processes. Additionally, there is no mechanism to clear the interval, resulting in background tasks leaking and writing to the beat file indefinitely even after a job finishes.",
+          "file": "src/queue.js",
+          "line_start": 15,
+          "line_end": 19,
+          "confidence": 1,
+          "recommendation": "Add a .catch handler to the fs.appendFile promise and return or store the interval ID so it can be cleared when the job finishes or fails:\n\nfunction startHeartbeat(id) {\n  const interval = setInterval(() => {\n    fs.appendFile(`/var/jobs/${id}.beat`, `${Date.now()}\\n`)\n      .catch((err) => {\n        console.error(`Heartbeat write failed for job ${id}:`, err);\n        clearInterval(interval);\n      });\n  }, 1000);\n  return interval;\n}"
         },
         {
           "severity": "medium",
-          "title": "Potential path traversal vulnerability via unvalidated job IDs",
-          "body": "The `id` parameter is directly interpolated into file paths (`/var/jobs/${id}.log` and `/var/jobs/${id}.beat`) without validation. If the `id` contains directory traversal sequences (e.g. `../../`), it could write/append files to arbitrary locations on the filesystem.",
+          "title": "Path traversal vulnerability via unvalidated job ID in file system path interpolation",
+          "body": "The job id parameter is interpolated directly into file paths '/var/jobs/${id}.log' and '/var/jobs/${id}.beat' without any verification or sanitization. If the job id originates from an untrusted source, path traversal sequences (such as '../') could allow writing to arbitrary file system locations outside the intended jobs directory.",
           "file": "src/queue.js",
-          "line_start": 5,
-          "line_end": 18,
+          "line_start": 6,
+          "line_end": 17,
           "confidence": 0.9,
-          "recommendation": "Validate that `id` adheres to a strict alphanumeric pattern: `if (!/^[a-zA-Z0-9_-]+$/.test(id)) throw new Error('Invalid job ID');`."
+          "recommendation": "Validate the job id to ensure it matches a strict alphanumeric/safe pattern before interpolating it into file system path strings:\n\nif (typeof id !== 'string' || !/^[a-zA-Z0-9-_]+$/.test(id)) {\n  throw new Error('Invalid job ID format');\n}"
         }
       ],
-      "latencyMs": 40181
-    },
-    {
-      "verdict": "needs-attention",
-      "summary": "Identified a critical error swallowing bug, file descriptor resource leaks, and unhandled promise rejections in queue.js.",
-      "findings": [
-        {
-          "severity": "critical",
-          "title": "Silent error swallowing in runOne",
-          "body": "In `runOne`, the `catch` block catches any error thrown by `openJob(id)` or `handle.write(...)` and returns `{ id, ok: true }`. This silent error swallowing falsely reports a failed job execution as successful, masking critical job run failures in production.",
-          "file": "src/queue.js",
-          "line_start": 26,
-          "line_end": 28,
-          "confidence": 1,
-          "recommendation": "Modify the `catch` block in `runOne` to return `{ id, ok: false }` instead of `{ id, ok: true }`."
-        },
-        {
-          "severity": "high",
-          "title": "Unclosed file handles (Resource Leak)",
-          "body": "File handles returned by `fs.open` in `openJob` are never closed. If the validation check `stat.size > 1_000_000` fails, the error is thrown without closing the handle. If `runOne` executes successfully or encounters an error writing to the handle, the handle is never closed either, leaking file descriptors indefinitely.",
-          "file": "src/queue.js",
-          "line_start": 5,
-          "line_end": 12,
-          "confidence": 1,
-          "recommendation": "Ensure `handle.close()` is called and awaited. In `openJob`, if validation fails, close the handle before throwing. In `runOne`, use a `finally` block to close the handle and remove it from the `handles` map."
-        },
-        {
-          "severity": "high",
-          "title": "Unhandled promise rejections in startHeartbeat",
-          "body": "In `startHeartbeat`, the async function `fs.appendFile` is invoked within `setInterval` without a promise catch handler. If the write fails (e.g., due to permissions, missing directory, or full disk), an unhandled promise rejection will occur, crashing the Node.js process. Additionally, the interval is never cleared or returned.",
-          "file": "src/queue.js",
-          "line_start": 15,
-          "line_end": 19,
-          "confidence": 1,
-          "recommendation": "Add error handling to `fs.appendFile` (e.g., `.catch(err => { ... })`) and return the interval ID to allow callers to clear the heartbeat."
-        }
-      ],
-      "latencyMs": 31687
+      "latencyMs": 51595
     }
   ],
-  "raw": "{\n  \"review\": \"Review\",\n  \"target\": {\n    \"mode\": \"working-tree\",\n    \"label\": \"working tree diff\",\n    \"explicit\": true\n  },\n  \"gemini\": {\n    \"status\": 0,\n    \"stdout\": \"{\\n  \\\"verdict\\\": \\\"needs-attention\\\",\\n  \\\"summary\\\": \\\"Identified a critical error swallowing bug, file descriptor resource leaks, and unhandled promise rejections in queue.js.\\\",\\n  \\\"findings\\\": [\\n    {\\n      \\\"severity\\\": \\\"critical\\\",\\n      \\\"title\\\": \\\"Silent error swallowing in runOne\\\",\\n      \\\"body\\\": \\\"In `runOne`, the `catch` block catches any error thrown by `openJob(id)` or `handle.write(...)` and returns `{ id, ok: true }`. This silent error swallowing falsely reports a failed job execution as successful, masking critical job run failures in production.\\\",\\n      \\\"file\\\": \\\"src/queue.js\\\",\\n      \\\"line_start\\\": 26,\\n      \\\"line_end\\\": 28,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Modify the `catch` block in `runOne` to return `{ id, ok: false }` instead of `{ id, ok: true }`.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"high\\\",\\n      \\\"title\\\": \\\"Unclosed file handles (Resource Leak)\\\",\\n      \\\"body\\\": \\\"File handles returned by `fs.open` in `openJob` are never closed. If the validation check `stat.size > 1_000_000` fails, the error is thrown without closing the handle. If `runOne` executes successfully or encounters an error writing to the handle, the handle is never closed either, leaking file descriptors indefinitely.\\\",\\n      \\\"file\\\": \\\"src/queue.js\\\",\\n      \\\"line_start\\\": 5,\\n      \\\"line_end\\\": 12,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Ensure `handle.close()` is called and awaited. In `openJob`, if validation fails, close the handle before throwing. In `runOne`, use a `finally` block to close the handle and remove it from the `handles` map.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"high\\\",\\n      \\\"title\\\": \\\"Unhandled promise rejections in startHeartbeat\\\",\\n      \\\"body\\\": \\\"In `startHeartbeat`, the async function `fs.appendFile` is invoked within `setInterval` without a promise catch handler. If the write fails (e.g., due to permissions, missing directory, or full disk), an unhandled promise rejection will occur, crashing the Node.js process. Additionally, the interval is never cleared or returned.\\\",\\n      \\\"file\\\": \\\"src/queue.js\\\",\\n      \\\"line_start\\\": 15,\\n      \\\"line_end\\\": 19,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Add error handling to `fs.appendFile` (e.g., `.catch(err => { ... })`) and return the interval ID to allow callers to clear the heartbeat.\\\"\\n    }\\n  ],\\n  \\\"next_steps\\\": [\\n    \\\"Fix the logic in the catch block of runOne to return ok: false on error.\\\",\\n    \\\"Introduce try-finally blocks in runOne and openJob to ensure file handles are properly closed and removed from the active handles map.\\\",\\n    \\\"Add error catching/logging inside the startHeartbeat interval and return the interval ID for cleanup.\\\"\\n  ]\\n}\",\n    \"stderr\": \"Warning: True color (24-bit) support not detected. Using a terminal with true color enabled will result in a better visual experience.\\nRipgrep is not available. Falling back to GrepTool.\\n[STARTUP] Phase 'cleanup_ops' was started but never ended. Skipping metrics.\\n[STARTUP] Cannot measure phase 'cleanup_ops': start mark 'startup:cleanup_ops:start' not found (likely cleared by reset).\\n\"\n  },\n  \"result\": {\n    \"verdict\": \"needs-attention\",\n    \"summary\": \"Identified a critical error swallowing bug, file descriptor resource leaks, and unhandled promise rejections in queue.js.\",\n    \"findings\": [\n      {\n        \"severity\": \"critical\",\n        \"title\": \"Silent error swallowing in runOne\",\n        \"body\": \"In `runOne`, the `catch` block catches any error thrown by `openJob(id)` or `handle.write(...)` and returns `{ id, ok: true }`. This silent error swallowing falsely reports a failed job execution as successful, masking critical job run failures in production.\",\n        \"file\": \"src/queue.js\",\n        \"line_start\": 26,\n        \"l"
+  "raw": "{\n  \"review\": \"Review\",\n  \"target\": {\n    \"mode\": \"working-tree\",\n    \"label\": \"working tree diff\",\n    \"explicit\": true\n  },\n  \"engine\": \"gemini\",\n  \"gemini\": {\n    \"status\": 0,\n    \"stdout\": \"{\\n  \\\"verdict\\\": \\\"needs-attention\\\",\\n  \\\"summary\\\": \\\"Identified critical file handle leaks on error, masked failures as successes, unhandled promise rejections in background heartbeat, and path traversal vulnerabilities in job handling.\\\",\\n  \\\"findings\\\": [\\n    {\\n      \\\"severity\\\": \\\"high\\\",\\n      \\\"title\\\": \\\"File handle leak in openJob on log size limit exceedance\\\",\\n      \\\"body\\\": \\\"In openJob(id), a file handle is opened using fs.open. If the file size exceeds 1,000,000 bytes, an Error is thrown, but the open handle is never closed and remains registered in the handles Map. This leads to file descriptor leakage under error conditions.\\\",\\n      \\\"file\\\": \\\"src/queue.js\\\",\\n      \\\"line_start\\\": 5,\\n      \\\"line_end\\\": 13,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Close the handle and delete it from handles Map before throwing the error:\\\\n\\\\nif (stat.size > 1_000_000) {\\\\n  await handle.close();\\\\n  handles.delete(id);\\\\n  throw new Error(`job ${id} log is too large to append to`);\\\\n}\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"high\\\",\\n      \\\"title\\\": \\\"Errors swallowed and masked as successful completions in runOne\\\",\\n      \\\"body\\\": \\\"In runOne(id), any error thrown during openJob(id) or handle.write() is caught in a generic catch block. The block swallows the error and returns { id, ok: true }, masking failures (such as missing folders, disk full, or log limit exceeded) as successful executions. Additionally, if handle.write() fails, the open file handle is never closed or cleaned up, compounding file descriptor leaks.\\\",\\n      \\\"file\\\": \\\"src/queue.js\\\",\\n      \\\"line_start\\\": 20,\\n      \\\"line_end\\\": 29,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Close the open file handle and return a failure status (e.g., { ok: false, error }) when an error occurs:\\\\n\\\\nasync function runOne(id) {\\\\n  let handle;\\\\n  try {\\\\n    handle = await openJob(id);\\\\n    await handle.write(\\\\\\\"started\\\\\\\\n\\\\\\\");\\\\n    return { id, ok: true };\\\\n  } catch (error) {\\\\n    if (handle) {\\\\n      try { await handle.close(); } catch {}\\\\n      handles.delete(id);\\\\n    }\\\\n    return { id, ok: false, error: error.message };\\\\n  }\\\\n}\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"high\\\",\\n      \\\"title\\\": \\\"Unhandled promise rejection and leaking interval in startHeartbeat\\\",\\n      \\\"body\\\": \\\"startHeartbeat(id) sets up an infinite setInterval that schedules fs.appendFile() asynchronously every second. Since fs.appendFile is an asynchronous operation returning a promise, any error (e.g. disk full, permission denied) results in an unhandled promise rejection, which crashes modern Node.js processes. Additionally, there is no mechanism to clear the interval, resulting in background tasks leaking and writing to the beat file indefinitely even after a job finishes.\\\",\\n      \\\"file\\\": \\\"src/queue.js\\\",\\n      \\\"line_start\\\": 15,\\n      \\\"line_end\\\": 19,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Add a .catch handler to the fs.appendFile promise and return or store the interval ID so it can be cleared when the job finishes or fails:\\\\n\\\\nfunction startHeartbeat(id) {\\\\n  const interval = setInterval(() => {\\\\n    fs.appendFile(`/var/jobs/${id}.beat`, `${Date.now()}\\\\\\\\n`)\\\\n      .catch((err) => {\\\\n        console.error(`Heartbeat write failed for job ${id}:`, err);\\\\n        clearInterval(interval);\\\\n      });\\\\n  }, 1000);\\\\n  return interval;\\\\n}\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"medium\\\",\\n      \\\"title\\\": \\\"Path traversal vulnerability via unvalidated job ID in file system path interpolation\\\",\\n      \\\"body\\\": \\\"The job id parameter is interpolated directly into file paths '/var/jobs/${id}.log' and '/var/jobs/${id}.beat' without any verification or sanitization. If the job id originates from an untrus"
 }

--- a/bench/cassettes/async-lifecycle/gemini.model.json
+++ b/bench/cassettes/async-lifecycle/gemini.model.json
@@ -1,195 +1,196 @@
 {
   "caseId": "async-lifecycle",
   "cell": "gemini.model",
-  "recordedAt": "2026-08-19T09:05:22.301Z",
+  "recordedAt": "2026-08-24T10:41:15.162Z",
   "verdict": "needs-attention",
-  "summary": "Multiple severe defects including swallowed errors returning false success, resource leaks with unclosable intervals, and file descriptor leaks on exceptions.",
+  "summary": "Critical errors exist including completely masked failures, severe file descriptor and interval leaks, and potential path traversal vulnerabilities.",
   "findings": [
     {
       "severity": "critical",
-      "title": "Swallowed error in runOne",
-      "body": "The catch block in `runOne` completely swallows exceptions (such as file not found or file too large) and incorrectly returns `{ id, ok: true }`, falsely indicating the job succeeded when it actually failed.",
+      "title": "Silent failure masking in runOne",
+      "body": "The catch block in `runOne` unconditionally returns `{ id, ok: true }` when an exception is caught. This masks all failures (such as the 1MB log limit or I/O errors) and incorrectly reports failed jobs as successful.",
       "file": "src/queue.js",
       "line_start": 26,
       "line_end": 28,
       "confidence": 1,
-      "recommendation": "Return `{ id, ok: false, error: err }` in the catch block or rethrow the error."
+      "recommendation": "Return `{ id, ok: false }` along with the error detail in the catch block."
     },
     {
       "severity": "high",
-      "title": "File handle leak on size exception",
-      "body": "In `openJob`, if the file size exceeds 1,000,000 bytes, an Error is thrown but the opened file handle is not closed and remains in the `handles` map, resulting in a file descriptor leak.",
+      "title": "File descriptor leak on job execution",
+      "body": "`runOne` opens a file handle via `openJob` but never closes it. Additionally, `openJob` leaves the handle open if it throws the file size error. This will exhaust system file descriptors (EMFILE) and crash the application.",
       "file": "src/queue.js",
       "line_start": 9,
-      "line_end": 12,
+      "line_end": 24,
       "confidence": 1,
-      "recommendation": "Call `await handle.close();` and remove the id from the `handles` map before throwing the error."
+      "recommendation": "Close the handle in `openJob` before throwing, and ensure `runOne` calls `await handle.close()` inside a `finally` block."
     },
     {
       "severity": "high",
-      "title": "Unstoppable interval and unhandled promises in startHeartbeat",
-      "body": "`startHeartbeat` creates a `setInterval` but does not return the timer ID, making it impossible to stop the heartbeat and causing a memory/resource leak. Additionally, the promise returned by `fs.appendFile` is ignored, which can lead to unhandled promise rejections.",
+      "title": "Unstoppable interval and unhandled promise rejection in heartbeat",
+      "body": "`startHeartbeat` creates a continuous interval without returning the interval ID, making it impossible to stop. Furthermore, it calls `fs.appendFile` (which returns a Promise in node:fs/promises) without `.catch()`, causing unhandled promise rejections on I/O failures.",
       "file": "src/queue.js",
       "line_start": 16,
       "line_end": 18,
       "confidence": 1,
-      "recommendation": "Return the interval ID so callers can invoke `clearInterval`. Attach a `.catch()` to `fs.appendFile` or handle the async operation safely."
+      "recommendation": "Return the interval ID from `startHeartbeat` so it can be cleared, and add a `.catch()` block to `fs.appendFile` to safely handle I/O failures."
     },
     {
       "severity": "medium",
       "title": "Path traversal vulnerability",
-      "body": "The `id` parameter is directly interpolated into file paths in `openJob` and `startHeartbeat` (e.g., `/var/jobs/${id}.log`). If `id` contains untrusted input like `../`, it can lead to arbitrary file writes outside the intended directory.",
+      "body": "The `id` parameter is directly interpolated into the file path (`/var/jobs/${id}.log`). If `id` is user-provided, it allows an attacker to append data to arbitrary files via directory traversal (e.g. `../../../etc/passwd`).",
       "file": "src/queue.js",
       "line_start": 6,
       "line_end": 17,
       "confidence": 0.9,
-      "recommendation": "Validate and sanitize the `id` parameter (e.g., ensure it only contains alphanumeric characters) before using it in path construction."
+      "recommendation": "Sanitize the `id` variable (e.g., validate it against a strict alphanumeric regex) or safely construct the path using `path.basename(id)`."
     }
   ],
-  "latencyMs": 24074,
-  "engineVersion": "0.55.1",
+  "latencyMs": 34024,
+  "engineVersion": "0.56.0",
+  "engineObserved": null,
   "samples": [
     {
       "verdict": "needs-attention",
-      "summary": "Critical defects include silent error masking returning false success, severe file handle and interval leaks, unhandled promise rejections, and unmitigated path traversal risks.",
+      "summary": "Severe resource leaks, silent error masking, and path traversal vulnerabilities detected.",
       "findings": [
         {
           "severity": "critical",
-          "title": "Silent Error Masking incorrectly reports success",
-          "body": "The catch block in runOne swallows all exceptions from file operations and incorrectly returns { id, ok: true }. Job failures will be silently reported as successes.",
+          "title": "Silent error masking in runOne",
+          "body": "The catch block in `runOne` returns `{ id, ok: true }` regardless of the error thrown (e.g., file too large, I/O errors). This completely masks failures and falsely reports success to the caller.",
           "file": "src/queue.js",
           "line_start": 26,
           "line_end": 28,
           "confidence": 1,
-          "recommendation": "Return { id, ok: false, error: err.message } in the catch block to correctly indicate failure."
+          "recommendation": "Return `{ id, ok: false, error: err }` or rethrow the error in the catch block."
         },
         {
           "severity": "high",
-          "title": "File handle resource leaks",
-          "body": "File handles opened via fs.open are never closed. In openJob, if the file exceeds the size limit, an error is thrown but the handle remains open. In runOne, the handle is successfully used but never closed. This will quickly exhaust system file descriptors.",
-          "file": "src/queue.js",
-          "line_start": 5,
-          "line_end": 28,
-          "confidence": 1,
-          "recommendation": "Ensure handles are explicitly closed. Close the handle before throwing the size limit error in openJob, and use a finally block in runOne to close the handle."
-        },
-        {
-          "severity": "high",
-          "title": "Unbounded interval leak and unhandled promise rejection",
-          "body": "startHeartbeat creates a setInterval that is never stored or cleared, leaking memory and I/O operations forever. Furthermore, the asynchronous fs.appendFile promise is not caught; if writing fails, it will cause an UnhandledPromiseRejection which can crash the Node.js process.",
-          "file": "src/queue.js",
-          "line_start": 15,
-          "line_end": 19,
-          "confidence": 1,
-          "recommendation": "Return the interval ID so it can be cleared when the job finishes. Append .catch(...) to the fs.appendFile call to handle I/O errors gracefully."
-        },
-        {
-          "severity": "high",
-          "title": "Path traversal vulnerability",
-          "body": "The id parameter is directly interpolated into file paths (/var/jobs/${id}.log). If an external user controls the id and provides input like `../`, it enables path traversal, allowing the application to write to arbitrary files on the filesystem.",
+          "title": "File descriptor leak in openJob and runOne",
+          "body": "File handles opened with `fs.open` are stored in a global `handles` map but are never closed. If the file size check throws an error, the open handle is immediately leaked. Furthermore, there is no mechanism to close handles when a job completes successfully.",
           "file": "src/queue.js",
           "line_start": 6,
-          "line_end": 17,
-          "confidence": 0.9,
-          "recommendation": "Validate id against a strict allowlist (e.g., alphanumeric UUIDs) before path construction to prevent directory traversal."
-        }
-      ],
-      "latencyMs": 28268
-    },
-    {
-      "verdict": "needs-attention",
-      "summary": "Multiple critical issues including path traversal, file descriptor leaks, incorrect error masking, and unmanaged intervals.",
-      "findings": [
-        {
-          "severity": "critical",
-          "title": "Path Traversal Vulnerability",
-          "body": "The `openJob` and `startHeartbeat` functions construct file paths using an unvalidated `id` parameter. If `id` contains traversal characters like `../`, it allows reading, writing, or appending to arbitrary files.",
-          "file": "src/queue.js",
-          "line_start": 6,
-          "line_end": 17,
-          "confidence": 0.95,
-          "recommendation": "Validate and sanitize the `id` parameter (e.g., ensure it matches a safe regex like `/^[a-zA-Z0-9_-]+$/`) before constructing file paths."
-        },
-        {
-          "severity": "high",
-          "title": "File Descriptor Leak on Error",
-          "body": "In `openJob`, if the log file size exceeds 1,000,000 bytes, an error is thrown but the opened `handle` is never closed and remains in the `handles` map.",
-          "file": "src/queue.js",
-          "line_start": 9,
           "line_end": 11,
           "confidence": 1,
-          "recommendation": "Call `await handle.close()` and remove the id from `handles` map before throwing the error."
+          "recommendation": "Call `await handle.close()` before throwing the size error, and implement a cleanup mechanism to close file handles once jobs complete."
         },
         {
-          "severity": "high",
-          "title": "Unstoppable Interval and Unhandled Rejection",
-          "body": "`startHeartbeat` creates a timer interval without returning its ID, making it impossible to stop. Additionally, the async `fs.appendFile` is called without error handling, which can crash the process with an unhandled promise rejection.",
+          "severity": "medium",
+          "title": "Unstoppable interval leak in startHeartbeat",
+          "body": "`startHeartbeat` creates a periodic interval using `setInterval` but does not store or return the resulting interval ID. This creates an unreferenced background task that will run indefinitely, keeping the Node process alive and continuously performing disk I/O.",
           "file": "src/queue.js",
           "line_start": 16,
           "line_end": 18,
           "confidence": 1,
-          "recommendation": "Return the timer ID so it can be cleared later. Add `.catch()` to the `fs.appendFile` promise."
-        },
-        {
-          "severity": "high",
-          "title": "Error Masked as Success and Unclosed Handle",
-          "body": "In `runOne`, the `catch` block returns `{ id, ok: true }`, masking any failures as successes. Furthermore, the successfully opened `handle` is not closed after use.",
-          "file": "src/queue.js",
-          "line_start": 26,
-          "line_end": 28,
-          "confidence": 1,
-          "recommendation": "Return `{ id, ok: false }` or rethrow the error in the catch block. Ensure `handle.close()` is called in a `finally` block or appropriately managed."
-        }
-      ],
-      "latencyMs": 26821
-    },
-    {
-      "verdict": "needs-attention",
-      "summary": "Multiple severe defects including swallowed errors returning false success, resource leaks with unclosable intervals, and file descriptor leaks on exceptions.",
-      "findings": [
-        {
-          "severity": "critical",
-          "title": "Swallowed error in runOne",
-          "body": "The catch block in `runOne` completely swallows exceptions (such as file not found or file too large) and incorrectly returns `{ id, ok: true }`, falsely indicating the job succeeded when it actually failed.",
-          "file": "src/queue.js",
-          "line_start": 26,
-          "line_end": 28,
-          "confidence": 1,
-          "recommendation": "Return `{ id, ok: false, error: err }` in the catch block or rethrow the error."
-        },
-        {
-          "severity": "high",
-          "title": "File handle leak on size exception",
-          "body": "In `openJob`, if the file size exceeds 1,000,000 bytes, an Error is thrown but the opened file handle is not closed and remains in the `handles` map, resulting in a file descriptor leak.",
-          "file": "src/queue.js",
-          "line_start": 9,
-          "line_end": 12,
-          "confidence": 1,
-          "recommendation": "Call `await handle.close();` and remove the id from the `handles` map before throwing the error."
-        },
-        {
-          "severity": "high",
-          "title": "Unstoppable interval and unhandled promises in startHeartbeat",
-          "body": "`startHeartbeat` creates a `setInterval` but does not return the timer ID, making it impossible to stop the heartbeat and causing a memory/resource leak. Additionally, the promise returned by `fs.appendFile` is ignored, which can lead to unhandled promise rejections.",
-          "file": "src/queue.js",
-          "line_start": 16,
-          "line_end": 18,
-          "confidence": 1,
-          "recommendation": "Return the interval ID so callers can invoke `clearInterval`. Attach a `.catch()` to `fs.appendFile` or handle the async operation safely."
+          "recommendation": "Return the interval ID from `startHeartbeat` so the caller can execute `clearInterval` when the heartbeat is no longer needed."
         },
         {
           "severity": "medium",
           "title": "Path traversal vulnerability",
-          "body": "The `id` parameter is directly interpolated into file paths in `openJob` and `startHeartbeat` (e.g., `/var/jobs/${id}.log`). If `id` contains untrusted input like `../`, it can lead to arbitrary file writes outside the intended directory.",
+          "body": "The `id` parameter is unsafely interpolated directly into file paths. If `id` originates from untrusted input, an attacker could supply payloads like `../../../etc/passwd` to perform arbitrary file writes/appends outside the intended `/var/jobs/` directory.",
           "file": "src/queue.js",
           "line_start": 6,
           "line_end": 17,
           "confidence": 0.9,
-          "recommendation": "Validate and sanitize the `id` parameter (e.g., ensure it only contains alphanumeric characters) before using it in path construction."
+          "recommendation": "Validate and sanitize the `id` parameter to ensure it only contains safe characters (e.g., strictly alphanumeric or UUID format) before using it in file paths."
         }
       ],
-      "latencyMs": 24074
+      "latencyMs": 27949
+    },
+    {
+      "verdict": "needs-attention",
+      "summary": "Critical defects found including masked errors falsely reporting success, file descriptor leaks, path traversal vulnerabilities, and unhandled promises.",
+      "findings": [
+        {
+          "severity": "critical",
+          "title": "Silenced errors falsely report success",
+          "body": "The catch block in `runOne` returns `{ id, ok: true }` upon encountering an error, silently masking failures (such as the file size limit being exceeded) and falsely reporting the job as successfully started.",
+          "file": "src/queue.js",
+          "line_start": 26,
+          "line_end": 28,
+          "confidence": 1,
+          "recommendation": "Change the catch block to return `{ id, ok: false }` along with the error details, or propagate the exception."
+        },
+        {
+          "severity": "high",
+          "title": "File descriptor leak on size validation failure",
+          "body": "In `openJob`, if the file size exceeds 1,000,000 bytes, an error is thrown but the `handle` is never closed. This will exhaust system file descriptors over time.",
+          "file": "src/queue.js",
+          "line_start": 9,
+          "line_end": 11,
+          "confidence": 1,
+          "recommendation": "Call `await handle.close()` before throwing the size limit error, and provide a broader mechanism to clean up closed jobs from the `handles` map."
+        },
+        {
+          "severity": "high",
+          "title": "Path traversal vulnerability",
+          "body": "The `id` parameter is directly interpolated into file paths (`/var/jobs/${id}.log` and `/var/jobs/${id}.beat`) without sanitization. An attacker could provide a malicious ID (e.g., `../../../etc/host`) to append to arbitrary system files.",
+          "file": "src/queue.js",
+          "line_start": 6,
+          "line_end": 17,
+          "confidence": 0.95,
+          "recommendation": "Validate `id` against a strict allowlist regex (e.g., alphanumeric/UUID) or use `path.basename(id)` before constructing the file path."
+        },
+        {
+          "severity": "medium",
+          "title": "Unstoppable interval and floating promise in heartbeat",
+          "body": "`startHeartbeat` creates a `setInterval` but never returns its ID, causing an unstoppable interval leak. Additionally, the asynchronous `fs.appendFile` promise is not awaited or caught, which can cause UnhandledPromiseRejection process crashes if writes fail.",
+          "file": "src/queue.js",
+          "line_start": 16,
+          "line_end": 18,
+          "confidence": 1,
+          "recommendation": "Return the timer ID from `startHeartbeat` to allow for proper cleanup (`clearInterval`), and add a `.catch()` block to handle `fs.appendFile` errors."
+        }
+      ],
+      "latencyMs": 33229
+    },
+    {
+      "verdict": "needs-attention",
+      "summary": "Critical errors exist including completely masked failures, severe file descriptor and interval leaks, and potential path traversal vulnerabilities.",
+      "findings": [
+        {
+          "severity": "critical",
+          "title": "Silent failure masking in runOne",
+          "body": "The catch block in `runOne` unconditionally returns `{ id, ok: true }` when an exception is caught. This masks all failures (such as the 1MB log limit or I/O errors) and incorrectly reports failed jobs as successful.",
+          "file": "src/queue.js",
+          "line_start": 26,
+          "line_end": 28,
+          "confidence": 1,
+          "recommendation": "Return `{ id, ok: false }` along with the error detail in the catch block."
+        },
+        {
+          "severity": "high",
+          "title": "File descriptor leak on job execution",
+          "body": "`runOne` opens a file handle via `openJob` but never closes it. Additionally, `openJob` leaves the handle open if it throws the file size error. This will exhaust system file descriptors (EMFILE) and crash the application.",
+          "file": "src/queue.js",
+          "line_start": 9,
+          "line_end": 24,
+          "confidence": 1,
+          "recommendation": "Close the handle in `openJob` before throwing, and ensure `runOne` calls `await handle.close()` inside a `finally` block."
+        },
+        {
+          "severity": "high",
+          "title": "Unstoppable interval and unhandled promise rejection in heartbeat",
+          "body": "`startHeartbeat` creates a continuous interval without returning the interval ID, making it impossible to stop. Furthermore, it calls `fs.appendFile` (which returns a Promise in node:fs/promises) without `.catch()`, causing unhandled promise rejections on I/O failures.",
+          "file": "src/queue.js",
+          "line_start": 16,
+          "line_end": 18,
+          "confidence": 1,
+          "recommendation": "Return the interval ID from `startHeartbeat` so it can be cleared, and add a `.catch()` block to `fs.appendFile` to safely handle I/O failures."
+        },
+        {
+          "severity": "medium",
+          "title": "Path traversal vulnerability",
+          "body": "The `id` parameter is directly interpolated into the file path (`/var/jobs/${id}.log`). If `id` is user-provided, it allows an attacker to append data to arbitrary files via directory traversal (e.g. `../../../etc/passwd`).",
+          "file": "src/queue.js",
+          "line_start": 6,
+          "line_end": 17,
+          "confidence": 0.9,
+          "recommendation": "Sanitize the `id` variable (e.g., validate it against a strict alphanumeric regex) or safely construct the path using `path.basename(id)`."
+        }
+      ],
+      "latencyMs": 34024
     }
   ],
-  "raw": "{\n  \"session_id\": \"415dbb28-607f-4390-8cba-6059f48822c7\",\n  \"response\": \"{\\n  \\\"verdict\\\": \\\"needs-attention\\\",\\n  \\\"summary\\\": \\\"Multiple severe defects including swallowed errors returning false success, resource leaks with unclosable intervals, and file descriptor leaks on exceptions.\\\",\\n  \\\"findings\\\": [\\n    {\\n      \\\"severity\\\": \\\"critical\\\",\\n      \\\"title\\\": \\\"Swallowed error in runOne\\\",\\n      \\\"body\\\": \\\"The catch block in `runOne` completely swallows exceptions (such as file not found or file too large) and incorrectly returns `{ id, ok: true }`, falsely indicating the job succeeded when it actually failed.\\\",\\n      \\\"file\\\": \\\"src/queue.js\\\",\\n      \\\"line_start\\\": 26,\\n      \\\"line_end\\\": 28,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Return `{ id, ok: false, error: err }` in the catch block or rethrow the error.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"high\\\",\\n      \\\"title\\\": \\\"File handle leak on size exception\\\",\\n      \\\"body\\\": \\\"In `openJob`, if the file size exceeds 1,000,000 bytes, an Error is thrown but the opened file handle is not closed and remains in the `handles` map, resulting in a file descriptor leak.\\\",\\n      \\\"file\\\": \\\"src/queue.js\\\",\\n      \\\"line_start\\\": 9,\\n      \\\"line_end\\\": 12,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Call `await handle.close();` and remove the id from the `handles` map before throwing the error.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"high\\\",\\n      \\\"title\\\": \\\"Unstoppable interval and unhandled promises in startHeartbeat\\\",\\n      \\\"body\\\": \\\"`startHeartbeat` creates a `setInterval` but does not return the timer ID, making it impossible to stop the heartbeat and causing a memory/resource leak. Additionally, the promise returned by `fs.appendFile` is ignored, which can lead to unhandled promise rejections.\\\",\\n      \\\"file\\\": \\\"src/queue.js\\\",\\n      \\\"line_start\\\": 16,\\n      \\\"line_end\\\": 18,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Return the interval ID so callers can invoke `clearInterval`. Attach a `.catch()` to `fs.appendFile` or handle the async operation safely.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"medium\\\",\\n      \\\"title\\\": \\\"Path traversal vulnerability\\\",\\n      \\\"body\\\": \\\"The `id` parameter is directly interpolated into file paths in `openJob` and `startHeartbeat` (e.g., `/var/jobs/${id}.log`). If `id` contains untrusted input like `../`, it can lead to arbitrary file writes outside the intended directory.\\\",\\n      \\\"file\\\": \\\"src/queue.js\\\",\\n      \\\"line_start\\\": 6,\\n      \\\"line_end\\\": 17,\\n      \\\"confidence\\\": 0.9,\\n      \\\"recommendation\\\": \\\"Validate and sanitize the `id` parameter (e.g., ensure it only contains alphanumeric characters) before using it in path construction.\\\"\\n    }\\n  ],\\n  \\\"next_steps\\\": [\\n    \\\"Fix the catch block in runOne to correctly return ok: false.\\\",\\n    \\\"Ensure file handles are properly closed when exceptions occur in openJob.\\\",\\n    \\\"Refactor startHeartbeat to return the timer ID and handle appendFile rejections safely.\\\",\\n    \\\"Add input validation for the id parameter to prevent path traversal.\\\"\\n  ]\\n}\",\n  \"stats\": {\n    \"models\": {\n      \"gemini-3.1-pro-preview\": {\n        \"api\": {\n          \"totalRequests\": 1,\n          \"totalErrors\": 0,\n          \"totalLatencyMs\": 22403,\n          \"errorsByType\": {}\n        },\n        \"tokens\": {\n          \"input\": 5213,\n          \"prompt\": 17433,\n          \"candidates\": 737,\n          \"total\": 20269,\n          \"cached\": 12220,\n          \"thoughts\": 2099,\n          \"tool\": 0\n        },\n        \"roles\": {\n          \"main\": {\n            \"totalRequests\": 1,\n            \"totalErrors\": 0,\n            \"totalLatencyMs\": 22403,\n            \"tokens\": {\n              \"input\": 5213,\n              \"prompt\": 17433,\n              \"candidates\": 737,\n              \"total\": 20269,\n              \"cached\": 12220,\n              \"thoughts\": 2099,\n              \"tool\": 0\n            }\n          }\n        }\n      }\n    },\n    \"tools\": {\n "
+  "raw": "{\n  \"session_id\": \"908d0853-17b2-48bb-a98d-072060825f00\",\n  \"response\": \"{\\n  \\\"verdict\\\": \\\"needs-attention\\\",\\n  \\\"summary\\\": \\\"Critical errors exist including completely masked failures, severe file descriptor and interval leaks, and potential path traversal vulnerabilities.\\\",\\n  \\\"findings\\\": [\\n    {\\n      \\\"severity\\\": \\\"critical\\\",\\n      \\\"title\\\": \\\"Silent failure masking in runOne\\\",\\n      \\\"body\\\": \\\"The catch block in `runOne` unconditionally returns `{ id, ok: true }` when an exception is caught. This masks all failures (such as the 1MB log limit or I/O errors) and incorrectly reports failed jobs as successful.\\\",\\n      \\\"file\\\": \\\"src/queue.js\\\",\\n      \\\"line_start\\\": 26,\\n      \\\"line_end\\\": 28,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Return `{ id, ok: false }` along with the error detail in the catch block.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"high\\\",\\n      \\\"title\\\": \\\"File descriptor leak on job execution\\\",\\n      \\\"body\\\": \\\"`runOne` opens a file handle via `openJob` but never closes it. Additionally, `openJob` leaves the handle open if it throws the file size error. This will exhaust system file descriptors (EMFILE) and crash the application.\\\",\\n      \\\"file\\\": \\\"src/queue.js\\\",\\n      \\\"line_start\\\": 9,\\n      \\\"line_end\\\": 24,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Close the handle in `openJob` before throwing, and ensure `runOne` calls `await handle.close()` inside a `finally` block.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"high\\\",\\n      \\\"title\\\": \\\"Unstoppable interval and unhandled promise rejection in heartbeat\\\",\\n      \\\"body\\\": \\\"`startHeartbeat` creates a continuous interval without returning the interval ID, making it impossible to stop. Furthermore, it calls `fs.appendFile` (which returns a Promise in node:fs/promises) without `.catch()`, causing unhandled promise rejections on I/O failures.\\\",\\n      \\\"file\\\": \\\"src/queue.js\\\",\\n      \\\"line_start\\\": 16,\\n      \\\"line_end\\\": 18,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Return the interval ID from `startHeartbeat` so it can be cleared, and add a `.catch()` block to `fs.appendFile` to safely handle I/O failures.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"medium\\\",\\n      \\\"title\\\": \\\"Path traversal vulnerability\\\",\\n      \\\"body\\\": \\\"The `id` parameter is directly interpolated into the file path (`/var/jobs/${id}.log`). If `id` is user-provided, it allows an attacker to append data to arbitrary files via directory traversal (e.g. `../../../etc/passwd`).\\\",\\n      \\\"file\\\": \\\"src/queue.js\\\",\\n      \\\"line_start\\\": 6,\\n      \\\"line_end\\\": 17,\\n      \\\"confidence\\\": 0.9,\\n      \\\"recommendation\\\": \\\"Sanitize the `id` variable (e.g., validate it against a strict alphanumeric regex) or safely construct the path using `path.basename(id)`.\\\"\\n    }\\n  ],\\n  \\\"next_steps\\\": [\\n    \\\"Fix error handling in runOne to accurately report failures.\\\",\\n    \\\"Implement proper resource cleanup for both file handles and timeouts.\\\",\\n    \\\"Sanitize the `id` argument to prevent path traversal.\\\",\\n    \\\"Limit concurrency in `runAll` (e.g., using a worker pool or bounded Promise concurrency) to prevent exhaustion of system resources.\\\"\\n  ]\\n}\",\n  \"stats\": {\n    \"models\": {\n      \"gemini-3.1-pro-preview\": {\n        \"api\": {\n          \"totalRequests\": 1,\n          \"totalErrors\": 0,\n          \"totalLatencyMs\": 31948,\n          \"errorsByType\": {}\n        },\n        \"tokens\": {\n          \"input\": 18314,\n          \"prompt\": 18314,\n          \"candidates\": 761,\n          \"total\": 21833,\n          \"cached\": 0,\n          \"thoughts\": 2758,\n          \"tool\": 0\n        },\n        \"roles\": {\n          \"main\": {\n            \"totalRequests\": 1,\n            \"totalErrors\": 0,\n            \"totalLatencyMs\": 31948,\n            \"tokens\": {\n              \"input\": 18314,\n              \"prompt\": 18314,\n              \"candidates\": 761,\n              \"total\": 21833,\n              \"cached\": 0,\n              \"thoughts\": 2758,\n        "
 }

--- a/bench/cassettes/auth-basic/agy.adversarial.json
+++ b/bench/cassettes/auth-basic/agy.adversarial.json
@@ -1,0 +1,196 @@
+{
+  "caseId": "auth-basic",
+  "cell": "agy.adversarial",
+  "recordedAt": "2026-08-24T11:20:19.462Z",
+  "verdict": "needs-attention",
+  "summary": "Do not ship: this change introduces critical SQL injection, hardcoded cryptographic secrets, and plaintext password verification.",
+  "findings": [
+    {
+      "severity": "critical",
+      "title": "SQL Injection in User Lookup",
+      "body": "The `findUser` function constructs SQL queries using direct string concatenation with untrusted input `username`. An attacker can inject SQL syntax to bypass authentication, extract user records, or alter the query structure.",
+      "file": "src/auth.js",
+      "line_start": 6,
+      "line_end": 11,
+      "confidence": 1,
+      "recommendation": "Use parameterized queries / prepared statements (e.g., `db.query('SELECT * FROM users WHERE name = ?', [username])`) instead of string concatenation."
+    },
+    {
+      "severity": "critical",
+      "title": "Hardcoded JWT Secret",
+      "body": "The JWT signing secret `JWT_SECRET` is embedded directly in the source code as a static string. Anyone with repository access can forge valid authentication tokens for arbitrary user IDs without credentials.",
+      "file": "src/auth.js",
+      "line_start": 4,
+      "line_end": 4,
+      "confidence": 1,
+      "recommendation": "Read the JWT signing key from environment variables or a secret management service (e.g., `process.env.JWT_SECRET`), and fail startup if it is not configured."
+    },
+    {
+      "severity": "high",
+      "title": "Plaintext Password Comparison and Missing User Null Check",
+      "body": "Passwords are verified via loose equality (`==`) against plaintext values rather than using a secure, constant-time password hashing algorithm like bcrypt or argon2. In addition, if `findUser` returns `null` or `undefined` for non-existent users, accessing `user.password` will throw an unhandled TypeError and crash the request.",
+      "file": "src/auth.js",
+      "line_start": 13,
+      "line_end": 19,
+      "confidence": 1,
+      "recommendation": "Check that `user` exists before accessing its properties, store passwords using salted cryptographic hashes, and verify passwords using a constant-time hashing library."
+    },
+    {
+      "severity": "medium",
+      "title": "Unhandled JSON Parse Exception on Invalid Session Input",
+      "body": "`parseSession` invokes `JSON.parse(raw)` without a `try/catch` guard or input type validation. Malformed or unexpected session inputs will throw an unhandled `SyntaxError` and fail the calling context.",
+      "file": "src/auth.js",
+      "line_start": 21,
+      "line_end": 24,
+      "confidence": 0.95,
+      "recommendation": "Wrap `JSON.parse` in a `try/catch` block or validate the session string structure before accessing `session.userId`."
+    }
+  ],
+  "latencyMs": 27272,
+  "engineVersion": "1.1.19",
+  "engineObserved": "agy",
+  "samples": [
+    {
+      "verdict": "needs-attention",
+      "summary": "This change introduces critical security vulnerabilities including SQL injection, plaintext credential comparisons, hardcoded secrets, and missing module dependencies that block production use.",
+      "findings": [
+        {
+          "severity": "critical",
+          "title": "SQL Injection in User Lookup",
+          "body": "The findUser function directly concatenates the username argument into a raw SQL query string. An attacker can supply malicious SQL input to bypass authentication, exfiltrate data, or tamper with database records.",
+          "file": "src/auth.js",
+          "line_start": 6,
+          "line_end": 11,
+          "confidence": 1,
+          "recommendation": "Use parameterized queries or prepared statements (e.g., db.query('SELECT * FROM users WHERE name = ?', [username])) instead of raw string concatenation."
+        },
+        {
+          "severity": "critical",
+          "title": "Plaintext Password Comparison and Unchecked Null User",
+          "body": "The login function accesses user.password without checking if findUser returned null or undefined, causing an unhandled TypeError on invalid usernames. Furthermore, passwords are verified in plaintext using loose equality (==) rather than comparing salted cryptographic hashes with constant-time equality checks.",
+          "file": "src/auth.js",
+          "line_start": 13,
+          "line_end": 19,
+          "confidence": 1,
+          "recommendation": "Check that the user object exists before accessing its properties, hash passwords using bcrypt or argon2, and verify incoming credentials using secure hash comparison routines."
+        },
+        {
+          "severity": "high",
+          "title": "Hardcoded JWT Secret and Indefinitely Valid Tokens",
+          "body": "JWT_SECRET is stored as a plaintext static string in source control, allowing anyone with repository read access to forge valid tokens. Additionally, jwt.sign does not specify an expiration time (exp claim), allowing tokens to remain valid indefinitely if intercepted.",
+          "file": "src/auth.js",
+          "line_start": 4,
+          "line_end": 17,
+          "confidence": 1,
+          "recommendation": "Load the JWT secret key from environment variables or a secret store, and provide token expiration options (e.g., { expiresIn: '1h' })."
+        },
+        {
+          "severity": "high",
+          "title": "Missing db Module and Undeclared Dependencies",
+          "body": "The module requires './db' and 'jsonwebtoken', but 'src/db.js' does not exist in the repository and there is no package.json declaring jsonwebtoken as a dependency, resulting in immediate MODULE_NOT_FOUND runtime crashes upon loading.",
+          "file": "src/auth.js",
+          "line_start": 1,
+          "line_end": 2,
+          "confidence": 0.95,
+          "recommendation": "Provide the database adapter implementation at src/db.js and create a package.json specifying all required runtime dependencies."
+        }
+      ],
+      "latencyMs": 48705
+    },
+    {
+      "verdict": "needs-attention",
+      "summary": "Do not ship: contains critical security vulnerabilities including SQL injection, hardcoded JWT secrets, plaintext password comparison, and unhandled exception crashes.",
+      "findings": [
+        {
+          "severity": "critical",
+          "title": "SQL Injection in findUser via Unsanitized String Concatenation",
+          "body": "The username parameter is concatenated directly into the SQL query string in findUser. An attacker can inject arbitrary SQL payloads (e.g., ' OR '1'='1) to bypass authentication, extract sensitive database contents, or modify records.",
+          "file": "src/auth.js",
+          "line_start": 7,
+          "line_end": 9,
+          "confidence": 1,
+          "recommendation": "Use parameterized queries or prepared statements (e.g., db.query('SELECT * FROM users WHERE name = ?', [username])) instead of raw string concatenation."
+        },
+        {
+          "severity": "high",
+          "title": "Hardcoded JWT Secret and Indefinite Token Lifetime",
+          "body": "JWT_SECRET is defined as a static hardcoded string in the source code, allowing anyone with repository access to forge valid JWT tokens for arbitrary user IDs. Additionally, jwt.sign does not specify an expiration time (expiresIn), issuing tokens that never expire.",
+          "file": "src/auth.js",
+          "line_start": 4,
+          "line_end": 16,
+          "confidence": 1,
+          "recommendation": "Load the secret from a secure environment variable (e.g., process.env.JWT_SECRET) and configure token expiration in jwt.sign (e.g., { expiresIn: '1h' })."
+        },
+        {
+          "severity": "high",
+          "title": "Plaintext Password Comparison and Unchecked Null User Dereference",
+          "body": "Passwords are compared directly in plaintext with loose equality (==), indicating unhashed password storage and potential type coercion risks. Furthermore, if findUser returns null or undefined for an unknown username, accessing user.password will throw an unhandled TypeError and crash the service.",
+          "file": "src/auth.js",
+          "line_start": 14,
+          "line_end": 17,
+          "confidence": 1,
+          "recommendation": "Store and verify password hashes using an algorithm like bcrypt/argon2 (e.g., await bcrypt.compare(password, user.passwordHash)), and verify that user exists before reading properties."
+        },
+        {
+          "severity": "medium",
+          "title": "Unhandled Exception on Malformed JSON in parseSession",
+          "body": "JSON.parse is called without error handling or structure validation. If raw is invalid JSON, an unhandled SyntaxError will crash the request handler. If raw parses to a non-object such as 'null', accessing session.userId will throw a TypeError.",
+          "file": "src/auth.js",
+          "line_start": 21,
+          "line_end": 24,
+          "confidence": 0.95,
+          "recommendation": "Wrap JSON.parse in a try/catch block and ensure the parsed session is a valid object before accessing userId."
+        }
+      ],
+      "latencyMs": 34215
+    },
+    {
+      "verdict": "needs-attention",
+      "summary": "Do not ship: this change introduces critical SQL injection, hardcoded cryptographic secrets, and plaintext password verification.",
+      "findings": [
+        {
+          "severity": "critical",
+          "title": "SQL Injection in User Lookup",
+          "body": "The `findUser` function constructs SQL queries using direct string concatenation with untrusted input `username`. An attacker can inject SQL syntax to bypass authentication, extract user records, or alter the query structure.",
+          "file": "src/auth.js",
+          "line_start": 6,
+          "line_end": 11,
+          "confidence": 1,
+          "recommendation": "Use parameterized queries / prepared statements (e.g., `db.query('SELECT * FROM users WHERE name = ?', [username])`) instead of string concatenation."
+        },
+        {
+          "severity": "critical",
+          "title": "Hardcoded JWT Secret",
+          "body": "The JWT signing secret `JWT_SECRET` is embedded directly in the source code as a static string. Anyone with repository access can forge valid authentication tokens for arbitrary user IDs without credentials.",
+          "file": "src/auth.js",
+          "line_start": 4,
+          "line_end": 4,
+          "confidence": 1,
+          "recommendation": "Read the JWT signing key from environment variables or a secret management service (e.g., `process.env.JWT_SECRET`), and fail startup if it is not configured."
+        },
+        {
+          "severity": "high",
+          "title": "Plaintext Password Comparison and Missing User Null Check",
+          "body": "Passwords are verified via loose equality (`==`) against plaintext values rather than using a secure, constant-time password hashing algorithm like bcrypt or argon2. In addition, if `findUser` returns `null` or `undefined` for non-existent users, accessing `user.password` will throw an unhandled TypeError and crash the request.",
+          "file": "src/auth.js",
+          "line_start": 13,
+          "line_end": 19,
+          "confidence": 1,
+          "recommendation": "Check that `user` exists before accessing its properties, store passwords using salted cryptographic hashes, and verify passwords using a constant-time hashing library."
+        },
+        {
+          "severity": "medium",
+          "title": "Unhandled JSON Parse Exception on Invalid Session Input",
+          "body": "`parseSession` invokes `JSON.parse(raw)` without a `try/catch` guard or input type validation. Malformed or unexpected session inputs will throw an unhandled `SyntaxError` and fail the calling context.",
+          "file": "src/auth.js",
+          "line_start": 21,
+          "line_end": 24,
+          "confidence": 0.95,
+          "recommendation": "Wrap `JSON.parse` in a `try/catch` block or validate the session string structure before accessing `session.userId`."
+        }
+      ],
+      "latencyMs": 27272
+    }
+  ],
+  "raw": "{\n  \"review\": \"Adversarial Review\",\n  \"target\": {\n    \"mode\": \"working-tree\",\n    \"label\": \"working tree diff\",\n    \"explicit\": true\n  },\n  \"engine\": \"agy\",\n  \"gemini\": {\n    \"status\": 0,\n    \"stdout\": \"{\\n  \\\"verdict\\\": \\\"needs-attention\\\",\\n  \\\"summary\\\": \\\"Do not ship: this change introduces critical SQL injection, hardcoded cryptographic secrets, and plaintext password verification.\\\",\\n  \\\"findings\\\": [\\n    {\\n      \\\"severity\\\": \\\"critical\\\",\\n      \\\"title\\\": \\\"SQL Injection in User Lookup\\\",\\n      \\\"body\\\": \\\"The `findUser` function constructs SQL queries using direct string concatenation with untrusted input `username`. An attacker can inject SQL syntax to bypass authentication, extract user records, or alter the query structure.\\\",\\n      \\\"file\\\": \\\"src/auth.js\\\",\\n      \\\"line_start\\\": 6,\\n      \\\"line_end\\\": 11,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Use parameterized queries / prepared statements (e.g., `db.query('SELECT * FROM users WHERE name = ?', [username])`) instead of string concatenation.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"critical\\\",\\n      \\\"title\\\": \\\"Hardcoded JWT Secret\\\",\\n      \\\"body\\\": \\\"The JWT signing secret `JWT_SECRET` is embedded directly in the source code as a static string. Anyone with repository access can forge valid authentication tokens for arbitrary user IDs without credentials.\\\",\\n      \\\"file\\\": \\\"src/auth.js\\\",\\n      \\\"line_start\\\": 4,\\n      \\\"line_end\\\": 4,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Read the JWT signing key from environment variables or a secret management service (e.g., `process.env.JWT_SECRET`), and fail startup if it is not configured.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"high\\\",\\n      \\\"title\\\": \\\"Plaintext Password Comparison and Missing User Null Check\\\",\\n      \\\"body\\\": \\\"Passwords are verified via loose equality (`==`) against plaintext values rather than using a secure, constant-time password hashing algorithm like bcrypt or argon2. In addition, if `findUser` returns `null` or `undefined` for non-existent users, accessing `user.password` will throw an unhandled TypeError and crash the request.\\\",\\n      \\\"file\\\": \\\"src/auth.js\\\",\\n      \\\"line_start\\\": 13,\\n      \\\"line_end\\\": 19,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Check that `user` exists before accessing its properties, store passwords using salted cryptographic hashes, and verify passwords using a constant-time hashing library.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"medium\\\",\\n      \\\"title\\\": \\\"Unhandled JSON Parse Exception on Invalid Session Input\\\",\\n      \\\"body\\\": \\\"`parseSession` invokes `JSON.parse(raw)` without a `try/catch` guard or input type validation. Malformed or unexpected session inputs will throw an unhandled `SyntaxError` and fail the calling context.\\\",\\n      \\\"file\\\": \\\"src/auth.js\\\",\\n      \\\"line_start\\\": 21,\\n      \\\"line_end\\\": 24,\\n      \\\"confidence\\\": 0.95,\\n      \\\"recommendation\\\": \\\"Wrap `JSON.parse` in a `try/catch` block or validate the session string structure before accessing `session.userId`.\\\"\\n    }\\n  ],\\n  \\\"next_steps\\\": [\\n    \\\"Refactor `findUser` to use parameterized queries.\\\",\\n    \\\"Replace hardcoded `JWT_SECRET` with environment configuration.\\\",\\n    \\\"Introduce cryptographic password hashing and guard against non-existent user lookups.\\\",\\n    \\\"Add error handling in `parseSession` for invalid JSON payloads.\\\"\\n  ]\\n}\",\n    \"stderr\": \"\"\n  },\n  \"result\": {\n    \"verdict\": \"needs-attention\",\n    \"summary\": \"Do not ship: this change introduces critical SQL injection, hardcoded cryptographic secrets, and plaintext password verification.\",\n    \"findings\": [\n      {\n        \"severity\": \"critical\",\n        \"title\": \"SQL Injection in User Lookup\",\n        \"body\": \"The `findUser` function constructs SQL queries using direct string concatenation with untrusted input `username`. An attacker can inject SQL syntax to bypass authentication, extract user records, or alter the query structure.\",\n   "
+}

--- a/bench/cassettes/auth-basic/agy.deep.json
+++ b/bench/cassettes/auth-basic/agy.deep.json
@@ -1,245 +1,236 @@
 {
   "caseId": "auth-basic",
   "cell": "agy.deep",
-  "recordedAt": "2026-08-19T03:18:29.495Z",
+  "recordedAt": "2026-08-24T09:44:50.204Z",
   "verdict": "needs-attention",
-  "summary": "The authentication module contains critical security vulnerabilities including SQL injection and hardcoded secrets, as well as unhandled runtime errors and missing dependencies.",
+  "summary": "Authentication module contains critical SQL injection, unhandled null references, plaintext password verification, and hardcoded secrets.",
   "findings": [
     {
       "severity": "critical",
-      "title": "SQL Injection in findUser",
-      "body": "The findUser function concatenates the username argument directly into the SQL query string without parameterization or escaping. An attacker can inject arbitrary SQL commands to manipulate queries or bypass authentication.",
+      "title": "SQL Injection in User Lookup",
+      "body": "The username input is directly concatenated into the SQL query in findUser without sanitization or parameterization, allowing arbitrary SQL injection attacks.",
       "file": "src/auth.js",
       "line_start": 7,
       "line_end": 9,
       "confidence": 1,
-      "recommendation": "Use parameterized queries or prepared statements (e.g. db.query('SELECT * FROM users WHERE name = $1', [username]))."
+      "recommendation": "Use parameterized queries or prepared statements (e.g., db.query('SELECT * FROM users WHERE name = ?', [username]))."
     },
     {
       "severity": "high",
-      "title": "Unchecked user lookup result causes unhandled TypeError",
-      "body": "If findUser returns null, undefined, or an empty result for a non-existent user, login accesses user.password directly, throwing an unhandled TypeError that crashes the request.",
+      "title": "Unhandled Null Pointer on Non-Existent User",
+      "body": "When findUser returns null or undefined for an unknown user, accessing user.password in login throws an unhandled TypeError.",
       "file": "src/auth.js",
       "line_start": 14,
-      "line_end": 17,
+      "line_end": 15,
       "confidence": 1,
-      "recommendation": "Check that the user object exists before reading properties (e.g. if (!user || !user.password) return null;)."
+      "recommendation": "Add a null check before accessing user properties (e.g., if (!user || !user.password) return null;)."
     },
     {
       "severity": "high",
-      "title": "Plaintext password comparison using loose equality",
-      "body": "Passwords are evaluated using loose equality (==) against plaintext values without hashing or constant-time comparison, creating serious credential exposure and timing attack risks.",
+      "title": "Plaintext Password Comparison",
+      "body": "Passwords are verified using plaintext loose equality (==) rather than comparing salted cryptographic hashes with constant-time equality checks.",
       "file": "src/auth.js",
       "line_start": 15,
       "line_end": 15,
       "confidence": 1,
-      "recommendation": "Store passwords as salted hashes and verify them using a secure hashing library such as bcrypt (e.g. await bcrypt.compare(password, user.password))."
+      "recommendation": "Use a secure password hashing library like bcrypt or argon2 to verify password hashes."
     },
     {
       "severity": "high",
-      "title": "Hardcoded JWT secret key",
-      "body": "JWT_SECRET is hardcoded in plaintext source code, exposing signing credentials and allowing unauthorized token generation if the repository is accessible.",
+      "title": "Hardcoded JWT Secret",
+      "body": "The JWT signing secret is hardcoded in source code, which risks credential exposure and allows unauthorized token generation if the codebase is leaked.",
       "file": "src/auth.js",
       "line_start": 4,
       "line_end": 4,
       "confidence": 1,
-      "recommendation": "Retrieve the JWT secret from environment variables (e.g. process.env.JWT_SECRET) or a secret manager."
-    },
-    {
-      "severity": "high",
-      "title": "Missing local database module dependency",
-      "body": "src/auth.js requires './db', but no corresponding db module or file exists in the repository, causing a runtime MODULE_NOT_FOUND error on load.",
-      "file": "src/auth.js",
-      "line_start": 2,
-      "line_end": 2,
-      "confidence": 0.95,
-      "recommendation": "Provide the database module at src/db.js or update the import path to the correct module."
+      "recommendation": "Retrieve the JWT secret from environment variables (e.g., process.env.JWT_SECRET) or a secrets manager."
     },
     {
       "severity": "medium",
-      "title": "Uncaught JSON.parse exception in parseSession",
-      "body": "parseSession executes JSON.parse on raw input without error handling, throwing an unhandled SyntaxError whenever malformed or invalid JSON is passed.",
+      "title": "Uncaught SyntaxError in Session Parsing",
+      "body": "JSON.parse(raw) throws an unhandled SyntaxError when provided malformed input, and will throw a TypeError accessing userId if raw parses to null.",
       "file": "src/auth.js",
       "line_start": 21,
       "line_end": 24,
       "confidence": 0.95,
-      "recommendation": "Wrap JSON.parse in a try-catch block and return null or handle errors gracefully on invalid input."
+      "recommendation": "Wrap JSON.parse in a try/catch block and verify the parsed result is a non-null object before accessing userId."
     }
   ],
-  "latencyMs": 40058,
-  "engineVersion": "1.1.14",
+  "latencyMs": 44433,
+  "engineVersion": "1.1.19",
+  "engineObserved": "agy",
   "samples": [
     {
       "verdict": "needs-attention",
-      "summary": "Authentication module contains critical security vulnerabilities including SQL injection, hardcoded secrets, and unsafe password comparison.",
+      "summary": "The authentication module contains a critical SQL injection vulnerability, hardcoded secrets, missing null checks on user lookup, and missing dependencies.",
       "findings": [
         {
           "severity": "critical",
-          "title": "SQL injection vulnerability via raw string concatenation",
-          "body": "findUser concatenates the username argument directly into the SQL query string passed to db.query, allowing arbitrary SQL injection and database compromise.",
+          "title": "SQL injection via string concatenation in findUser",
+          "body": "In findUser(), the username parameter is directly concatenated into the SQL query string without sanitization or parameterization. An attacker can supply SQL payloads to bypass authentication or extract/modify database records.",
           "file": "src/auth.js",
           "line_start": 7,
           "line_end": 9,
           "confidence": 1,
-          "recommendation": "Use parameterized queries (e.g., db.query('SELECT * FROM users WHERE name = ?', [username])) to safely pass user input."
+          "recommendation": "Use parameterized queries or prepared statements supported by your database client (e.g., db.query('SELECT * FROM users WHERE name = ?', [username]))."
         },
         {
           "severity": "high",
-          "title": "Missing null check on user lookup and plaintext password comparison",
-          "body": "login attempts property access user.password without checking if findUser returned null/undefined, causing an unhandled TypeError crash; furthermore, passwords are evaluated in plaintext using loose equality ==.",
-          "file": "src/auth.js",
-          "line_start": 14,
-          "line_end": 17,
-          "confidence": 1,
-          "recommendation": "Check that user is non-null before accessing properties and compare hashed passwords using a secure library such as bcrypt."
-        },
-        {
-          "severity": "high",
-          "title": "Hardcoded JWT secret key in source code",
-          "body": "JWT_SECRET is defined as a static literal in source code, exposing cryptographic signing credentials and enabling token forgery.",
-          "file": "src/auth.js",
-          "line_start": 4,
-          "line_end": 4,
-          "confidence": 1,
-          "recommendation": "Read the secret from environment variables (e.g., process.env.JWT_SECRET) with runtime validation."
-        },
-        {
-          "severity": "medium",
-          "title": "Uncaught exception on invalid JSON in parseSession",
-          "body": "parseSession calls JSON.parse on raw without error handling, which will throw an unhandled SyntaxError on malformed input or a TypeError if parsed to null.",
-          "file": "src/auth.js",
-          "line_start": 21,
-          "line_end": 24,
-          "confidence": 0.95,
-          "recommendation": "Wrap JSON.parse in a try-catch block and validate the parsed output before accessing session.userId."
-        }
-      ],
-      "latencyMs": 36783
-    },
-    {
-      "verdict": "needs-attention",
-      "summary": "Authentication module contains critical SQL injection, unhandled null references, hardcoded secrets, missing error handling, and broken module imports.",
-      "findings": [
-        {
-          "severity": "critical",
-          "title": "SQL injection in findUser query",
-          "body": "The username argument is concatenated directly into the raw SQL query in findUser, allowing SQL injection. An attacker can manipulate query syntax to bypass authentication or extract sensitive data.",
-          "file": "src/auth.js",
-          "line_start": 7,
-          "line_end": 9,
-          "confidence": 1,
-          "recommendation": "Use parameterized queries or prepared statements (e.g. `db.query('SELECT * FROM users WHERE name = ?', [username])`) instead of string concatenation."
-        },
-        {
-          "severity": "high",
-          "title": "Unhandled null user in login",
-          "body": "login accesses user.password directly without verifying that findUser returned a valid user object. If a user is not found, this throws an unhandled TypeError: Cannot read properties of null/undefined.",
+          "title": "Uncaught TypeError on user lookup failure in login",
+          "body": "In login(), findUser(username) is called and user.password is accessed directly without verifying if user exists. If no matching user is returned (null/undefined), accessing user.password throws an unhandled TypeError.",
           "file": "src/auth.js",
           "line_start": 14,
           "line_end": 18,
           "confidence": 1,
-          "recommendation": "Check that user is non-null before accessing user.password (e.g. `if (!user || user.password !== password) return null;`) and use secure password hashing comparisons."
-        },
-        {
-          "severity": "high",
-          "title": "Hardcoded JWT secret",
-          "body": "JWT_SECRET is hardcoded in source code. If deployed, tokens can be forged by anyone with access to the codebase.",
-          "file": "src/auth.js",
-          "line_start": 4,
-          "line_end": 4,
-          "confidence": 0.95,
-          "recommendation": "Load JWT_SECRET from environment variables (e.g. `process.env.JWT_SECRET`) and fail fast if the environment variable is not defined."
-        },
-        {
-          "severity": "high",
-          "title": "Missing db module dependency and package.json manifest",
-          "body": "src/auth.js requires './db' which does not exist in the repository, and requires 'jsonwebtoken' without a package.json manifest declaring the dependency. Requiring this module will throw MODULE_NOT_FOUND at runtime.",
-          "file": "src/auth.js",
-          "line_start": 1,
-          "line_end": 2,
-          "confidence": 0.95,
-          "recommendation": "Implement the missing './db' module and add a package.json declaring required dependencies."
-        },
-        {
-          "severity": "medium",
-          "title": "Unhandled JSON parse error in parseSession",
-          "body": "parseSession calls JSON.parse(raw) without error handling and directly dereferences session.userId. Malformed JSON will throw an uncaught SyntaxError.",
-          "file": "src/auth.js",
-          "line_start": 21,
-          "line_end": 24,
-          "confidence": 0.9,
-          "recommendation": "Wrap JSON.parse in a try-catch block and validate the resulting session object before returning userId."
-        }
-      ],
-      "latencyMs": 36027
-    },
-    {
-      "verdict": "needs-attention",
-      "summary": "The authentication module contains critical security vulnerabilities including SQL injection and hardcoded secrets, as well as unhandled runtime errors and missing dependencies.",
-      "findings": [
-        {
-          "severity": "critical",
-          "title": "SQL Injection in findUser",
-          "body": "The findUser function concatenates the username argument directly into the SQL query string without parameterization or escaping. An attacker can inject arbitrary SQL commands to manipulate queries or bypass authentication.",
-          "file": "src/auth.js",
-          "line_start": 7,
-          "line_end": 9,
-          "confidence": 1,
-          "recommendation": "Use parameterized queries or prepared statements (e.g. db.query('SELECT * FROM users WHERE name = $1', [username]))."
-        },
-        {
-          "severity": "high",
-          "title": "Unchecked user lookup result causes unhandled TypeError",
-          "body": "If findUser returns null, undefined, or an empty result for a non-existent user, login accesses user.password directly, throwing an unhandled TypeError that crashes the request.",
-          "file": "src/auth.js",
-          "line_start": 14,
-          "line_end": 17,
-          "confidence": 1,
-          "recommendation": "Check that the user object exists before reading properties (e.g. if (!user || !user.password) return null;)."
-        },
-        {
-          "severity": "high",
-          "title": "Plaintext password comparison using loose equality",
-          "body": "Passwords are evaluated using loose equality (==) against plaintext values without hashing or constant-time comparison, creating serious credential exposure and timing attack risks.",
-          "file": "src/auth.js",
-          "line_start": 15,
-          "line_end": 15,
-          "confidence": 1,
-          "recommendation": "Store passwords as salted hashes and verify them using a secure hashing library such as bcrypt (e.g. await bcrypt.compare(password, user.password))."
+          "recommendation": "Check that user is non-null before accessing user.password (e.g., if (user && user.password === password))."
         },
         {
           "severity": "high",
           "title": "Hardcoded JWT secret key",
-          "body": "JWT_SECRET is hardcoded in plaintext source code, exposing signing credentials and allowing unauthorized token generation if the repository is accessible.",
+          "body": "The secret key used to sign JWT tokens is hardcoded as a plain string in source code. Anyone with access to the codebase can sign valid JWTs and impersonate arbitrary users.",
           "file": "src/auth.js",
           "line_start": 4,
           "line_end": 4,
           "confidence": 1,
-          "recommendation": "Retrieve the JWT secret from environment variables (e.g. process.env.JWT_SECRET) or a secret manager."
+          "recommendation": "Load the JWT secret from an environment variable (e.g., process.env.JWT_SECRET) and throw an error at startup if it is not configured."
         },
         {
           "severity": "high",
-          "title": "Missing local database module dependency",
-          "body": "src/auth.js requires './db', but no corresponding db module or file exists in the repository, causing a runtime MODULE_NOT_FOUND error on load.",
+          "title": "Missing local module './db' and undeclared dependencies",
+          "body": "The file requires './db' which does not exist in the repository, and imports 'jsonwebtoken' without a package.json manifest defining the dependency, leading to MODULE_NOT_FOUND runtime errors.",
           "file": "src/auth.js",
-          "line_start": 2,
+          "line_start": 1,
           "line_end": 2,
-          "confidence": 0.95,
-          "recommendation": "Provide the database module at src/db.js or update the import path to the correct module."
+          "confidence": 1,
+          "recommendation": "Implement the missing db module at src/db.js and create a package.json file declaring jsonwebtoken."
         },
         {
           "severity": "medium",
-          "title": "Uncaught JSON.parse exception in parseSession",
-          "body": "parseSession executes JSON.parse on raw input without error handling, throwing an unhandled SyntaxError whenever malformed or invalid JSON is passed.",
+          "title": "Unhandled exception in parseSession on malformed input",
+          "body": "parseSession passes the raw parameter directly into JSON.parse without error handling. Invalid JSON or undefined/non-string inputs will throw an unhandled SyntaxError/TypeError.",
           "file": "src/auth.js",
           "line_start": 21,
           "line_end": 24,
           "confidence": 0.95,
-          "recommendation": "Wrap JSON.parse in a try-catch block and return null or handle errors gracefully on invalid input."
+          "recommendation": "Wrap JSON.parse in a try/catch block and validate the parsed object before returning userId."
         }
       ],
-      "latencyMs": 40058
+      "latencyMs": 41031
+    },
+    {
+      "verdict": "needs-attention",
+      "summary": "The authentication module contains critical SQL injection, missing module dependencies, hardcoded secrets, and unhandled runtime exceptions.",
+      "findings": [
+        {
+          "severity": "critical",
+          "title": "SQL injection in user lookup query",
+          "body": "In findUser, username is directly concatenated into the SQL query string without parameterization or escaping. This allows attackers to manipulate the SQL statement, bypass authentication, and access unauthorized data.",
+          "file": "src/auth.js",
+          "line_start": 7,
+          "line_end": 9,
+          "confidence": 1,
+          "recommendation": "Use parameterized queries or prepared statements (e.g., db.query('SELECT * FROM users WHERE name = ?', [username]))."
+        },
+        {
+          "severity": "high",
+          "title": "Missing ./db module dependency",
+          "body": "src/auth.js requires './db', but no corresponding db.js file exists in the repository, resulting in a MODULE_NOT_FOUND error when the module is imported.",
+          "file": "src/auth.js",
+          "line_start": 2,
+          "line_end": 2,
+          "confidence": 0.95,
+          "recommendation": "Provide the missing ./db module and configure a package.json declaring jsonwebtoken and other dependencies."
+        },
+        {
+          "severity": "high",
+          "title": "Unchecked user lookup result causes TypeError",
+          "body": "In login, if findUser returns null or undefined when a user is not found, evaluating user.password throws an unhandled TypeError.",
+          "file": "src/auth.js",
+          "line_start": 14,
+          "line_end": 16,
+          "confidence": 0.95,
+          "recommendation": "Verify that user exists before checking credentials (e.g., if (user && user.password === password))."
+        },
+        {
+          "severity": "high",
+          "title": "Hardcoded JWT secret and plaintext password verification",
+          "body": "The JWT signing secret is hardcoded directly in source code, and passwords are authenticated via plain equality comparison rather than using a secure cryptographic hashing function like bcrypt.",
+          "file": "src/auth.js",
+          "line_start": 4,
+          "line_end": 16,
+          "confidence": 0.95,
+          "recommendation": "Load secrets from environment variables (process.env.JWT_SECRET) and use a secure hashing algorithm (such as bcrypt) for password verification."
+        },
+        {
+          "severity": "medium",
+          "title": "Unhandled JSON.parse exception on malformed input",
+          "body": "parseSession calls JSON.parse on raw input without error handling, which will throw an unhandled SyntaxError and crash the caller on malformed strings.",
+          "file": "src/auth.js",
+          "line_start": 21,
+          "line_end": 24,
+          "confidence": 0.9,
+          "recommendation": "Wrap JSON.parse in a try-catch block and return null or handle malformed input gracefully."
+        }
+      ],
+      "latencyMs": 43819
+    },
+    {
+      "verdict": "needs-attention",
+      "summary": "Authentication module contains critical SQL injection, unhandled null references, plaintext password verification, and hardcoded secrets.",
+      "findings": [
+        {
+          "severity": "critical",
+          "title": "SQL Injection in User Lookup",
+          "body": "The username input is directly concatenated into the SQL query in findUser without sanitization or parameterization, allowing arbitrary SQL injection attacks.",
+          "file": "src/auth.js",
+          "line_start": 7,
+          "line_end": 9,
+          "confidence": 1,
+          "recommendation": "Use parameterized queries or prepared statements (e.g., db.query('SELECT * FROM users WHERE name = ?', [username]))."
+        },
+        {
+          "severity": "high",
+          "title": "Unhandled Null Pointer on Non-Existent User",
+          "body": "When findUser returns null or undefined for an unknown user, accessing user.password in login throws an unhandled TypeError.",
+          "file": "src/auth.js",
+          "line_start": 14,
+          "line_end": 15,
+          "confidence": 1,
+          "recommendation": "Add a null check before accessing user properties (e.g., if (!user || !user.password) return null;)."
+        },
+        {
+          "severity": "high",
+          "title": "Plaintext Password Comparison",
+          "body": "Passwords are verified using plaintext loose equality (==) rather than comparing salted cryptographic hashes with constant-time equality checks.",
+          "file": "src/auth.js",
+          "line_start": 15,
+          "line_end": 15,
+          "confidence": 1,
+          "recommendation": "Use a secure password hashing library like bcrypt or argon2 to verify password hashes."
+        },
+        {
+          "severity": "high",
+          "title": "Hardcoded JWT Secret",
+          "body": "The JWT signing secret is hardcoded in source code, which risks credential exposure and allows unauthorized token generation if the codebase is leaked.",
+          "file": "src/auth.js",
+          "line_start": 4,
+          "line_end": 4,
+          "confidence": 1,
+          "recommendation": "Retrieve the JWT secret from environment variables (e.g., process.env.JWT_SECRET) or a secrets manager."
+        },
+        {
+          "severity": "medium",
+          "title": "Uncaught SyntaxError in Session Parsing",
+          "body": "JSON.parse(raw) throws an unhandled SyntaxError when provided malformed input, and will throw a TypeError accessing userId if raw parses to null.",
+          "file": "src/auth.js",
+          "line_start": 21,
+          "line_end": 24,
+          "confidence": 0.95,
+          "recommendation": "Wrap JSON.parse in a try/catch block and verify the parsed result is a non-null object before accessing userId."
+        }
+      ],
+      "latencyMs": 44433
     }
   ],
-  "raw": "{\n  \"review\": \"Review\",\n  \"target\": {\n    \"mode\": \"working-tree\",\n    \"label\": \"working tree diff\",\n    \"explicit\": true\n  },\n  \"gemini\": {\n    \"status\": 0,\n    \"stdout\": \"{\\n  \\\"verdict\\\": \\\"needs-attention\\\",\\n  \\\"summary\\\": \\\"The authentication module contains critical security vulnerabilities including SQL injection and hardcoded secrets, as well as unhandled runtime errors and missing dependencies.\\\",\\n  \\\"findings\\\": [\\n    {\\n      \\\"severity\\\": \\\"critical\\\",\\n      \\\"title\\\": \\\"SQL Injection in findUser\\\",\\n      \\\"body\\\": \\\"The findUser function concatenates the username argument directly into the SQL query string without parameterization or escaping. An attacker can inject arbitrary SQL commands to manipulate queries or bypass authentication.\\\",\\n      \\\"file\\\": \\\"src/auth.js\\\",\\n      \\\"line_start\\\": 7,\\n      \\\"line_end\\\": 9,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Use parameterized queries or prepared statements (e.g. db.query('SELECT * FROM users WHERE name = $1', [username])).\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"high\\\",\\n      \\\"title\\\": \\\"Unchecked user lookup result causes unhandled TypeError\\\",\\n      \\\"body\\\": \\\"If findUser returns null, undefined, or an empty result for a non-existent user, login accesses user.password directly, throwing an unhandled TypeError that crashes the request.\\\",\\n      \\\"file\\\": \\\"src/auth.js\\\",\\n      \\\"line_start\\\": 14,\\n      \\\"line_end\\\": 17,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Check that the user object exists before reading properties (e.g. if (!user || !user.password) return null;).\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"high\\\",\\n      \\\"title\\\": \\\"Plaintext password comparison using loose equality\\\",\\n      \\\"body\\\": \\\"Passwords are evaluated using loose equality (==) against plaintext values without hashing or constant-time comparison, creating serious credential exposure and timing attack risks.\\\",\\n      \\\"file\\\": \\\"src/auth.js\\\",\\n      \\\"line_start\\\": 15,\\n      \\\"line_end\\\": 15,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Store passwords as salted hashes and verify them using a secure hashing library such as bcrypt (e.g. await bcrypt.compare(password, user.password)).\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"high\\\",\\n      \\\"title\\\": \\\"Hardcoded JWT secret key\\\",\\n      \\\"body\\\": \\\"JWT_SECRET is hardcoded in plaintext source code, exposing signing credentials and allowing unauthorized token generation if the repository is accessible.\\\",\\n      \\\"file\\\": \\\"src/auth.js\\\",\\n      \\\"line_start\\\": 4,\\n      \\\"line_end\\\": 4,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Retrieve the JWT secret from environment variables (e.g. process.env.JWT_SECRET) or a secret manager.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"high\\\",\\n      \\\"title\\\": \\\"Missing local database module dependency\\\",\\n      \\\"body\\\": \\\"src/auth.js requires './db', but no corresponding db module or file exists in the repository, causing a runtime MODULE_NOT_FOUND error on load.\\\",\\n      \\\"file\\\": \\\"src/auth.js\\\",\\n      \\\"line_start\\\": 2,\\n      \\\"line_end\\\": 2,\\n      \\\"confidence\\\": 0.95,\\n      \\\"recommendation\\\": \\\"Provide the database module at src/db.js or update the import path to the correct module.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"medium\\\",\\n      \\\"title\\\": \\\"Uncaught JSON.parse exception in parseSession\\\",\\n      \\\"body\\\": \\\"parseSession executes JSON.parse on raw input without error handling, throwing an unhandled SyntaxError whenever malformed or invalid JSON is passed.\\\",\\n      \\\"file\\\": \\\"src/auth.js\\\",\\n      \\\"line_start\\\": 21,\\n      \\\"line_end\\\": 24,\\n      \\\"confidence\\\": 0.95,\\n      \\\"recommendation\\\": \\\"Wrap JSON.parse in a try-catch block and return null or handle errors gracefully on invalid input.\\\"\\n    }\\n  ],\\n  \\\"next_steps\\\": [\\n    \\\"Refactor findUser to use parameterized SQL queries.\\\",\\n    \\\"Add null checks on the user lookup in login and adopt cryptographic password hashing.\\\",\\n    \\\"Move JWT_SECRET t"
+  "raw": "{\n  \"review\": \"Review\",\n  \"target\": {\n    \"mode\": \"working-tree\",\n    \"label\": \"working tree diff\",\n    \"explicit\": true\n  },\n  \"engine\": \"agy\",\n  \"gemini\": {\n    \"status\": 0,\n    \"stdout\": \"{\\n  \\\"verdict\\\": \\\"needs-attention\\\",\\n  \\\"summary\\\": \\\"Authentication module contains critical SQL injection, unhandled null references, plaintext password verification, and hardcoded secrets.\\\",\\n  \\\"findings\\\": [\\n    {\\n      \\\"severity\\\": \\\"critical\\\",\\n      \\\"title\\\": \\\"SQL Injection in User Lookup\\\",\\n      \\\"body\\\": \\\"The username input is directly concatenated into the SQL query in findUser without sanitization or parameterization, allowing arbitrary SQL injection attacks.\\\",\\n      \\\"file\\\": \\\"src/auth.js\\\",\\n      \\\"line_start\\\": 7,\\n      \\\"line_end\\\": 9,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Use parameterized queries or prepared statements (e.g., db.query('SELECT * FROM users WHERE name = ?', [username])).\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"high\\\",\\n      \\\"title\\\": \\\"Unhandled Null Pointer on Non-Existent User\\\",\\n      \\\"body\\\": \\\"When findUser returns null or undefined for an unknown user, accessing user.password in login throws an unhandled TypeError.\\\",\\n      \\\"file\\\": \\\"src/auth.js\\\",\\n      \\\"line_start\\\": 14,\\n      \\\"line_end\\\": 15,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Add a null check before accessing user properties (e.g., if (!user || !user.password) return null;).\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"high\\\",\\n      \\\"title\\\": \\\"Plaintext Password Comparison\\\",\\n      \\\"body\\\": \\\"Passwords are verified using plaintext loose equality (==) rather than comparing salted cryptographic hashes with constant-time equality checks.\\\",\\n      \\\"file\\\": \\\"src/auth.js\\\",\\n      \\\"line_start\\\": 15,\\n      \\\"line_end\\\": 15,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Use a secure password hashing library like bcrypt or argon2 to verify password hashes.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"high\\\",\\n      \\\"title\\\": \\\"Hardcoded JWT Secret\\\",\\n      \\\"body\\\": \\\"The JWT signing secret is hardcoded in source code, which risks credential exposure and allows unauthorized token generation if the codebase is leaked.\\\",\\n      \\\"file\\\": \\\"src/auth.js\\\",\\n      \\\"line_start\\\": 4,\\n      \\\"line_end\\\": 4,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Retrieve the JWT secret from environment variables (e.g., process.env.JWT_SECRET) or a secrets manager.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"medium\\\",\\n      \\\"title\\\": \\\"Uncaught SyntaxError in Session Parsing\\\",\\n      \\\"body\\\": \\\"JSON.parse(raw) throws an unhandled SyntaxError when provided malformed input, and will throw a TypeError accessing userId if raw parses to null.\\\",\\n      \\\"file\\\": \\\"src/auth.js\\\",\\n      \\\"line_start\\\": 21,\\n      \\\"line_end\\\": 24,\\n      \\\"confidence\\\": 0.95,\\n      \\\"recommendation\\\": \\\"Wrap JSON.parse in a try/catch block and verify the parsed result is a non-null object before accessing userId.\\\"\\n    }\\n  ],\\n  \\\"next_steps\\\": [\\n    \\\"Refactor findUser to use parameterized SQL queries\\\",\\n    \\\"Add existence validation for user lookup in login\\\",\\n    \\\"Integrate a secure password hashing library for password verification\\\",\\n    \\\"Move JWT_SECRET to environment configuration\\\",\\n    \\\"Add error handling to parseSession for malformed or null JSON payloads\\\"\\n  ]\\n}\",\n    \"stderr\": \"\"\n  },\n  \"result\": {\n    \"verdict\": \"needs-attention\",\n    \"summary\": \"Authentication module contains critical SQL injection, unhandled null references, plaintext password verification, and hardcoded secrets.\",\n    \"findings\": [\n      {\n        \"severity\": \"critical\",\n        \"title\": \"SQL Injection in User Lookup\",\n        \"body\": \"The username input is directly concatenated into the SQL query in findUser without sanitization or parameterization, allowing arbitrary SQL injection attacks.\",\n        \"file\": \"src/auth.js\",\n        \"line_start\": 7,\n        \"line_end\": 9,\n        \"confidence\": 1,\n        \"r"
 }

--- a/bench/cassettes/auth-basic/agy.model.json
+++ b/bench/cassettes/auth-basic/agy.model.json
@@ -1,205 +1,236 @@
 {
   "caseId": "auth-basic",
   "cell": "agy.model",
-  "recordedAt": "2026-08-19T03:14:53.863Z",
+  "recordedAt": "2026-08-24T04:59:48.337Z",
   "verdict": "needs-attention",
-  "summary": "The authentication module contains critical vulnerabilities including SQL injection, hardcoded secrets, plaintext password comparison, and missing null/exception handling.",
+  "summary": "Auth module contains SQL injection, a hardcoded secret, plaintext password comparison, and unguarded parsing.",
   "findings": [
     {
       "severity": "critical",
-      "title": "SQL Injection in findUser",
-      "body": "User input is directly concatenated into the SQL query string in findUser, allowing arbitrary SQL execution and authentication bypass.",
+      "title": "SQL injection in findUser",
+      "body": "The username is concatenated directly into the SQL query string without parameterisation. An attacker can supply a crafted username (e.g. `' OR '1'='1' --`) to bypass authentication, exfiltrate data, or modify the database.",
       "file": "src/auth.js",
       "line_start": 7,
       "line_end": 9,
       "confidence": 1,
-      "recommendation": "Use parameterized queries or prepared statements (e.g. db.query('SELECT * FROM users WHERE name = $1', [username])) instead of string concatenation."
+      "recommendation": "Use a parameterised query: `db.query(\"SELECT * FROM users WHERE name = $1\", [username])` (or the equivalent placeholder syntax for your driver)."
     },
     {
       "severity": "critical",
-      "title": "Plaintext Password Comparison and Potential Null Dereference",
-      "body": "Passwords are verified via loose equality against unhashed values without constant-time comparison. Additionally, if findUser returns null or undefined for non-existent users, accessing user.password will throw an unhandled TypeError.",
-      "file": "src/auth.js",
-      "line_start": 14,
-      "line_end": 17,
-      "confidence": 1,
-      "recommendation": "Check if user exists before accessing properties, store password hashes using a secure algorithm such as argon2 or bcrypt, and verify using timing-safe comparison functions."
-    },
-    {
-      "severity": "high",
-      "title": "Hardcoded JWT Secret",
-      "body": "The JWT signing secret is hardcoded in source code, exposing cryptographic keys if the repository is shared or accessed.",
+      "title": "Hardcoded JWT secret",
+      "body": "JWT_SECRET is a plaintext string committed to source. Anyone with repository access can forge valid tokens for any user, completely bypassing authentication.",
       "file": "src/auth.js",
       "line_start": 4,
       "line_end": 4,
       "confidence": 1,
-      "recommendation": "Load the JWT secret from environment variables or a secure key management system (e.g. process.env.JWT_SECRET)."
+      "recommendation": "Load the secret from an environment variable or a secrets manager (e.g. `process.env.JWT_SECRET`) and fail fast if it is missing."
+    },
+    {
+      "severity": "high",
+      "title": "Plaintext password comparison with loose equality",
+      "body": "`user.password == password` implies passwords are stored and compared in plaintext, and uses `==` which performs type coercion. Passwords should be hashed; even if they were, timing-safe comparison is required to prevent timing attacks.",
+      "file": "src/auth.js",
+      "line_start": 15,
+      "line_end": 15,
+      "confidence": 0.95,
+      "recommendation": "Store passwords hashed (e.g. bcrypt) and compare with `bcrypt.compare(password, user.password)`. At minimum use `===` and a constant-time comparison."
+    },
+    {
+      "severity": "high",
+      "title": "No null/undefined check on user before property access",
+      "body": "If `findUser` returns `undefined` or an empty result set, accessing `user.password` on line 15 will throw a TypeError, crashing the request. There is no error handling for a non-existent user.",
+      "file": "src/auth.js",
+      "line_start": 14,
+      "line_end": 15,
+      "confidence": 0.95,
+      "recommendation": "Guard with `if (!user) return null;` before accessing `user.password`."
     },
     {
       "severity": "medium",
-      "title": "Unhandled JSON.parse Exception in parseSession",
-      "body": "Calling JSON.parse directly on raw input without error handling will crash the execution context if invalid JSON is provided.",
+      "title": "parseSession throws on invalid input",
+      "body": "`JSON.parse(raw)` will throw a SyntaxError if `raw` is not valid JSON, and accessing `.userId` on the result will throw if the key is absent. There is no try/catch or validation.",
       "file": "src/auth.js",
-      "line_start": 21,
-      "line_end": 24,
-      "confidence": 0.95,
-      "recommendation": "Wrap JSON.parse in a try-catch block to handle malformed input gracefully and validate session object structure."
+      "line_start": 22,
+      "line_end": 23,
+      "confidence": 0.9,
+      "recommendation": "Wrap in a try/catch, return `null` or throw a domain-specific error on invalid input, and validate that `session.userId` exists."
     }
   ],
-  "latencyMs": 33833,
-  "engineVersion": "1.1.14",
+  "latencyMs": 39519,
+  "engineVersion": "1.1.19",
+  "engineObserved": null,
   "samples": [
     {
       "verdict": "needs-attention",
-      "summary": "The authentication module introduces critical SQL injection, hardcoded secrets, and unhandled null and parsing exceptions.",
+      "summary": "Authentication module contains SQL injection, a hardcoded JWT secret, plaintext password comparison, and missing null-checks on query results.",
       "findings": [
         {
           "severity": "critical",
-          "title": "SQL Injection in findUser query",
-          "body": "The findUser function concatenates the untrusted username parameter directly into the SQL query string, allowing arbitrary SQL injection and database compromise.",
+          "title": "SQL injection in findUser",
+          "body": "The username parameter is concatenated directly into the SQL query string without parameterization. An attacker can supply a crafted username (e.g. `' OR '1'='1' --`) to bypass authentication, exfiltrate data, or modify the database.",
           "file": "src/auth.js",
           "line_start": 7,
           "line_end": 9,
           "confidence": 1,
-          "recommendation": "Use parameterized queries or prepared statements (e.g., db.query('SELECT * FROM users WHERE name = ?', [username]))."
+          "recommendation": "Use a parameterized query: `db.query('SELECT * FROM users WHERE name = $1', [username])` (or the equivalent placeholder syntax for your DB driver)."
         },
         {
-          "severity": "high",
-          "title": "Unchecked user lookup result causes unhandled TypeError",
-          "body": "If findUser returns null or undefined for nonexistent users, accessing user.password will throw an unhandled TypeError and crash the authentication flow.",
-          "file": "src/auth.js",
-          "line_start": 14,
-          "line_end": 17,
-          "confidence": 0.95,
-          "recommendation": "Check if user exists and verify password using a secure hash comparison (e.g., if (user && await bcrypt.compare(password, user.passwordHash)))."
-        },
-        {
-          "severity": "high",
-          "title": "Hardcoded JWT secret key",
-          "body": "JWT_SECRET is hardcoded in source control, allowing anyone with repository access to forge valid JWT authentication tokens.",
+          "severity": "critical",
+          "title": "Hardcoded JWT signing secret",
+          "body": "`JWT_SECRET` is a static string committed to source code. Anyone with repository access can forge arbitrary JWT tokens and impersonate any user.",
           "file": "src/auth.js",
           "line_start": 4,
           "line_end": 4,
           "confidence": 1,
-          "recommendation": "Retrieve the JWT secret from environment variables or a secrets manager (e.g., process.env.JWT_SECRET) and ensure it is properly validated on startup."
+          "recommendation": "Load the secret from an environment variable or a secrets manager (e.g. `process.env.JWT_SECRET`) and fail fast at startup if it is missing."
+        },
+        {
+          "severity": "high",
+          "title": "Plaintext password comparison (no hashing, loose equality, not timing-safe)",
+          "body": "`user.password == password` implies passwords are stored and compared in plaintext. Additionally, `==` performs type coercion, and the comparison is not constant-time, making it vulnerable to timing attacks.",
+          "file": "src/auth.js",
+          "line_start": 15,
+          "line_end": 15,
+          "confidence": 1,
+          "recommendation": "Store passwords as bcrypt (or argon2) hashes and compare with `bcrypt.compare(password, user.password)`, which is both hash-based and timing-safe."
+        },
+        {
+          "severity": "high",
+          "title": "No null/undefined check on findUser result before property access",
+          "body": "If the query returns no rows (user not found), `user` will be `null`, `undefined`, or an empty array depending on the DB driver. Accessing `user.password` will throw an unhandled TypeError, crashing the process or leaking stack traces.",
+          "file": "src/auth.js",
+          "line_start": 14,
+          "line_end": 15,
+          "confidence": 0.95,
+          "recommendation": "Guard with `if (!user) return null;` before accessing `user.password`."
         },
         {
           "severity": "medium",
-          "title": "Unhandled JSON.parse exception in parseSession",
-          "body": "Calling JSON.parse directly on untrusted raw input without a try/catch block will throw a SyntaxError on malformed input.",
+          "title": "parseSession throws on invalid input with no error handling",
+          "body": "`JSON.parse(raw)` will throw a SyntaxError if `raw` is not valid JSON, and there is no try/catch. The returned `session.userId` is also not validated, so it could be `undefined` and silently propagate as an unauthenticated identity.",
           "file": "src/auth.js",
-          "line_start": 21,
-          "line_end": 24,
+          "line_start": 22,
+          "line_end": 23,
           "confidence": 0.9,
-          "recommendation": "Wrap JSON.parse in a try/catch block or helper to safely handle malformed input and return null or an error."
+          "recommendation": "Wrap in try/catch, return a safe default or throw a domain-specific error, and validate that `session.userId` is defined."
         }
       ],
-      "latencyMs": 34168
+      "latencyMs": 46698
     },
     {
       "verdict": "needs-attention",
-      "summary": "Critical security vulnerabilities including SQL injection and hardcoded secrets, alongside missing error and null checks, require remediation.",
+      "summary": "Auth module contains SQL injection, a hardcoded secret, plaintext password comparison with loose equality, and unguarded JSON parsing.",
       "findings": [
         {
           "severity": "critical",
-          "title": "SQL Injection via Unsanitized Concatenation",
-          "body": "The username parameter is concatenated directly into the SQL query in findUser, enabling arbitrary SQL injection that can lead to authentication bypass or data leakage.",
+          "title": "SQL injection in findUser",
+          "body": "The username parameter is concatenated directly into the SQL query string without parameterization or escaping. An attacker can supply a crafted username (e.g. `' OR 1=1 --`) to exfiltrate or modify arbitrary data.",
           "file": "src/auth.js",
           "line_start": 7,
           "line_end": 9,
           "confidence": 1,
-          "recommendation": "Use parameterized queries (e.g. `db.query('SELECT * FROM users WHERE name = ?', [username])`)."
+          "recommendation": "Use a parameterized query: `db.query(\"SELECT * FROM users WHERE name = $1\", [username])` (or the equivalent placeholder syntax for your driver)."
         },
         {
-          "severity": "high",
-          "title": "Unchecked User Existence Before Password Access",
-          "body": "If findUser returns null or undefined for an unknown username, accessing user.password will throw an unhandled TypeError and crash the request.",
+          "severity": "critical",
+          "title": "Hardcoded JWT secret",
+          "body": "JWT_SECRET is a plaintext string committed to source. Anyone with repository access can forge valid tokens for any user, bypassing all authentication.",
           "file": "src/auth.js",
-          "line_start": 14,
-          "line_end": 15,
+          "line_start": 4,
+          "line_end": 4,
           "confidence": 1,
-          "recommendation": "Verify that user exists before inspecting properties (e.g., `if (user && user.password ...)`)."
+          "recommendation": "Load the secret from an environment variable or a secrets manager: `const JWT_SECRET = process.env.JWT_SECRET;` and validate it is set at startup."
         },
         {
           "severity": "high",
-          "title": "Plaintext Password Comparison and Loose Equality",
-          "body": "Passwords are evaluated in plaintext using loose equality (`==`) rather than a secure, constant-time password hashing and verification function (e.g. bcrypt/argon2).",
+          "title": "Plaintext password comparison with loose equality",
+          "body": "`user.password == password` implies passwords are stored in plaintext (no hashing) and uses `==` which performs type coercion. Plaintext storage means a database breach exposes all credentials. The loose equality can also produce unexpected matches (e.g. `0 == \"\"` is true).",
           "file": "src/auth.js",
           "line_start": 15,
           "line_end": 15,
           "confidence": 0.95,
-          "recommendation": "Store and verify password hashes using an algorithm like bcrypt or argon2."
+          "recommendation": "Store passwords hashed with bcrypt (or argon2) and compare with `bcrypt.compare(password, user.password)`. At minimum, use `===` instead of `==`."
         },
         {
           "severity": "medium",
-          "title": "Hardcoded JWT Secret",
-          "body": "JWT_SECRET is hardcoded in the source file, which exposes the signing key and prevents environment-specific rotation.",
+          "title": "No null/undefined check on user before property access",
+          "body": "If `findUser` returns `undefined` or an empty result set, accessing `user.password` on line 15 will throw a TypeError, crashing the request instead of returning a controlled auth-failure response.",
           "file": "src/auth.js",
-          "line_start": 4,
-          "line_end": 4,
-          "confidence": 1,
-          "recommendation": "Load the JWT secret from environment variables (e.g. `process.env.JWT_SECRET`)."
+          "line_start": 14,
+          "line_end": 15,
+          "confidence": 0.9,
+          "recommendation": "Guard with `if (!user) return null;` before accessing user properties."
         },
         {
-          "severity": "low",
-          "title": "Unhandled SyntaxError in JSON Parsing",
-          "body": "parseSession calls JSON.parse on raw input without error handling, which throws an unhandled SyntaxError if invalid JSON is provided.",
+          "severity": "medium",
+          "title": "parseSession throws on invalid input",
+          "body": "`JSON.parse(raw)` will throw a SyntaxError if `raw` is not valid JSON, and accessing `.userId` on a parsed object that lacks the property silently returns `undefined`. Neither case is handled.",
           "file": "src/auth.js",
-          "line_start": 21,
-          "line_end": 24,
-          "confidence": 0.95,
-          "recommendation": "Wrap JSON.parse in a try/catch block and handle invalid input gracefully."
+          "line_start": 22,
+          "line_end": 23,
+          "confidence": 0.85,
+          "recommendation": "Wrap in a try/catch and validate the parsed shape, e.g. `try { const s = JSON.parse(raw); return s?.userId ?? null; } catch { return null; }`."
         }
       ],
-      "latencyMs": 29552
+      "latencyMs": 40469
     },
     {
       "verdict": "needs-attention",
-      "summary": "The authentication module contains critical vulnerabilities including SQL injection, hardcoded secrets, plaintext password comparison, and missing null/exception handling.",
+      "summary": "Auth module contains SQL injection, a hardcoded secret, plaintext password comparison, and unguarded parsing.",
       "findings": [
         {
           "severity": "critical",
-          "title": "SQL Injection in findUser",
-          "body": "User input is directly concatenated into the SQL query string in findUser, allowing arbitrary SQL execution and authentication bypass.",
+          "title": "SQL injection in findUser",
+          "body": "The username is concatenated directly into the SQL query string without parameterisation. An attacker can supply a crafted username (e.g. `' OR '1'='1' --`) to bypass authentication, exfiltrate data, or modify the database.",
           "file": "src/auth.js",
           "line_start": 7,
           "line_end": 9,
           "confidence": 1,
-          "recommendation": "Use parameterized queries or prepared statements (e.g. db.query('SELECT * FROM users WHERE name = $1', [username])) instead of string concatenation."
+          "recommendation": "Use a parameterised query: `db.query(\"SELECT * FROM users WHERE name = $1\", [username])` (or the equivalent placeholder syntax for your driver)."
         },
         {
           "severity": "critical",
-          "title": "Plaintext Password Comparison and Potential Null Dereference",
-          "body": "Passwords are verified via loose equality against unhashed values without constant-time comparison. Additionally, if findUser returns null or undefined for non-existent users, accessing user.password will throw an unhandled TypeError.",
-          "file": "src/auth.js",
-          "line_start": 14,
-          "line_end": 17,
-          "confidence": 1,
-          "recommendation": "Check if user exists before accessing properties, store password hashes using a secure algorithm such as argon2 or bcrypt, and verify using timing-safe comparison functions."
-        },
-        {
-          "severity": "high",
-          "title": "Hardcoded JWT Secret",
-          "body": "The JWT signing secret is hardcoded in source code, exposing cryptographic keys if the repository is shared or accessed.",
+          "title": "Hardcoded JWT secret",
+          "body": "JWT_SECRET is a plaintext string committed to source. Anyone with repository access can forge valid tokens for any user, completely bypassing authentication.",
           "file": "src/auth.js",
           "line_start": 4,
           "line_end": 4,
           "confidence": 1,
-          "recommendation": "Load the JWT secret from environment variables or a secure key management system (e.g. process.env.JWT_SECRET)."
+          "recommendation": "Load the secret from an environment variable or a secrets manager (e.g. `process.env.JWT_SECRET`) and fail fast if it is missing."
+        },
+        {
+          "severity": "high",
+          "title": "Plaintext password comparison with loose equality",
+          "body": "`user.password == password` implies passwords are stored and compared in plaintext, and uses `==` which performs type coercion. Passwords should be hashed; even if they were, timing-safe comparison is required to prevent timing attacks.",
+          "file": "src/auth.js",
+          "line_start": 15,
+          "line_end": 15,
+          "confidence": 0.95,
+          "recommendation": "Store passwords hashed (e.g. bcrypt) and compare with `bcrypt.compare(password, user.password)`. At minimum use `===` and a constant-time comparison."
+        },
+        {
+          "severity": "high",
+          "title": "No null/undefined check on user before property access",
+          "body": "If `findUser` returns `undefined` or an empty result set, accessing `user.password` on line 15 will throw a TypeError, crashing the request. There is no error handling for a non-existent user.",
+          "file": "src/auth.js",
+          "line_start": 14,
+          "line_end": 15,
+          "confidence": 0.95,
+          "recommendation": "Guard with `if (!user) return null;` before accessing `user.password`."
         },
         {
           "severity": "medium",
-          "title": "Unhandled JSON.parse Exception in parseSession",
-          "body": "Calling JSON.parse directly on raw input without error handling will crash the execution context if invalid JSON is provided.",
+          "title": "parseSession throws on invalid input",
+          "body": "`JSON.parse(raw)` will throw a SyntaxError if `raw` is not valid JSON, and accessing `.userId` on the result will throw if the key is absent. There is no try/catch or validation.",
           "file": "src/auth.js",
-          "line_start": 21,
-          "line_end": 24,
-          "confidence": 0.95,
-          "recommendation": "Wrap JSON.parse in a try-catch block to handle malformed input gracefully and validate session object structure."
+          "line_start": 22,
+          "line_end": 23,
+          "confidence": 0.9,
+          "recommendation": "Wrap in a try/catch, return `null` or throw a domain-specific error on invalid input, and validate that `session.userId` exists."
         }
       ],
-      "latencyMs": 33833
+      "latencyMs": 39519
     }
   ],
-  "raw": "{\"conversation_id\":\"f6ac8215-8ead-4b49-8944-a0309a598137\",\"status\":\"SUCCESS\",\"response\":\"{\\n  \\\"verdict\\\": \\\"needs-attention\\\",\\n  \\\"summary\\\": \\\"The authentication module contains critical vulnerabilities including SQL injection, hardcoded secrets, plaintext password comparison, and missing null/exception handling.\\\",\\n  \\\"findings\\\": [\\n    {\\n      \\\"severity\\\": \\\"critical\\\",\\n      \\\"title\\\": \\\"SQL Injection in findUser\\\",\\n      \\\"body\\\": \\\"User input is directly concatenated into the SQL query string in findUser, allowing arbitrary SQL execution and authentication bypass.\\\",\\n      \\\"file\\\": \\\"src/auth.js\\\",\\n      \\\"line_start\\\": 7,\\n      \\\"line_end\\\": 9,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Use parameterized queries or prepared statements (e.g. db.query('SELECT * FROM users WHERE name = $1', [username])) instead of string concatenation.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"critical\\\",\\n      \\\"title\\\": \\\"Plaintext Password Comparison and Potential Null Dereference\\\",\\n      \\\"body\\\": \\\"Passwords are verified via loose equality against unhashed values without constant-time comparison. Additionally, if findUser returns null or undefined for non-existent users, accessing user.password will throw an unhandled TypeError.\\\",\\n      \\\"file\\\": \\\"src/auth.js\\\",\\n      \\\"line_start\\\": 14,\\n      \\\"line_end\\\": 17,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Check if user exists before accessing properties, store password hashes using a secure algorithm such as argon2 or bcrypt, and verify using timing-safe comparison functions.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"high\\\",\\n      \\\"title\\\": \\\"Hardcoded JWT Secret\\\",\\n      \\\"body\\\": \\\"The JWT signing secret is hardcoded in source code, exposing cryptographic keys if the repository is shared or accessed.\\\",\\n      \\\"file\\\": \\\"src/auth.js\\\",\\n      \\\"line_start\\\": 4,\\n      \\\"line_end\\\": 4,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Load the JWT secret from environment variables or a secure key management system (e.g. process.env.JWT_SECRET).\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"medium\\\",\\n      \\\"title\\\": \\\"Unhandled JSON.parse Exception in parseSession\\\",\\n      \\\"body\\\": \\\"Calling JSON.parse directly on raw input without error handling will crash the execution context if invalid JSON is provided.\\\",\\n      \\\"file\\\": \\\"src/auth.js\\\",\\n      \\\"line_start\\\": 21,\\n      \\\"line_end\\\": 24,\\n      \\\"confidence\\\": 0.95,\\n      \\\"recommendation\\\": \\\"Wrap JSON.parse in a try-catch block to handle malformed input gracefully and validate session object structure.\\\"\\n    }\\n  ],\\n  \\\"next_steps\\\": [\\n    \\\"Refactor db.query calls to use parameterized queries.\\\",\\n    \\\"Implement password hashing and timing-safe verification.\\\",\\n    \\\"Extract secrets to environment configuration.\\\",\\n    \\\"Add error handling and null-checks to parseSession and login functions.\\\"\\n  ]\\n}\\n\",\"duration_seconds\":29.3649742,\"num_turns\":1,\"usage\":{\"input_tokens\":3523,\"output_tokens\":1995,\"thinking_tokens\":1375,\"cache_read_tokens\":15489,\"total_tokens\":5518}}\n"
+  "raw": "{\"conversation_id\":\"40daca16-f03e-41ab-b044-ea59476c614f\",\"status\":\"SUCCESS\",\"response\":\"{\\\"verdict\\\":\\\"needs-attention\\\",\\\"summary\\\":\\\"Auth module contains SQL injection, a hardcoded secret, plaintext password comparison, and unguarded parsing.\\\",\\\"findings\\\":[{\\\"severity\\\":\\\"critical\\\",\\\"title\\\":\\\"SQL injection in findUser\\\",\\\"body\\\":\\\"The username is concatenated directly into the SQL query string without parameterisation. An attacker can supply a crafted username (e.g. `' OR '1'='1' --`) to bypass authentication, exfiltrate data, or modify the database.\\\",\\\"file\\\":\\\"src/auth.js\\\",\\\"line_start\\\":7,\\\"line_end\\\":9,\\\"confidence\\\":1.0,\\\"recommendation\\\":\\\"Use a parameterised query: `db.query(\\\\\\\"SELECT * FROM users WHERE name = $1\\\\\\\", [username])` (or the equivalent placeholder syntax for your driver).\\\"},{\\\"severity\\\":\\\"critical\\\",\\\"title\\\":\\\"Hardcoded JWT secret\\\",\\\"body\\\":\\\"JWT_SECRET is a plaintext string committed to source. Anyone with repository access can forge valid tokens for any user, completely bypassing authentication.\\\",\\\"file\\\":\\\"src/auth.js\\\",\\\"line_start\\\":4,\\\"line_end\\\":4,\\\"confidence\\\":1.0,\\\"recommendation\\\":\\\"Load the secret from an environment variable or a secrets manager (e.g. `process.env.JWT_SECRET`) and fail fast if it is missing.\\\"},{\\\"severity\\\":\\\"high\\\",\\\"title\\\":\\\"Plaintext password comparison with loose equality\\\",\\\"body\\\":\\\"`user.password == password` implies passwords are stored and compared in plaintext, and uses `==` which performs type coercion. Passwords should be hashed; even if they were, timing-safe comparison is required to prevent timing attacks.\\\",\\\"file\\\":\\\"src/auth.js\\\",\\\"line_start\\\":15,\\\"line_end\\\":15,\\\"confidence\\\":0.95,\\\"recommendation\\\":\\\"Store passwords hashed (e.g. bcrypt) and compare with `bcrypt.compare(password, user.password)`. At minimum use `===` and a constant-time comparison.\\\"},{\\\"severity\\\":\\\"high\\\",\\\"title\\\":\\\"No null/undefined check on user before property access\\\",\\\"body\\\":\\\"If `findUser` returns `undefined` or an empty result set, accessing `user.password` on line 15 will throw a TypeError, crashing the request. There is no error handling for a non-existent user.\\\",\\\"file\\\":\\\"src/auth.js\\\",\\\"line_start\\\":14,\\\"line_end\\\":15,\\\"confidence\\\":0.95,\\\"recommendation\\\":\\\"Guard with `if (!user) return null;` before accessing `user.password`.\\\"},{\\\"severity\\\":\\\"medium\\\",\\\"title\\\":\\\"parseSession throws on invalid input\\\",\\\"body\\\":\\\"`JSON.parse(raw)` will throw a SyntaxError if `raw` is not valid JSON, and accessing `.userId` on the result will throw if the key is absent. There is no try/catch or validation.\\\",\\\"file\\\":\\\"src/auth.js\\\",\\\"line_start\\\":22,\\\"line_end\\\":23,\\\"confidence\\\":0.9,\\\"recommendation\\\":\\\"Wrap in a try/catch, return `null` or throw a domain-specific error on invalid input, and validate that `session.userId` exists.\\\"}],\\\"next_steps\\\":[\\\"Fix the SQL injection and hardcoded secret before merging — these are exploitable as-is.\\\",\\\"Introduce password hashing (bcrypt) and update the comparison logic.\\\",\\\"Add null-checks and error handling in login and parseSession.\\\"]}\\n\",\"duration_seconds\":35.042688,\"num_turns\":1,\"usage\":{\"input_tokens\":22554,\"output_tokens\":756,\"thinking_tokens\":0,\"cache_read_tokens\":0,\"total_tokens\":23310}}\n"
 }

--- a/bench/cassettes/auth-basic/agy.shallow.json
+++ b/bench/cassettes/auth-basic/agy.shallow.json
@@ -1,0 +1,196 @@
+{
+  "caseId": "auth-basic",
+  "cell": "agy.shallow",
+  "recordedAt": "2026-08-24T15:30:05.898Z",
+  "verdict": "needs-attention",
+  "summary": "The new auth module introduces critical SQL injection vulnerabilities, hardcoded credentials, and missing error and null checks.",
+  "findings": [
+    {
+      "severity": "critical",
+      "title": "SQL injection via string concatenation in findUser",
+      "body": "Direct concatenation of the `username` parameter into the SQL query allows attackers to execute arbitrary SQL commands and bypass authentication.",
+      "file": "src/auth.js",
+      "line_start": 7,
+      "line_end": 9,
+      "confidence": 1,
+      "recommendation": "Use parameterized queries or prepared statements (e.g., `db.query('SELECT * FROM users WHERE name = ?', [username])`) instead of string concatenation."
+    },
+    {
+      "severity": "high",
+      "title": "Unchecked null user in login causes unhandled TypeError",
+      "body": "If `findUser` returns `null` or `undefined` for a non-existent user, accessing `user.password` throws an unhandled TypeError, crashing the request.",
+      "file": "src/auth.js",
+      "line_start": 14,
+      "line_end": 15,
+      "confidence": 0.95,
+      "recommendation": "Check that `user` exists before evaluating credentials (e.g., `if (!user || user.password !== password) return null;`)."
+    },
+    {
+      "severity": "high",
+      "title": "Hardcoded JWT secret in source code",
+      "body": "A static secret string is hardcoded in `JWT_SECRET`, exposing token signing credentials in source control and preventing key rotation.",
+      "file": "src/auth.js",
+      "line_start": 4,
+      "line_end": 4,
+      "confidence": 1,
+      "recommendation": "Load the JWT secret from environment variables (e.g., `process.env.JWT_SECRET`) and fail fast if it is missing."
+    },
+    {
+      "severity": "medium",
+      "title": "Uncaught SyntaxError in parseSession for malformed JSON",
+      "body": "`JSON.parse(raw)` throws an unhandled SyntaxError when provided with invalid JSON, causing unexpected runtime crashes.",
+      "file": "src/auth.js",
+      "line_start": 21,
+      "line_end": 24,
+      "confidence": 0.9,
+      "recommendation": "Wrap `JSON.parse` in a `try...catch` block to handle parse failures and return `null` or throw a domain-specific error."
+    }
+  ],
+  "latencyMs": 23343,
+  "engineVersion": "1.1.19",
+  "engineObserved": "agy",
+  "samples": [
+    {
+      "verdict": "needs-attention",
+      "summary": "The authentication implementation contains a critical SQL injection vulnerability, crashes on non-existent user lookups, uses a hardcoded JWT secret, and lacks JSON parsing error handling.",
+      "findings": [
+        {
+          "severity": "critical",
+          "title": "SQL Injection in findUser",
+          "body": "The findUser function concatenates the unescaped username argument directly into the SQL string on line 8. This allows attackers to perform SQL injection to bypass authentication, read sensitive data, or modify the database.",
+          "file": "src/auth.js",
+          "line_start": 7,
+          "line_end": 9,
+          "confidence": 1,
+          "recommendation": "Use parameterized queries or prepared statements (e.g., db.query('SELECT * FROM users WHERE name = $1', [username]) or equivalent for the database driver)."
+        },
+        {
+          "severity": "high",
+          "title": "Uncaught TypeError when user is not found",
+          "body": "In login, if findUser returns null or undefined for a non-existent username, accessing user.password on line 15 throws an unhandled TypeError, causing authentication requests for invalid users to crash the handler.",
+          "file": "src/auth.js",
+          "line_start": 14,
+          "line_end": 17,
+          "confidence": 0.95,
+          "recommendation": "Check that user exists before inspecting properties (e.g., if (user && user.password === password))."
+        },
+        {
+          "severity": "high",
+          "title": "Hardcoded JWT secret key",
+          "body": "The signing secret JWT_SECRET is hardcoded in source code on line 4, exposing the secret to anyone with codebase access and preventing environment-specific secret configuration or rotation.",
+          "file": "src/auth.js",
+          "line_start": 4,
+          "line_end": 4,
+          "confidence": 1,
+          "recommendation": "Retrieve the JWT secret from environment variables (e.g., process.env.JWT_SECRET) and fail fast if it is missing."
+        },
+        {
+          "severity": "medium",
+          "title": "Unhandled SyntaxError and null reference in parseSession",
+          "body": "JSON.parse(raw) on line 22 will throw an unhandled SyntaxError on malformed input, and if raw parses to null or a non-object, line 23 will throw a TypeError.",
+          "file": "src/auth.js",
+          "line_start": 21,
+          "line_end": 24,
+          "confidence": 0.9,
+          "recommendation": "Wrap JSON.parse in a try/catch block and validate that the parsed result is an object before accessing userId."
+        }
+      ],
+      "latencyMs": 21246
+    },
+    {
+      "verdict": "needs-attention",
+      "summary": "The authentication module contains critical security vulnerabilities including SQL injection, hardcoded secrets, plaintext password comparison, and unhandled null/parsing exceptions.",
+      "findings": [
+        {
+          "severity": "critical",
+          "title": "SQL Injection in findUser",
+          "body": "User input `username` is directly concatenated into the SQL query string in `findUser`, enabling attackers to execute arbitrary SQL commands and bypass authentication.",
+          "file": "src/auth.js",
+          "line_start": 7,
+          "line_end": 9,
+          "confidence": 1,
+          "recommendation": "Use parameterized queries or prepared statements instead of string concatenation."
+        },
+        {
+          "severity": "critical",
+          "title": "Missing user check and plaintext password comparison in login",
+          "body": "If `findUser` returns null or undefined for nonexistent users, accessing `user.password` causes an unhandled TypeError crash; furthermore, passwords are authenticated using loose equality against plaintext rather than a secure hash comparison.",
+          "file": "src/auth.js",
+          "line_start": 14,
+          "line_end": 17,
+          "confidence": 1,
+          "recommendation": "Verify that `user` exists before accessing properties and compare passwords using a secure hashing algorithm (such as bcrypt or argon2) with constant-time comparison."
+        },
+        {
+          "severity": "high",
+          "title": "Hardcoded JWT Secret",
+          "body": "The JWT signing key `JWT_SECRET` is hardcoded as a static string in source code, allowing anyone with access to the repository to forge authentication tokens.",
+          "file": "src/auth.js",
+          "line_start": 4,
+          "line_end": 4,
+          "confidence": 1,
+          "recommendation": "Retrieve the JWT secret from environment variables (e.g., `process.env.JWT_SECRET`) and ensure the application fails to start if it is missing."
+        },
+        {
+          "severity": "medium",
+          "title": "Unhandled JSON parse exception in parseSession",
+          "body": "`JSON.parse(raw)` is invoked without error handling. Passing malformed JSON or invalid inputs will throw an uncaught SyntaxError, crashing the calling path.",
+          "file": "src/auth.js",
+          "line_start": 21,
+          "line_end": 24,
+          "confidence": 0.95,
+          "recommendation": "Wrap `JSON.parse` in a try/catch block and handle invalid inputs or missing `userId` properties safely."
+        }
+      ],
+      "latencyMs": 22535
+    },
+    {
+      "verdict": "needs-attention",
+      "summary": "The new auth module introduces critical SQL injection vulnerabilities, hardcoded credentials, and missing error and null checks.",
+      "findings": [
+        {
+          "severity": "critical",
+          "title": "SQL injection via string concatenation in findUser",
+          "body": "Direct concatenation of the `username` parameter into the SQL query allows attackers to execute arbitrary SQL commands and bypass authentication.",
+          "file": "src/auth.js",
+          "line_start": 7,
+          "line_end": 9,
+          "confidence": 1,
+          "recommendation": "Use parameterized queries or prepared statements (e.g., `db.query('SELECT * FROM users WHERE name = ?', [username])`) instead of string concatenation."
+        },
+        {
+          "severity": "high",
+          "title": "Unchecked null user in login causes unhandled TypeError",
+          "body": "If `findUser` returns `null` or `undefined` for a non-existent user, accessing `user.password` throws an unhandled TypeError, crashing the request.",
+          "file": "src/auth.js",
+          "line_start": 14,
+          "line_end": 15,
+          "confidence": 0.95,
+          "recommendation": "Check that `user` exists before evaluating credentials (e.g., `if (!user || user.password !== password) return null;`)."
+        },
+        {
+          "severity": "high",
+          "title": "Hardcoded JWT secret in source code",
+          "body": "A static secret string is hardcoded in `JWT_SECRET`, exposing token signing credentials in source control and preventing key rotation.",
+          "file": "src/auth.js",
+          "line_start": 4,
+          "line_end": 4,
+          "confidence": 1,
+          "recommendation": "Load the JWT secret from environment variables (e.g., `process.env.JWT_SECRET`) and fail fast if it is missing."
+        },
+        {
+          "severity": "medium",
+          "title": "Uncaught SyntaxError in parseSession for malformed JSON",
+          "body": "`JSON.parse(raw)` throws an unhandled SyntaxError when provided with invalid JSON, causing unexpected runtime crashes.",
+          "file": "src/auth.js",
+          "line_start": 21,
+          "line_end": 24,
+          "confidence": 0.9,
+          "recommendation": "Wrap `JSON.parse` in a `try...catch` block to handle parse failures and return `null` or throw a domain-specific error."
+        }
+      ],
+      "latencyMs": 23343
+    }
+  ],
+  "raw": "{\n  \"review\": \"Review\",\n  \"target\": {\n    \"mode\": \"working-tree\",\n    \"label\": \"working tree diff\",\n    \"explicit\": true\n  },\n  \"engine\": \"agy\",\n  \"gemini\": {\n    \"status\": 0,\n    \"stdout\": \"{\\n  \\\"verdict\\\": \\\"needs-attention\\\",\\n  \\\"summary\\\": \\\"The new auth module introduces critical SQL injection vulnerabilities, hardcoded credentials, and missing error and null checks.\\\",\\n  \\\"findings\\\": [\\n    {\\n      \\\"severity\\\": \\\"critical\\\",\\n      \\\"title\\\": \\\"SQL injection via string concatenation in findUser\\\",\\n      \\\"body\\\": \\\"Direct concatenation of the `username` parameter into the SQL query allows attackers to execute arbitrary SQL commands and bypass authentication.\\\",\\n      \\\"file\\\": \\\"src/auth.js\\\",\\n      \\\"line_start\\\": 7,\\n      \\\"line_end\\\": 9,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Use parameterized queries or prepared statements (e.g., `db.query('SELECT * FROM users WHERE name = ?', [username])`) instead of string concatenation.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"high\\\",\\n      \\\"title\\\": \\\"Unchecked null user in login causes unhandled TypeError\\\",\\n      \\\"body\\\": \\\"If `findUser` returns `null` or `undefined` for a non-existent user, accessing `user.password` throws an unhandled TypeError, crashing the request.\\\",\\n      \\\"file\\\": \\\"src/auth.js\\\",\\n      \\\"line_start\\\": 14,\\n      \\\"line_end\\\": 15,\\n      \\\"confidence\\\": 0.95,\\n      \\\"recommendation\\\": \\\"Check that `user` exists before evaluating credentials (e.g., `if (!user || user.password !== password) return null;`).\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"high\\\",\\n      \\\"title\\\": \\\"Hardcoded JWT secret in source code\\\",\\n      \\\"body\\\": \\\"A static secret string is hardcoded in `JWT_SECRET`, exposing token signing credentials in source control and preventing key rotation.\\\",\\n      \\\"file\\\": \\\"src/auth.js\\\",\\n      \\\"line_start\\\": 4,\\n      \\\"line_end\\\": 4,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Load the JWT secret from environment variables (e.g., `process.env.JWT_SECRET`) and fail fast if it is missing.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"medium\\\",\\n      \\\"title\\\": \\\"Uncaught SyntaxError in parseSession for malformed JSON\\\",\\n      \\\"body\\\": \\\"`JSON.parse(raw)` throws an unhandled SyntaxError when provided with invalid JSON, causing unexpected runtime crashes.\\\",\\n      \\\"file\\\": \\\"src/auth.js\\\",\\n      \\\"line_start\\\": 21,\\n      \\\"line_end\\\": 24,\\n      \\\"confidence\\\": 0.9,\\n      \\\"recommendation\\\": \\\"Wrap `JSON.parse` in a `try...catch` block to handle parse failures and return `null` or throw a domain-specific error.\\\"\\n    }\\n  ],\\n  \\\"next_steps\\\": [\\n    \\\"Refactor findUser to use parameterized SQL queries.\\\",\\n    \\\"Add null checks and secure password hashing comparisons in login.\\\",\\n    \\\"Move JWT_SECRET configuration to process.env.\\\",\\n    \\\"Add error handling around JSON parsing in parseSession.\\\"\\n  ]\\n}\",\n    \"stderr\": \"\"\n  },\n  \"result\": {\n    \"verdict\": \"needs-attention\",\n    \"summary\": \"The new auth module introduces critical SQL injection vulnerabilities, hardcoded credentials, and missing error and null checks.\",\n    \"findings\": [\n      {\n        \"severity\": \"critical\",\n        \"title\": \"SQL injection via string concatenation in findUser\",\n        \"body\": \"Direct concatenation of the `username` parameter into the SQL query allows attackers to execute arbitrary SQL commands and bypass authentication.\",\n        \"file\": \"src/auth.js\",\n        \"line_start\": 7,\n        \"line_end\": 9,\n        \"confidence\": 1,\n        \"recommendation\": \"Use parameterized queries or prepared statements (e.g., `db.query('SELECT * FROM users WHERE name = ?', [username])`) instead of string concatenation.\"\n      },\n      {\n        \"severity\": \"high\",\n        \"title\": \"Unchecked null user in login causes unhandled TypeError\",\n        \"body\": \"If `findUser` returns `null` or `undefined` for a non-existent user, accessing `user.password` throws an unhandled TypeError, crashing the request.\",\n        \"file\": \"src/auth.j"
+}

--- a/bench/cassettes/auth-basic/codex.adversarial.json
+++ b/bench/cassettes/auth-basic/codex.adversarial.json
@@ -1,0 +1,166 @@
+{
+  "caseId": "auth-basic",
+  "cell": "codex.adversarial",
+  "recordedAt": "2026-08-24T11:12:13.428Z",
+  "verdict": "needs-attention",
+  "summary": "Do not ship: the new authentication path is vulnerable to SQL injection and uses a source-controlled JWT signing key, enabling account compromise and forged sessions.",
+  "findings": [
+    {
+      "severity": "critical",
+      "title": "Username interpolation permits SQL injection in the authentication query",
+      "body": "`username` is concatenated directly into SQL. An attacker can alter the WHERE clause or append database-specific payloads through the login input. Depending on the database driver's result behavior, this can bypass authentication, expose user records, or modify data; the injection itself is directly established even though the exact downstream exploit depends on `db.query`.",
+      "file": "src/auth.js",
+      "line_start": 7,
+      "line_end": 9,
+      "confidence": 0.99,
+      "recommendation": "Use a parameterized query with a bound username value and select only the required columns. Add tests using quote, tautology, comment, and stacked-query payloads supported by the configured database."
+    },
+    {
+      "severity": "critical",
+      "title": "Hardcoded JWT secret allows session forgery",
+      "body": "The signing key is embedded in source code and used directly to mint authentication tokens. Anyone who can read the repository, a packaged artifact, or leaked source can generate valid tokens for arbitrary `sub` values. The key also cannot be rotated safely per environment without changing and redeploying code.",
+      "file": "src/auth.js",
+      "line_start": 4,
+      "line_end": 4,
+      "confidence": 0.99,
+      "recommendation": "Load a high-entropy signing key from a managed secret, fail startup when it is absent or weak, separate keys by environment, and implement key rotation using explicit key identifiers."
+    },
+    {
+      "severity": "high",
+      "title": "Password verification appears to compare raw credentials directly",
+      "body": "The login path compares the supplied password directly with `user.password`, with no password-hash verification. Unless `db.query` performs undocumented transformation, this requires stored plaintext or equivalently recoverable passwords, turning any database disclosure into immediate credential compromise. Loose equality also permits type coercion.",
+      "file": "src/auth.js",
+      "line_start": 13,
+      "line_end": 16,
+      "confidence": 0.94,
+      "recommendation": "Store passwords using a password-specific hash such as Argon2id or bcrypt and verify with its constant-time library API. Use a dummy hash for unknown users to reduce account-enumeration timing differences."
+    }
+  ],
+  "latencyMs": 27144,
+  "engineVersion": "codex-cli 0.149.0",
+  "engineObserved": null,
+  "samples": [
+    {
+      "verdict": "needs-attention",
+      "summary": "Do not ship: the new authentication path is SQL-injectable and uses a committed JWT signing secret, enabling account compromise and token forgery.",
+      "findings": [
+        {
+          "severity": "critical",
+          "title": "Username is interpolated directly into an SQL query",
+          "body": "An attacker-controlled username is concatenated into the WHERE clause. A value such as `' OR '1'='1' --` can alter the query and may make login operate on an unintended user; impact depends on the database driver's result semantics, but authentication bypass and user-data exposure are credible.",
+          "file": "src/auth.js",
+          "line_start": 7,
+          "line_end": 9,
+          "confidence": 0.99,
+          "recommendation": "Use a parameterized query with a bound username value, select only required columns, and add a test proving SQL metacharacters are treated as data."
+        },
+        {
+          "severity": "critical",
+          "title": "Committed JWT secret allows token forgery",
+          "body": "Every deployment using this source shares a publicly readable signing key. Anyone who obtains the code can mint arbitrary JWTs, including tokens with another user's `sub`; tokens also have no expiration, extending compromise indefinitely.",
+          "file": "src/auth.js",
+          "line_start": 4,
+          "line_end": 16,
+          "confidence": 0.99,
+          "recommendation": "Load a high-entropy secret from managed runtime configuration, rotate this exposed key before deployment, set and validate expiration plus issuer/audience claims, and fail startup when the secret is absent."
+        },
+        {
+          "severity": "high",
+          "title": "Password verification uses direct loose equality",
+          "body": "The supplied password is compared directly with the database value using coercive `==`. This indicates plaintext-equivalent verification and permits type coercion rather than cryptographic password validation, exposing stored credentials and potentially accepting non-identical values.",
+          "file": "src/auth.js",
+          "line_start": 12,
+          "line_end": 15,
+          "confidence": 0.96,
+          "recommendation": "Store passwords using a password-hashing function with unique salts and verify them through its constant-time comparison API; require string inputs and reject malformed values before querying."
+        }
+      ],
+      "latencyMs": 46701
+    },
+    {
+      "verdict": "needs-attention",
+      "summary": "Do not ship: the new authentication path permits SQL injection, exposes its JWT signing key, and performs unsafe password verification.",
+      "findings": [
+        {
+          "severity": "critical",
+          "title": "Username is interpolated directly into an SQL query",
+          "body": "An attacker-controlled username is concatenated into the WHERE clause. A value such as `' OR 1=1 --` can alter query semantics and potentially select another user's record; depending on the database driver's multi-statement behavior, broader reads or writes may also be possible. This compromises the authentication boundary.",
+          "file": "src/auth.js",
+          "line_start": 7,
+          "line_end": 9,
+          "confidence": 0.99,
+          "recommendation": "Use the database driver's parameterized-query API, such as `WHERE name = ?` or `WHERE name = $1`, and pass the username separately. Add injection regression tests."
+        },
+        {
+          "severity": "critical",
+          "title": "Committed JWT secret allows token forgery",
+          "body": "Anyone who can read this source obtains the signing key and can generate a valid token with an arbitrary `sub`, bypassing login entirely. The same fixed key will also be shared across every deployment that uses this code.",
+          "file": "src/auth.js",
+          "line_start": 4,
+          "line_end": 4,
+          "confidence": 1,
+          "recommendation": "Load a high-entropy secret from a deployment secret store or environment variable, fail startup when it is absent, and rotate any environment that has used this key."
+        },
+        {
+          "severity": "high",
+          "title": "Passwords are compared directly with loose equality",
+          "body": "The login path compares the supplied password directly to the database value, with no password-hash verification. This implies recoverable plaintext credentials unless hashing occurs outside the shown path, and `==` additionally permits type coercion. A database disclosure would expose every password immediately.",
+          "file": "src/auth.js",
+          "line_start": 13,
+          "line_end": 15,
+          "confidence": 0.96,
+          "recommendation": "Store passwords using a dedicated password hash such as Argon2id or bcrypt and verify them with the library's constant-time comparison API; reject non-string credentials."
+        },
+        {
+          "severity": "high",
+          "title": "Issued authentication tokens never expire",
+          "body": "`jwt.sign` is called without `expiresIn`, so captured tokens remain valid indefinitely unless every verifier adds an independent lifetime policy. This makes token theft persistent and prevents bounded recovery after credential or device compromise.",
+          "file": "src/auth.js",
+          "line_start": 15,
+          "line_end": 15,
+          "confidence": 0.98,
+          "recommendation": "Set a short explicit `expiresIn`, include and validate issuer and audience, and add a refresh or revocation mechanism appropriate to the session model."
+        }
+      ],
+      "latencyMs": 34535
+    },
+    {
+      "verdict": "needs-attention",
+      "summary": "Do not ship: the new authentication path is vulnerable to SQL injection and uses a source-controlled JWT signing key, enabling account compromise and forged sessions.",
+      "findings": [
+        {
+          "severity": "critical",
+          "title": "Username interpolation permits SQL injection in the authentication query",
+          "body": "`username` is concatenated directly into SQL. An attacker can alter the WHERE clause or append database-specific payloads through the login input. Depending on the database driver's result behavior, this can bypass authentication, expose user records, or modify data; the injection itself is directly established even though the exact downstream exploit depends on `db.query`.",
+          "file": "src/auth.js",
+          "line_start": 7,
+          "line_end": 9,
+          "confidence": 0.99,
+          "recommendation": "Use a parameterized query with a bound username value and select only the required columns. Add tests using quote, tautology, comment, and stacked-query payloads supported by the configured database."
+        },
+        {
+          "severity": "critical",
+          "title": "Hardcoded JWT secret allows session forgery",
+          "body": "The signing key is embedded in source code and used directly to mint authentication tokens. Anyone who can read the repository, a packaged artifact, or leaked source can generate valid tokens for arbitrary `sub` values. The key also cannot be rotated safely per environment without changing and redeploying code.",
+          "file": "src/auth.js",
+          "line_start": 4,
+          "line_end": 4,
+          "confidence": 0.99,
+          "recommendation": "Load a high-entropy signing key from a managed secret, fail startup when it is absent or weak, separate keys by environment, and implement key rotation using explicit key identifiers."
+        },
+        {
+          "severity": "high",
+          "title": "Password verification appears to compare raw credentials directly",
+          "body": "The login path compares the supplied password directly with `user.password`, with no password-hash verification. Unless `db.query` performs undocumented transformation, this requires stored plaintext or equivalently recoverable passwords, turning any database disclosure into immediate credential compromise. Loose equality also permits type coercion.",
+          "file": "src/auth.js",
+          "line_start": 13,
+          "line_end": 16,
+          "confidence": 0.94,
+          "recommendation": "Store passwords using a password-specific hash such as Argon2id or bcrypt and verify with its constant-time library API. Use a dummy hash for unknown users to reduce account-enumeration timing differences."
+        }
+      ],
+      "latencyMs": 27144
+    }
+  ],
+  "raw": "{\n  \"review\": \"Adversarial Review\",\n  \"target\": {\n    \"mode\": \"working-tree\",\n    \"label\": \"working tree diff\",\n    \"explicit\": true\n  },\n  \"threadId\": \"01a03378-2f68-7823-976c-df76c1c63f63\",\n  \"context\": {\n    \"repoRoot\": \"C:/Users/arcobaleno/AppData/Local/Temp/bench-auth-basic-pa9kuD\",\n    \"branch\": \"main\",\n    \"summary\": \"Reviewing 0 staged, 1 unstaged, and 0 untracked file(s).\"\n  },\n  \"codex\": {\n    \"status\": 0,\n    \"stderr\": \"\",\n    \"stdout\": \"{\\\"verdict\\\":\\\"needs-attention\\\",\\\"summary\\\":\\\"Do not ship: the new authentication path is vulnerable to SQL injection and uses a source-controlled JWT signing key, enabling account compromise and forged sessions.\\\",\\\"findings\\\":[{\\\"severity\\\":\\\"critical\\\",\\\"title\\\":\\\"Username interpolation permits SQL injection in the authentication query\\\",\\\"body\\\":\\\"`username` is concatenated directly into SQL. An attacker can alter the WHERE clause or append database-specific payloads through the login input. Depending on the database driver's result behavior, this can bypass authentication, expose user records, or modify data; the injection itself is directly established even though the exact downstream exploit depends on `db.query`.\\\",\\\"file\\\":\\\"src/auth.js\\\",\\\"line_start\\\":7,\\\"line_end\\\":9,\\\"confidence\\\":0.99,\\\"recommendation\\\":\\\"Use a parameterized query with a bound username value and select only the required columns. Add tests using quote, tautology, comment, and stacked-query payloads supported by the configured database.\\\"},{\\\"severity\\\":\\\"critical\\\",\\\"title\\\":\\\"Hardcoded JWT secret allows session forgery\\\",\\\"body\\\":\\\"The signing key is embedded in source code and used directly to mint authentication tokens. Anyone who can read the repository, a packaged artifact, or leaked source can generate valid tokens for arbitrary `sub` values. The key also cannot be rotated safely per environment without changing and redeploying code.\\\",\\\"file\\\":\\\"src/auth.js\\\",\\\"line_start\\\":4,\\\"line_end\\\":4,\\\"confidence\\\":0.99,\\\"recommendation\\\":\\\"Load a high-entropy signing key from a managed secret, fail startup when it is absent or weak, separate keys by environment, and implement key rotation using explicit key identifiers.\\\"},{\\\"severity\\\":\\\"high\\\",\\\"title\\\":\\\"Password verification appears to compare raw credentials directly\\\",\\\"body\\\":\\\"The login path compares the supplied password directly with `user.password`, with no password-hash verification. Unless `db.query` performs undocumented transformation, this requires stored plaintext or equivalently recoverable passwords, turning any database disclosure into immediate credential compromise. Loose equality also permits type coercion.\\\",\\\"file\\\":\\\"src/auth.js\\\",\\\"line_start\\\":13,\\\"line_end\\\":16,\\\"confidence\\\":0.94,\\\"recommendation\\\":\\\"Store passwords using a password-specific hash such as Argon2id or bcrypt and verify with its constant-time library API. Use a dummy hash for unknown users to reduce account-enumeration timing differences.\\\"}],\\\"next_steps\\\":[\\\"Block shipment until all three authentication defects are fixed.\\\",\\\"Add adversarial tests for SQL payloads, forged JWTs, missing or rotated keys, invalid users, and incorrect passwords.\\\"]}\",\n    \"reasoning\": []\n  },\n  \"result\": {\n    \"verdict\": \"needs-attention\",\n    \"summary\": \"Do not ship: the new authentication path is vulnerable to SQL injection and uses a source-controlled JWT signing key, enabling account compromise and forged sessions.\",\n    \"findings\": [\n      {\n        \"severity\": \"critical\",\n        \"title\": \"Username interpolation permits SQL injection in the authentication query\",\n        \"body\": \"`username` is concatenated directly into SQL. An attacker can alter the WHERE clause or append database-specific payloads through the login input. Depending on the database driver's result behavior, this can bypass authentication, expose user records, or modify data; the injection itself is directly established even though the exact downstream exploit depends on `db.query`.\",\n        \"file\": \"src/a"
+}

--- a/bench/cassettes/auth-basic/codex.model.json
+++ b/bench/cassettes/auth-basic/codex.model.json
@@ -1,225 +1,196 @@
 {
   "caseId": "auth-basic",
   "cell": "codex.model",
-  "recordedAt": "2026-08-19T03:13:16.223Z",
+  "recordedAt": "2026-08-24T04:43:45.305Z",
   "verdict": "needs-attention",
-  "summary": "Authentication is vulnerable to SQL injection, credential compromise, and forged or indefinitely reusable tokens.",
+  "summary": "Authentication is vulnerable to SQL injection, token forgery, and insecure password verification.",
   "findings": [
     {
       "severity": "critical",
-      "title": "SQL injection in user lookup",
-      "body": "The username is concatenated directly into the SQL query, allowing attacker-controlled input to alter the statement and potentially bypass authentication or access/modify database data.",
+      "title": "Username is interpolated into SQL",
+      "body": "findUser concatenates attacker-controlled username directly into the query, allowing crafted input to alter the statement and potentially bypass authentication or access/modify database data.",
       "file": "src/auth.js",
-      "line_start": 6,
+      "line_start": 5,
       "line_end": 8,
       "confidence": 1,
       "recommendation": "Use a parameterized query or prepared statement and pass username as a bound parameter."
     },
     {
       "severity": "high",
-      "title": "Hardcoded JWT signing secret",
-      "body": "The signing key is embedded in source code, so anyone with source or artifact access can forge valid authentication tokens; rotating the compromised key also requires a code change and redeployment.",
+      "title": "JWT signing secret is embedded in source",
+      "body": "Every deployment uses the exposed constant to sign tokens; anyone who obtains the source can forge valid authentication tokens for arbitrary user IDs.",
       "file": "src/auth.js",
       "line_start": 4,
       "line_end": 4,
       "confidence": 1,
-      "recommendation": "Load a high-entropy signing key from a secret manager or protected environment variable, fail startup when it is absent, and rotate the exposed key."
+      "recommendation": "Load a strong per-environment secret from protected configuration, fail startup when it is missing, and rotate the exposed key."
     },
     {
       "severity": "high",
-      "title": "Passwords are compared directly",
-      "body": "The submitted password is compared directly with the stored value, indicating plaintext or equivalently reusable password storage instead of a slow password-hash verification flow; a database disclosure would expose user credentials.",
+      "title": "Password is compared directly to stored value",
+      "body": "login compares the submitted password to user.password with a direct equality check, indicating passwords are authenticated without a password-hash verification function; a database disclosure can therefore expose reusable credentials if values are stored as expected by this code.",
       "file": "src/auth.js",
-      "line_start": 11,
-      "line_end": 14,
-      "confidence": 0.98,
-      "recommendation": "Store passwords using Argon2id, bcrypt, or scrypt with per-password salts and verify them using the library's comparison function."
-    },
-    {
-      "severity": "medium",
-      "title": "JWTs never expire",
-      "body": "Tokens are signed without an expiration claim, so a stolen token remains valid indefinitely unless all tokens are invalidated through signing-key rotation.",
-      "file": "src/auth.js",
-      "line_start": 15,
+      "line_start": 13,
       "line_end": 15,
-      "confidence": 0.99,
-      "recommendation": "Set a short explicit expiresIn value and implement refresh-token rotation or another bounded session-renewal mechanism."
+      "confidence": 0.98,
+      "recommendation": "Store passwords using a suitable password-hashing algorithm such as Argon2id or bcrypt and verify them with the library's constant-time comparison API."
     },
     {
       "severity": "medium",
-      "title": "Malformed session input throws uncaught exception",
-      "body": "parseSession calls JSON.parse without handling malformed input or validating the decoded shape, so attacker-controlled invalid JSON can propagate an exception through request processing and potentially cause repeated request failures.",
+      "title": "Missing-user path can throw",
+      "body": "login dereferences user.password without checking whether findUser returned a user, so an unknown username or empty query result can cause an exception instead of a controlled authentication failure.",
       "file": "src/auth.js",
-      "line_start": 20,
-      "line_end": 23,
-      "confidence": 0.96,
-      "recommendation": "Catch JSON parsing failures, validate that the result is an object with an acceptable userId, and return or throw a controlled authentication error."
+      "line_start": 12,
+      "line_end": 14,
+      "confidence": 0.93,
+      "recommendation": "Normalize the query result and return an authentication failure when no user exists before accessing user fields."
     }
   ],
-  "latencyMs": 20209,
-  "engineVersion": "codex-cli 0.147.0",
+  "latencyMs": 23293,
+  "engineVersion": "codex-cli 0.149.0",
+  "engineObserved": null,
   "samples": [
     {
       "verdict": "needs-attention",
-      "summary": "Authentication is vulnerable to SQL injection, credential compromise, token forgery, and malformed-input crashes.",
-      "findings": [
-        {
-          "severity": "critical",
-          "title": "SQL injection in user lookup",
-          "body": "The username is concatenated directly into the SQL statement, allowing attacker-controlled input to alter the query and potentially bypass authentication or access database data.",
-          "file": "src/auth.js",
-          "line_start": 6,
-          "line_end": 8,
-          "confidence": 1,
-          "recommendation": "Use a parameterized query with the username supplied as a bound parameter."
-        },
-        {
-          "severity": "critical",
-          "title": "Hardcoded JWT signing secret",
-          "body": "The signing key is embedded in source code, so anyone who obtains the code can forge valid authentication tokens; the same key is also likely to be reused across deployments.",
-          "file": "src/auth.js",
-          "line_start": 4,
-          "line_end": 4,
-          "confidence": 1,
-          "recommendation": "Load a strong, deployment-specific secret from a protected secret store or environment variable, fail startup if absent, and rotate the exposed key."
-        },
-        {
-          "severity": "high",
-          "title": "Passwords compared as plaintext",
-          "body": "The supplied password is compared directly with the stored value, implying plaintext or reversibly stored credentials and exposing all accounts if the database is compromised.",
-          "file": "src/auth.js",
-          "line_start": 12,
-          "line_end": 16,
-          "confidence": 0.98,
-          "recommendation": "Store passwords using a password-hashing algorithm such as Argon2id or bcrypt and verify them with the library's constant-time comparison function."
-        },
-        {
-          "severity": "medium",
-          "title": "Unknown users can crash login",
-          "body": "The code dereferences user.password without checking whether findUser returned a user, so an unknown username can cause an exception instead of a controlled authentication failure.",
-          "file": "src/auth.js",
-          "line_start": 13,
-          "line_end": 14,
-          "confidence": 0.94,
-          "recommendation": "Validate that exactly one user was returned before accessing its fields and return a uniform authentication failure otherwise."
-        },
-        {
-          "severity": "medium",
-          "title": "Malformed session input throws uncaught exception",
-          "body": "JSON.parse is called on untrusted raw input without error handling or schema validation, so malformed JSON can propagate an exception and potentially terminate or disrupt the request path.",
-          "file": "src/auth.js",
-          "line_start": 20,
-          "line_end": 23,
-          "confidence": 0.97,
-          "recommendation": "Catch parse failures, reject non-object payloads, and validate userId before returning it."
-        }
-      ],
-      "latencyMs": 19094
-    },
-    {
-      "verdict": "needs-attention",
-      "summary": "Authentication is vulnerable to SQL injection, credential exposure, and JWT forgery.",
+      "summary": "Authentication is vulnerable to SQL injection, token forgery, plaintext password comparison, and invalid-user crashes.",
       "findings": [
         {
           "severity": "critical",
           "title": "Username enables SQL injection",
-          "body": "findUser concatenates attacker-controlled username directly into the SQL statement, allowing authentication bypass, data disclosure, or database modification depending on driver and account permissions.",
+          "body": "findUser concatenates attacker-controlled username directly into the SQL statement at lines 7-9. A crafted username can alter the query, bypass authentication, or access/modify database data depending on driver permissions.",
           "file": "src/auth.js",
           "line_start": 7,
           "line_end": 9,
           "confidence": 1,
-          "recommendation": "Use a parameterized query with a bound username value."
+          "recommendation": "Use a parameterized query with username supplied as a bound parameter."
         },
         {
           "severity": "high",
-          "title": "JWT signing secret is hardcoded",
-          "body": "The signing key is committed in source, so anyone who obtains the code can forge valid authentication tokens for arbitrary user IDs.",
+          "title": "Hardcoded JWT signing secret permits token forgery",
+          "body": "The JWT secret is embedded in source code at line 4. Anyone who obtains the source or deployed artifact can sign arbitrary session tokens, and the same secret is likely reused across environments.",
           "file": "src/auth.js",
           "line_start": 4,
           "line_end": 4,
           "confidence": 1,
-          "recommendation": "Load a high-entropy secret from protected runtime configuration, fail startup if absent, and rotate the exposed key."
+          "recommendation": "Load a strong secret from an environment-specific secret store, fail startup when absent, and rotate the exposed key."
+        },
+        {
+          "severity": "high",
+          "title": "Passwords are compared directly without verification hashing",
+          "body": "login compares the supplied password directly with user.password at line 15, indicating passwords must be stored or exposed in directly comparable form. A database compromise would expose usable credentials; loose equality also permits coercion.",
+          "file": "src/auth.js",
+          "line_start": 15,
+          "line_end": 15,
+          "confidence": 0.99,
+          "recommendation": "Store salted password hashes and verify them with a password-hashing library using strict, timing-safe verification."
+        },
+        {
+          "severity": "medium",
+          "title": "Unknown users cause login to throw",
+          "body": "login dereferences user.password without checking whether findUser returned a user. A normal login attempt for a nonexistent username can therefore raise an exception instead of returning an authentication failure, potentially producing 500 responses or denial-of-service noise.",
+          "file": "src/auth.js",
+          "line_start": 14,
+          "line_end": 15,
+          "confidence": 0.92,
+          "recommendation": "Handle an absent user before dereferencing it and return the same generic failure used for an incorrect password."
+        }
+      ],
+      "latencyMs": 25679
+    },
+    {
+      "verdict": "needs-attention",
+      "summary": "Authentication is vulnerable to SQL injection, token forgery after secret disclosure, and insecure password verification.",
+      "findings": [
+        {
+          "severity": "critical",
+          "title": "Username enables SQL injection",
+          "body": "findUser concatenates attacker-controlled username directly into the SQL statement at lines 7-9. A crafted username can alter the query, bypass authentication, or read and modify database data depending on database permissions.",
+          "file": "src/auth.js",
+          "line_start": 7,
+          "line_end": 9,
+          "confidence": 1,
+          "recommendation": "Use a parameterized query with username passed as a bound parameter."
+        },
+        {
+          "severity": "high",
+          "title": "JWT signing secret is embedded in source",
+          "body": "The static signing key at line 4 is exposed to anyone who can read the source or built artifact. Disclosure permits forging valid authentication tokens for arbitrary user IDs, and every deployment shares the same compromised key.",
+          "file": "src/auth.js",
+          "line_start": 4,
+          "line_end": 4,
+          "confidence": 1,
+          "recommendation": "Load a strong deployment-specific secret from a secret manager or required environment variable, fail startup if absent, and rotate the exposed key."
         },
         {
           "severity": "high",
           "title": "Passwords are compared as plaintext",
-          "body": "login directly compares the submitted password with the stored value, implying plaintext or equivalently reversible credential storage and exposing every account if the database is compromised.",
+          "body": "login compares the supplied password directly with user.password, implying passwords are stored or otherwise handled as plaintext rather than verified against a password hash. A database disclosure would expose reusable credentials.",
           "file": "src/auth.js",
-          "line_start": 14,
-          "line_end": 16,
-          "confidence": 0.99,
-          "recommendation": "Store salted password hashes using a password-specific algorithm such as Argon2id or bcrypt and verify them with the library's constant-time verification function."
+          "line_start": 13,
+          "line_end": 18,
+          "confidence": 0.98,
+          "recommendation": "Store passwords using a password-hashing algorithm such as Argon2id or bcrypt and verify them with the library's comparison function."
         },
         {
           "severity": "medium",
-          "title": "Issued tokens never expire",
-          "body": "jwt.sign is called without an expiration, so stolen tokens remain usable indefinitely unless the signing key is rotated.",
+          "title": "Issued authentication tokens never expire",
+          "body": "jwt.sign is called without an expiration, so stolen tokens remain valid indefinitely unless the signing key is rotated.",
           "file": "src/auth.js",
-          "line_start": 17,
-          "line_end": 17,
-          "confidence": 0.98,
-          "recommendation": "Set a short explicit expiresIn value and implement an appropriate refresh or revocation mechanism."
+          "line_start": 16,
+          "line_end": 16,
+          "confidence": 0.99,
+          "recommendation": "Set a short explicit expiresIn value and implement an appropriate refresh or reauthentication flow."
         }
       ],
-      "latencyMs": 18171
+      "latencyMs": 24329
     },
     {
       "verdict": "needs-attention",
-      "summary": "Authentication is vulnerable to SQL injection, credential compromise, and forged or indefinitely reusable tokens.",
+      "summary": "Authentication is vulnerable to SQL injection, token forgery, and insecure password verification.",
       "findings": [
         {
           "severity": "critical",
-          "title": "SQL injection in user lookup",
-          "body": "The username is concatenated directly into the SQL query, allowing attacker-controlled input to alter the statement and potentially bypass authentication or access/modify database data.",
+          "title": "Username is interpolated into SQL",
+          "body": "findUser concatenates attacker-controlled username directly into the query, allowing crafted input to alter the statement and potentially bypass authentication or access/modify database data.",
           "file": "src/auth.js",
-          "line_start": 6,
+          "line_start": 5,
           "line_end": 8,
           "confidence": 1,
           "recommendation": "Use a parameterized query or prepared statement and pass username as a bound parameter."
         },
         {
           "severity": "high",
-          "title": "Hardcoded JWT signing secret",
-          "body": "The signing key is embedded in source code, so anyone with source or artifact access can forge valid authentication tokens; rotating the compromised key also requires a code change and redeployment.",
+          "title": "JWT signing secret is embedded in source",
+          "body": "Every deployment uses the exposed constant to sign tokens; anyone who obtains the source can forge valid authentication tokens for arbitrary user IDs.",
           "file": "src/auth.js",
           "line_start": 4,
           "line_end": 4,
           "confidence": 1,
-          "recommendation": "Load a high-entropy signing key from a secret manager or protected environment variable, fail startup when it is absent, and rotate the exposed key."
+          "recommendation": "Load a strong per-environment secret from protected configuration, fail startup when it is missing, and rotate the exposed key."
         },
         {
           "severity": "high",
-          "title": "Passwords are compared directly",
-          "body": "The submitted password is compared directly with the stored value, indicating plaintext or equivalently reusable password storage instead of a slow password-hash verification flow; a database disclosure would expose user credentials.",
+          "title": "Password is compared directly to stored value",
+          "body": "login compares the submitted password to user.password with a direct equality check, indicating passwords are authenticated without a password-hash verification function; a database disclosure can therefore expose reusable credentials if values are stored as expected by this code.",
           "file": "src/auth.js",
-          "line_start": 11,
-          "line_end": 14,
-          "confidence": 0.98,
-          "recommendation": "Store passwords using Argon2id, bcrypt, or scrypt with per-password salts and verify them using the library's comparison function."
-        },
-        {
-          "severity": "medium",
-          "title": "JWTs never expire",
-          "body": "Tokens are signed without an expiration claim, so a stolen token remains valid indefinitely unless all tokens are invalidated through signing-key rotation.",
-          "file": "src/auth.js",
-          "line_start": 15,
+          "line_start": 13,
           "line_end": 15,
-          "confidence": 0.99,
-          "recommendation": "Set a short explicit expiresIn value and implement refresh-token rotation or another bounded session-renewal mechanism."
+          "confidence": 0.98,
+          "recommendation": "Store passwords using a suitable password-hashing algorithm such as Argon2id or bcrypt and verify them with the library's constant-time comparison API."
         },
         {
           "severity": "medium",
-          "title": "Malformed session input throws uncaught exception",
-          "body": "parseSession calls JSON.parse without handling malformed input or validating the decoded shape, so attacker-controlled invalid JSON can propagate an exception through request processing and potentially cause repeated request failures.",
+          "title": "Missing-user path can throw",
+          "body": "login dereferences user.password without checking whether findUser returned a user, so an unknown username or empty query result can cause an exception instead of a controlled authentication failure.",
           "file": "src/auth.js",
-          "line_start": 20,
-          "line_end": 23,
-          "confidence": 0.96,
-          "recommendation": "Catch JSON parsing failures, validate that the result is an object with an acceptable userId, and return or throw a controlled authentication error."
+          "line_start": 12,
+          "line_end": 14,
+          "confidence": 0.93,
+          "recommendation": "Normalize the query result and return an authentication failure when no user exists before accessing user fields."
         }
       ],
-      "latencyMs": 20209
+      "latencyMs": 23293
     }
   ],
-  "raw": "{\"verdict\":\"needs-attention\",\"summary\":\"Authentication is vulnerable to SQL injection, credential compromise, and forged or indefinitely reusable tokens.\",\"findings\":[{\"severity\":\"critical\",\"title\":\"SQL injection in user lookup\",\"body\":\"The username is concatenated directly into the SQL query, allowing attacker-controlled input to alter the statement and potentially bypass authentication or access/modify database data.\",\"file\":\"src/auth.js\",\"line_start\":6,\"line_end\":8,\"confidence\":1.0,\"recommendation\":\"Use a parameterized query or prepared statement and pass username as a bound parameter.\"},{\"severity\":\"high\",\"title\":\"Hardcoded JWT signing secret\",\"body\":\"The signing key is embedded in source code, so anyone with source or artifact access can forge valid authentication tokens; rotating the compromised key also requires a code change and redeployment.\",\"file\":\"src/auth.js\",\"line_start\":4,\"line_end\":4,\"confidence\":1.0,\"recommendation\":\"Load a high-entropy signing key from a secret manager or protected environment variable, fail startup when it is absent, and rotate the exposed key.\"},{\"severity\":\"high\",\"title\":\"Passwords are compared directly\",\"body\":\"The submitted password is compared directly with the stored value, indicating plaintext or equivalently reusable password storage instead of a slow password-hash verification flow; a database disclosure would expose user credentials.\",\"file\":\"src/auth.js\",\"line_start\":11,\"line_end\":14,\"confidence\":0.98,\"recommendation\":\"Store passwords using Argon2id, bcrypt, or scrypt with per-password salts and verify them using the library's comparison function.\"},{\"severity\":\"medium\",\"title\":\"JWTs never expire\",\"body\":\"Tokens are signed without an expiration claim, so a stolen token remains valid indefinitely unless all tokens are invalidated through signing-key rotation.\",\"file\":\"src/auth.js\",\"line_start\":15,\"line_end\":15,\"confidence\":0.99,\"recommendation\":\"Set a short explicit expiresIn value and implement refresh-token rotation or another bounded session-renewal mechanism.\"},{\"severity\":\"medium\",\"title\":\"Malformed session input throws uncaught exception\",\"body\":\"parseSession calls JSON.parse without handling malformed input or validating the decoded shape, so attacker-controlled invalid JSON can propagate an exception through request processing and potentially cause repeated request failures.\",\"file\":\"src/auth.js\",\"line_start\":20,\"line_end\":23,\"confidence\":0.96,\"recommendation\":\"Catch JSON parsing failures, validate that the result is an object with an acceptable userId, and return or throw a controlled authentication error.\"}],\"next_steps\":[\"Parameterize the database query and add SQL-injection regression tests.\",\"Replace direct password comparison with password-hash verification and migrate existing credentials safely.\",\"Move the JWT key to protected configuration, rotate it, and enforce token expiration.\",\"Validate session input and convert malformed data into a controlled authentication failure.\"]}\n"
+  "raw": "{\"verdict\":\"needs-attention\",\"summary\":\"Authentication is vulnerable to SQL injection, token forgery, and insecure password verification.\",\"findings\":[{\"severity\":\"critical\",\"title\":\"Username is interpolated into SQL\",\"body\":\"findUser concatenates attacker-controlled username directly into the query, allowing crafted input to alter the statement and potentially bypass authentication or access/modify database data.\",\"file\":\"src/auth.js\",\"line_start\":5,\"line_end\":8,\"confidence\":1.0,\"recommendation\":\"Use a parameterized query or prepared statement and pass username as a bound parameter.\"},{\"severity\":\"high\",\"title\":\"JWT signing secret is embedded in source\",\"body\":\"Every deployment uses the exposed constant to sign tokens; anyone who obtains the source can forge valid authentication tokens for arbitrary user IDs.\",\"file\":\"src/auth.js\",\"line_start\":4,\"line_end\":4,\"confidence\":1.0,\"recommendation\":\"Load a strong per-environment secret from protected configuration, fail startup when it is missing, and rotate the exposed key.\"},{\"severity\":\"high\",\"title\":\"Password is compared directly to stored value\",\"body\":\"login compares the submitted password to user.password with a direct equality check, indicating passwords are authenticated without a password-hash verification function; a database disclosure can therefore expose reusable credentials if values are stored as expected by this code.\",\"file\":\"src/auth.js\",\"line_start\":13,\"line_end\":15,\"confidence\":0.98,\"recommendation\":\"Store passwords using a suitable password-hashing algorithm such as Argon2id or bcrypt and verify them with the library's constant-time comparison API.\"},{\"severity\":\"medium\",\"title\":\"Missing-user path can throw\",\"body\":\"login dereferences user.password without checking whether findUser returned a user, so an unknown username or empty query result can cause an exception instead of a controlled authentication failure.\",\"file\":\"src/auth.js\",\"line_start\":12,\"line_end\":14,\"confidence\":0.93,\"recommendation\":\"Normalize the query result and return an authentication failure when no user exists before accessing user fields.\"}],\"next_steps\":[\"Parameterize the lookup query and define its single-row result contract.\",\"Replace the embedded JWT key and rotate it.\",\"Implement hashed-password verification and test valid, invalid, missing-user, and injection inputs.\"]}\n"
 }

--- a/bench/cassettes/auth-basic/gemini.deep.json
+++ b/bench/cassettes/auth-basic/gemini.deep.json
@@ -1,225 +1,216 @@
 {
   "caseId": "auth-basic",
   "cell": "gemini.deep",
-  "recordedAt": "2026-08-19T12:07:48.879Z",
+  "recordedAt": "2026-08-24T10:50:24.540Z",
   "verdict": "needs-attention",
-  "summary": "The authentication implementation contains severe security risks including SQL injection, plaintext password verification, hardcoded secrets, and missing error handling.",
+  "summary": "The authentication module contains critical security vulnerabilities including SQL injection, plaintext password comparison, a hardcoded JWT secret, and potential runtime crashes from unhandled null values and parsing exceptions.",
   "findings": [
     {
       "severity": "critical",
-      "title": "SQL Injection vulnerability in findUser",
-      "body": "The username query parameter is concatenated directly into the SQL statement, which allows arbitrary SQL command injection.",
+      "title": "SQL Injection in User Lookup",
+      "body": "The user input 'username' is directly concatenated into the SQL query string inside the 'findUser' function. A malicious actor can exploit this to inject arbitrary SQL commands, potentially bypassing authentication, extracting sensitive database contents, or modifying data.",
       "file": "src/auth.js",
-      "line_start": 6,
-      "line_end": 11,
+      "line_start": 7,
+      "line_end": 9,
       "confidence": 1,
-      "recommendation": "Use parameterized queries instead of string concatenation, for example: `db.query('SELECT * FROM users WHERE name = ?', [username])`."
+      "recommendation": "Use parameterized queries or prepared statements to safely bind the username parameter, for example: db.query('SELECT * FROM users WHERE name = ?', [username])."
     },
     {
       "severity": "high",
-      "title": "Plaintext Password Comparison and Missing Null/Empty Result Validation",
-      "body": "The password is compared in plaintext using the loose equality operator (==). Additionally, there is no check to see if findUser returns a valid user object, which can lead to TypeError exceptions if the user does not exist.",
+      "title": "Unhandled Missing User and Potential Null Reference Crash",
+      "body": "In the 'login' function, the return value of 'findUser(username)' is directly dereferenced with 'user.password' without checking if 'user' is null or undefined. If the user does not exist in the database, this dereference will throw a TypeError and crash the execution context.",
       "file": "src/auth.js",
-      "line_start": 13,
-      "line_end": 19,
-      "confidence": 0.95,
-      "recommendation": "Check if user is truthy before validating password, and use a secure hashing algorithm (such as bcrypt) for password storage and verification."
+      "line_start": 14,
+      "line_end": 17,
+      "confidence": 1,
+      "recommendation": "Add a check to verify that 'user' is returned and valid before accessing its properties, or retrieve the first row if findUser returns an array."
     },
     {
       "severity": "high",
-      "title": "Hardcoded JWT Secret",
-      "body": "The JWT signing secret 'hardcoded-super-secret-key' is stored directly in the source file, which exposes it to anybody with source code access.",
+      "title": "Plaintext Password Verification",
+      "body": "Passwords are compared directly as plaintext in 'user.password == password'. This indicates that user credentials are likely stored in plaintext or compared insecurely, exposing user passwords to exposure during database breaches or leaks.",
+      "file": "src/auth.js",
+      "line_start": 15,
+      "line_end": 15,
+      "confidence": 1,
+      "recommendation": "Use a secure, industry-standard password hashing library such as bcrypt or argon2 to hash and verify user passwords."
+    },
+    {
+      "severity": "high",
+      "title": "Hardcoded JWT Secret Key",
+      "body": "The 'JWT_SECRET' variable is hardcoded with a static string value ('hardcoded-super-secret-key'). If this key is committed to version control, any attacker can easily forge valid JWT session tokens to impersonate users.",
       "file": "src/auth.js",
       "line_start": 4,
       "line_end": 4,
       "confidence": 1,
-      "recommendation": "Load the JWT secret key from environment variables (e.g., process.env.JWT_SECRET)."
+      "recommendation": "Retrieve the JWT signing secret from a secure environment variable (e.g., process.env.JWT_SECRET) or secrets vault."
     },
     {
       "severity": "medium",
-      "title": "Unhandled Exception on parseSession JSON Parsing",
-      "body": "JSON.parse(raw) is called directly without a try-catch block, which can cause unhandled exceptions and system crashes if raw is not valid JSON.",
+      "title": "Unhandled JSON.parse Exception",
+      "body": "In 'parseSession', the 'raw' argument is parsed with 'JSON.parse(raw)' without a try-catch block. If the input is not valid JSON, it throws an unhandled SyntaxError, which can crash the application or unhandled middleware chain.",
       "file": "src/auth.js",
       "line_start": 21,
       "line_end": 24,
       "confidence": 1,
-      "recommendation": "Wrap JSON.parse in a try-catch block and return null or handle the error gracefully."
-    },
-    {
-      "severity": "high",
-      "title": "Missing Dependencies and db.js Module",
-      "body": "The code requires './db' which does not exist in the repository, and relies on 'jsonwebtoken' without a package.json file to manage it.",
-      "file": "src/auth.js",
-      "line_start": 1,
-      "line_end": 2,
-      "confidence": 1,
-      "recommendation": "Implement the missing db.js module and initialize package.json with dependencies."
+      "recommendation": "Wrap the JSON.parse operation inside a try-catch block to handle malformed inputs gracefully."
     }
   ],
-  "latencyMs": 32841,
-  "engineVersion": "0.55.1",
+  "latencyMs": 30071,
+  "engineVersion": "0.56.0",
+  "engineObserved": "gemini",
   "samples": [
     {
       "verdict": "needs-attention",
-      "summary": "The authentication implementation contains critical security vulnerabilities, including SQL injection, a hardcoded secret key, plaintext password verification, and potential runtime crashes due to missing null checks and unhandled exceptions.",
-      "findings": [
-        {
-          "severity": "critical",
-          "title": "SQL Injection in User Lookup",
-          "body": "In `src/auth.js` inside `findUser(username)`, the `username` parameter is directly concatenated into the SQL query string. This allows an attacker to manipulate the input and execute arbitrary SQL commands, potentially leading to unauthorized data access, database modification, or authentication bypass.",
-          "file": "src/auth.js",
-          "line_start": 5,
-          "line_end": 10,
-          "confidence": 1,
-          "recommendation": "Use parameterized queries or prepared statements instead of string concatenation. For example, rewrite the query to use placeholders: `await db.query('SELECT * FROM users WHERE name = ?', [username])`."
-        },
-        {
-          "severity": "high",
-          "title": "Unsafe Password Verification and Unchecked Null Object",
-          "body": "In `src/auth.js` inside `login(username, password)`, the password verification `user.password == password` is performed directly on the object returned by `findUser`. If no user is found, `user` may be null or undefined, causing a `TypeError` (e.g., 'Cannot read properties of undefined') that crashes the execution flow. Additionally, comparing passwords in plaintext is highly insecure and vulnerable to data breaches.",
-          "file": "src/auth.js",
-          "line_start": 12,
-          "line_end": 18,
-          "confidence": 1,
-          "recommendation": "Verify that `user` is not null/undefined before accessing `user.password`. Store passwords using a secure cryptographic hashing algorithm (e.g., bcrypt or argon2) and use the corresponding compare function (e.g., `await bcrypt.compare(password, user.password)`) instead of direct plaintext comparison."
-        },
-        {
-          "severity": "high",
-          "title": "Hardcoded JWT Secret Key",
-          "body": "The JWT signing secret `JWT_SECRET` is hardcoded as a string constant inside `src/auth.js`. Hardcoding secrets in source code increases the risk of accidental exposure via source control or unauthorized access, allowing attackers to forge valid authentication tokens.",
-          "file": "src/auth.js",
-          "line_start": 3,
-          "line_end": 3,
-          "confidence": 1,
-          "recommendation": "Load the JWT secret from environment variables (e.g., `process.env.JWT_SECRET`) and ensure the application throws an error at startup if the secret is not defined."
-        },
-        {
-          "severity": "medium",
-          "title": "Uncaught Exception in JSON Parsing",
-          "body": "In `src/auth.js` inside `parseSession(raw)`, `JSON.parse(raw)` is called without safety checks or exception handling. If `raw` is malformed, empty, or not a string, `JSON.parse` will throw a `SyntaxError` that is uncaught, potentially crashing the application. Additionally, if the parsed object is null, accessing `session.userId` will throw a TypeError.",
-          "file": "src/auth.js",
-          "line_start": 20,
-          "line_end": 24,
-          "confidence": 1,
-          "recommendation": "Wrap `JSON.parse(raw)` in a `try-catch` block to handle parsing failures gracefully, and ensure the parsed session object is non-null before accessing its properties."
-        }
-      ],
-      "latencyMs": 35066
-    },
-    {
-      "verdict": "needs-attention",
-      "summary": "The authentication module contains critical security vulnerabilities, including SQL injection, hardcoded secrets, plaintext password handling, and potential unhandled exceptions.",
+      "summary": "Critical security vulnerabilities and potential runtime errors identified in authentication, querying, and session parsing.",
       "findings": [
         {
           "severity": "critical",
           "title": "SQL Injection in findUser",
-          "body": "The findUser function constructs SQL queries by directly concatenating the user-provided 'username' parameter. An attacker can manipulate this parameter to inject arbitrary SQL commands, potentially bypassing authentication or reading/modifying database records.",
+          "body": "The findUser function constructs a SQL query by directly concatenating the unvalidated 'username' argument. This allows attackers to perform SQL injection, potentially gaining unauthorized access or manipulating database data.",
           "file": "src/auth.js",
           "line_start": 6,
           "line_end": 11,
           "confidence": 1,
-          "recommendation": "Use parameterized queries to safely pass input to the database: await db.query('SELECT * FROM users WHERE name = ?', [username]);"
+          "recommendation": "Use parameterized queries or prepared statements, such as: await db.query('SELECT * FROM users WHERE name = ?', [username])"
         },
         {
           "severity": "critical",
-          "title": "Plaintext Password Comparison and Lack of Hashing",
-          "body": "The login function directly compares passwords using plaintext string equality. Storing or comparing passwords in plaintext exposes credentials in the event of database access, and string equality checks are susceptible to timing attacks.",
+          "title": "Plaintext Password Comparison and Missing Null Check",
+          "body": "The login function compares passwords in plaintext using loose equality ('==') instead of cryptographic hashing. Additionally, if findUser returns no user (e.g., null or undefined), accessing user.password will throw a TypeError and crash the process.",
           "file": "src/auth.js",
-          "line_start": 14,
-          "line_end": 18,
+          "line_start": 13,
+          "line_end": 19,
           "confidence": 1,
-          "recommendation": "Use a secure password hashing library such as bcrypt or argon2 to hash passwords during storage and verify them using secure constant-time comparison utilities (e.g., bcrypt.compare)."
+          "recommendation": "First, verify that the 'user' object exists. Second, use a secure password hashing mechanism (like bcrypt) to hash and verify passwords."
         },
         {
           "severity": "high",
           "title": "Hardcoded JWT Secret Key",
-          "body": "The JWT_SECRET is hardcoded in the source code as a constant string literal. This exposes the signing key to anyone with repository access, allowing them to forge valid JWT tokens and bypass authentication.",
+          "body": "The signature key 'JWT_SECRET' is hardcoded as a string literal. Hardcoding secrets in source code can lead to unauthorized token generation if the source code is compromised or publicly exposed.",
           "file": "src/auth.js",
           "line_start": 4,
           "line_end": 4,
           "confidence": 1,
-          "recommendation": "Load the JWT secret from environment variables or a secure configuration management system: const JWT_SECRET = process.env.JWT_SECRET;"
-        },
-        {
-          "severity": "high",
-          "title": "Unsafe Access on Potential Null/Undefined User",
-          "body": "The login function attempts to read 'user.password' immediately after calling findUser without verifying if a user was successfully found. If the user does not exist (or findUser returns null/undefined), this will throw a TypeError and crash the execution path.",
-          "file": "src/auth.js",
-          "line_start": 14,
-          "line_end": 15,
-          "confidence": 0.9,
-          "recommendation": "Validate that the user object is not null or undefined before accessing its properties: if (!user || !user.password) { return null; }"
+          "recommendation": "Retrieve the JWT secret from environment variables (e.g., process.env.JWT_SECRET) instead of hardcoding it."
         },
         {
           "severity": "medium",
-          "title": "Unhandled SyntaxError in parseSession",
-          "body": "The parseSession function calls JSON.parse on the 'raw' argument without error handling. If 'raw' is not valid JSON, a SyntaxError is thrown, which could crash the application or result in unhandled promise rejections depending on caller context.",
+          "title": "Unhandled Exception in JSON.parse",
+          "body": "The parseSession function calls JSON.parse directly. If the 'raw' parameter is malformed or invalid JSON, an unhandled exception will be thrown, potentially crashing the application.",
           "file": "src/auth.js",
           "line_start": 21,
           "line_end": 24,
           "confidence": 1,
-          "recommendation": "Wrap the JSON.parse statement in a try-catch block and handle invalid JSON input gracefully by returning null or throwing a structured error."
+          "recommendation": "Wrap JSON.parse in a try-catch block to handle syntax errors gracefully."
         }
       ],
-      "latencyMs": 32125
+      "latencyMs": 44528
     },
     {
       "verdict": "needs-attention",
-      "summary": "The authentication implementation contains severe security risks including SQL injection, plaintext password verification, hardcoded secrets, and missing error handling.",
+      "summary": "The authentication module contains a critical SQL injection vulnerability, a hardcoded secret key, plaintext password comparison with crash risks, and unsafe JSON parsing.",
       "findings": [
         {
           "severity": "critical",
-          "title": "SQL Injection vulnerability in findUser",
-          "body": "The username query parameter is concatenated directly into the SQL statement, which allows arbitrary SQL command injection.",
+          "title": "SQL Injection in User Lookup",
+          "body": "In `findUser`, the SQL query is constructed via string concatenation with the raw, unsanitized `username` parameter: `\"SELECT * FROM users WHERE name = '\" + username + \"'\"`. An attacker can inject SQL commands to bypass authentication, dump users, or perform destructive database operations.",
           "file": "src/auth.js",
           "line_start": 6,
           "line_end": 11,
           "confidence": 1,
-          "recommendation": "Use parameterized queries instead of string concatenation, for example: `db.query('SELECT * FROM users WHERE name = ?', [username])`."
+          "recommendation": "Use parameterized queries or prepared statements provided by your database client/driver (e.g., `await db.query(\"SELECT * FROM users WHERE name = ?\", [username])`)."
         },
         {
           "severity": "high",
-          "title": "Plaintext Password Comparison and Missing Null/Empty Result Validation",
-          "body": "The password is compared in plaintext using the loose equality operator (==). Additionally, there is no check to see if findUser returns a valid user object, which can lead to TypeError exceptions if the user does not exist.",
-          "file": "src/auth.js",
-          "line_start": 13,
-          "line_end": 19,
-          "confidence": 0.95,
-          "recommendation": "Check if user is truthy before validating password, and use a secure hashing algorithm (such as bcrypt) for password storage and verification."
-        },
-        {
-          "severity": "high",
-          "title": "Hardcoded JWT Secret",
-          "body": "The JWT signing secret 'hardcoded-super-secret-key' is stored directly in the source file, which exposes it to anybody with source code access.",
+          "title": "Hardcoded JWT Secret Key",
+          "body": "The secret key used for signing JWT tokens is hardcoded as a string literal: `const JWT_SECRET = \"hardcoded-super-secret-key\"`. Anyone with read access to the codebase can sign valid JWT sessions and impersonate any user.",
           "file": "src/auth.js",
           "line_start": 4,
           "line_end": 4,
           "confidence": 1,
-          "recommendation": "Load the JWT secret key from environment variables (e.g., process.env.JWT_SECRET)."
+          "recommendation": "Retrieve the signing secret from environment variables (e.g., `process.env.JWT_SECRET`) and raise an error at start up if the secret is missing."
+        },
+        {
+          "severity": "high",
+          "title": "Plaintext Password Comparison and Missing User Null-Checks",
+          "body": "The code compares passwords in plaintext (`user.password == password`). Furthermore, if `findUser` returns no user (returning `null`, `undefined`, or an empty array), accessing `user.password` will throw a TypeError and crash/reject the promise. If `findUser` returns an empty array, `user.password` will be `undefined`, which may unintentionally match an undefined `password` argument.",
+          "file": "src/auth.js",
+          "line_start": 13,
+          "line_end": 19,
+          "confidence": 0.95,
+          "recommendation": "Check if a valid user row was found first. Hash passwords using a robust hashing scheme (such as bcrypt or argon2) and verify them using secure comparison functions."
         },
         {
           "severity": "medium",
-          "title": "Unhandled Exception on parseSession JSON Parsing",
-          "body": "JSON.parse(raw) is called directly without a try-catch block, which can cause unhandled exceptions and system crashes if raw is not valid JSON.",
+          "title": "Unhandled Exception in Session Parsing",
+          "body": "The `parseSession` function executes `JSON.parse(raw)` without a try-catch block. If `raw` is malformed, null, or undefined, `JSON.parse` will throw an unhandled exception, causing the application to crash or reject the promise.",
           "file": "src/auth.js",
           "line_start": 21,
           "line_end": 24,
           "confidence": 1,
-          "recommendation": "Wrap JSON.parse in a try-catch block and return null or handle the error gracefully."
+          "recommendation": "Wrap `JSON.parse` in a try-catch block to handle syntax errors gracefully, and validate that the parsed object is not null and has a `userId` property before returning it."
+        }
+      ],
+      "latencyMs": 32181
+    },
+    {
+      "verdict": "needs-attention",
+      "summary": "The authentication module contains critical security vulnerabilities including SQL injection, plaintext password comparison, a hardcoded JWT secret, and potential runtime crashes from unhandled null values and parsing exceptions.",
+      "findings": [
+        {
+          "severity": "critical",
+          "title": "SQL Injection in User Lookup",
+          "body": "The user input 'username' is directly concatenated into the SQL query string inside the 'findUser' function. A malicious actor can exploit this to inject arbitrary SQL commands, potentially bypassing authentication, extracting sensitive database contents, or modifying data.",
+          "file": "src/auth.js",
+          "line_start": 7,
+          "line_end": 9,
+          "confidence": 1,
+          "recommendation": "Use parameterized queries or prepared statements to safely bind the username parameter, for example: db.query('SELECT * FROM users WHERE name = ?', [username])."
         },
         {
           "severity": "high",
-          "title": "Missing Dependencies and db.js Module",
-          "body": "The code requires './db' which does not exist in the repository, and relies on 'jsonwebtoken' without a package.json file to manage it.",
+          "title": "Unhandled Missing User and Potential Null Reference Crash",
+          "body": "In the 'login' function, the return value of 'findUser(username)' is directly dereferenced with 'user.password' without checking if 'user' is null or undefined. If the user does not exist in the database, this dereference will throw a TypeError and crash the execution context.",
           "file": "src/auth.js",
-          "line_start": 1,
-          "line_end": 2,
+          "line_start": 14,
+          "line_end": 17,
           "confidence": 1,
-          "recommendation": "Implement the missing db.js module and initialize package.json with dependencies."
+          "recommendation": "Add a check to verify that 'user' is returned and valid before accessing its properties, or retrieve the first row if findUser returns an array."
+        },
+        {
+          "severity": "high",
+          "title": "Plaintext Password Verification",
+          "body": "Passwords are compared directly as plaintext in 'user.password == password'. This indicates that user credentials are likely stored in plaintext or compared insecurely, exposing user passwords to exposure during database breaches or leaks.",
+          "file": "src/auth.js",
+          "line_start": 15,
+          "line_end": 15,
+          "confidence": 1,
+          "recommendation": "Use a secure, industry-standard password hashing library such as bcrypt or argon2 to hash and verify user passwords."
+        },
+        {
+          "severity": "high",
+          "title": "Hardcoded JWT Secret Key",
+          "body": "The 'JWT_SECRET' variable is hardcoded with a static string value ('hardcoded-super-secret-key'). If this key is committed to version control, any attacker can easily forge valid JWT session tokens to impersonate users.",
+          "file": "src/auth.js",
+          "line_start": 4,
+          "line_end": 4,
+          "confidence": 1,
+          "recommendation": "Retrieve the JWT signing secret from a secure environment variable (e.g., process.env.JWT_SECRET) or secrets vault."
+        },
+        {
+          "severity": "medium",
+          "title": "Unhandled JSON.parse Exception",
+          "body": "In 'parseSession', the 'raw' argument is parsed with 'JSON.parse(raw)' without a try-catch block. If the input is not valid JSON, it throws an unhandled SyntaxError, which can crash the application or unhandled middleware chain.",
+          "file": "src/auth.js",
+          "line_start": 21,
+          "line_end": 24,
+          "confidence": 1,
+          "recommendation": "Wrap the JSON.parse operation inside a try-catch block to handle malformed inputs gracefully."
         }
       ],
-      "latencyMs": 32841
+      "latencyMs": 30071
     }
   ],
-  "raw": "{\n  \"review\": \"Review\",\n  \"target\": {\n    \"mode\": \"working-tree\",\n    \"label\": \"working tree diff\",\n    \"explicit\": true\n  },\n  \"gemini\": {\n    \"status\": 0,\n    \"stdout\": \"{\\n  \\\"verdict\\\": \\\"needs-attention\\\",\\n  \\\"summary\\\": \\\"The authentication implementation contains severe security risks including SQL injection, plaintext password verification, hardcoded secrets, and missing error handling.\\\",\\n  \\\"findings\\\": [\\n    {\\n      \\\"severity\\\": \\\"critical\\\",\\n      \\\"title\\\": \\\"SQL Injection vulnerability in findUser\\\",\\n      \\\"body\\\": \\\"The username query parameter is concatenated directly into the SQL statement, which allows arbitrary SQL command injection.\\\",\\n      \\\"file\\\": \\\"src/auth.js\\\",\\n      \\\"line_start\\\": 6,\\n      \\\"line_end\\\": 11,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Use parameterized queries instead of string concatenation, for example: `db.query('SELECT * FROM users WHERE name = ?', [username])`.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"high\\\",\\n      \\\"title\\\": \\\"Plaintext Password Comparison and Missing Null/Empty Result Validation\\\",\\n      \\\"body\\\": \\\"The password is compared in plaintext using the loose equality operator (==). Additionally, there is no check to see if findUser returns a valid user object, which can lead to TypeError exceptions if the user does not exist.\\\",\\n      \\\"file\\\": \\\"src/auth.js\\\",\\n      \\\"line_start\\\": 13,\\n      \\\"line_end\\\": 19,\\n      \\\"confidence\\\": 0.95,\\n      \\\"recommendation\\\": \\\"Check if user is truthy before validating password, and use a secure hashing algorithm (such as bcrypt) for password storage and verification.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"high\\\",\\n      \\\"title\\\": \\\"Hardcoded JWT Secret\\\",\\n      \\\"body\\\": \\\"The JWT signing secret 'hardcoded-super-secret-key' is stored directly in the source file, which exposes it to anybody with source code access.\\\",\\n      \\\"file\\\": \\\"src/auth.js\\\",\\n      \\\"line_start\\\": 4,\\n      \\\"line_end\\\": 4,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Load the JWT secret key from environment variables (e.g., process.env.JWT_SECRET).\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"medium\\\",\\n      \\\"title\\\": \\\"Unhandled Exception on parseSession JSON Parsing\\\",\\n      \\\"body\\\": \\\"JSON.parse(raw) is called directly without a try-catch block, which can cause unhandled exceptions and system crashes if raw is not valid JSON.\\\",\\n      \\\"file\\\": \\\"src/auth.js\\\",\\n      \\\"line_start\\\": 21,\\n      \\\"line_end\\\": 24,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Wrap JSON.parse in a try-catch block and return null or handle the error gracefully.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"high\\\",\\n      \\\"title\\\": \\\"Missing Dependencies and db.js Module\\\",\\n      \\\"body\\\": \\\"The code requires './db' which does not exist in the repository, and relies on 'jsonwebtoken' without a package.json file to manage it.\\\",\\n      \\\"file\\\": \\\"src/auth.js\\\",\\n      \\\"line_start\\\": 1,\\n      \\\"line_end\\\": 2,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Implement the missing db.js module and initialize package.json with dependencies.\\\"\\n    }\\n  ],\\n  \\\"next_steps\\\": [\\n    \\\"Refactor findUser to use prepared SQL statements to prevent SQL injection.\\\",\\n    \\\"Validate that user exists before referencing its password, and implement password hashing.\\\",\\n    \\\"Move JWT_SECRET to environment variables.\\\",\\n    \\\"Add error handling (try-catch block) in parseSession.\\\",\\n    \\\"Create src/db.js and package.json to resolve missing dependency errors.\\\"\\n  ]\\n}\",\n    \"stderr\": \"Warning: True color (24-bit) support not detected. Using a terminal with true color enabled will result in a better visual experience.\\nRipgrep is not available. Falling back to GrepTool.\\n[STARTUP] Phase 'cleanup_ops' was started but never ended. Skipping metrics.\\n[STARTUP] Cannot measure phase 'cleanup_ops': start mark 'startup:cleanup_ops:start' not found (likely cleared by reset).\\n\"\n  },\n  \"result\": {\n    \"verdict\": \"needs-attention\","
+  "raw": "{\n  \"review\": \"Review\",\n  \"target\": {\n    \"mode\": \"working-tree\",\n    \"label\": \"working tree diff\",\n    \"explicit\": true\n  },\n  \"engine\": \"gemini\",\n  \"gemini\": {\n    \"status\": 0,\n    \"stdout\": \"{\\n  \\\"verdict\\\": \\\"needs-attention\\\",\\n  \\\"summary\\\": \\\"The authentication module contains critical security vulnerabilities including SQL injection, plaintext password comparison, a hardcoded JWT secret, and potential runtime crashes from unhandled null values and parsing exceptions.\\\",\\n  \\\"findings\\\": [\\n    {\\n      \\\"severity\\\": \\\"critical\\\",\\n      \\\"title\\\": \\\"SQL Injection in User Lookup\\\",\\n      \\\"body\\\": \\\"The user input 'username' is directly concatenated into the SQL query string inside the 'findUser' function. A malicious actor can exploit this to inject arbitrary SQL commands, potentially bypassing authentication, extracting sensitive database contents, or modifying data.\\\",\\n      \\\"file\\\": \\\"src/auth.js\\\",\\n      \\\"line_start\\\": 7,\\n      \\\"line_end\\\": 9,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Use parameterized queries or prepared statements to safely bind the username parameter, for example: db.query('SELECT * FROM users WHERE name = ?', [username]).\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"high\\\",\\n      \\\"title\\\": \\\"Unhandled Missing User and Potential Null Reference Crash\\\",\\n      \\\"body\\\": \\\"In the 'login' function, the return value of 'findUser(username)' is directly dereferenced with 'user.password' without checking if 'user' is null or undefined. If the user does not exist in the database, this dereference will throw a TypeError and crash the execution context.\\\",\\n      \\\"file\\\": \\\"src/auth.js\\\",\\n      \\\"line_start\\\": 14,\\n      \\\"line_end\\\": 17,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Add a check to verify that 'user' is returned and valid before accessing its properties, or retrieve the first row if findUser returns an array.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"high\\\",\\n      \\\"title\\\": \\\"Plaintext Password Verification\\\",\\n      \\\"body\\\": \\\"Passwords are compared directly as plaintext in 'user.password == password'. This indicates that user credentials are likely stored in plaintext or compared insecurely, exposing user passwords to exposure during database breaches or leaks.\\\",\\n      \\\"file\\\": \\\"src/auth.js\\\",\\n      \\\"line_start\\\": 15,\\n      \\\"line_end\\\": 15,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Use a secure, industry-standard password hashing library such as bcrypt or argon2 to hash and verify user passwords.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"high\\\",\\n      \\\"title\\\": \\\"Hardcoded JWT Secret Key\\\",\\n      \\\"body\\\": \\\"The 'JWT_SECRET' variable is hardcoded with a static string value ('hardcoded-super-secret-key'). If this key is committed to version control, any attacker can easily forge valid JWT session tokens to impersonate users.\\\",\\n      \\\"file\\\": \\\"src/auth.js\\\",\\n      \\\"line_start\\\": 4,\\n      \\\"line_end\\\": 4,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Retrieve the JWT signing secret from a secure environment variable (e.g., process.env.JWT_SECRET) or secrets vault.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"medium\\\",\\n      \\\"title\\\": \\\"Unhandled JSON.parse Exception\\\",\\n      \\\"body\\\": \\\"In 'parseSession', the 'raw' argument is parsed with 'JSON.parse(raw)' without a try-catch block. If the input is not valid JSON, it throws an unhandled SyntaxError, which can crash the application or unhandled middleware chain.\\\",\\n      \\\"file\\\": \\\"src/auth.js\\\",\\n      \\\"line_start\\\": 21,\\n      \\\"line_end\\\": 24,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Wrap the JSON.parse operation inside a try-catch block to handle malformed inputs gracefully.\\\"\\n    }\\n  ],\\n  \\\"next_steps\\\": [\\n    \\\"Refactor src/auth.js to use parameterized queries for db.query.\\\",\\n    \\\"Implement password hashing using bcrypt or argon2.\\\",\\n    \\\"Move JWT_SECRET to environment variables or a configuration file.\\\",\\n    \\\"Add error/null checks"
 }

--- a/bench/cassettes/auth-basic/gemini.model.json
+++ b/bench/cassettes/auth-basic/gemini.model.json
@@ -1,215 +1,216 @@
 {
   "caseId": "auth-basic",
   "cell": "gemini.model",
-  "recordedAt": "2026-08-19T09:06:35.296Z",
+  "recordedAt": "2026-08-24T10:42:33.082Z",
   "verdict": "needs-attention",
-  "summary": "Critical security vulnerabilities including SQL injection, hardcoded secrets, plaintext password handling, and missing error guards.",
+  "summary": "Critical security flaws identified including SQL injection, hardcoded JWT secrets, and plaintext password storage, plus missing error handling for unparsed JSON and null user records.",
   "findings": [
     {
       "severity": "critical",
-      "title": "SQL Injection vulnerability",
-      "body": "The findUser function constructs a SQL query by concatenating the username parameter directly. This exposes the database to SQL injection attacks.",
+      "title": "SQL Injection Vulnerability",
+      "body": "The findUser function concatenates the 'username' parameter directly into the SQL query string, allowing for SQL injection attacks.",
       "file": "src/auth.js",
       "line_start": 7,
       "line_end": 9,
       "confidence": 1,
-      "recommendation": "Use parameterized queries or prepared statements (e.g., db.query('SELECT * FROM users WHERE name = ?', [username]))."
+      "recommendation": "Use parameterized queries or prepared statements instead of string concatenation."
     },
     {
       "severity": "critical",
-      "title": "Hardcoded JWT secret",
-      "body": "The JWT signing secret is hardcoded directly in the source code. Anyone with access to the code can forge authentication tokens to impersonate any user.",
+      "title": "Hardcoded JWT Secret",
+      "body": "The JWT_SECRET is hardcoded in the source code, compromising the integrity of all issued tokens if the source code is exposed.",
       "file": "src/auth.js",
       "line_start": 4,
       "line_end": 4,
       "confidence": 1,
-      "recommendation": "Remove the hardcoded secret and load it from environment variables (e.g., process.env.JWT_SECRET)."
+      "recommendation": "Load the JWT secret from a secure environment variable or secrets management service."
     },
     {
       "severity": "high",
-      "title": "Plaintext password comparison & missing null check",
-      "body": "Passwords appear to be stored and compared in plaintext using loose equality, lacking cryptographic hashing. Furthermore, if findUser returns null or undefined, attempting to read user.password will throw a TypeError, leading to an application crash or unhandled promise rejection.",
+      "title": "Plaintext Password Comparison and Missing Null Check",
+      "body": "The login function compares passwords in plaintext and fails to check if 'user' is null before accessing 'user.password', which will throw a TypeError if the user does not exist.",
       "file": "src/auth.js",
       "line_start": 14,
       "line_end": 15,
       "confidence": 0.95,
-      "recommendation": "Implement a strong password hashing library like bcrypt for storage and comparison. Add a guard clause (if (!user) return null;) before evaluating the password."
+      "recommendation": "Hash passwords using a strong algorithm (e.g., bcrypt, argon2) before storage and use a secure compare function. Add a null check for 'user' before accessing properties."
     },
     {
       "severity": "medium",
-      "title": "Unhandled exception risk on JSON parsing",
-      "body": "The parseSession function blindly parses raw input via JSON.parse without error handling. Passing malformed JSON will throw a synchronous exception that can crash the Node.js process.",
+      "title": "Unhandled JSON.parse Exception",
+      "body": "The parseSession function calls JSON.parse on raw input without a try-catch block, which will crash the application if the input is malformed.",
       "file": "src/auth.js",
       "line_start": 22,
-      "line_end": 22,
+      "line_end": 23,
       "confidence": 0.9,
-      "recommendation": "Wrap JSON.parse within a try-catch block and return a safe fallback or throw a handled error if parsing fails."
+      "recommendation": "Wrap JSON.parse in a try-catch block and handle invalid JSON input gracefully."
     }
   ],
-  "latencyMs": 25242,
-  "engineVersion": "0.55.1",
+  "latencyMs": 24090,
+  "engineVersion": "0.56.0",
+  "engineObserved": null,
   "samples": [
     {
       "verdict": "needs-attention",
-      "summary": "Critical security vulnerabilities including SQL injection, hardcoded secrets, and plaintext password handling, along with unhandled exceptions.",
+      "summary": "This diff introduces critical security vulnerabilities including SQL injection, hardcoded secrets, plaintext password comparisons, and unhandled exceptions.",
       "findings": [
         {
           "severity": "critical",
           "title": "SQL Injection Vulnerability",
-          "body": "The `findUser` function constructs a SQL query using string concatenation with the `username` parameter, making it highly vulnerable to SQL injection attacks.",
+          "body": "The `findUser` function constructs a SQL query by directly concatenating the `username` parameter, exposing the application to SQL injection attacks.",
           "file": "src/auth.js",
           "line_start": 7,
           "line_end": 9,
           "confidence": 1,
-          "recommendation": "Use parameterized queries or prepared statements instead of string concatenation (e.g., `db.query('SELECT * FROM users WHERE name = ?', [username])`)."
+          "recommendation": "Use parameterized queries or prepared statements provided by your database driver instead of string concatenation."
         },
         {
           "severity": "critical",
-          "title": "Plaintext Password Comparison",
-          "body": "Passwords are being compared in plaintext. This implies passwords are stored in plaintext in the database, exposing user credentials in the event of a data breach.",
-          "file": "src/auth.js",
-          "line_start": 15,
-          "line_end": 15,
-          "confidence": 0.95,
-          "recommendation": "Hash passwords before storing them using a strong algorithm like bcrypt or Argon2, and use the corresponding library method to compare the input against the hash."
-        },
-        {
-          "severity": "high",
           "title": "Hardcoded JWT Secret",
-          "body": "The JWT signing secret is hardcoded directly into the source code. Anyone with access to the source code can forge valid JSON Web Tokens to spoof any user.",
+          "body": "A hardcoded JWT secret is checked into source control, allowing anyone with access to the code to forge authentication tokens.",
           "file": "src/auth.js",
           "line_start": 4,
           "line_end": 4,
           "confidence": 1,
-          "recommendation": "Extract the secret to an environment variable or a secure secrets management service (e.g., `process.env.JWT_SECRET`)."
+          "recommendation": "Load the JWT secret from a secure environment variable (e.g., process.env.JWT_SECRET)."
+        },
+        {
+          "severity": "critical",
+          "title": "Plaintext Password Comparison",
+          "body": "The `login` function compares passwords using plaintext equality. This implies passwords are not hashed in the database, compromising user security.",
+          "file": "src/auth.js",
+          "line_start": 15,
+          "line_end": 15,
+          "confidence": 1,
+          "recommendation": "Hash incoming passwords using a strong algorithm like bcrypt or Argon2 and compare them against stored hashes using a timing-safe function."
         },
         {
           "severity": "high",
-          "title": "Missing Null/Undefined Check",
-          "body": "If `findUser` returns null or undefined (e.g., when a user does not exist), accessing `user.password` will throw an unhandled TypeError, potentially crashing the application.",
+          "title": "Missing Null Check for User Object",
+          "body": "If `findUser` returns no result (null or undefined), accessing `user.password` will throw an unhandled exception, causing a crash or denial of service.",
           "file": "src/auth.js",
-          "line_start": 14,
+          "line_start": 15,
           "line_end": 15,
           "confidence": 0.9,
-          "recommendation": "Add a guard clause to verify the user exists before accessing its properties: `if (!user) return null;`."
+          "recommendation": "Add a check `if (!user) return null;` before accessing properties on the `user` object."
         },
         {
           "severity": "medium",
           "title": "Unhandled Exception in JSON Parsing",
-          "body": "The `parseSession` function calls `JSON.parse` on raw input without a try/catch block. Malformed or malicious JSON input will throw a synchronous error.",
+          "body": "The `parseSession` function calls `JSON.parse(raw)` without a try-catch block. Malformed JSON input will throw an exception and crash the execution path.",
           "file": "src/auth.js",
           "line_start": 22,
           "line_end": 22,
-          "confidence": 1,
-          "recommendation": "Wrap `JSON.parse` in a try-catch block and handle invalid input gracefully, returning a safe default or a structured error."
+          "confidence": 0.9,
+          "recommendation": "Wrap `JSON.parse` in a try-catch block and handle invalid input gracefully, returning null or an appropriate error response."
         }
       ],
-      "latencyMs": 23127
+      "latencyMs": 24285
     },
     {
       "verdict": "needs-attention",
-      "summary": "Critical security vulnerabilities including SQL injection, hardcoded credentials, plaintext passwords, and absent error handling.",
+      "summary": "Multiple critical security vulnerabilities including SQL injection, hardcoded secrets, and plaintext passwords, alongside severe missing error handling.",
       "findings": [
         {
           "severity": "critical",
-          "title": "Hardcoded JWT Secret",
-          "body": "The JWT signing secret is hardcoded directly in the source code. If the source code is compromised or exposed, attackers can forge valid JWTs and impersonate any user.",
-          "file": "src/auth.js",
-          "line_start": 4,
-          "line_end": 4,
-          "confidence": 1,
-          "recommendation": "Load the secret from a secure environment variable or a secret management service (e.g., process.env.JWT_SECRET)."
-        },
-        {
-          "severity": "critical",
           "title": "SQL Injection Vulnerability",
-          "body": "The SQL query string is constructed using direct string concatenation with user input. This allows attackers to manipulate the query logic, potentially bypassing authentication or exfiltrating data.",
+          "body": "The username parameter is concatenated directly into the SQL query string. This allows attackers to manipulate the query logic, potentially bypassing authentication entirely or exfiltrating data.",
           "file": "src/auth.js",
           "line_start": 7,
           "line_end": 9,
           "confidence": 1,
-          "recommendation": "Use parameterized queries or prepared statements (e.g., db.query('SELECT * FROM users WHERE name = ?', [username]))."
+          "recommendation": "Use parameterized queries or prepared statements provided by the database driver instead of string concatenation."
+        },
+        {
+          "severity": "critical",
+          "title": "Hardcoded JWT Secret",
+          "body": "The JWT signing secret is hardcoded in the source code. Anyone with read access to the code can forge valid JWTs and impersonate any user.",
+          "file": "src/auth.js",
+          "line_start": 4,
+          "line_end": 4,
+          "confidence": 1,
+          "recommendation": "Load the JWT secret securely from environment variables (e.g., process.env.JWT_SECRET) and rotate the current exposed key."
         },
         {
           "severity": "critical",
           "title": "Plaintext Password Comparison",
-          "body": "The application checks passwords using a plaintext comparison ('user.password == password'), which implies passwords are not securely hashed in the database. This exposes user credentials to severe risk if the database is breached.",
-          "file": "src/auth.js",
-          "line_start": 15,
-          "line_end": 15,
-          "confidence": 1,
-          "recommendation": "Hash passwords using a strong, salted cryptographic algorithm like bcrypt or Argon2 during registration, and use a constant-time comparison function (e.g., bcrypt.compare()) during login."
-        },
-        {
-          "severity": "high",
-          "title": "Missing Null Check on User Object",
-          "body": "If 'findUser' returns null or undefined for a non-existent username, evaluating 'user.password' will throw a TypeError and crash the request/process.",
+          "body": "The code compares passwords in plaintext. This implies passwords are stored unhashed, exposing all user credentials if the database is breached.",
           "file": "src/auth.js",
           "line_start": 15,
           "line_end": 15,
           "confidence": 0.95,
-          "recommendation": "Add a guard clause to check if 'user' exists before accessing its properties: 'if (!user) return null;'."
+          "recommendation": "Use a secure password hashing library like bcrypt or Argon2 to verify passwords against a stored hash."
+        },
+        {
+          "severity": "high",
+          "title": "Missing Null Check for User Object",
+          "body": "If the requested username is not found, `findUser` likely returns null/undefined. Accessing `user.password` immediately after will throw an unhandled TypeError, potentially crashing the application.",
+          "file": "src/auth.js",
+          "line_start": 15,
+          "line_end": 15,
+          "confidence": 0.95,
+          "recommendation": "Add an existence check for `user` before attempting to access its properties (e.g., `if (!user) return null;`)."
         },
         {
           "severity": "medium",
-          "title": "Unhandled JSON.parse Exception",
-          "body": "The 'parseSession' function parses a raw string synchronously without a try/catch block. If 'raw' is not a valid JSON string, JSON.parse will throw an error, likely resulting in an unhandled exception server crash.",
+          "title": "Unhandled Exception in JSON Parsing",
+          "body": "`JSON.parse` is called on input without a try/catch block. Passing malformed or empty JSON to this function will throw an exception that can crash the process.",
           "file": "src/auth.js",
           "line_start": 22,
           "line_end": 22,
-          "confidence": 0.9,
-          "recommendation": "Wrap the parsing logic in a try/catch block and handle the error gracefully, returning null or throwing a custom application error."
+          "confidence": 1,
+          "recommendation": "Wrap `JSON.parse` in a try/catch block and handle invalid payloads gracefully."
         }
       ],
-      "latencyMs": 24306
+      "latencyMs": 28880
     },
     {
       "verdict": "needs-attention",
-      "summary": "Critical security vulnerabilities including SQL injection, hardcoded secrets, plaintext password handling, and missing error guards.",
+      "summary": "Critical security flaws identified including SQL injection, hardcoded JWT secrets, and plaintext password storage, plus missing error handling for unparsed JSON and null user records.",
       "findings": [
         {
           "severity": "critical",
-          "title": "SQL Injection vulnerability",
-          "body": "The findUser function constructs a SQL query by concatenating the username parameter directly. This exposes the database to SQL injection attacks.",
+          "title": "SQL Injection Vulnerability",
+          "body": "The findUser function concatenates the 'username' parameter directly into the SQL query string, allowing for SQL injection attacks.",
           "file": "src/auth.js",
           "line_start": 7,
           "line_end": 9,
           "confidence": 1,
-          "recommendation": "Use parameterized queries or prepared statements (e.g., db.query('SELECT * FROM users WHERE name = ?', [username]))."
+          "recommendation": "Use parameterized queries or prepared statements instead of string concatenation."
         },
         {
           "severity": "critical",
-          "title": "Hardcoded JWT secret",
-          "body": "The JWT signing secret is hardcoded directly in the source code. Anyone with access to the code can forge authentication tokens to impersonate any user.",
+          "title": "Hardcoded JWT Secret",
+          "body": "The JWT_SECRET is hardcoded in the source code, compromising the integrity of all issued tokens if the source code is exposed.",
           "file": "src/auth.js",
           "line_start": 4,
           "line_end": 4,
           "confidence": 1,
-          "recommendation": "Remove the hardcoded secret and load it from environment variables (e.g., process.env.JWT_SECRET)."
+          "recommendation": "Load the JWT secret from a secure environment variable or secrets management service."
         },
         {
           "severity": "high",
-          "title": "Plaintext password comparison & missing null check",
-          "body": "Passwords appear to be stored and compared in plaintext using loose equality, lacking cryptographic hashing. Furthermore, if findUser returns null or undefined, attempting to read user.password will throw a TypeError, leading to an application crash or unhandled promise rejection.",
+          "title": "Plaintext Password Comparison and Missing Null Check",
+          "body": "The login function compares passwords in plaintext and fails to check if 'user' is null before accessing 'user.password', which will throw a TypeError if the user does not exist.",
           "file": "src/auth.js",
           "line_start": 14,
           "line_end": 15,
           "confidence": 0.95,
-          "recommendation": "Implement a strong password hashing library like bcrypt for storage and comparison. Add a guard clause (if (!user) return null;) before evaluating the password."
+          "recommendation": "Hash passwords using a strong algorithm (e.g., bcrypt, argon2) before storage and use a secure compare function. Add a null check for 'user' before accessing properties."
         },
         {
           "severity": "medium",
-          "title": "Unhandled exception risk on JSON parsing",
-          "body": "The parseSession function blindly parses raw input via JSON.parse without error handling. Passing malformed JSON will throw a synchronous exception that can crash the Node.js process.",
+          "title": "Unhandled JSON.parse Exception",
+          "body": "The parseSession function calls JSON.parse on raw input without a try-catch block, which will crash the application if the input is malformed.",
           "file": "src/auth.js",
           "line_start": 22,
-          "line_end": 22,
+          "line_end": 23,
           "confidence": 0.9,
-          "recommendation": "Wrap JSON.parse within a try-catch block and return a safe fallback or throw a handled error if parsing fails."
+          "recommendation": "Wrap JSON.parse in a try-catch block and handle invalid JSON input gracefully."
         }
       ],
-      "latencyMs": 25242
+      "latencyMs": 24090
     }
   ],
-  "raw": "{\n  \"session_id\": \"2b02b8aa-fdac-4eb8-b0d2-3044c2180b75\",\n  \"response\": \"{\\n  \\\"verdict\\\": \\\"needs-attention\\\",\\n  \\\"summary\\\": \\\"Critical security vulnerabilities including SQL injection, hardcoded secrets, plaintext password handling, and missing error guards.\\\",\\n  \\\"findings\\\": [\\n    {\\n      \\\"severity\\\": \\\"critical\\\",\\n      \\\"title\\\": \\\"SQL Injection vulnerability\\\",\\n      \\\"body\\\": \\\"The findUser function constructs a SQL query by concatenating the username parameter directly. This exposes the database to SQL injection attacks.\\\",\\n      \\\"file\\\": \\\"src/auth.js\\\",\\n      \\\"line_start\\\": 7,\\n      \\\"line_end\\\": 9,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Use parameterized queries or prepared statements (e.g., db.query('SELECT * FROM users WHERE name = ?', [username])).\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"critical\\\",\\n      \\\"title\\\": \\\"Hardcoded JWT secret\\\",\\n      \\\"body\\\": \\\"The JWT signing secret is hardcoded directly in the source code. Anyone with access to the code can forge authentication tokens to impersonate any user.\\\",\\n      \\\"file\\\": \\\"src/auth.js\\\",\\n      \\\"line_start\\\": 4,\\n      \\\"line_end\\\": 4,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Remove the hardcoded secret and load it from environment variables (e.g., process.env.JWT_SECRET).\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"high\\\",\\n      \\\"title\\\": \\\"Plaintext password comparison & missing null check\\\",\\n      \\\"body\\\": \\\"Passwords appear to be stored and compared in plaintext using loose equality, lacking cryptographic hashing. Furthermore, if findUser returns null or undefined, attempting to read user.password will throw a TypeError, leading to an application crash or unhandled promise rejection.\\\",\\n      \\\"file\\\": \\\"src/auth.js\\\",\\n      \\\"line_start\\\": 14,\\n      \\\"line_end\\\": 15,\\n      \\\"confidence\\\": 0.95,\\n      \\\"recommendation\\\": \\\"Implement a strong password hashing library like bcrypt for storage and comparison. Add a guard clause (if (!user) return null;) before evaluating the password.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"medium\\\",\\n      \\\"title\\\": \\\"Unhandled exception risk on JSON parsing\\\",\\n      \\\"body\\\": \\\"The parseSession function blindly parses raw input via JSON.parse without error handling. Passing malformed JSON will throw a synchronous exception that can crash the Node.js process.\\\",\\n      \\\"file\\\": \\\"src/auth.js\\\",\\n      \\\"line_start\\\": 22,\\n      \\\"line_end\\\": 22,\\n      \\\"confidence\\\": 0.9,\\n      \\\"recommendation\\\": \\\"Wrap JSON.parse within a try-catch block and return a safe fallback or throw a handled error if parsing fails.\\\"\\n    }\\n  ],\\n  \\\"next_steps\\\": [\\n    \\\"Refactor SQL queries to use parameterized inputs.\\\",\\n    \\\"Extract the JWT secret to environment configurations.\\\",\\n    \\\"Integrate a secure password hashing mechanism (e.g., bcrypt) and ensure passwords are never stored in plaintext.\\\",\\n    \\\"Add appropriate error handling and null safety checks throughout the module.\\\"\\n  ]\\n}\",\n  \"stats\": {\n    \"models\": {\n      \"gemini-3.1-pro-preview\": {\n        \"api\": {\n          \"totalRequests\": 1,\n          \"totalErrors\": 0,\n          \"totalLatencyMs\": 23558,\n          \"errorsByType\": {}\n        },\n        \"tokens\": {\n          \"input\": 17324,\n          \"prompt\": 17324,\n          \"candidates\": 646,\n          \"total\": 19784,\n          \"cached\": 0,\n          \"thoughts\": 1814,\n          \"tool\": 0\n        },\n        \"roles\": {\n          \"main\": {\n            \"totalRequests\": 1,\n            \"totalErrors\": 0,\n            \"totalLatencyMs\": 23558,\n            \"tokens\": {\n              \"input\": 17324,\n              \"prompt\": 17324,\n              \"candidates\": 646,\n              \"total\": 19784,\n              \"cached\": 0,\n              \"thoughts\": 1814,\n              \"tool\": 0\n            }\n          }\n        }\n      }\n    },\n    \"tools\": {\n      \"totalCalls\": 0,\n      \"totalSuccess\": 0,\n      \"totalFail\": 0,\n      \"totalDurationMs\": 0,\n      \"totalDecisions\": {\n        \"accept\": "
+  "raw": "{\n  \"session_id\": \"b3b931d7-4c57-4b59-8ab4-506a6b29b469\",\n  \"response\": \"{\\n  \\\"verdict\\\": \\\"needs-attention\\\",\\n  \\\"summary\\\": \\\"Critical security flaws identified including SQL injection, hardcoded JWT secrets, and plaintext password storage, plus missing error handling for unparsed JSON and null user records.\\\",\\n  \\\"findings\\\": [\\n    {\\n      \\\"severity\\\": \\\"critical\\\",\\n      \\\"title\\\": \\\"SQL Injection Vulnerability\\\",\\n      \\\"body\\\": \\\"The findUser function concatenates the 'username' parameter directly into the SQL query string, allowing for SQL injection attacks.\\\",\\n      \\\"file\\\": \\\"src/auth.js\\\",\\n      \\\"line_start\\\": 7,\\n      \\\"line_end\\\": 9,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Use parameterized queries or prepared statements instead of string concatenation.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"critical\\\",\\n      \\\"title\\\": \\\"Hardcoded JWT Secret\\\",\\n      \\\"body\\\": \\\"The JWT_SECRET is hardcoded in the source code, compromising the integrity of all issued tokens if the source code is exposed.\\\",\\n      \\\"file\\\": \\\"src/auth.js\\\",\\n      \\\"line_start\\\": 4,\\n      \\\"line_end\\\": 4,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Load the JWT secret from a secure environment variable or secrets management service.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"high\\\",\\n      \\\"title\\\": \\\"Plaintext Password Comparison and Missing Null Check\\\",\\n      \\\"body\\\": \\\"The login function compares passwords in plaintext and fails to check if 'user' is null before accessing 'user.password', which will throw a TypeError if the user does not exist.\\\",\\n      \\\"file\\\": \\\"src/auth.js\\\",\\n      \\\"line_start\\\": 14,\\n      \\\"line_end\\\": 15,\\n      \\\"confidence\\\": 0.95,\\n      \\\"recommendation\\\": \\\"Hash passwords using a strong algorithm (e.g., bcrypt, argon2) before storage and use a secure compare function. Add a null check for 'user' before accessing properties.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"medium\\\",\\n      \\\"title\\\": \\\"Unhandled JSON.parse Exception\\\",\\n      \\\"body\\\": \\\"The parseSession function calls JSON.parse on raw input without a try-catch block, which will crash the application if the input is malformed.\\\",\\n      \\\"file\\\": \\\"src/auth.js\\\",\\n      \\\"line_start\\\": 22,\\n      \\\"line_end\\\": 23,\\n      \\\"confidence\\\": 0.9,\\n      \\\"recommendation\\\": \\\"Wrap JSON.parse in a try-catch block and handle invalid JSON input gracefully.\\\"\\n    }\\n  ],\\n  \\\"next_steps\\\": [\\n    \\\"Refactor database queries to use parameterization to prevent SQL injection.\\\",\\n    \\\"Migrate sensitive configuration like JWT_SECRET to environment variables.\\\",\\n    \\\"Implement a secure password hashing mechanism for user authentication.\\\",\\n    \\\"Add error handling for database misses and invalid inputs.\\\"\\n  ]\\n}\",\n  \"stats\": {\n    \"models\": {\n      \"gemini-3.1-pro-preview\": {\n        \"api\": {\n          \"totalRequests\": 1,\n          \"totalErrors\": 0,\n          \"totalLatencyMs\": 22485,\n          \"errorsByType\": {}\n        },\n        \"tokens\": {\n          \"input\": 10397,\n          \"prompt\": 18203,\n          \"candidates\": 605,\n          \"total\": 20705,\n          \"cached\": 7806,\n          \"thoughts\": 1897,\n          \"tool\": 0\n        },\n        \"roles\": {\n          \"main\": {\n            \"totalRequests\": 1,\n            \"totalErrors\": 0,\n            \"totalLatencyMs\": 22485,\n            \"tokens\": {\n              \"input\": 10397,\n              \"prompt\": 18203,\n              \"candidates\": 605,\n              \"total\": 20705,\n              \"cached\": 7806,\n              \"thoughts\": 1897,\n              \"tool\": 0\n            }\n          }\n        }\n      }\n    },\n    \"tools\": {\n      \"totalCalls\": 0,\n      \"totalSuccess\": 0,\n      \"totalFail\": 0,\n      \"totalDurationMs\": 0,\n      \"totalDecisions\": {\n        \"accept\": 0,\n        \"reject\": 0,\n        \"modify\": 0,\n        \"auto_accept\": 0\n      },\n      \"byName\": {}\n    },\n    \"files\": {\n      \"totalLinesAdded\": 0,\n      \"totalLinesRemoved\": 0\n    }\n  }\n}"
 }

--- a/bench/cassettes/caller-contract/agy.deep.json
+++ b/bench/cassettes/caller-contract/agy.deep.json
@@ -1,0 +1,86 @@
+{
+  "caseId": "caller-contract",
+  "cell": "agy.deep",
+  "recordedAt": "2026-08-24T14:39:53.435Z",
+  "verdict": "needs-attention",
+  "summary": "Changing findUser to return a result envelope breaks existing callers in profile and admin routes.",
+  "findings": [
+    {
+      "severity": "critical",
+      "title": "Breaking change in findUser return signature breaks callers in profile and admin routes",
+      "body": "findUser was changed from returning User | null to returning a result envelope ({ ok: true, user } | { ok: false, reason: 'not-found' }). Existing callers in src/routes/profile.js and src/routes/admin.js were not updated. In profile.js, absent users receive a truthy { ok: false } object which bypasses the !user 404 check and responds with 200 and undefined fields, while found users have undefined id and name properties. In admin.js, checking user.role on the envelope evaluates to undefined, causing requireAdmin to reject all valid admins with 403 Forbidden.",
+      "file": "src/store.js",
+      "line_start": 7,
+      "line_end": 13,
+      "confidence": 1,
+      "recommendation": "Update src/routes/profile.js and src/routes/admin.js to handle the result envelope (checking result.ok and accessing result.user), or keep findUser returning User | null to preserve backward compatibility."
+    }
+  ],
+  "latencyMs": 33387,
+  "engineVersion": "1.1.19",
+  "engineObserved": "agy",
+  "samples": [
+    {
+      "verdict": "needs-attention",
+      "summary": "Updating findUser to return a result envelope breaks call sites in admin middleware and profile routes.",
+      "findings": [
+        {
+          "severity": "high",
+          "title": "Profile route does not unwrap findUser result envelope",
+          "body": "findUser was modified to return an envelope object ({ ok: true, user } or { ok: false, reason }), but profileRoute still expects a direct user object or null. Because the returned object is always truthy, missing users bypass the 404 check, and accessing user.id / user.name evaluates to undefined.",
+          "file": "src/routes/profile.js",
+          "line_start": 4,
+          "line_end": 8,
+          "confidence": 1,
+          "recommendation": "Update profileRoute to check result.ok (returning 404 when false) and access user properties via result.user."
+        },
+        {
+          "severity": "high",
+          "title": "Admin middleware fails authorization due to changed findUser contract",
+          "body": "findUser now returns a result envelope ({ ok: true, user }), but requireAdmin checks user.role directly on the returned envelope object where role is undefined. Consequently, admin access checks will always fail with 403 Forbidden.",
+          "file": "src/routes/admin.js",
+          "line_start": 4,
+          "line_end": 8,
+          "confidence": 1,
+          "recommendation": "Update requireAdmin to check result.ok && result.user.role === 'admin' before calling next()."
+        }
+      ],
+      "latencyMs": 44753
+    },
+    {
+      "verdict": "needs-attention",
+      "summary": "Changing findUser to return a result envelope breaks existing callers in the admin and profile routes.",
+      "findings": [
+        {
+          "severity": "critical",
+          "title": "Breaking change to findUser return signature breaks existing callers",
+          "body": "findUser previously returned the user object directly or null. It now returns an envelope ({ ok: true, user } or { ok: false, reason: 'not-found' }). Existing callers in src/routes/admin.js and src/routes/profile.js still treat the return value as the user object or null. In src/routes/profile.js, failure objects evaluate truthy, bypassing the not-found check and returning undefined fields with HTTP 200; successful lookups also fail to read id and name directly. In src/routes/admin.js, user.role is undefined for all users, causing valid admins to be blocked with HTTP 403.",
+          "file": "src/store.js",
+          "line_start": 7,
+          "line_end": 13,
+          "confidence": 1,
+          "recommendation": "Update callers in src/routes/admin.js and src/routes/profile.js to check result.ok and access result.user, or preserve backwards compatibility in findUser."
+        }
+      ],
+      "latencyMs": 34053
+    },
+    {
+      "verdict": "needs-attention",
+      "summary": "Changing findUser to return a result envelope breaks existing callers in profile and admin routes.",
+      "findings": [
+        {
+          "severity": "critical",
+          "title": "Breaking change in findUser return signature breaks callers in profile and admin routes",
+          "body": "findUser was changed from returning User | null to returning a result envelope ({ ok: true, user } | { ok: false, reason: 'not-found' }). Existing callers in src/routes/profile.js and src/routes/admin.js were not updated. In profile.js, absent users receive a truthy { ok: false } object which bypasses the !user 404 check and responds with 200 and undefined fields, while found users have undefined id and name properties. In admin.js, checking user.role on the envelope evaluates to undefined, causing requireAdmin to reject all valid admins with 403 Forbidden.",
+          "file": "src/store.js",
+          "line_start": 7,
+          "line_end": 13,
+          "confidence": 1,
+          "recommendation": "Update src/routes/profile.js and src/routes/admin.js to handle the result envelope (checking result.ok and accessing result.user), or keep findUser returning User | null to preserve backward compatibility."
+        }
+      ],
+      "latencyMs": 33387
+    }
+  ],
+  "raw": "{\n  \"review\": \"Review\",\n  \"target\": {\n    \"mode\": \"working-tree\",\n    \"label\": \"working tree diff\",\n    \"explicit\": true\n  },\n  \"engine\": \"agy\",\n  \"gemini\": {\n    \"status\": 0,\n    \"stdout\": \"{\\n  \\\"verdict\\\": \\\"needs-attention\\\",\\n  \\\"summary\\\": \\\"Changing findUser to return a result envelope breaks existing callers in profile and admin routes.\\\",\\n  \\\"findings\\\": [\\n    {\\n      \\\"severity\\\": \\\"critical\\\",\\n      \\\"title\\\": \\\"Breaking change in findUser return signature breaks callers in profile and admin routes\\\",\\n      \\\"body\\\": \\\"findUser was changed from returning User | null to returning a result envelope ({ ok: true, user } | { ok: false, reason: 'not-found' }). Existing callers in src/routes/profile.js and src/routes/admin.js were not updated. In profile.js, absent users receive a truthy { ok: false } object which bypasses the !user 404 check and responds with 200 and undefined fields, while found users have undefined id and name properties. In admin.js, checking user.role on the envelope evaluates to undefined, causing requireAdmin to reject all valid admins with 403 Forbidden.\\\",\\n      \\\"file\\\": \\\"src/store.js\\\",\\n      \\\"line_start\\\": 7,\\n      \\\"line_end\\\": 13,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Update src/routes/profile.js and src/routes/admin.js to handle the result envelope (checking result.ok and accessing result.user), or keep findUser returning User | null to preserve backward compatibility.\\\"\\n    }\\n  ],\\n  \\\"next_steps\\\": [\\n    \\\"Update src/routes/profile.js to check result.ok and access result.user\\\",\\n    \\\"Update src/routes/admin.js to check result.ok and verify result.user.role === 'admin'\\\",\\n    \\\"Add test cases for requireAdmin and profileRoute covering existing, missing, and non-admin users\\\"\\n  ]\\n}\",\n    \"stderr\": \"\"\n  },\n  \"result\": {\n    \"verdict\": \"needs-attention\",\n    \"summary\": \"Changing findUser to return a result envelope breaks existing callers in profile and admin routes.\",\n    \"findings\": [\n      {\n        \"severity\": \"critical\",\n        \"title\": \"Breaking change in findUser return signature breaks callers in profile and admin routes\",\n        \"body\": \"findUser was changed from returning User | null to returning a result envelope ({ ok: true, user } | { ok: false, reason: 'not-found' }). Existing callers in src/routes/profile.js and src/routes/admin.js were not updated. In profile.js, absent users receive a truthy { ok: false } object which bypasses the !user 404 check and responds with 200 and undefined fields, while found users have undefined id and name properties. In admin.js, checking user.role on the envelope evaluates to undefined, causing requireAdmin to reject all valid admins with 403 Forbidden.\",\n        \"file\": \"src/store.js\",\n        \"line_start\": 7,\n        \"line_end\": 13,\n        \"confidence\": 1,\n        \"recommendation\": \"Update src/routes/profile.js and src/routes/admin.js to handle the result envelope (checking result.ok and accessing result.user), or keep findUser returning User | null to preserve backward compatibility.\"\n      }\n    ],\n    \"next_steps\": [\n      \"Update src/routes/profile.js to check result.ok and access result.user\",\n      \"Update src/routes/admin.js to check result.ok and verify result.user.role === 'admin'\",\n      \"Add test cases for requireAdmin and profileRoute covering existing, missing, and non-admin users\"\n    ]\n  }\n}\n"
+}

--- a/bench/cassettes/caller-contract/agy.model.json
+++ b/bench/cassettes/caller-contract/agy.model.json
@@ -1,0 +1,32 @@
+{
+  "caseId": "caller-contract",
+  "cell": "agy.model",
+  "recordedAt": "2026-08-24T14:38:00.137Z",
+  "verdict": "approve",
+  "summary": "Refactored findUser to return a result envelope for successful and not-found lookups with no internal defects in the diff.",
+  "findings": [],
+  "latencyMs": 16831,
+  "engineVersion": "1.1.19",
+  "engineObserved": null,
+  "samples": [
+    {
+      "verdict": "approve",
+      "summary": "The refactored user lookup cleanly returns a result envelope for success and not-found cases without material defects.",
+      "findings": [],
+      "latencyMs": 19417
+    },
+    {
+      "verdict": "approve",
+      "summary": "The function correctly refactors findUser to return a structured result envelope with no material defects.",
+      "findings": [],
+      "latencyMs": 17003
+    },
+    {
+      "verdict": "approve",
+      "summary": "Refactored findUser to return a result envelope for successful and not-found lookups with no internal defects in the diff.",
+      "findings": [],
+      "latencyMs": 16831
+    }
+  ],
+  "raw": "{\"conversation_id\":\"3e725cea-1e31-455f-bc8e-2b11b217862b\",\"status\":\"SUCCESS\",\"response\":\"{\\n  \\\"verdict\\\": \\\"approve\\\",\\n  \\\"summary\\\": \\\"Refactored findUser to return a result envelope for successful and not-found lookups with no internal defects in the diff.\\\",\\n  \\\"findings\\\": [],\\n  \\\"next_steps\\\": [\\n    \\\"Update callers of findUser to consume the new result envelope structure instead of direct user objects or null.\\\"\\n  ]\\n}\\n\",\"duration_seconds\":10.6336153,\"num_turns\":1,\"usage\":{\"input_tokens\":18940,\"output_tokens\":1618,\"thinking_tokens\":1534,\"cache_read_tokens\":0,\"total_tokens\":20558}}\n"
+}

--- a/bench/cassettes/caller-contract/agy.shallow.json
+++ b/bench/cassettes/caller-contract/agy.shallow.json
@@ -1,0 +1,32 @@
+{
+  "caseId": "caller-contract",
+  "cell": "agy.shallow",
+  "recordedAt": "2026-08-24T15:26:34.882Z",
+  "verdict": "approve",
+  "summary": "Refactored findUser to return a structured result envelope cleanly and without defects.",
+  "findings": [],
+  "latencyMs": 17545,
+  "engineVersion": "1.1.19",
+  "engineObserved": "agy",
+  "samples": [
+    {
+      "verdict": "approve",
+      "summary": "findUser correctly returns a result envelope for both matched and unmatched user lookups.",
+      "findings": [],
+      "latencyMs": 17920
+    },
+    {
+      "verdict": "approve",
+      "summary": "The findUser function correctly implements the result envelope pattern without logic or safety defects.",
+      "findings": [],
+      "latencyMs": 18197
+    },
+    {
+      "verdict": "approve",
+      "summary": "Refactored findUser to return a structured result envelope cleanly and without defects.",
+      "findings": [],
+      "latencyMs": 17545
+    }
+  ],
+  "raw": "{\n  \"review\": \"Review\",\n  \"target\": {\n    \"mode\": \"working-tree\",\n    \"label\": \"working tree diff\",\n    \"explicit\": true\n  },\n  \"engine\": \"agy\",\n  \"gemini\": {\n    \"status\": 0,\n    \"stdout\": \"{\\n  \\\"verdict\\\": \\\"approve\\\",\\n  \\\"summary\\\": \\\"Refactored findUser to return a structured result envelope cleanly and without defects.\\\",\\n  \\\"findings\\\": [],\\n  \\\"next_steps\\\": []\\n}\",\n    \"stderr\": \"\"\n  },\n  \"result\": {\n    \"verdict\": \"approve\",\n    \"summary\": \"Refactored findUser to return a structured result envelope cleanly and without defects.\",\n    \"findings\": [],\n    \"next_steps\": []\n  }\n}\n"
+}

--- a/bench/cassettes/caller-contract/codex.adversarial.json
+++ b/bench/cassettes/caller-contract/codex.adversarial.json
@@ -1,0 +1,76 @@
+{
+  "caseId": "caller-contract",
+  "cell": "codex.adversarial",
+  "recordedAt": "2026-08-24T23:26:54.527Z",
+  "verdict": "needs-attention",
+  "summary": "Do not ship: the return-type change breaks every existing caller.",
+  "findings": [
+    {
+      "severity": "high",
+      "title": "Result envelope is incompatible with both route callers",
+      "body": "`findUser` now always returns a truthy envelope and moves record fields under `user`, but callers still treat the result as a nullable user record. `profileRoute` therefore returns HTTP 200 with missing `id` and `name` for both found and absent IDs, while `requireAdmin` reads `role` from the envelope and rejects even valid administrators. This is directly evidenced by `src/routes/profile.js:4-8` and `src/routes/admin.js:4-8`.",
+      "file": "src/store.js",
+      "line_start": 7,
+      "line_end": 12,
+      "confidence": 1,
+      "recommendation": "Update all callers atomically to branch on `result.ok` and read `result.user`; add route tests covering an existing admin, existing member, and unknown ID."
+    }
+  ],
+  "latencyMs": 47356,
+  "engineVersion": "codex-cli 0.149.0",
+  "engineObserved": null,
+  "samples": [
+    {
+      "verdict": "needs-attention",
+      "summary": "Do not ship: the return-type change breaks every existing caller.",
+      "findings": [
+        {
+          "severity": "high",
+          "title": "Result envelope is incompatible with all existing callers",
+          "body": "`findUser` now always returns a truthy envelope and moves user fields under `user`, but callers still expect a nullable user record. Consequently, `profileRoute` returns HTTP 200 with missing `id` and `name` even for unknown IDs, while `requireAdmin` reads an absent top-level `role` and rejects every administrator. This is directly evidenced by `profile.js:4-8` and `admin.js:4-8`.",
+          "file": "src/store.js",
+          "line_start": 9,
+          "line_end": 12,
+          "confidence": 1,
+          "recommendation": "Update every caller atomically to branch on `result.ok` and read `result.user`, with tests covering found, missing, admin, and non-admin users; otherwise retain the original nullable-record contract."
+        }
+      ],
+      "latencyMs": 38782
+    },
+    {
+      "verdict": "needs-attention",
+      "summary": "Do not ship: this silently breaks the exported function’s established return contract.",
+      "findings": [
+        {
+          "severity": "high",
+          "title": "Return-type change breaks existing callers and absence checks",
+          "body": "`findUser` previously returned a user record or `null`; it now always returns a truthy envelope. Existing callers that read fields directly (for example, `findUser(id).name`) will receive `undefined`, while checks such as `if (findUser(id))` will incorrectly treat missing users as present. Because the function is exported and the diff contains no coordinated caller migration or compatibility layer, this is a plausible runtime regression.",
+          "file": "src/store.js",
+          "line_start": 6,
+          "line_end": 13,
+          "confidence": 0.98,
+          "recommendation": "Either preserve the record-or-null contract, introduce a separately named envelope-returning API, or update every caller atomically and add tests covering direct field access and truthiness-based not-found handling."
+        }
+      ],
+      "latencyMs": 21334
+    },
+    {
+      "verdict": "needs-attention",
+      "summary": "Do not ship: the return-type change breaks every existing caller.",
+      "findings": [
+        {
+          "severity": "high",
+          "title": "Result envelope is incompatible with both route callers",
+          "body": "`findUser` now always returns a truthy envelope and moves record fields under `user`, but callers still treat the result as a nullable user record. `profileRoute` therefore returns HTTP 200 with missing `id` and `name` for both found and absent IDs, while `requireAdmin` reads `role` from the envelope and rejects even valid administrators. This is directly evidenced by `src/routes/profile.js:4-8` and `src/routes/admin.js:4-8`.",
+          "file": "src/store.js",
+          "line_start": 7,
+          "line_end": 12,
+          "confidence": 1,
+          "recommendation": "Update all callers atomically to branch on `result.ok` and read `result.user`; add route tests covering an existing admin, existing member, and unknown ID."
+        }
+      ],
+      "latencyMs": 47356
+    }
+  ],
+  "raw": "{\n  \"review\": \"Adversarial Review\",\n  \"target\": {\n    \"mode\": \"working-tree\",\n    \"label\": \"working tree diff\",\n    \"explicit\": true\n  },\n  \"threadId\": \"01a03618-7fb2-79b1-a279-f707007e5912\",\n  \"context\": {\n    \"repoRoot\": \"C:/Users/arcobaleno/AppData/Local/Temp/bench-caller-contract-2mEqNH\",\n    \"branch\": \"main\",\n    \"summary\": \"Reviewing 0 staged, 1 unstaged, and 0 untracked file(s).\"\n  },\n  \"codex\": {\n    \"status\": 0,\n    \"stderr\": \"\",\n    \"stdout\": \"{\\\"verdict\\\":\\\"needs-attention\\\",\\\"summary\\\":\\\"Do not ship: the return-type change breaks every existing caller.\\\",\\\"findings\\\":[{\\\"severity\\\":\\\"high\\\",\\\"title\\\":\\\"Result envelope is incompatible with both route callers\\\",\\\"body\\\":\\\"`findUser` now always returns a truthy envelope and moves record fields under `user`, but callers still treat the result as a nullable user record. `profileRoute` therefore returns HTTP 200 with missing `id` and `name` for both found and absent IDs, while `requireAdmin` reads `role` from the envelope and rejects even valid administrators. This is directly evidenced by `src/routes/profile.js:4-8` and `src/routes/admin.js:4-8`.\\\",\\\"file\\\":\\\"src/store.js\\\",\\\"line_start\\\":7,\\\"line_end\\\":12,\\\"confidence\\\":1,\\\"recommendation\\\":\\\"Update all callers atomically to branch on `result.ok` and read `result.user`; add route tests covering an existing admin, existing member, and unknown ID.\\\"}],\\\"next_steps\\\":[\\\"Fix both callers and run route-level regression tests before shipping.\\\"]}\",\n    \"reasoning\": []\n  },\n  \"result\": {\n    \"verdict\": \"needs-attention\",\n    \"summary\": \"Do not ship: the return-type change breaks every existing caller.\",\n    \"findings\": [\n      {\n        \"severity\": \"high\",\n        \"title\": \"Result envelope is incompatible with both route callers\",\n        \"body\": \"`findUser` now always returns a truthy envelope and moves record fields under `user`, but callers still treat the result as a nullable user record. `profileRoute` therefore returns HTTP 200 with missing `id` and `name` for both found and absent IDs, while `requireAdmin` reads `role` from the envelope and rejects even valid administrators. This is directly evidenced by `src/routes/profile.js:4-8` and `src/routes/admin.js:4-8`.\",\n        \"file\": \"src/store.js\",\n        \"line_start\": 7,\n        \"line_end\": 12,\n        \"confidence\": 1,\n        \"recommendation\": \"Update all callers atomically to branch on `result.ok` and read `result.user`; add route tests covering an existing admin, existing member, and unknown ID.\"\n      }\n    ],\n    \"next_steps\": [\n      \"Fix both callers and run route-level regression tests before shipping.\"\n    ]\n  },\n  \"rawOutput\": \"{\\\"verdict\\\":\\\"needs-attention\\\",\\\"summary\\\":\\\"Do not ship: the return-type change breaks every existing caller.\\\",\\\"findings\\\":[{\\\"severity\\\":\\\"high\\\",\\\"title\\\":\\\"Result envelope is incompatible with both route callers\\\",\\\"body\\\":\\\"`findUser` now always returns a truthy envelope and moves record fields under `user`, but callers still treat the result as a nullable user record. `profileRoute` therefore returns HTTP 200 with missing `id` and `name` for both found and absent IDs, while `requireAdmin` reads `role` from the envelope and rejects even valid administrators. This is directly evidenced by `src/routes/profile.js:4-8` and `src/routes/admin.js:4-8`.\\\",\\\"file\\\":\\\"src/store.js\\\",\\\"line_start\\\":7,\\\"line_end\\\":12,\\\"confidence\\\":1,\\\"recommendation\\\":\\\"Update all callers atomically to branch on `result.ok` and read `result.user`; add route tests covering an existing admin, existing member, and unknown ID.\\\"}],\\\"next_steps\\\":[\\\"Fix both callers and run route-level regression tests before shipping.\\\"]}\",\n  \"parseError\": null,\n  \"reasoningSummary\": []\n}\n"
+}

--- a/bench/cassettes/caller-contract/codex.model.json
+++ b/bench/cassettes/caller-contract/codex.model.json
@@ -1,0 +1,32 @@
+{
+  "caseId": "caller-contract",
+  "cell": "codex.model",
+  "recordedAt": "2026-08-24T23:23:43.203Z",
+  "verdict": "approve",
+  "summary": "The result-envelope implementation correctly distinguishes found and absent users within the provided diff.",
+  "findings": [],
+  "latencyMs": 14382,
+  "engineVersion": "codex-cli 0.149.0",
+  "engineObserved": null,
+  "samples": [
+    {
+      "verdict": "approve",
+      "summary": "The result-envelope implementation is internally consistent and introduces no material defect visible in the provided diff.",
+      "findings": [],
+      "latencyMs": 17989
+    },
+    {
+      "verdict": "approve",
+      "summary": "The result-envelope change is internally consistent and introduces no material defect visible in the diff.",
+      "findings": [],
+      "latencyMs": 16628
+    },
+    {
+      "verdict": "approve",
+      "summary": "The result-envelope implementation correctly distinguishes found and absent users within the provided diff.",
+      "findings": [],
+      "latencyMs": 14382
+    }
+  ],
+  "raw": "{\"verdict\":\"approve\",\"summary\":\"The result-envelope implementation correctly distinguishes found and absent users within the provided diff.\",\"findings\":[],\"next_steps\":[]}\n"
+}

--- a/bench/cassettes/path-and-input/agy.adversarial.json
+++ b/bench/cassettes/path-and-input/agy.adversarial.json
@@ -1,0 +1,116 @@
+{
+  "caseId": "path-and-input",
+  "cell": "agy.adversarial",
+  "recordedAt": "2026-08-24T11:21:45.196Z",
+  "verdict": "needs-attention",
+  "summary": "Do not ship: introduces critical command injection in archive() and path traversal in readUpload().",
+  "findings": [
+    {
+      "severity": "critical",
+      "title": "Command injection in archive()",
+      "body": "The archive function constructs a shell command string by directly interpolating the 'name' parameter into execSync. An attacker supplying shell metacharacters (such as ';', '&&', or '$(...)') within 'name' can execute arbitrary system commands with the privileges of the Node.js process.",
+      "file": "src/files.js",
+      "line_start": 12,
+      "line_end": 14,
+      "confidence": 1,
+      "recommendation": "Use child_process.execFileSync or child_process.spawn with an array of arguments rather than shell string interpolation, and validate/sanitize input parameters."
+    },
+    {
+      "severity": "high",
+      "title": "Path traversal in readUpload()",
+      "body": "readUpload concatenates ROOT and 'name' using path.join without verifying that the resolved path stays within ROOT. Supplying relative path traversal sequences (e.g., '../../etc/passwd') allows reading arbitrary files from the host filesystem.",
+      "file": "src/files.js",
+      "line_start": 7,
+      "line_end": 10,
+      "confidence": 1,
+      "recommendation": "Sanitize 'name' using path.basename(name) or verify that path.resolve(ROOT, name).startsWith(path.resolve(ROOT) + path.sep) before reading."
+    }
+  ],
+  "latencyMs": 21809,
+  "engineVersion": "1.1.19",
+  "engineObserved": "agy",
+  "samples": [
+    {
+      "verdict": "needs-attention",
+      "summary": "Block shipping due to critical remote command execution and arbitrary file read vulnerabilities in file handling utilities.",
+      "findings": [
+        {
+          "severity": "critical",
+          "title": "Remote command execution via shell command interpolation in archive()",
+          "body": "The `archive` function interpolates the `name` parameter directly into a shell command passed to `execSync`. An attacker supplying shell metacharacters (such as `;`, `|`, `&`, or backticks) in `name` can execute arbitrary commands with the privileges of the Node.js process, resulting in full server compromise.",
+          "file": "src/files.js",
+          "line_start": 12,
+          "line_end": 14,
+          "confidence": 1,
+          "recommendation": "Replace `execSync` with `execFile` or `spawn` using an arguments array rather than invoking a shell with string interpolation, and enforce strict alphanumeric/safe character validation on `name`."
+        },
+        {
+          "severity": "high",
+          "title": "Arbitrary file disclosure via path traversal in readUpload()",
+          "body": "`path.join(ROOT, name)` does not restrict directory traversal if `name` contains relative traversal segments (`../`). An attacker can supply traversal sequences to escape `/srv/uploads` and read arbitrary files on the host filesystem accessible to the process.",
+          "file": "src/files.js",
+          "line_start": 7,
+          "line_end": 10,
+          "confidence": 1,
+          "recommendation": "Resolve the target path using `path.resolve(ROOT, name)` and verify that `target.startsWith(path.resolve(ROOT) + path.sep)` before reading from the filesystem."
+        }
+      ],
+      "latencyMs": 32762
+    },
+    {
+      "verdict": "needs-attention",
+      "summary": "Do not ship: the changes introduce critical remote command execution and arbitrary file read vulnerabilities via unsanitized inputs.",
+      "findings": [
+        {
+          "severity": "critical",
+          "title": "Command injection in archive function via shell string interpolation",
+          "body": "The archive function directly interpolates the `name` argument into a shell command executed via `execSync`. If `name` contains shell metacharacters (e.g., `;`, `|`, `&`, or command substitutions), an attacker can execute arbitrary shell commands with the privileges of the Node.js process.",
+          "file": "src/files.js",
+          "line_start": 12,
+          "line_end": 14,
+          "confidence": 1,
+          "recommendation": "Replace `execSync` shell string execution with `execFileSync` or `spawnSync` using a discrete arguments array, and validate/sanitize `name` against an allowlist."
+        },
+        {
+          "severity": "high",
+          "title": "Path traversal leading to arbitrary file read in readUpload",
+          "body": "The `readUpload` function constructs target paths with `path.join(ROOT, name)` without verifying that the resolved path stays within `ROOT`. An input containing directory traversal sequences (e.g., `../../etc/passwd`) allows unauthenticated reading of arbitrary files on the host filesystem.",
+          "file": "src/files.js",
+          "line_start": 7,
+          "line_end": 10,
+          "confidence": 1,
+          "recommendation": "Resolve the absolute path using `path.resolve(ROOT, name)` and assert that the target starts with `path.resolve(ROOT) + path.sep`, or restrict `name` to `path.basename(name)`."
+        }
+      ],
+      "latencyMs": 24233
+    },
+    {
+      "verdict": "needs-attention",
+      "summary": "Do not ship: introduces critical command injection in archive() and path traversal in readUpload().",
+      "findings": [
+        {
+          "severity": "critical",
+          "title": "Command injection in archive()",
+          "body": "The archive function constructs a shell command string by directly interpolating the 'name' parameter into execSync. An attacker supplying shell metacharacters (such as ';', '&&', or '$(...)') within 'name' can execute arbitrary system commands with the privileges of the Node.js process.",
+          "file": "src/files.js",
+          "line_start": 12,
+          "line_end": 14,
+          "confidence": 1,
+          "recommendation": "Use child_process.execFileSync or child_process.spawn with an array of arguments rather than shell string interpolation, and validate/sanitize input parameters."
+        },
+        {
+          "severity": "high",
+          "title": "Path traversal in readUpload()",
+          "body": "readUpload concatenates ROOT and 'name' using path.join without verifying that the resolved path stays within ROOT. Supplying relative path traversal sequences (e.g., '../../etc/passwd') allows reading arbitrary files from the host filesystem.",
+          "file": "src/files.js",
+          "line_start": 7,
+          "line_end": 10,
+          "confidence": 1,
+          "recommendation": "Sanitize 'name' using path.basename(name) or verify that path.resolve(ROOT, name).startsWith(path.resolve(ROOT) + path.sep) before reading."
+        }
+      ],
+      "latencyMs": 21809
+    }
+  ],
+  "raw": "{\n  \"review\": \"Adversarial Review\",\n  \"target\": {\n    \"mode\": \"working-tree\",\n    \"label\": \"working tree diff\",\n    \"explicit\": true\n  },\n  \"engine\": \"agy\",\n  \"gemini\": {\n    \"status\": 0,\n    \"stdout\": \"{\\n  \\\"verdict\\\": \\\"needs-attention\\\",\\n  \\\"summary\\\": \\\"Do not ship: introduces critical command injection in archive() and path traversal in readUpload().\\\",\\n  \\\"findings\\\": [\\n    {\\n      \\\"severity\\\": \\\"critical\\\",\\n      \\\"title\\\": \\\"Command injection in archive()\\\",\\n      \\\"body\\\": \\\"The archive function constructs a shell command string by directly interpolating the 'name' parameter into execSync. An attacker supplying shell metacharacters (such as ';', '&&', or '$(...)') within 'name' can execute arbitrary system commands with the privileges of the Node.js process.\\\",\\n      \\\"file\\\": \\\"src/files.js\\\",\\n      \\\"line_start\\\": 12,\\n      \\\"line_end\\\": 14,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Use child_process.execFileSync or child_process.spawn with an array of arguments rather than shell string interpolation, and validate/sanitize input parameters.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"high\\\",\\n      \\\"title\\\": \\\"Path traversal in readUpload()\\\",\\n      \\\"body\\\": \\\"readUpload concatenates ROOT and 'name' using path.join without verifying that the resolved path stays within ROOT. Supplying relative path traversal sequences (e.g., '../../etc/passwd') allows reading arbitrary files from the host filesystem.\\\",\\n      \\\"file\\\": \\\"src/files.js\\\",\\n      \\\"line_start\\\": 7,\\n      \\\"line_end\\\": 10,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Sanitize 'name' using path.basename(name) or verify that path.resolve(ROOT, name).startsWith(path.resolve(ROOT) + path.sep) before reading.\\\"\\n    }\\n  ],\\n  \\\"next_steps\\\": [\\n    \\\"Refactor archive() to use execFileSync or spawn without a shell.\\\",\\n    \\\"Enforce strict path containment checks on all filesystem operations in src/files.js.\\\"\\n  ]\\n}\",\n    \"stderr\": \"\"\n  },\n  \"result\": {\n    \"verdict\": \"needs-attention\",\n    \"summary\": \"Do not ship: introduces critical command injection in archive() and path traversal in readUpload().\",\n    \"findings\": [\n      {\n        \"severity\": \"critical\",\n        \"title\": \"Command injection in archive()\",\n        \"body\": \"The archive function constructs a shell command string by directly interpolating the 'name' parameter into execSync. An attacker supplying shell metacharacters (such as ';', '&&', or '$(...)') within 'name' can execute arbitrary system commands with the privileges of the Node.js process.\",\n        \"file\": \"src/files.js\",\n        \"line_start\": 12,\n        \"line_end\": 14,\n        \"confidence\": 1,\n        \"recommendation\": \"Use child_process.execFileSync or child_process.spawn with an array of arguments rather than shell string interpolation, and validate/sanitize input parameters.\"\n      },\n      {\n        \"severity\": \"high\",\n        \"title\": \"Path traversal in readUpload()\",\n        \"body\": \"readUpload concatenates ROOT and 'name' using path.join without verifying that the resolved path stays within ROOT. Supplying relative path traversal sequences (e.g., '../../etc/passwd') allows reading arbitrary files from the host filesystem.\",\n        \"file\": \"src/files.js\",\n        \"line_start\": 7,\n        \"line_end\": 10,\n        \"confidence\": 1,\n        \"recommendation\": \"Sanitize 'name' using path.basename(name) or verify that path.resolve(ROOT, name).startsWith(path.resolve(ROOT) + path.sep) before reading.\"\n      }\n    ],\n    \"next_steps\": [\n      \"Refactor archive() to use execFileSync or spawn without a shell.\",\n      \"Enforce strict path containment checks on all filesystem operations in src/files.js.\"\n    ]\n  }\n}\n"
+}

--- a/bench/cassettes/path-and-input/agy.deep.json
+++ b/bench/cassettes/path-and-input/agy.deep.json
@@ -1,145 +1,156 @@
 {
   "caseId": "path-and-input",
   "cell": "agy.deep",
-  "recordedAt": "2026-08-19T08:29:22.409Z",
+  "recordedAt": "2026-08-24T09:46:22.302Z",
   "verdict": "needs-attention",
-  "summary": "Critical command injection, path traversal, and unvalidated input handling defects were identified in src/files.js.",
+  "summary": "Identified critical command injection, path traversal, and missing input validation vulnerabilities across file operations.",
   "findings": [
     {
       "severity": "critical",
-      "title": "Command injection in archive function",
-      "body": "The archive function directly interpolates the untrusted 'name' argument into a shell command executed via execSync. Passing shell metacharacters allows arbitrary command execution.",
+      "title": "Command injection vulnerability in archive",
+      "body": "In archive(), the unvalidated name parameter is directly interpolated into a shell string executed via execSync. An attacker providing shell metacharacters in name can execute arbitrary commands on the system.",
       "file": "src/files.js",
       "line_start": 12,
       "line_end": 14,
       "confidence": 1,
-      "recommendation": "Use execFileSync or spawnSync with an argument array instead of a shell string, and strictly validate or sanitize the filename."
+      "recommendation": "Avoid shell command interpolation. Use execFileSync or spawn with an argument array (e.g. execFileSync('tar', ['-czf', `${name}.tar.gz`, path.join(ROOT, name)])) and sanitize the archive name."
     },
     {
       "severity": "high",
-      "title": "Path traversal in readUpload",
-      "body": "readUpload concatenates ROOT and 'name' using path.join without verifying that the resolved path resides within ROOT. Input containing '../' allows reading arbitrary files from the filesystem.",
+      "title": "Path traversal vulnerability in readUpload",
+      "body": "In readUpload(), path.join(ROOT, name) resolves relative path components such as '..'. An attacker can supply a relative path to escape the ROOT directory and read arbitrary files from the filesystem.",
       "file": "src/files.js",
       "line_start": 7,
       "line_end": 10,
       "confidence": 1,
-      "recommendation": "Validate that path.resolve(ROOT, name).startsWith(path.resolve(ROOT) + path.sep) or sanitize 'name' using path.basename."
+      "recommendation": "Resolve the target path with path.resolve and verify that it starts with the resolved ROOT path (e.g., target.startsWith(path.resolve(ROOT) + path.sep)) before reading."
     },
     {
       "severity": "medium",
-      "title": "Unsafe property access and missing bounds check in pickPage",
-      "body": "pickPage accesses body.page without checking if body is null/undefined, parses without an explicit radix, and accesses pages[page] without verifying that page is a non-negative integer within the pages array bounds.",
+      "title": "Missing null check, radix, and bounds validation in pickPage",
+      "body": "pickPage accesses body.page without verifying body exists and parses page with parseInt without a specified radix or bounds check against the pages array. This can throw a TypeError on null/undefined body or return undefined on invalid/out-of-bounds indices.",
       "file": "src/files.js",
       "line_start": 16,
       "line_end": 19,
       "confidence": 0.95,
-      "recommendation": "Add null-safe access for body, specify radix 10 for parseInt, and validate that page is an integer within 0 <= page < pages.length before returning."
+      "recommendation": "Ensure body is defined, parse body.page with an explicit radix (parseInt(body?.page, 10)), and validate that page is a non-negative integer within the pages array bounds."
     }
   ],
-  "latencyMs": 24606,
-  "engineVersion": "1.1.15",
+  "latencyMs": 31473,
+  "engineVersion": "1.1.19",
+  "engineObserved": "agy",
   "samples": [
     {
       "verdict": "needs-attention",
-      "summary": "Critical command injection and high-severity path traversal vulnerabilities detected in src/files.js.",
-      "findings": [
-        {
-          "severity": "critical",
-          "title": "Command injection via unescaped input in archive function",
-          "body": "In src/files.js at line 13, execSync executes a shell command constructed via template string interpolation with the parameter name. If name contains shell metacharacters, an attacker can achieve arbitrary command execution.",
-          "file": "src/files.js",
-          "line_start": 12,
-          "line_end": 14,
-          "confidence": 1,
-          "recommendation": "Use child_process.execFileSync or child_process.spawn with an array of arguments rather than shell interpolation, and sanitize or restrict name."
-        },
-        {
-          "severity": "high",
-          "title": "Path traversal in readUpload allowing arbitrary file reading",
-          "body": "In src/files.js at line 8, path.join(ROOT, name) does not prevent relative path traversal sequences (e.g., ../). An attacker can supply a crafted filename to read arbitrary files outside ROOT via fs.readFileSync.",
-          "file": "src/files.js",
-          "line_start": 7,
-          "line_end": 10,
-          "confidence": 1,
-          "recommendation": "Validate that path.resolve(ROOT, name) starts with path.resolve(ROOT) + path.sep, or restrict name with path.basename."
-        }
-      ],
-      "latencyMs": 16574
-    },
-    {
-      "verdict": "needs-attention",
-      "summary": "Identified critical command injection, path traversal, and missing input validation issues in src/files.js.",
+      "summary": "Identified critical command injection, high-severity path traversal, and unhandled input validation issues in src/files.js.",
       "findings": [
         {
           "severity": "critical",
           "title": "Command injection in archive function",
-          "body": "The archive function interpolates the unsanitized parameter `name` directly into a shell command executed via `execSync`. If `name` contains shell metacharacters, an attacker can execute arbitrary commands on the host system.",
+          "body": "In archive(name), the name parameter is directly interpolated into a shell string executed via execSync without sanitization. An attacker supplying shell metacharacters can execute arbitrary system commands.",
           "file": "src/files.js",
           "line_start": 12,
           "line_end": 14,
           "confidence": 1,
-          "recommendation": "Use `execFileSync` or `spawnSync` with an explicit argument array instead of shell execution via template literals."
+          "recommendation": "Use child_process.execFileSync or spawnSync with argument arrays instead of shell interpolation, and validate the filename."
         },
         {
           "severity": "high",
           "title": "Path traversal in readUpload",
-          "body": "The readUpload function constructs file paths using `path.join(ROOT, name)` without validating that the target resides within `/srv/uploads`. An attacker supplying traversal sequences (such as `../`) can read arbitrary files from the filesystem.",
+          "body": "In readUpload(name), target is constructed via path.join(ROOT, name) without ensuring the resolved path remains inside ROOT (/srv/uploads). Supplying relative traversal sequences (e.g., ../) allows arbitrary file reads.",
           "file": "src/files.js",
           "line_start": 7,
           "line_end": 10,
           "confidence": 1,
-          "recommendation": "Verify that `path.resolve(ROOT, name).startsWith(path.resolve(ROOT) + path.sep)` or sanitize `name` using `path.basename(name)`."
+          "recommendation": "Resolve the path and verify that the target starts with the canonical ROOT directory path before calling fs.readFileSync."
         },
         {
           "severity": "medium",
-          "title": "Missing input validation and boundary checks in pickPage",
-          "body": "The pickPage function does not safely handle null/undefined `body`, parses `body.page` without an explicit radix, and does not check for `NaN` or out-of-bounds indices, resulting in potential runtime TypeErrors or unexpected `undefined` returns.",
+          "title": "Missing validation and potential TypeError in pickPage",
+          "body": "In pickPage(body, pages), accessing body.page throws a TypeError if body is null or undefined, and parseInt produces NaN if page is not a valid number string. Accessing pages[page] may also throw if pages is null or undefined, or return undefined when page is NaN or out of bounds.",
           "file": "src/files.js",
           "line_start": 16,
           "line_end": 19,
           "confidence": 0.95,
-          "recommendation": "Safely access `body?.page`, parse using `parseInt(body.page, 10)`, and validate that the result is an integer within `0 <= page < pages.length`."
+          "recommendation": "Validate that body and pages exist, parse page with explicit radix (parseInt(body?.page, 10)), and verify the resulting index is within valid array bounds."
         }
       ],
-      "latencyMs": 20849
+      "latencyMs": 27539
     },
     {
       "verdict": "needs-attention",
-      "summary": "Critical command injection, path traversal, and unvalidated input handling defects were identified in src/files.js.",
+      "summary": "Identified critical command injection and high-severity path traversal vulnerabilities along with missing input validation in src/files.js.",
       "findings": [
         {
           "severity": "critical",
-          "title": "Command injection in archive function",
-          "body": "The archive function directly interpolates the untrusted 'name' argument into a shell command executed via execSync. Passing shell metacharacters allows arbitrary command execution.",
+          "title": "Command injection via unescaped string interpolation in execSync",
+          "body": "The archive function interpolates the unvalidated 'name' argument directly into a shell command string executed by execSync. An input containing shell metacharacters or command separators will result in arbitrary shell command execution.",
           "file": "src/files.js",
           "line_start": 12,
           "line_end": 14,
           "confidence": 1,
-          "recommendation": "Use execFileSync or spawnSync with an argument array instead of a shell string, and strictly validate or sanitize the filename."
+          "recommendation": "Use child_process.execFileSync or spawnSync with an argument array instead of executing a formatted shell string, and strictly validate the archive name."
         },
         {
           "severity": "high",
-          "title": "Path traversal in readUpload",
-          "body": "readUpload concatenates ROOT and 'name' using path.join without verifying that the resolved path resides within ROOT. Input containing '../' allows reading arbitrary files from the filesystem.",
+          "title": "Path traversal in readUpload allowing arbitrary file read",
+          "body": "readUpload combines ROOT and the user-supplied 'name' using path.join without verifying that the resolved path remains within the ROOT directory. Supplying relative path segments like '..' allows reading arbitrary files from the filesystem.",
           "file": "src/files.js",
           "line_start": 7,
           "line_end": 10,
           "confidence": 1,
-          "recommendation": "Validate that path.resolve(ROOT, name).startsWith(path.resolve(ROOT) + path.sep) or sanitize 'name' using path.basename."
+          "recommendation": "Resolve the target path with path.resolve(ROOT, name) and verify it starts with path.resolve(ROOT) + path.sep, or enforce path.basename(name)."
         },
         {
           "severity": "medium",
-          "title": "Unsafe property access and missing bounds check in pickPage",
-          "body": "pickPage accesses body.page without checking if body is null/undefined, parses without an explicit radix, and accesses pages[page] without verifying that page is a non-negative integer within the pages array bounds.",
+          "title": "Missing null check and array bounds validation in pickPage",
+          "body": "pickPage attempts to access body.page without checking if body is null or undefined, throwing an unhandled TypeError. Additionally, it does not validate that parseInt produces a valid index within the range of pages.",
           "file": "src/files.js",
           "line_start": 16,
           "line_end": 19,
           "confidence": 0.95,
-          "recommendation": "Add null-safe access for body, specify radix 10 for parseInt, and validate that page is an integer within 0 <= page < pages.length before returning."
+          "recommendation": "Safely access body using optional chaining or guard checks, parse with an explicit radix (parseInt(body?.page, 10)), and verify that the index is non-negative and less than pages.length."
         }
       ],
-      "latencyMs": 24606
+      "latencyMs": 22889
+    },
+    {
+      "verdict": "needs-attention",
+      "summary": "Identified critical command injection, path traversal, and missing input validation vulnerabilities across file operations.",
+      "findings": [
+        {
+          "severity": "critical",
+          "title": "Command injection vulnerability in archive",
+          "body": "In archive(), the unvalidated name parameter is directly interpolated into a shell string executed via execSync. An attacker providing shell metacharacters in name can execute arbitrary commands on the system.",
+          "file": "src/files.js",
+          "line_start": 12,
+          "line_end": 14,
+          "confidence": 1,
+          "recommendation": "Avoid shell command interpolation. Use execFileSync or spawn with an argument array (e.g. execFileSync('tar', ['-czf', `${name}.tar.gz`, path.join(ROOT, name)])) and sanitize the archive name."
+        },
+        {
+          "severity": "high",
+          "title": "Path traversal vulnerability in readUpload",
+          "body": "In readUpload(), path.join(ROOT, name) resolves relative path components such as '..'. An attacker can supply a relative path to escape the ROOT directory and read arbitrary files from the filesystem.",
+          "file": "src/files.js",
+          "line_start": 7,
+          "line_end": 10,
+          "confidence": 1,
+          "recommendation": "Resolve the target path with path.resolve and verify that it starts with the resolved ROOT path (e.g., target.startsWith(path.resolve(ROOT) + path.sep)) before reading."
+        },
+        {
+          "severity": "medium",
+          "title": "Missing null check, radix, and bounds validation in pickPage",
+          "body": "pickPage accesses body.page without verifying body exists and parses page with parseInt without a specified radix or bounds check against the pages array. This can throw a TypeError on null/undefined body or return undefined on invalid/out-of-bounds indices.",
+          "file": "src/files.js",
+          "line_start": 16,
+          "line_end": 19,
+          "confidence": 0.95,
+          "recommendation": "Ensure body is defined, parse body.page with an explicit radix (parseInt(body?.page, 10)), and validate that page is a non-negative integer within the pages array bounds."
+        }
+      ],
+      "latencyMs": 31473
     }
   ],
-  "raw": "{\n  \"review\": \"Review\",\n  \"target\": {\n    \"mode\": \"working-tree\",\n    \"label\": \"working tree diff\",\n    \"explicit\": true\n  },\n  \"gemini\": {\n    \"status\": 0,\n    \"stdout\": \"{\\n  \\\"verdict\\\": \\\"needs-attention\\\",\\n  \\\"summary\\\": \\\"Critical command injection, path traversal, and unvalidated input handling defects were identified in src/files.js.\\\",\\n  \\\"findings\\\": [\\n    {\\n      \\\"severity\\\": \\\"critical\\\",\\n      \\\"title\\\": \\\"Command injection in archive function\\\",\\n      \\\"body\\\": \\\"The archive function directly interpolates the untrusted 'name' argument into a shell command executed via execSync. Passing shell metacharacters allows arbitrary command execution.\\\",\\n      \\\"file\\\": \\\"src/files.js\\\",\\n      \\\"line_start\\\": 12,\\n      \\\"line_end\\\": 14,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Use execFileSync or spawnSync with an argument array instead of a shell string, and strictly validate or sanitize the filename.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"high\\\",\\n      \\\"title\\\": \\\"Path traversal in readUpload\\\",\\n      \\\"body\\\": \\\"readUpload concatenates ROOT and 'name' using path.join without verifying that the resolved path resides within ROOT. Input containing '../' allows reading arbitrary files from the filesystem.\\\",\\n      \\\"file\\\": \\\"src/files.js\\\",\\n      \\\"line_start\\\": 7,\\n      \\\"line_end\\\": 10,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Validate that path.resolve(ROOT, name).startsWith(path.resolve(ROOT) + path.sep) or sanitize 'name' using path.basename.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"medium\\\",\\n      \\\"title\\\": \\\"Unsafe property access and missing bounds check in pickPage\\\",\\n      \\\"body\\\": \\\"pickPage accesses body.page without checking if body is null/undefined, parses without an explicit radix, and accesses pages[page] without verifying that page is a non-negative integer within the pages array bounds.\\\",\\n      \\\"file\\\": \\\"src/files.js\\\",\\n      \\\"line_start\\\": 16,\\n      \\\"line_end\\\": 19,\\n      \\\"confidence\\\": 0.95,\\n      \\\"recommendation\\\": \\\"Add null-safe access for body, specify radix 10 for parseInt, and validate that page is an integer within 0 <= page < pages.length before returning.\\\"\\n    }\\n  ],\\n  \\\"next_steps\\\": [\\n    \\\"Replace execSync with execFileSync using parameterized arguments in archive().\\\",\\n    \\\"Add directory containment checks for path resolution against ROOT in readUpload().\\\",\\n    \\\"Add null checks, radix specification, and bounds validation in pickPage().\\\"\\n  ]\\n}\",\n    \"stderr\": \"\"\n  },\n  \"result\": {\n    \"verdict\": \"needs-attention\",\n    \"summary\": \"Critical command injection, path traversal, and unvalidated input handling defects were identified in src/files.js.\",\n    \"findings\": [\n      {\n        \"severity\": \"critical\",\n        \"title\": \"Command injection in archive function\",\n        \"body\": \"The archive function directly interpolates the untrusted 'name' argument into a shell command executed via execSync. Passing shell metacharacters allows arbitrary command execution.\",\n        \"file\": \"src/files.js\",\n        \"line_start\": 12,\n        \"line_end\": 14,\n        \"confidence\": 1,\n        \"recommendation\": \"Use execFileSync or spawnSync with an argument array instead of a shell string, and strictly validate or sanitize the filename.\"\n      },\n      {\n        \"severity\": \"high\",\n        \"title\": \"Path traversal in readUpload\",\n        \"body\": \"readUpload concatenates ROOT and 'name' using path.join without verifying that the resolved path resides within ROOT. Input containing '../' allows reading arbitrary files from the filesystem.\",\n        \"file\": \"src/files.js\",\n        \"line_start\": 7,\n        \"line_end\": 10,\n        \"confidence\": 1,\n        \"recommendation\": \"Validate that path.resolve(ROOT, name).startsWith(path.resolve(ROOT) + path.sep) or sanitize 'name' using path.basename.\"\n      },\n      {\n        \"severity\": \"medium\",\n        \"title\": \"Unsafe property access and missing bounds check in pickPage\",\n        \"body\": \"pickPage "
+  "raw": "{\n  \"review\": \"Review\",\n  \"target\": {\n    \"mode\": \"working-tree\",\n    \"label\": \"working tree diff\",\n    \"explicit\": true\n  },\n  \"engine\": \"agy\",\n  \"gemini\": {\n    \"status\": 0,\n    \"stdout\": \"{\\n  \\\"verdict\\\": \\\"needs-attention\\\",\\n  \\\"summary\\\": \\\"Identified critical command injection, path traversal, and missing input validation vulnerabilities across file operations.\\\",\\n  \\\"findings\\\": [\\n    {\\n      \\\"severity\\\": \\\"critical\\\",\\n      \\\"title\\\": \\\"Command injection vulnerability in archive\\\",\\n      \\\"body\\\": \\\"In archive(), the unvalidated name parameter is directly interpolated into a shell string executed via execSync. An attacker providing shell metacharacters in name can execute arbitrary commands on the system.\\\",\\n      \\\"file\\\": \\\"src/files.js\\\",\\n      \\\"line_start\\\": 12,\\n      \\\"line_end\\\": 14,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Avoid shell command interpolation. Use execFileSync or spawn with an argument array (e.g. execFileSync('tar', ['-czf', `${name}.tar.gz`, path.join(ROOT, name)])) and sanitize the archive name.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"high\\\",\\n      \\\"title\\\": \\\"Path traversal vulnerability in readUpload\\\",\\n      \\\"body\\\": \\\"In readUpload(), path.join(ROOT, name) resolves relative path components such as '..'. An attacker can supply a relative path to escape the ROOT directory and read arbitrary files from the filesystem.\\\",\\n      \\\"file\\\": \\\"src/files.js\\\",\\n      \\\"line_start\\\": 7,\\n      \\\"line_end\\\": 10,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Resolve the target path with path.resolve and verify that it starts with the resolved ROOT path (e.g., target.startsWith(path.resolve(ROOT) + path.sep)) before reading.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"medium\\\",\\n      \\\"title\\\": \\\"Missing null check, radix, and bounds validation in pickPage\\\",\\n      \\\"body\\\": \\\"pickPage accesses body.page without verifying body exists and parses page with parseInt without a specified radix or bounds check against the pages array. This can throw a TypeError on null/undefined body or return undefined on invalid/out-of-bounds indices.\\\",\\n      \\\"file\\\": \\\"src/files.js\\\",\\n      \\\"line_start\\\": 16,\\n      \\\"line_end\\\": 19,\\n      \\\"confidence\\\": 0.95,\\n      \\\"recommendation\\\": \\\"Ensure body is defined, parse body.page with an explicit radix (parseInt(body?.page, 10)), and validate that page is a non-negative integer within the pages array bounds.\\\"\\n    }\\n  ],\\n  \\\"next_steps\\\": [\\n    \\\"Refactor archive() to use execFileSync with arguments array instead of shell interpolation.\\\",\\n    \\\"Add boundary path validation in readUpload() to block path traversal.\\\",\\n    \\\"Add null checks, radix specification, and array bounds verification in pickPage().\\\"\\n  ]\\n}\",\n    \"stderr\": \"\"\n  },\n  \"result\": {\n    \"verdict\": \"needs-attention\",\n    \"summary\": \"Identified critical command injection, path traversal, and missing input validation vulnerabilities across file operations.\",\n    \"findings\": [\n      {\n        \"severity\": \"critical\",\n        \"title\": \"Command injection vulnerability in archive\",\n        \"body\": \"In archive(), the unvalidated name parameter is directly interpolated into a shell string executed via execSync. An attacker providing shell metacharacters in name can execute arbitrary commands on the system.\",\n        \"file\": \"src/files.js\",\n        \"line_start\": 12,\n        \"line_end\": 14,\n        \"confidence\": 1,\n        \"recommendation\": \"Avoid shell command interpolation. Use execFileSync or spawn with an argument array (e.g. execFileSync('tar', ['-czf', `${name}.tar.gz`, path.join(ROOT, name)])) and sanitize the archive name.\"\n      },\n      {\n        \"severity\": \"high\",\n        \"title\": \"Path traversal vulnerability in readUpload\",\n        \"body\": \"In readUpload(), path.join(ROOT, name) resolves relative path components such as '..'. An attacker can supply a relative path to escape the ROOT directory and read arbitrary files from the filesystem.\",\n        \"fi"
 }

--- a/bench/cassettes/path-and-input/agy.model.json
+++ b/bench/cassettes/path-and-input/agy.model.json
@@ -1,155 +1,156 @@
 {
   "caseId": "path-and-input",
   "cell": "agy.model",
-  "recordedAt": "2026-08-19T08:26:59.739Z",
+  "recordedAt": "2026-08-24T05:01:57.870Z",
   "verdict": "needs-attention",
-  "summary": "The diff introduces critical command injection, arbitrary path traversal vulnerabilities, and unvalidated index access.",
+  "summary": "Unsanitised user input enables command injection and path traversal; array access is unbounded.",
   "findings": [
     {
       "severity": "critical",
-      "title": "Command injection vulnerability in archive",
-      "body": "In `archive`, the `name` parameter is directly interpolated into the shell command string passed to `execSync`. An attacker providing shell metacharacters in `name` can execute arbitrary system commands.",
+      "title": "Command injection in archive()",
+      "body": "The `name` parameter is interpolated directly into a shell command string passed to `execSync`. An attacker-controlled `name` such as `\"; rm -rf / #\"` executes arbitrary OS commands. `path.join(ROOT, name)` in the second interpolation is equally unsanitised.",
       "file": "src/files.js",
-      "line_start": 12,
-      "line_end": 14,
-      "confidence": 1,
-      "recommendation": "Use `execFileSync` with an argument array instead of a shell string (e.g., `execFileSync('tar', ['-czf', `${name}.tar.gz`, targetPath])`) and sanitize/validate `name`."
+      "line_start": 13,
+      "line_end": 13,
+      "confidence": 0.99,
+      "recommendation": "Never build shell strings from user input. Use `execFileSync('tar', ['-czf', outPath, srcPath])` (no shell) and validate/sanitise `name` (reject path separators, null bytes, shell metacharacters)."
     },
     {
-      "severity": "high",
-      "title": "Arbitrary file read via path traversal in readUpload",
-      "body": "In `readUpload`, `path.join(ROOT, name)` does not prevent directory traversal sequences such as `..`. An attacker can supply a relative path to read arbitrary files from the filesystem.",
+      "severity": "critical",
+      "title": "Path traversal in readUpload()",
+      "body": "`path.join('/srv/uploads', '../../etc/passwd')` resolves to `/etc/passwd`. Because `name` is not validated, any caller can read arbitrary files on the filesystem as the process user.",
       "file": "src/files.js",
-      "line_start": 7,
-      "line_end": 10,
-      "confidence": 1,
-      "recommendation": "Sanitize `name` by stripping directory separators or ensure `path.resolve(ROOT, name).startsWith(path.resolve(ROOT) + path.sep)` before reading."
+      "line_start": 8,
+      "line_end": 9,
+      "confidence": 0.98,
+      "recommendation": "After joining, call `path.resolve(target)` and verify it starts with `ROOT + path.sep` (or use `path.relative(ROOT, target)` and reject results starting with `..`). Reject null bytes as well."
     },
     {
       "severity": "medium",
-      "title": "Unvalidated input and missing bounds check in pickPage",
-      "body": "In `pickPage`, `parseInt(body.page)` lacks a radix, does not check if `body` or `body.page` is defined, and does not validate whether the resulting index is within the valid bounds of `pages` (or if it evaluates to `NaN`).",
+      "title": "Unbounded and unvalidated array access in pickPage()",
+      "body": "`parseInt(body.page)` can return `NaN` (yields `undefined`), a negative number (yields `undefined` or a prototype property via numeric coercion), or an index beyond `pages.length`. No error is surfaced; callers silently receive `undefined`, likely causing downstream failures or information disclosure if `pages` is an object with unexpected keys.",
       "file": "src/files.js",
-      "line_start": 16,
-      "line_end": 19,
-      "confidence": 0.95,
-      "recommendation": "Validate `body?.page`, parse using `Number.parseInt(body.page, 10)`, and verify `Number.isInteger(page) && page >= 0 && page < pages.length` before accessing `pages`."
+      "line_start": 17,
+      "line_end": 18,
+      "confidence": 0.85,
+      "recommendation": "Validate that the parsed page is a finite integer within `[0, pages.length)` and return an explicit error or default when it is not."
     }
   ],
-  "latencyMs": 25093,
-  "engineVersion": "1.1.15",
+  "latencyMs": 43749,
+  "engineVersion": "1.1.19",
+  "engineObserved": null,
   "samples": [
     {
       "verdict": "needs-attention",
-      "summary": "The diff introduces critical security vulnerabilities including remote command injection and path traversal, alongside unvalidated input handling.",
+      "summary": "User-controlled input flows unsanitized into file-system reads and a shell command, enabling path-traversal and remote-code-execution.",
       "findings": [
         {
           "severity": "critical",
-          "title": "Command injection via unescaped shell string in archive",
-          "body": "In archive(), user-controlled input 'name' is directly interpolated into a shell command passed to execSync, enabling arbitrary remote command execution.",
+          "title": "Command injection via unsanitised shell interpolation",
+          "body": "In `archive()`, `name` is interpolated directly into a string passed to `execSync`. An attacker-controlled `name` such as `\"; rm -rf / #\"` would execute arbitrary OS commands. `execSync` runs a full shell, so all shell meta-characters are live.",
           "file": "src/files.js",
-          "line_start": 12,
-          "line_end": 14,
-          "confidence": 1,
-          "recommendation": "Replace execSync with execFileSync or spawnSync passing arguments as an array, e.g. execFileSync('tar', ['-czf', `${name}.tar.gz`, targetPath])."
+          "line_start": 13,
+          "line_end": 13,
+          "confidence": 0.99,
+          "recommendation": "Use `execFileSync('tar', ['-czf', `${name}.tar.gz`, path.join(ROOT, name)])` to avoid a shell, and validate/sanitise `name` to reject path separators and special characters."
         },
         {
-          "severity": "high",
-          "title": "Path traversal in readUpload and archive",
-          "body": "Using path.join(ROOT, name) without path containment verification allows path traversal (e.g. '../../etc/passwd') to access files outside the /srv/uploads directory.",
+          "severity": "critical",
+          "title": "Path traversal in readUpload allows arbitrary file read",
+          "body": "`path.join(ROOT, name)` does not confine the result to ROOT. A `name` of `../../etc/shadow` resolves outside `/srv/uploads`, letting callers read any file the process can access. No check (e.g. `realpath` starts-with guard) is performed.",
           "file": "src/files.js",
-          "line_start": 7,
-          "line_end": 10,
-          "confidence": 1,
-          "recommendation": "Resolve the absolute path and verify it starts with path.resolve(ROOT) + path.sep, or strip directory components using path.basename(name)."
+          "line_start": 8,
+          "line_end": 9,
+          "confidence": 0.98,
+          "recommendation": "After joining, resolve with `path.resolve()` and verify the result starts with `ROOT + path.sep` (or use `realpath` and compare). Reject the request otherwise."
         },
         {
           "severity": "medium",
-          "title": "Unchecked property access and array index bounds in pickPage",
-          "body": "pickPage() accesses body.page without null-checking body, parses without an explicit radix, and accesses pages[page] without bounds validation, risking runtime exceptions or undefined returns.",
+          "title": "Unbounded array access in pickPage",
+          "body": "`parseInt(body.page)` can produce `NaN`, a negative number, or an index beyond `pages.length`. The function silently returns `undefined` in all these cases, which will likely propagate as a runtime error or data leak downstream. There is no bounds check.",
           "file": "src/files.js",
-          "line_start": 16,
-          "line_end": 19,
-          "confidence": 0.95,
-          "recommendation": "Validate body?.page, specify base 10 in parseInt(body.page, 10), and ensure the index is a non-negative integer within Array.isArray(pages) bounds."
+          "line_start": 17,
+          "line_end": 18,
+          "confidence": 0.85,
+          "recommendation": "Validate that `page` is a finite integer in range `[0, pages.length)` and return an explicit error or default when it is not."
         }
       ],
-      "latencyMs": 15409
+      "latencyMs": 44084
     },
     {
       "verdict": "needs-attention",
-      "summary": "Critical security vulnerabilities including command injection and path traversal, along with unsafe input access, were identified.",
+      "summary": "File contains a path-traversal vulnerability, a shell command-injection vulnerability, and an unbounded array access.",
       "findings": [
         {
           "severity": "critical",
-          "title": "Command injection via unescaped shell argument in archive",
-          "body": "The archive function directly interpolates the unvalidated 'name' argument into a shell string executed by execSync. An attacker passing shell metacharacters in 'name' can execute arbitrary system commands.",
-          "file": "src/files.js",
-          "line_start": 12,
-          "line_end": 14,
-          "confidence": 1,
-          "recommendation": "Use execFileSync or spawnSync with an array of arguments rather than shell interpolation, or validate that 'name' matches a strict alphanumeric whitelist."
-        },
-        {
-          "severity": "high",
           "title": "Path traversal in readUpload",
-          "body": "readUpload combines ROOT and 'name' using path.join without ensuring the resolved path remains inside ROOT. A name containing relative segments like '../' allows reading arbitrary files from the filesystem.",
+          "body": "path.join(\"/srv/uploads\", name) does not prevent directory traversal. A caller supplying name = \"../../etc/passwd\" produces \"/etc/passwd\", allowing arbitrary file reads outside the uploads root.",
           "file": "src/files.js",
-          "line_start": 7,
-          "line_end": 10,
-          "confidence": 1,
-          "recommendation": "Resolve the full target path and verify that path.resolve(ROOT, name).startsWith(path.resolve(ROOT) + path.sep), or reject names containing directory separators."
+          "line_start": 8,
+          "line_end": 9,
+          "confidence": 0.98,
+          "recommendation": "After joining, call path.resolve and verify the result starts with ROOT (e.g. `if (!resolved.startsWith(ROOT + path.sep)) throw …`), or use path.basename(name) to strip directory components."
+        },
+        {
+          "severity": "critical",
+          "title": "Shell command injection in archive",
+          "body": "The `name` parameter is interpolated unsanitised into a shell string passed to execSync. An attacker supplying name = `; rm -rf / #` achieves arbitrary command execution.",
+          "file": "src/files.js",
+          "line_start": 13,
+          "line_end": 13,
+          "confidence": 0.98,
+          "recommendation": "Use execFileSync('tar', ['-czf', `${name}.tar.gz`, path.join(ROOT, name)]) to avoid shell interpolation, and validate/sanitise `name` beforehand (e.g. reject anything that is not a simple filename)."
         },
         {
           "severity": "medium",
-          "title": "Unsafe property access and unvalidated index in pickPage",
-          "body": "pickPage accesses body.page without verifying that body is defined, resulting in a runtime TypeError if body is null or undefined. Additionally, parseInt(body.page) without a radix or bounds check can produce NaN or out-of-bounds access.",
+          "title": "Unbounded and unvalidated array index in pickPage",
+          "body": "parseInt(body.page) can return NaN, a negative number, or an index beyond the array length. pages[NaN] silently returns undefined, and negative indices access non-existent properties. No falsy/undefined check is performed on the return value, so callers receive undefined without warning.",
           "file": "src/files.js",
-          "line_start": 16,
-          "line_end": 19,
-          "confidence": 0.95,
-          "recommendation": "Safely check body?.page, parse with parseInt(body.page, 10), and ensure the parsed value is a valid integer within the bounds of the pages array."
+          "line_start": 17,
+          "line_end": 18,
+          "confidence": 0.85,
+          "recommendation": "Validate that the parsed page is a finite integer within [0, pages.length) and return a clear error or default when it is not."
         }
       ],
-      "latencyMs": 14794
+      "latencyMs": 41441
     },
     {
       "verdict": "needs-attention",
-      "summary": "The diff introduces critical command injection, arbitrary path traversal vulnerabilities, and unvalidated index access.",
+      "summary": "Unsanitised user input enables command injection and path traversal; array access is unbounded.",
       "findings": [
         {
           "severity": "critical",
-          "title": "Command injection vulnerability in archive",
-          "body": "In `archive`, the `name` parameter is directly interpolated into the shell command string passed to `execSync`. An attacker providing shell metacharacters in `name` can execute arbitrary system commands.",
+          "title": "Command injection in archive()",
+          "body": "The `name` parameter is interpolated directly into a shell command string passed to `execSync`. An attacker-controlled `name` such as `\"; rm -rf / #\"` executes arbitrary OS commands. `path.join(ROOT, name)` in the second interpolation is equally unsanitised.",
           "file": "src/files.js",
-          "line_start": 12,
-          "line_end": 14,
-          "confidence": 1,
-          "recommendation": "Use `execFileSync` with an argument array instead of a shell string (e.g., `execFileSync('tar', ['-czf', `${name}.tar.gz`, targetPath])`) and sanitize/validate `name`."
+          "line_start": 13,
+          "line_end": 13,
+          "confidence": 0.99,
+          "recommendation": "Never build shell strings from user input. Use `execFileSync('tar', ['-czf', outPath, srcPath])` (no shell) and validate/sanitise `name` (reject path separators, null bytes, shell metacharacters)."
         },
         {
-          "severity": "high",
-          "title": "Arbitrary file read via path traversal in readUpload",
-          "body": "In `readUpload`, `path.join(ROOT, name)` does not prevent directory traversal sequences such as `..`. An attacker can supply a relative path to read arbitrary files from the filesystem.",
+          "severity": "critical",
+          "title": "Path traversal in readUpload()",
+          "body": "`path.join('/srv/uploads', '../../etc/passwd')` resolves to `/etc/passwd`. Because `name` is not validated, any caller can read arbitrary files on the filesystem as the process user.",
           "file": "src/files.js",
-          "line_start": 7,
-          "line_end": 10,
-          "confidence": 1,
-          "recommendation": "Sanitize `name` by stripping directory separators or ensure `path.resolve(ROOT, name).startsWith(path.resolve(ROOT) + path.sep)` before reading."
+          "line_start": 8,
+          "line_end": 9,
+          "confidence": 0.98,
+          "recommendation": "After joining, call `path.resolve(target)` and verify it starts with `ROOT + path.sep` (or use `path.relative(ROOT, target)` and reject results starting with `..`). Reject null bytes as well."
         },
         {
           "severity": "medium",
-          "title": "Unvalidated input and missing bounds check in pickPage",
-          "body": "In `pickPage`, `parseInt(body.page)` lacks a radix, does not check if `body` or `body.page` is defined, and does not validate whether the resulting index is within the valid bounds of `pages` (or if it evaluates to `NaN`).",
+          "title": "Unbounded and unvalidated array access in pickPage()",
+          "body": "`parseInt(body.page)` can return `NaN` (yields `undefined`), a negative number (yields `undefined` or a prototype property via numeric coercion), or an index beyond `pages.length`. No error is surfaced; callers silently receive `undefined`, likely causing downstream failures or information disclosure if `pages` is an object with unexpected keys.",
           "file": "src/files.js",
-          "line_start": 16,
-          "line_end": 19,
-          "confidence": 0.95,
-          "recommendation": "Validate `body?.page`, parse using `Number.parseInt(body.page, 10)`, and verify `Number.isInteger(page) && page >= 0 && page < pages.length` before accessing `pages`."
+          "line_start": 17,
+          "line_end": 18,
+          "confidence": 0.85,
+          "recommendation": "Validate that the parsed page is a finite integer within `[0, pages.length)` and return an explicit error or default when it is not."
         }
       ],
-      "latencyMs": 25093
+      "latencyMs": 43749
     }
   ],
-  "raw": "{\"conversation_id\":\"c034bae4-eac3-4266-ae5f-fdc66e13f311\",\"status\":\"SUCCESS\",\"response\":\"{\\n  \\\"verdict\\\": \\\"needs-attention\\\",\\n  \\\"summary\\\": \\\"The diff introduces critical command injection, arbitrary path traversal vulnerabilities, and unvalidated index access.\\\",\\n  \\\"findings\\\": [\\n    {\\n      \\\"severity\\\": \\\"critical\\\",\\n      \\\"title\\\": \\\"Command injection vulnerability in archive\\\",\\n      \\\"body\\\": \\\"In `archive`, the `name` parameter is directly interpolated into the shell command string passed to `execSync`. An attacker providing shell metacharacters in `name` can execute arbitrary system commands.\\\",\\n      \\\"file\\\": \\\"src/files.js\\\",\\n      \\\"line_start\\\": 12,\\n      \\\"line_end\\\": 14,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Use `execFileSync` with an argument array instead of a shell string (e.g., `execFileSync('tar', ['-czf', `${name}.tar.gz`, targetPath])`) and sanitize/validate `name`.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"high\\\",\\n      \\\"title\\\": \\\"Arbitrary file read via path traversal in readUpload\\\",\\n      \\\"body\\\": \\\"In `readUpload`, `path.join(ROOT, name)` does not prevent directory traversal sequences such as `..`. An attacker can supply a relative path to read arbitrary files from the filesystem.\\\",\\n      \\\"file\\\": \\\"src/files.js\\\",\\n      \\\"line_start\\\": 7,\\n      \\\"line_end\\\": 10,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Sanitize `name` by stripping directory separators or ensure `path.resolve(ROOT, name).startsWith(path.resolve(ROOT) + path.sep)` before reading.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"medium\\\",\\n      \\\"title\\\": \\\"Unvalidated input and missing bounds check in pickPage\\\",\\n      \\\"body\\\": \\\"In `pickPage`, `parseInt(body.page)` lacks a radix, does not check if `body` or `body.page` is defined, and does not validate whether the resulting index is within the valid bounds of `pages` (or if it evaluates to `NaN`).\\\",\\n      \\\"file\\\": \\\"src/files.js\\\",\\n      \\\"line_start\\\": 16,\\n      \\\"line_end\\\": 19,\\n      \\\"confidence\\\": 0.95,\\n      \\\"recommendation\\\": \\\"Validate `body?.page`, parse using `Number.parseInt(body.page, 10)`, and verify `Number.isInteger(page) \\u0026\\u0026 page \\u003e= 0 \\u0026\\u0026 page \\u003c pages.length` before accessing `pages`.\\\"\\n    }\\n  ],\\n  \\\"next_steps\\\": [\\n    \\\"Replace `execSync` with `execFileSync` using safe argument arrays.\\\",\\n    \\\"Implement path traversal guards for all functions accessing `ROOT`.\\\",\\n    \\\"Add parameter validation and array bounds checks to `pickPage`.\\\"\\n  ]\\n}\\n\",\"duration_seconds\":21.7661162,\"num_turns\":1,\"usage\":{\"input_tokens\":18985,\"output_tokens\":2286,\"thinking_tokens\":1703,\"cache_read_tokens\":0,\"total_tokens\":21271}}\n"
+  "raw": "{\"conversation_id\":\"bde8d4ea-9afc-4d59-93e8-8bc581dd294f\",\"status\":\"SUCCESS\",\"response\":\"{\\\"verdict\\\":\\\"needs-attention\\\",\\\"summary\\\":\\\"Unsanitised user input enables command injection and path traversal; array access is unbounded.\\\",\\\"findings\\\":[{\\\"severity\\\":\\\"critical\\\",\\\"title\\\":\\\"Command injection in archive()\\\",\\\"body\\\":\\\"The `name` parameter is interpolated directly into a shell command string passed to `execSync`. An attacker-controlled `name` such as `\\\\\\\"; rm -rf / #\\\\\\\"` executes arbitrary OS commands. `path.join(ROOT, name)` in the second interpolation is equally unsanitised.\\\",\\\"file\\\":\\\"src/files.js\\\",\\\"line_start\\\":13,\\\"line_end\\\":13,\\\"confidence\\\":0.99,\\\"recommendation\\\":\\\"Never build shell strings from user input. Use `execFileSync('tar', ['-czf', outPath, srcPath])` (no shell) and validate/sanitise `name` (reject path separators, null bytes, shell metacharacters).\\\"},{\\\"severity\\\":\\\"critical\\\",\\\"title\\\":\\\"Path traversal in readUpload()\\\",\\\"body\\\":\\\"`path.join('/srv/uploads', '../../etc/passwd')` resolves to `/etc/passwd`. Because `name` is not validated, any caller can read arbitrary files on the filesystem as the process user.\\\",\\\"file\\\":\\\"src/files.js\\\",\\\"line_start\\\":8,\\\"line_end\\\":9,\\\"confidence\\\":0.98,\\\"recommendation\\\":\\\"After joining, call `path.resolve(target)` and verify it starts with `ROOT + path.sep` (or use `path.relative(ROOT, target)` and reject results starting with `..`). Reject null bytes as well.\\\"},{\\\"severity\\\":\\\"medium\\\",\\\"title\\\":\\\"Unbounded and unvalidated array access in pickPage()\\\",\\\"body\\\":\\\"`parseInt(body.page)` can return `NaN` (yields `undefined`), a negative number (yields `undefined` or a prototype property via numeric coercion), or an index beyond `pages.length`. No error is surfaced; callers silently receive `undefined`, likely causing downstream failures or information disclosure if `pages` is an object with unexpected keys.\\\",\\\"file\\\":\\\"src/files.js\\\",\\\"line_start\\\":17,\\\"line_end\\\":18,\\\"confidence\\\":0.85,\\\"recommendation\\\":\\\"Validate that the parsed page is a finite integer within `[0, pages.length)` and return an explicit error or default when it is not.\\\"}],\\\"next_steps\\\":[\\\"Fix command injection: replace execSync template string with execFileSync and an argument array\\\",\\\"Fix path traversal: add a resolved-path containment check against ROOT before reading\\\",\\\"Add input validation and bounds checking in pickPage\\\"]}\\n\",\"duration_seconds\":40.0299439,\"num_turns\":1,\"usage\":{\"input_tokens\":22534,\"output_tokens\":1093,\"thinking_tokens\":0,\"cache_read_tokens\":0,\"total_tokens\":23627}}\n"
 }

--- a/bench/cassettes/path-and-input/agy.shallow.json
+++ b/bench/cassettes/path-and-input/agy.shallow.json
@@ -1,0 +1,156 @@
+{
+  "caseId": "path-and-input",
+  "cell": "agy.shallow",
+  "recordedAt": "2026-08-24T15:31:22.530Z",
+  "verdict": "needs-attention",
+  "summary": "Critical command injection, path traversal vulnerabilities, and missing input checks were identified in file operations.",
+  "findings": [
+    {
+      "severity": "critical",
+      "title": "Arbitrary command execution via unescaped shell string in execSync",
+      "body": "In archive(), the name parameter is interpolated directly into a shell command template passed to execSync. Untrusted input containing shell metacharacters allows arbitrary command execution on the host.",
+      "file": "src/files.js",
+      "line_start": 12,
+      "line_end": 14,
+      "confidence": 1,
+      "recommendation": "Use execFileSync with an arguments array (e.g. execFileSync('tar', ['-czf', `${name}.tar.gz`, targetPath])) instead of executing a formatted shell string, and strictly validate the filename."
+    },
+    {
+      "severity": "high",
+      "title": "Path traversal allowing arbitrary file read in readUpload",
+      "body": "In readUpload(), path.join(ROOT, name) resolves relative path components such as '..', allowing callers to traverse outside /srv/uploads and read arbitrary files from the filesystem.",
+      "file": "src/files.js",
+      "line_start": 7,
+      "line_end": 10,
+      "confidence": 1,
+      "recommendation": "Sanitize name using path.basename(name) or verify that path.resolve(ROOT, name).startsWith(path.resolve(ROOT) + path.sep)."
+    },
+    {
+      "severity": "medium",
+      "title": "Unsafe property access and unvalidated array indexing in pickPage",
+      "body": "In pickPage(), accessing body.page throws a TypeError if body is null or undefined. Additionally, parseInt(body.page, 10) can result in NaN, negative indices, or out-of-bounds access on pages without verification.",
+      "file": "src/files.js",
+      "line_start": 16,
+      "line_end": 19,
+      "confidence": 0.95,
+      "recommendation": "Safely access body?.page, specify radix in parseInt, check for Number.isInteger, and ensure the index is within the bounds of the pages array before access."
+    }
+  ],
+  "latencyMs": 17606,
+  "engineVersion": "1.1.19",
+  "engineObserved": "agy",
+  "samples": [
+    {
+      "verdict": "needs-attention",
+      "summary": "Identified critical command injection, path traversal, and missing boundary validation in file operations.",
+      "findings": [
+        {
+          "severity": "critical",
+          "title": "Command injection vulnerability in archive",
+          "body": "The archive function interpolates the unvalidated name parameter directly into a shell command executed via execSync. If name contains shell metacharacters, an attacker can execute arbitrary commands on the server.",
+          "file": "src/files.js",
+          "line_start": 12,
+          "line_end": 14,
+          "confidence": 1,
+          "recommendation": "Use execFile or spawn with argument arrays instead of shell command string interpolation, and validate/sanitize input."
+        },
+        {
+          "severity": "high",
+          "title": "Path traversal vulnerability in readUpload",
+          "body": "The readUpload function uses path.join(ROOT, name) without verifying that the resolved path stays within ROOT. An attacker can use directory traversal sequences (such as ../) in name to read arbitrary files from the filesystem.",
+          "file": "src/files.js",
+          "line_start": 7,
+          "line_end": 10,
+          "confidence": 1,
+          "recommendation": "Resolve the target path and assert that it begins with path.resolve(ROOT), or sanitize name to reject directory traversal characters."
+        },
+        {
+          "severity": "medium",
+          "title": "Missing bounds and NaN checking in pickPage",
+          "body": "pickPage uses parseInt without an explicit radix and does not check for NaN or verify that the resulting page index is within the valid range of pages. If body is null/undefined or page is invalid, it may throw an error or return undefined.",
+          "file": "src/files.js",
+          "line_start": 16,
+          "line_end": 19,
+          "confidence": 0.95,
+          "recommendation": "Pass radix 10 to parseInt, validate that body and pages exist, and verify that page is an integer within array bounds."
+        }
+      ],
+      "latencyMs": 21850
+    },
+    {
+      "verdict": "needs-attention",
+      "summary": "Critical command injection and path traversal vulnerabilities were identified along with unhandled input edge cases.",
+      "findings": [
+        {
+          "severity": "critical",
+          "title": "Command injection vulnerability via unescaped shell execution",
+          "body": "The archive function passes user-controlled parameter name directly into a shell command template inside execSync. An input containing shell metacharacters (e.g., '; rm -rf /') allows arbitrary command execution with the privileges of the Node.js process.",
+          "file": "src/files.js",
+          "line_start": 12,
+          "line_end": 14,
+          "confidence": 1,
+          "recommendation": "Use child_process.execFileSync with argument arrays instead of execSync with a template string, and validate that name matches an allowed filename pattern."
+        },
+        {
+          "severity": "high",
+          "title": "Arbitrary file read via path traversal",
+          "body": "The readUpload function constructs target paths using path.join(ROOT, name) without validating that the resolved path stays within ROOT. Inputs containing directory traversal sequences like '../../etc/passwd' allow reading arbitrary files from the filesystem.",
+          "file": "src/files.js",
+          "line_start": 7,
+          "line_end": 10,
+          "confidence": 1,
+          "recommendation": "Use path.basename(name) or verify that path.resolve(ROOT, name).startsWith(path.resolve(ROOT) + path.sep) before attempting to read the file."
+        },
+        {
+          "severity": "medium",
+          "title": "Unvalidated property access and index boundary handling",
+          "body": "pickPage accesses body.page without null/type checks on body, omits the radix parameter in parseInt, and does not validate if the parsed index is a valid non-negative integer within bounds of pages, potentially leading to TypeErrors or undefined returns.",
+          "file": "src/files.js",
+          "line_start": 16,
+          "line_end": 19,
+          "confidence": 0.9,
+          "recommendation": "Safely extract body?.page, parse using Number.parseInt(..., 10), and verify that the page index is an integer within 0 <= page < pages.length before indexing."
+        }
+      ],
+      "latencyMs": 29922
+    },
+    {
+      "verdict": "needs-attention",
+      "summary": "Critical command injection, path traversal vulnerabilities, and missing input checks were identified in file operations.",
+      "findings": [
+        {
+          "severity": "critical",
+          "title": "Arbitrary command execution via unescaped shell string in execSync",
+          "body": "In archive(), the name parameter is interpolated directly into a shell command template passed to execSync. Untrusted input containing shell metacharacters allows arbitrary command execution on the host.",
+          "file": "src/files.js",
+          "line_start": 12,
+          "line_end": 14,
+          "confidence": 1,
+          "recommendation": "Use execFileSync with an arguments array (e.g. execFileSync('tar', ['-czf', `${name}.tar.gz`, targetPath])) instead of executing a formatted shell string, and strictly validate the filename."
+        },
+        {
+          "severity": "high",
+          "title": "Path traversal allowing arbitrary file read in readUpload",
+          "body": "In readUpload(), path.join(ROOT, name) resolves relative path components such as '..', allowing callers to traverse outside /srv/uploads and read arbitrary files from the filesystem.",
+          "file": "src/files.js",
+          "line_start": 7,
+          "line_end": 10,
+          "confidence": 1,
+          "recommendation": "Sanitize name using path.basename(name) or verify that path.resolve(ROOT, name).startsWith(path.resolve(ROOT) + path.sep)."
+        },
+        {
+          "severity": "medium",
+          "title": "Unsafe property access and unvalidated array indexing in pickPage",
+          "body": "In pickPage(), accessing body.page throws a TypeError if body is null or undefined. Additionally, parseInt(body.page, 10) can result in NaN, negative indices, or out-of-bounds access on pages without verification.",
+          "file": "src/files.js",
+          "line_start": 16,
+          "line_end": 19,
+          "confidence": 0.95,
+          "recommendation": "Safely access body?.page, specify radix in parseInt, check for Number.isInteger, and ensure the index is within the bounds of the pages array before access."
+        }
+      ],
+      "latencyMs": 17606
+    }
+  ],
+  "raw": "{\n  \"review\": \"Review\",\n  \"target\": {\n    \"mode\": \"working-tree\",\n    \"label\": \"working tree diff\",\n    \"explicit\": true\n  },\n  \"engine\": \"agy\",\n  \"gemini\": {\n    \"status\": 0,\n    \"stdout\": \"{\\n  \\\"verdict\\\": \\\"needs-attention\\\",\\n  \\\"summary\\\": \\\"Critical command injection, path traversal vulnerabilities, and missing input checks were identified in file operations.\\\",\\n  \\\"findings\\\": [\\n    {\\n      \\\"severity\\\": \\\"critical\\\",\\n      \\\"title\\\": \\\"Arbitrary command execution via unescaped shell string in execSync\\\",\\n      \\\"body\\\": \\\"In archive(), the name parameter is interpolated directly into a shell command template passed to execSync. Untrusted input containing shell metacharacters allows arbitrary command execution on the host.\\\",\\n      \\\"file\\\": \\\"src/files.js\\\",\\n      \\\"line_start\\\": 12,\\n      \\\"line_end\\\": 14,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Use execFileSync with an arguments array (e.g. execFileSync('tar', ['-czf', `${name}.tar.gz`, targetPath])) instead of executing a formatted shell string, and strictly validate the filename.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"high\\\",\\n      \\\"title\\\": \\\"Path traversal allowing arbitrary file read in readUpload\\\",\\n      \\\"body\\\": \\\"In readUpload(), path.join(ROOT, name) resolves relative path components such as '..', allowing callers to traverse outside /srv/uploads and read arbitrary files from the filesystem.\\\",\\n      \\\"file\\\": \\\"src/files.js\\\",\\n      \\\"line_start\\\": 7,\\n      \\\"line_end\\\": 10,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Sanitize name using path.basename(name) or verify that path.resolve(ROOT, name).startsWith(path.resolve(ROOT) + path.sep).\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"medium\\\",\\n      \\\"title\\\": \\\"Unsafe property access and unvalidated array indexing in pickPage\\\",\\n      \\\"body\\\": \\\"In pickPage(), accessing body.page throws a TypeError if body is null or undefined. Additionally, parseInt(body.page, 10) can result in NaN, negative indices, or out-of-bounds access on pages without verification.\\\",\\n      \\\"file\\\": \\\"src/files.js\\\",\\n      \\\"line_start\\\": 16,\\n      \\\"line_end\\\": 19,\\n      \\\"confidence\\\": 0.95,\\n      \\\"recommendation\\\": \\\"Safely access body?.page, specify radix in parseInt, check for Number.isInteger, and ensure the index is within the bounds of the pages array before access.\\\"\\n    }\\n  ],\\n  \\\"next_steps\\\": [\\n    \\\"Refactor archive() to use execFileSync with explicit argument arrays\\\",\\n    \\\"Add path containment checks in readUpload() and archive() to prevent directory traversal\\\",\\n    \\\"Add input validation and bounds checking to pickPage()\\\"\\n  ]\\n}\",\n    \"stderr\": \"\"\n  },\n  \"result\": {\n    \"verdict\": \"needs-attention\",\n    \"summary\": \"Critical command injection, path traversal vulnerabilities, and missing input checks were identified in file operations.\",\n    \"findings\": [\n      {\n        \"severity\": \"critical\",\n        \"title\": \"Arbitrary command execution via unescaped shell string in execSync\",\n        \"body\": \"In archive(), the name parameter is interpolated directly into a shell command template passed to execSync. Untrusted input containing shell metacharacters allows arbitrary command execution on the host.\",\n        \"file\": \"src/files.js\",\n        \"line_start\": 12,\n        \"line_end\": 14,\n        \"confidence\": 1,\n        \"recommendation\": \"Use execFileSync with an arguments array (e.g. execFileSync('tar', ['-czf', `${name}.tar.gz`, targetPath])) instead of executing a formatted shell string, and strictly validate the filename.\"\n      },\n      {\n        \"severity\": \"high\",\n        \"title\": \"Path traversal allowing arbitrary file read in readUpload\",\n        \"body\": \"In readUpload(), path.join(ROOT, name) resolves relative path components such as '..', allowing callers to traverse outside /srv/uploads and read arbitrary files from the filesystem.\",\n        \"file\": \"src/files.js\",\n        \"line_start\": 7,\n        \"line_end\": 10,\n        \"confidence\": 1,\n        \"recommen"
+}

--- a/bench/cassettes/path-and-input/codex.adversarial.json
+++ b/bench/cassettes/path-and-input/codex.adversarial.json
@@ -1,0 +1,116 @@
+{
+  "caseId": "path-and-input",
+  "cell": "codex.adversarial",
+  "recordedAt": "2026-08-24T11:13:34.081Z",
+  "verdict": "needs-attention",
+  "summary": "Do not ship: attacker-controlled filenames enable arbitrary command execution and reads outside the upload directory.",
+  "findings": [
+    {
+      "severity": "critical",
+      "title": "Shell interpolation allows arbitrary command execution",
+      "body": "`archive` inserts `name` directly into a shell command twice. A filename containing shell metacharacters such as `;`, `$()`, or redirection operators will be interpreted by the shell when `execSync` runs, allowing arbitrary commands with the application's privileges. Escaping only the path would remain fragile because the archive filename is independently injectable.",
+      "file": "src/files.js",
+      "line_start": 12,
+      "line_end": 14,
+      "confidence": 0.99,
+      "recommendation": "Replace `execSync` with `execFileSync(\"tar\", [\"-czf\", archivePath, \"--\", validatedTarget])`, validate `name` as a basename, and place the archive at an explicitly controlled path."
+    },
+    {
+      "severity": "high",
+      "title": "Path traversal permits reading files outside the upload root",
+      "body": "`path.join(ROOT, name)` normalizes `..` segments but does not enforce that the result remains beneath `/srv/uploads`. A value such as `../secrets.txt` resolves outside the upload directory and is read synchronously, exposing any readable file reachable through traversal.",
+      "file": "src/files.js",
+      "line_start": 7,
+      "line_end": 10,
+      "confidence": 0.99,
+      "recommendation": "Resolve the candidate against `ROOT`, reject absolute names and traversal, then verify the resolved path starts with `path.resolve(ROOT) + path.sep`; consider accepting only a basename or server-generated upload ID."
+    }
+  ],
+  "latencyMs": 24377,
+  "engineVersion": "codex-cli 0.149.0",
+  "engineObserved": null,
+  "samples": [
+    {
+      "verdict": "needs-attention",
+      "summary": "Do not ship: attacker-controlled filenames can escape the upload directory, and archive creation permits shell command injection.",
+      "findings": [
+        {
+          "severity": "critical",
+          "title": "Filename interpolation enables arbitrary command execution",
+          "body": "`archive` inserts `name` and the derived path directly into a shell command. If `name` is externally influenced, shell metacharacters such as `;`, `&&`, command substitutions, or whitespace can execute additional commands under the service account. The same interpolation also lets option-like names alter `tar` behavior.",
+          "file": "src/files.js",
+          "line_start": 11,
+          "line_end": 13,
+          "confidence": 0.99,
+          "recommendation": "Do not invoke a shell. Use `execFileSync`/`spawnSync` with `tar` and each argument supplied separately, reject absolute or traversal names, use `--` before file operands, and place the output under a validated fixed directory."
+        },
+        {
+          "severity": "high",
+          "title": "Path traversal allows reads outside the upload root",
+          "body": "`readUpload` joins an untrusted name to `ROOT` without verifying the normalized result remains inside `/srv/uploads`. A value such as `../../etc/passwd` resolves outside the intended directory and is read synchronously, exposing any service-readable UTF-8 file.",
+          "file": "src/files.js",
+          "line_start": 7,
+          "line_end": 9,
+          "confidence": 0.99,
+          "recommendation": "Resolve the candidate against `ROOT`, verify it is a descendant using `path.relative` with explicit rejection of `..` and absolute results, and consider an allowlisted server-generated upload identifier instead of accepting paths."
+        }
+      ],
+      "latencyMs": 23526
+    },
+    {
+      "verdict": "needs-attention",
+      "summary": "Do not ship: attacker-controlled filenames enable arbitrary command execution and reads outside the upload directory.",
+      "findings": [
+        {
+          "severity": "critical",
+          "title": "Filename interpolation permits arbitrary shell command execution",
+          "body": "`archive` inserts `name` directly into a shell command. A value containing shell metacharacters such as `;`, `&&`, `$()`, or backticks can execute arbitrary commands with the service's privileges. Unquoted whitespace and leading tar options also make benign filenames unsafe.",
+          "file": "src/files.js",
+          "line_start": 12,
+          "line_end": 13,
+          "confidence": 0.99,
+          "recommendation": "Replace `execSync` with `execFileSync` or `spawnSync` using a fixed executable and argument array, pass `--` before file operands, validate the archive name, and reject any resolved source path outside `ROOT`."
+        },
+        {
+          "severity": "high",
+          "title": "Path traversal allows reading arbitrary accessible files",
+          "body": "`path.join(ROOT, name)` normalizes traversal segments but does not enforce containment. A name such as `../../etc/passwd` resolves outside `/srv/uploads`, allowing disclosure of any UTF-8-readable file accessible to the process. Symlinks inside the upload directory can create the same escape unless canonical paths are checked.",
+          "file": "src/files.js",
+          "line_start": 7,
+          "line_end": 9,
+          "confidence": 0.99,
+          "recommendation": "Resolve and canonicalize both `ROOT` and the target, then reject targets whose canonical path is not a descendant of `ROOT`; define and enforce a restricted filename format if nested paths are unnecessary."
+        }
+      ],
+      "latencyMs": 25347
+    },
+    {
+      "verdict": "needs-attention",
+      "summary": "Do not ship: attacker-controlled filenames enable arbitrary command execution and reads outside the upload directory.",
+      "findings": [
+        {
+          "severity": "critical",
+          "title": "Shell interpolation allows arbitrary command execution",
+          "body": "`archive` inserts `name` directly into a shell command twice. A filename containing shell metacharacters such as `;`, `$()`, or redirection operators will be interpreted by the shell when `execSync` runs, allowing arbitrary commands with the application's privileges. Escaping only the path would remain fragile because the archive filename is independently injectable.",
+          "file": "src/files.js",
+          "line_start": 12,
+          "line_end": 14,
+          "confidence": 0.99,
+          "recommendation": "Replace `execSync` with `execFileSync(\"tar\", [\"-czf\", archivePath, \"--\", validatedTarget])`, validate `name` as a basename, and place the archive at an explicitly controlled path."
+        },
+        {
+          "severity": "high",
+          "title": "Path traversal permits reading files outside the upload root",
+          "body": "`path.join(ROOT, name)` normalizes `..` segments but does not enforce that the result remains beneath `/srv/uploads`. A value such as `../secrets.txt` resolves outside the upload directory and is read synchronously, exposing any readable file reachable through traversal.",
+          "file": "src/files.js",
+          "line_start": 7,
+          "line_end": 10,
+          "confidence": 0.99,
+          "recommendation": "Resolve the candidate against `ROOT`, reject absolute names and traversal, then verify the resolved path starts with `path.resolve(ROOT) + path.sep`; consider accepting only a basename or server-generated upload ID."
+        }
+      ],
+      "latencyMs": 24377
+    }
+  ],
+  "raw": "{\n  \"review\": \"Adversarial Review\",\n  \"target\": {\n    \"mode\": \"working-tree\",\n    \"label\": \"working tree diff\",\n    \"explicit\": true\n  },\n  \"threadId\": \"01a03379-73a8-7e42-b3a4-f5247ca1de06\",\n  \"context\": {\n    \"repoRoot\": \"C:/Users/arcobaleno/AppData/Local/Temp/bench-path-and-input-IBEIiQ\",\n    \"branch\": \"main\",\n    \"summary\": \"Reviewing 0 staged, 1 unstaged, and 0 untracked file(s).\"\n  },\n  \"codex\": {\n    \"status\": 0,\n    \"stderr\": \"\",\n    \"stdout\": \"{\\\"verdict\\\":\\\"needs-attention\\\",\\\"summary\\\":\\\"Do not ship: attacker-controlled filenames enable arbitrary command execution and reads outside the upload directory.\\\",\\\"findings\\\":[{\\\"severity\\\":\\\"critical\\\",\\\"title\\\":\\\"Shell interpolation allows arbitrary command execution\\\",\\\"body\\\":\\\"`archive` inserts `name` directly into a shell command twice. A filename containing shell metacharacters such as `;`, `$()`, or redirection operators will be interpreted by the shell when `execSync` runs, allowing arbitrary commands with the application's privileges. Escaping only the path would remain fragile because the archive filename is independently injectable.\\\",\\\"file\\\":\\\"src/files.js\\\",\\\"line_start\\\":12,\\\"line_end\\\":14,\\\"confidence\\\":0.99,\\\"recommendation\\\":\\\"Replace `execSync` with `execFileSync(\\\\\\\"tar\\\\\\\", [\\\\\\\"-czf\\\\\\\", archivePath, \\\\\\\"--\\\\\\\", validatedTarget])`, validate `name` as a basename, and place the archive at an explicitly controlled path.\\\"},{\\\"severity\\\":\\\"high\\\",\\\"title\\\":\\\"Path traversal permits reading files outside the upload root\\\",\\\"body\\\":\\\"`path.join(ROOT, name)` normalizes `..` segments but does not enforce that the result remains beneath `/srv/uploads`. A value such as `../secrets.txt` resolves outside the upload directory and is read synchronously, exposing any readable file reachable through traversal.\\\",\\\"file\\\":\\\"src/files.js\\\",\\\"line_start\\\":7,\\\"line_end\\\":10,\\\"confidence\\\":0.99,\\\"recommendation\\\":\\\"Resolve the candidate against `ROOT`, reject absolute names and traversal, then verify the resolved path starts with `path.resolve(ROOT) + path.sep`; consider accepting only a basename or server-generated upload ID.\\\"}],\\\"next_steps\\\":[\\\"Remove shell evaluation from `archive` and add injection regression tests.\\\",\\\"Add traversal containment checks and tests for `..`, absolute paths, and encoded or mixed-separator inputs.\\\"]}\",\n    \"reasoning\": []\n  },\n  \"result\": {\n    \"verdict\": \"needs-attention\",\n    \"summary\": \"Do not ship: attacker-controlled filenames enable arbitrary command execution and reads outside the upload directory.\",\n    \"findings\": [\n      {\n        \"severity\": \"critical\",\n        \"title\": \"Shell interpolation allows arbitrary command execution\",\n        \"body\": \"`archive` inserts `name` directly into a shell command twice. A filename containing shell metacharacters such as `;`, `$()`, or redirection operators will be interpreted by the shell when `execSync` runs, allowing arbitrary commands with the application's privileges. Escaping only the path would remain fragile because the archive filename is independently injectable.\",\n        \"file\": \"src/files.js\",\n        \"line_start\": 12,\n        \"line_end\": 14,\n        \"confidence\": 0.99,\n        \"recommendation\": \"Replace `execSync` with `execFileSync(\\\"tar\\\", [\\\"-czf\\\", archivePath, \\\"--\\\", validatedTarget])`, validate `name` as a basename, and place the archive at an explicitly controlled path.\"\n      },\n      {\n        \"severity\": \"high\",\n        \"title\": \"Path traversal permits reading files outside the upload root\",\n        \"body\": \"`path.join(ROOT, name)` normalizes `..` segments but does not enforce that the result remains beneath `/srv/uploads`. A value such as `../secrets.txt` resolves outside the upload directory and is read synchronously, exposing any readable file reachable through traversal.\",\n        \"file\": \"src/files.js\",\n        \"line_start\": 7,\n        \"line_end\": 10,\n        \"confidence\": 0.99,\n        \"recommendation\": \"Resolve the candidate against `ROOT`, reject absolute names"
+}

--- a/bench/cassettes/path-and-input/codex.model.json
+++ b/bench/cassettes/path-and-input/codex.model.json
@@ -1,0 +1,126 @@
+{
+  "caseId": "path-and-input",
+  "cell": "codex.model",
+  "recordedAt": "2026-08-24T04:41:05.746Z",
+  "verdict": "needs-attention",
+  "summary": "User-controlled names permit arbitrary file reads and shell command execution.",
+  "findings": [
+    {
+      "severity": "critical",
+      "title": "Shell command injection in archive",
+      "body": "archive interpolates name directly into an execSync shell command. A crafted name containing shell metacharacters can execute arbitrary commands with the process privileges; quoting only the path would also be insufficient without avoiding the shell.",
+      "file": "src/files.js",
+      "line_start": 12,
+      "line_end": 14,
+      "confidence": 0.99,
+      "recommendation": "Use spawnSync or execFileSync with an argument array and shell disabled, validate name against an allowlist, and constrain the resolved source path to ROOT."
+    },
+    {
+      "severity": "high",
+      "title": "Path traversal permits arbitrary file reads",
+      "body": "readUpload joins an untrusted name to ROOT without verifying containment. Absolute paths or ../ segments can escape /srv/uploads and expose any readable UTF-8 file on the host.",
+      "file": "src/files.js",
+      "line_start": 7,
+      "line_end": 10,
+      "confidence": 0.99,
+      "recommendation": "Resolve the candidate path, verify it remains beneath ROOT using path.relative or an equivalent containment check, and reject absolute paths and traversal segments."
+    }
+  ],
+  "latencyMs": 18262,
+  "engineVersion": "codex-cli 0.149.0",
+  "engineObserved": null,
+  "samples": [
+    {
+      "verdict": "needs-attention",
+      "summary": "Untrusted upload names enable arbitrary file reads and shell command execution.",
+      "findings": [
+        {
+          "severity": "critical",
+          "title": "Shell command injection in archive",
+          "body": "archive interpolates name directly into an execSync shell command on line 13. A crafted name containing shell metacharacters can execute arbitrary commands with the process privileges; spaces or option-like names can also corrupt the tar invocation.",
+          "file": "src/files.js",
+          "line_start": 12,
+          "line_end": 14,
+          "confidence": 0.99,
+          "recommendation": "Avoid the shell: use execFileSync or spawnSync with an argument array, validate the name, resolve the source under ROOT, and pass -- before file operands."
+        },
+        {
+          "severity": "high",
+          "title": "Path traversal permits reads outside upload root",
+          "body": "readUpload joins ROOT with an unvalidated name. Values containing ../ are normalized and can escape /srv/uploads, allowing disclosure of any readable UTF-8 file on the host.",
+          "file": "src/files.js",
+          "line_start": 7,
+          "line_end": 10,
+          "confidence": 0.99,
+          "recommendation": "Resolve the candidate path, verify it remains inside ROOT using a separator-aware containment check, and reject absolute or traversal-containing names before reading."
+        }
+      ],
+      "latencyMs": 21553
+    },
+    {
+      "verdict": "needs-attention",
+      "summary": "Untrusted names enable command execution and filesystem access outside the upload directory.",
+      "findings": [
+        {
+          "severity": "critical",
+          "title": "Shell command injection in archive",
+          "body": "archive interpolates name directly into an execSync shell command twice without quoting or validation. A crafted name containing shell metacharacters can execute arbitrary commands with the service's privileges; leading option characters can also alter tar behavior.",
+          "file": "src/files.js",
+          "line_start": 12,
+          "line_end": 14,
+          "confidence": 1,
+          "recommendation": "Use execFileSync or spawnSync with an argument array and shell disabled, validate the name against an allowlist, and pass -- before file operands."
+        },
+        {
+          "severity": "high",
+          "title": "Upload path traversal",
+          "body": "readUpload joins an unchecked name to ROOT. Values containing parent-directory segments can normalize outside /srv/uploads, allowing disclosure of any readable UTF-8 file reachable by the process.",
+          "file": "src/files.js",
+          "line_start": 7,
+          "line_end": 10,
+          "confidence": 0.99,
+          "recommendation": "Resolve the candidate path, verify it remains beneath ROOT using path.relative or a separator-aware prefix check, and reject absolute paths and traversal segments."
+        },
+        {
+          "severity": "medium",
+          "title": "Page input is accepted without validation",
+          "body": "parseInt accepts malformed prefixes such as \"1junk\", while negative, out-of-range, missing, or nonnumeric values produce unintended indexing or undefined. Callers can therefore receive the wrong page or silently continue with no page.",
+          "file": "src/files.js",
+          "line_start": 16,
+          "line_end": 19,
+          "confidence": 0.96,
+          "recommendation": "Require a canonical integer value, verify Number.isInteger(page) and 0 <= page < pages.length, and return or throw an explicit input error otherwise."
+        }
+      ],
+      "latencyMs": 23438
+    },
+    {
+      "verdict": "needs-attention",
+      "summary": "User-controlled names permit arbitrary file reads and shell command execution.",
+      "findings": [
+        {
+          "severity": "critical",
+          "title": "Shell command injection in archive",
+          "body": "archive interpolates name directly into an execSync shell command. A crafted name containing shell metacharacters can execute arbitrary commands with the process privileges; quoting only the path would also be insufficient without avoiding the shell.",
+          "file": "src/files.js",
+          "line_start": 12,
+          "line_end": 14,
+          "confidence": 0.99,
+          "recommendation": "Use spawnSync or execFileSync with an argument array and shell disabled, validate name against an allowlist, and constrain the resolved source path to ROOT."
+        },
+        {
+          "severity": "high",
+          "title": "Path traversal permits arbitrary file reads",
+          "body": "readUpload joins an untrusted name to ROOT without verifying containment. Absolute paths or ../ segments can escape /srv/uploads and expose any readable UTF-8 file on the host.",
+          "file": "src/files.js",
+          "line_start": 7,
+          "line_end": 10,
+          "confidence": 0.99,
+          "recommendation": "Resolve the candidate path, verify it remains beneath ROOT using path.relative or an equivalent containment check, and reject absolute paths and traversal segments."
+        }
+      ],
+      "latencyMs": 18262
+    }
+  ],
+  "raw": "{\"verdict\":\"needs-attention\",\"summary\":\"User-controlled names permit arbitrary file reads and shell command execution.\",\"findings\":[{\"severity\":\"critical\",\"title\":\"Shell command injection in archive\",\"body\":\"archive interpolates name directly into an execSync shell command. A crafted name containing shell metacharacters can execute arbitrary commands with the process privileges; quoting only the path would also be insufficient without avoiding the shell.\",\"file\":\"src/files.js\",\"line_start\":12,\"line_end\":14,\"confidence\":0.99,\"recommendation\":\"Use spawnSync or execFileSync with an argument array and shell disabled, validate name against an allowlist, and constrain the resolved source path to ROOT.\"},{\"severity\":\"high\",\"title\":\"Path traversal permits arbitrary file reads\",\"body\":\"readUpload joins an untrusted name to ROOT without verifying containment. Absolute paths or ../ segments can escape /srv/uploads and expose any readable UTF-8 file on the host.\",\"file\":\"src/files.js\",\"line_start\":7,\"line_end\":10,\"confidence\":0.99,\"recommendation\":\"Resolve the candidate path, verify it remains beneath ROOT using path.relative or an equivalent containment check, and reject absolute paths and traversal segments.\"}],\"next_steps\":[\"Replace shell command construction and add canonical-path containment validation with traversal and command-injection tests.\"]}\n"
+}

--- a/bench/cassettes/path-and-input/gemini.deep.json
+++ b/bench/cassettes/path-and-input/gemini.deep.json
@@ -1,155 +1,166 @@
 {
   "caseId": "path-and-input",
   "cell": "gemini.deep",
-  "recordedAt": "2026-08-19T12:09:15.318Z",
+  "recordedAt": "2026-08-24T10:52:07.567Z",
   "verdict": "needs-attention",
-  "summary": "Identified critical command injection, path traversal, and missing validation bugs in the newly added files utility.",
+  "summary": "Identified critical command injection, high-severity directory traversal, and missing validation bugs in src/files.js.",
   "findings": [
     {
       "severity": "critical",
-      "title": "Command injection vulnerability in archive",
-      "body": "The archive function uses execSync to run a shell command constructed via direct string interpolation of the user-controlled name parameter, allowing arbitrary remote code execution.",
+      "title": "Command Injection in archive Function",
+      "body": "The 'archive' function interpolates the 'name' parameter directly into a shell command executed by 'execSync'. An attacker who controls the 'name' parameter can append shell metacharacters (e.g., semicolons, backticks, or subshells) to execute arbitrary commands with the privileges of the Node.js application process.",
       "file": "src/files.js",
       "line_start": 12,
       "line_end": 14,
       "confidence": 1,
-      "recommendation": "Avoid using string interpolation for shell commands. Use execFile or spawnSync with an arguments array, or rigorously validate that the name parameter contains only alphanumeric characters."
+      "recommendation": "Do not pass user-controlled inputs directly into a shell command string. Use 'execFileSync' or 'spawnSync' where arguments are passed safely as an array of strings, or validate the 'name' input against a strict alphanumeric whitelist before execution."
     },
     {
       "severity": "high",
-      "title": "Path traversal vulnerability in readUpload",
-      "body": "The readUpload function resolves the file target path using path.join(ROOT, name) without ensuring the resolved path remains inside the ROOT directory. An attacker can supply a name containing relative traversal segments (e.g. '../../etc/passwd') to read arbitrary files.",
+      "title": "Path Traversal in readUpload and archive Functions",
+      "body": "Both 'readUpload' and 'archive' resolve their target path using 'path.join(ROOT, name)'. Because 'path.join' resolves relative path components (such as '..'), an attacker can supply sequences like '../../etc/passwd' to escape the intended '/srv/uploads' root and read or archive arbitrary files on the host filesystem.",
       "file": "src/files.js",
       "line_start": 7,
-      "line_end": 10,
+      "line_end": 14,
       "confidence": 1,
-      "recommendation": "Normalize the resolved path using path.resolve and verify that it starts with the resolved ROOT path before reading the file."
+      "recommendation": "Resolve the full absolute path of the target file using 'path.resolve' and verify that it starts with the resolved absolute path of the 'ROOT' directory before reading or archiving any files."
     },
     {
-      "severity": "medium",
-      "title": "Missing validation of inputs and potential crash in pickPage",
-      "body": "The pickPage function accesses body.page and pages[page] without verifying that body is defined, page is a valid number, and page is within the array bounds of pages. This can lead to unhandled TypeErrors or propagating undefined values.",
+      "severity": "low",
+      "title": "Unvalidated Array Indexing in pickPage Function",
+      "body": "The 'pickPage' function parses 'body.page' using 'parseInt' without a specified radix, and accesses the 'pages' array directly without checking if the parsed index is a valid integer, non-negative, or within the bounds of the array. This can result in returning 'undefined', leading to runtime errors downstream.",
       "file": "src/files.js",
       "line_start": 16,
       "line_end": 19,
-      "confidence": 0.95,
-      "recommendation": "Verify that body is not null/undefined, body.page is parsed correctly, and page index is a valid number within the bounds of the pages array."
+      "confidence": 1,
+      "recommendation": "Validate that 'body' and 'body.page' exist, parse 'body.page' with an explicit radix (e.g. 'parseInt(body.page, 10)'), and check that the resulting index is a non-negative integer within the bounds of 'pages' before retrieving the page."
     }
   ],
-  "latencyMs": 27074,
-  "engineVersion": "0.55.1",
+  "latencyMs": 34448,
+  "engineVersion": "0.56.0",
+  "engineObserved": "gemini",
   "samples": [
     {
       "verdict": "needs-attention",
-      "summary": "Identified critical command injection, path traversal, and missing boundary validation issues in file handling and page selection utilities.",
+      "summary": "The codebase contains critical command injection and path traversal vulnerabilities along with missing error handling and unvalidated input logic.",
       "findings": [
         {
           "severity": "critical",
-          "title": "Command Injection in archive()",
-          "body": "The archive function in src/files.js executes a shell command using execSync with an unescaped, interpolated string parameter. An attacker controlling the 'name' parameter can inject arbitrary shell commands, leading to remote code execution (RCE) with the privileges of the running application.",
+          "title": "Arbitrary Command Injection in archive function",
+          "body": "In src/files.js inside the archive function, the name parameter is directly interpolated into a shell command executed via execSync. If an attacker supplies a name containing shell metacharacters (such as semicolons, ampersands, backticks, or subshell expansions), they can execute arbitrary shell commands with the privileges of the Node.js process.",
           "file": "src/files.js",
           "line_start": 12,
           "line_end": 14,
           "confidence": 1,
-          "recommendation": "Avoid using string interpolation in execSync. Instead, use child_process.spawnSync or child_process.execFile with arguments passed as an array and shell execution disabled."
+          "recommendation": "Avoid executing shell commands using string interpolation with unsanitized parameters. Instead, use process execution APIs such as execFileSync or spawnSync from node:child_process, passing arguments as elements of an array, or validate and sanitize the name argument before execution."
         },
         {
           "severity": "high",
-          "title": "Path Traversal in readUpload() and archive()",
-          "body": "The readUpload and archive functions use path.join(ROOT, name) without validating that the resolved path remains within ROOT (/srv/uploads). An attacker can supply a relative path containing directory traversal sequences (such as '../') to read or archive arbitrary files from the filesystem.",
+          "title": "Path Traversal in readUpload and archive functions",
+          "body": "In src/files.js, path.join(ROOT, name) resolves paths without validation or checking whether the resulting path remains within the ROOT directory (/srv/uploads). Using directory traversal sequences (like ../) allows reading or archiving files outside of the intended directory, exposing sensitive system files.",
           "file": "src/files.js",
           "line_start": 7,
           "line_end": 14,
           "confidence": 1,
-          "recommendation": "Resolve the target path using path.resolve and verify that it starts with the absolute path of the ROOT directory before performing any file operations."
+          "recommendation": "Verify that the resolved target path actually starts with the intended ROOT directory. You can resolve the absolute path using path.resolve and check if targetPath.startsWith(path.resolve(ROOT)) is true. Alternatively, sanitize input to disallow traversal sequences."
         },
         {
           "severity": "medium",
-          "title": "Unchecked Input and Missing Bounds Checking in pickPage()",
-          "body": "The pickPage function accesses body.page and indexes pages without checking if body is null/undefined, whether body.page is a valid integer, or whether pages is defined and has the parsed index. This will throw a TypeError if body is null/undefined, or return undefined/throw if page is out of bounds.",
+          "title": "Missing Error Handling in File and Process Operations",
+          "body": "Both fs.readFileSync and execSync are synchronous blocking calls that can throw exceptions (for instance, if the target file does not exist, permissions are missing, or the command execution returns a non-zero exit code). Since there is no error handling around these operations, these errors will propagate as unhandled exceptions and potentially crash the application.",
+          "file": "src/files.js",
+          "line_start": 7,
+          "line_end": 14,
+          "confidence": 1,
+          "recommendation": "Wrap calls to fs.readFileSync and execSync in try-catch blocks to handle potential errors gracefully (e.g., logging the failure and returning an informative error status or raising a clean application-level exception)."
+        },
+        {
+          "severity": "low",
+          "title": "Unvalidated Input and Lack of Radix in pickPage",
+          "body": "The pickPage function accesses body.page without verifying if body is defined (which can throw a TypeError if null/undefined). It also parses the page string using parseInt without a radix argument, and uses the resulting index directly on the pages array without any bounds checks or validation that the parsed value is a safe integer, which can result in returning undefined.",
           "file": "src/files.js",
           "line_start": 16,
           "line_end": 19,
           "confidence": 1,
-          "recommendation": "Add a check to ensure body and pages are not nullish, validate that parseInt(body.page) yields a valid integer, and verify that the index is non-negative and within the bounds of the pages array."
+          "recommendation": "Check if body and body.page are defined, supply a radix of 10 to parseInt(body.page, 10), and validate that the parsed index is a non-negative integer within the bounds of the pages array before indexing into it."
         }
       ],
-      "latencyMs": 33066
+      "latencyMs": 33827
     },
     {
       "verdict": "needs-attention",
-      "summary": "The codebase contains critical security vulnerabilities including OS command injection, path traversal, and unsafe object property access without validation.",
+      "summary": "The uploaded files module contains critical command injection and path traversal vulnerabilities, along with missing validation for boundary parameters.",
       "findings": [
         {
           "severity": "critical",
-          "title": "Remote Code Execution via OS Command Injection",
-          "body": "The archive function uses execSync with a template literal string to interpolate the name parameter directly into a system shell command. This allows an attacker to execute arbitrary OS commands on the host system.",
+          "title": "Command Injection in archive function",
+          "body": "In the `archive(name)` function, the `name` parameter is interpolated directly into a shell command executed via `execSync`. Because the command runs within a shell context, an attacker passing a malicious filename (such as `\"; rm -rf /; #\"`) can execute arbitrary commands with the privileges of the Node.js process.",
           "file": "src/files.js",
           "line_start": 12,
           "line_end": 14,
           "confidence": 1,
-          "recommendation": "Do not pass user input to a shell. Use execFile or spawn with argument arrays to prevent shell interpretation, or strictly validate that the input contains only safe, alphanumeric characters."
+          "recommendation": "Avoid using string interpolation in shell commands. Instead, use `execFileSync` or `spawnSync` from `node:child_process` and pass the command arguments as an array so that no shell parsing occurs. Additionally, validate that the filename contains only safe, alphanumeric characters."
         },
         {
           "severity": "high",
-          "title": "Arbitrary File Read via Path Traversal",
-          "body": "The readUpload function uses path.join on ROOT and the user-supplied name directly, which allows path traversal sequences (such as '../') to escape the designated directory and read arbitrary files on the filesystem.",
+          "title": "Path Traversal in readUpload and archive functions",
+          "body": "In both `readUpload(name)` and `archive(name)`, `path.join` is used to combine the root directory `/srv/uploads` with a user-supplied `name`. Because `path.join` resolves relative segment characters like `..`, a name containing sequences like `../../etc/passwd` allows an attacker to escape the designated upload directory and read or manipulate arbitrary files on the host filesystem.",
           "file": "src/files.js",
           "line_start": 7,
           "line_end": 10,
           "confidence": 1,
-          "recommendation": "Resolve the absolute path of the target file using path.resolve and verify that it starts with the resolved absolute path of ROOT before attempting to read it."
+          "recommendation": "Resolve the path fully using `path.resolve` and check that the resolved target path starts with the resolved `ROOT` directory path (for example, `target.startsWith(path.resolve(ROOT))`), or reject any file names containing path separators and relative segments."
         },
         {
           "severity": "medium",
-          "title": "Unsafe Object Property Access and Missing Boundary Check",
-          "body": "The pickPage function attempts to access body.page without checking if body is null or undefined, and accesses pages by index without checking array bounds or validating that the index is a valid number.",
-          "file": "src/files.js",
-          "line_start": 16,
-          "line_end": 19,
-          "confidence": 0.9,
-          "recommendation": "Add null/undefined checks for 'body' and 'pages', and ensure that 'page' is a valid, non-negative integer within the bounds of the 'pages' array before indexing."
-        }
-      ],
-      "latencyMs": 25545
-    },
-    {
-      "verdict": "needs-attention",
-      "summary": "Identified critical command injection, path traversal, and missing validation bugs in the newly added files utility.",
-      "findings": [
-        {
-          "severity": "critical",
-          "title": "Command injection vulnerability in archive",
-          "body": "The archive function uses execSync to run a shell command constructed via direct string interpolation of the user-controlled name parameter, allowing arbitrary remote code execution.",
-          "file": "src/files.js",
-          "line_start": 12,
-          "line_end": 14,
-          "confidence": 1,
-          "recommendation": "Avoid using string interpolation for shell commands. Use execFile or spawnSync with an arguments array, or rigorously validate that the name parameter contains only alphanumeric characters."
-        },
-        {
-          "severity": "high",
-          "title": "Path traversal vulnerability in readUpload",
-          "body": "The readUpload function resolves the file target path using path.join(ROOT, name) without ensuring the resolved path remains inside the ROOT directory. An attacker can supply a name containing relative traversal segments (e.g. '../../etc/passwd') to read arbitrary files.",
-          "file": "src/files.js",
-          "line_start": 7,
-          "line_end": 10,
-          "confidence": 1,
-          "recommendation": "Normalize the resolved path using path.resolve and verify that it starts with the resolved ROOT path before reading the file."
-        },
-        {
-          "severity": "medium",
-          "title": "Missing validation of inputs and potential crash in pickPage",
-          "body": "The pickPage function accesses body.page and pages[page] without verifying that body is defined, page is a valid number, and page is within the array bounds of pages. This can lead to unhandled TypeErrors or propagating undefined values.",
+          "title": "Unsafe inputs and missing validation in pickPage function",
+          "body": "The `pickPage(body, pages)` function lacks nullish checks for its arguments. If `body` is null or undefined, accessing `body.page` throws a `TypeError`. If `pages` is not an object or array, indexing it throws a `TypeError`. Furthermore, if `parseInt` parses a non-numeric string, it returns `NaN`, and accessing `pages[NaN]` will return `undefined`, which may lead to downstream runtime exceptions.",
           "file": "src/files.js",
           "line_start": 16,
           "line_end": 19,
           "confidence": 0.95,
-          "recommendation": "Verify that body is not null/undefined, body.page is parsed correctly, and page index is a valid number within the bounds of the pages array."
+          "recommendation": "Verify that `body`, `body.page`, and `pages` are defined and valid. Ensure that the parsed page index is a safe, non-negative integer within the actual bounds of the `pages` collection."
         }
       ],
-      "latencyMs": 27074
+      "latencyMs": 26823
+    },
+    {
+      "verdict": "needs-attention",
+      "summary": "Identified critical command injection, high-severity directory traversal, and missing validation bugs in src/files.js.",
+      "findings": [
+        {
+          "severity": "critical",
+          "title": "Command Injection in archive Function",
+          "body": "The 'archive' function interpolates the 'name' parameter directly into a shell command executed by 'execSync'. An attacker who controls the 'name' parameter can append shell metacharacters (e.g., semicolons, backticks, or subshells) to execute arbitrary commands with the privileges of the Node.js application process.",
+          "file": "src/files.js",
+          "line_start": 12,
+          "line_end": 14,
+          "confidence": 1,
+          "recommendation": "Do not pass user-controlled inputs directly into a shell command string. Use 'execFileSync' or 'spawnSync' where arguments are passed safely as an array of strings, or validate the 'name' input against a strict alphanumeric whitelist before execution."
+        },
+        {
+          "severity": "high",
+          "title": "Path Traversal in readUpload and archive Functions",
+          "body": "Both 'readUpload' and 'archive' resolve their target path using 'path.join(ROOT, name)'. Because 'path.join' resolves relative path components (such as '..'), an attacker can supply sequences like '../../etc/passwd' to escape the intended '/srv/uploads' root and read or archive arbitrary files on the host filesystem.",
+          "file": "src/files.js",
+          "line_start": 7,
+          "line_end": 14,
+          "confidence": 1,
+          "recommendation": "Resolve the full absolute path of the target file using 'path.resolve' and verify that it starts with the resolved absolute path of the 'ROOT' directory before reading or archiving any files."
+        },
+        {
+          "severity": "low",
+          "title": "Unvalidated Array Indexing in pickPage Function",
+          "body": "The 'pickPage' function parses 'body.page' using 'parseInt' without a specified radix, and accesses the 'pages' array directly without checking if the parsed index is a valid integer, non-negative, or within the bounds of the array. This can result in returning 'undefined', leading to runtime errors downstream.",
+          "file": "src/files.js",
+          "line_start": 16,
+          "line_end": 19,
+          "confidence": 1,
+          "recommendation": "Validate that 'body' and 'body.page' exist, parse 'body.page' with an explicit radix (e.g. 'parseInt(body.page, 10)'), and check that the resulting index is a non-negative integer within the bounds of 'pages' before retrieving the page."
+        }
+      ],
+      "latencyMs": 34448
     }
   ],
-  "raw": "{\n  \"review\": \"Review\",\n  \"target\": {\n    \"mode\": \"working-tree\",\n    \"label\": \"working tree diff\",\n    \"explicit\": true\n  },\n  \"gemini\": {\n    \"status\": 0,\n    \"stdout\": \"{\\n  \\\"verdict\\\": \\\"needs-attention\\\",\\n  \\\"summary\\\": \\\"Identified critical command injection, path traversal, and missing validation bugs in the newly added files utility.\\\",\\n  \\\"findings\\\": [\\n    {\\n      \\\"severity\\\": \\\"critical\\\",\\n      \\\"title\\\": \\\"Command injection vulnerability in archive\\\",\\n      \\\"body\\\": \\\"The archive function uses execSync to run a shell command constructed via direct string interpolation of the user-controlled name parameter, allowing arbitrary remote code execution.\\\",\\n      \\\"file\\\": \\\"src/files.js\\\",\\n      \\\"line_start\\\": 12,\\n      \\\"line_end\\\": 14,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Avoid using string interpolation for shell commands. Use execFile or spawnSync with an arguments array, or rigorously validate that the name parameter contains only alphanumeric characters.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"high\\\",\\n      \\\"title\\\": \\\"Path traversal vulnerability in readUpload\\\",\\n      \\\"body\\\": \\\"The readUpload function resolves the file target path using path.join(ROOT, name) without ensuring the resolved path remains inside the ROOT directory. An attacker can supply a name containing relative traversal segments (e.g. '../../etc/passwd') to read arbitrary files.\\\",\\n      \\\"file\\\": \\\"src/files.js\\\",\\n      \\\"line_start\\\": 7,\\n      \\\"line_end\\\": 10,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Normalize the resolved path using path.resolve and verify that it starts with the resolved ROOT path before reading the file.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"medium\\\",\\n      \\\"title\\\": \\\"Missing validation of inputs and potential crash in pickPage\\\",\\n      \\\"body\\\": \\\"The pickPage function accesses body.page and pages[page] without verifying that body is defined, page is a valid number, and page is within the array bounds of pages. This can lead to unhandled TypeErrors or propagating undefined values.\\\",\\n      \\\"file\\\": \\\"src/files.js\\\",\\n      \\\"line_start\\\": 16,\\n      \\\"line_end\\\": 19,\\n      \\\"confidence\\\": 0.95,\\n      \\\"recommendation\\\": \\\"Verify that body is not null/undefined, body.page is parsed correctly, and page index is a valid number within the bounds of the pages array.\\\"\\n    }\\n  ],\\n  \\\"next_steps\\\": [\\n    \\\"Refactor src/files.js to prevent command injection in archive using execFile.\\\",\\n    \\\"Implement path traversal checks in readUpload.\\\",\\n    \\\"Add robust validation and bounds checking in pickPage.\\\"\\n  ]\\n}\",\n    \"stderr\": \"Warning: True color (24-bit) support not detected. Using a terminal with true color enabled will result in a better visual experience.\\nRipgrep is not available. Falling back to GrepTool.\\n[STARTUP] Phase 'cleanup_ops' was started but never ended. Skipping metrics.\\n[STARTUP] Cannot measure phase 'cleanup_ops': start mark 'startup:cleanup_ops:start' not found (likely cleared by reset).\\n\"\n  },\n  \"result\": {\n    \"verdict\": \"needs-attention\",\n    \"summary\": \"Identified critical command injection, path traversal, and missing validation bugs in the newly added files utility.\",\n    \"findings\": [\n      {\n        \"severity\": \"critical\",\n        \"title\": \"Command injection vulnerability in archive\",\n        \"body\": \"The archive function uses execSync to run a shell command constructed via direct string interpolation of the user-controlled name parameter, allowing arbitrary remote code execution.\",\n        \"file\": \"src/files.js\",\n        \"line_start\": 12,\n        \"line_end\": 14,\n        \"confidence\": 1,\n        \"recommendation\": \"Avoid using string interpolation for shell commands. Use execFile or spawnSync with an arguments array, or rigorously validate that the name parameter contains only alphanumeric characters.\"\n      },\n      {\n        \"severity\": \"high\",\n        \"title\": \"Path traversal vulnerability in readUpload\",\n        \"body\": \"The "
+  "raw": "{\n  \"review\": \"Review\",\n  \"target\": {\n    \"mode\": \"working-tree\",\n    \"label\": \"working tree diff\",\n    \"explicit\": true\n  },\n  \"engine\": \"gemini\",\n  \"gemini\": {\n    \"status\": 0,\n    \"stdout\": \"{\\n  \\\"verdict\\\": \\\"needs-attention\\\",\\n  \\\"summary\\\": \\\"Identified critical command injection, high-severity directory traversal, and missing validation bugs in src/files.js.\\\",\\n  \\\"findings\\\": [\\n    {\\n      \\\"severity\\\": \\\"critical\\\",\\n      \\\"title\\\": \\\"Command Injection in archive Function\\\",\\n      \\\"body\\\": \\\"The 'archive' function interpolates the 'name' parameter directly into a shell command executed by 'execSync'. An attacker who controls the 'name' parameter can append shell metacharacters (e.g., semicolons, backticks, or subshells) to execute arbitrary commands with the privileges of the Node.js application process.\\\",\\n      \\\"file\\\": \\\"src/files.js\\\",\\n      \\\"line_start\\\": 12,\\n      \\\"line_end\\\": 14,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Do not pass user-controlled inputs directly into a shell command string. Use 'execFileSync' or 'spawnSync' where arguments are passed safely as an array of strings, or validate the 'name' input against a strict alphanumeric whitelist before execution.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"high\\\",\\n      \\\"title\\\": \\\"Path Traversal in readUpload and archive Functions\\\",\\n      \\\"body\\\": \\\"Both 'readUpload' and 'archive' resolve their target path using 'path.join(ROOT, name)'. Because 'path.join' resolves relative path components (such as '..'), an attacker can supply sequences like '../../etc/passwd' to escape the intended '/srv/uploads' root and read or archive arbitrary files on the host filesystem.\\\",\\n      \\\"file\\\": \\\"src/files.js\\\",\\n      \\\"line_start\\\": 7,\\n      \\\"line_end\\\": 14,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Resolve the full absolute path of the target file using 'path.resolve' and verify that it starts with the resolved absolute path of the 'ROOT' directory before reading or archiving any files.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"low\\\",\\n      \\\"title\\\": \\\"Unvalidated Array Indexing in pickPage Function\\\",\\n      \\\"body\\\": \\\"The 'pickPage' function parses 'body.page' using 'parseInt' without a specified radix, and accesses the 'pages' array directly without checking if the parsed index is a valid integer, non-negative, or within the bounds of the array. This can result in returning 'undefined', leading to runtime errors downstream.\\\",\\n      \\\"file\\\": \\\"src/files.js\\\",\\n      \\\"line_start\\\": 16,\\n      \\\"line_end\\\": 19,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Validate that 'body' and 'body.page' exist, parse 'body.page' with an explicit radix (e.g. 'parseInt(body.page, 10)'), and check that the resulting index is a non-negative integer within the bounds of 'pages' before retrieving the page.\\\"\\n    }\\n  ],\\n  \\\"next_steps\\\": [\\n    \\\"Refactor 'archive' to use safe, array-based execution APIs instead of 'execSync' shell string execution.\\\",\\n    \\\"Add target path resolution and ancestor validation in 'readUpload' and 'archive' to eliminate path traversal vulnerabilities.\\\",\\n    \\\"Implement safe input validation, parsing, and array bounds checks in 'pickPage'.\\\"\\n  ]\\n}\",\n    \"stderr\": \"Warning: 256-color support not detected. Using a terminal with at least 256-color support is recommended for a better visual experience.\\nRipgrep is not available. Falling back to GrepTool.\\n\"\n  },\n  \"result\": {\n    \"verdict\": \"needs-attention\",\n    \"summary\": \"Identified critical command injection, high-severity directory traversal, and missing validation bugs in src/files.js.\",\n    \"findings\": [\n      {\n        \"severity\": \"critical\",\n        \"title\": \"Command Injection in archive Function\",\n        \"body\": \"The 'archive' function interpolates the 'name' parameter directly into a shell command executed by 'execSync'. An attacker who controls the 'name' parameter can append shell metacharacters (e.g., semicolons, backticks,"
 }

--- a/bench/cassettes/path-and-input/gemini.model.json
+++ b/bench/cassettes/path-and-input/gemini.model.json
@@ -1,175 +1,176 @@
 {
   "caseId": "path-and-input",
   "cell": "gemini.model",
-  "recordedAt": "2026-08-19T09:07:52.117Z",
+  "recordedAt": "2026-08-24T10:44:01.667Z",
   "verdict": "needs-attention",
-  "summary": "The code introduces critical security vulnerabilities including command injection and path traversal, alongside missing error handling.",
+  "summary": "The code contains critical security flaws including command injection and path traversal vulnerabilities.",
   "findings": [
     {
       "severity": "critical",
-      "title": "Command Injection in archive function",
-      "body": "The `name` parameter is directly interpolated into a shell command string executed by `execSync` without any sanitization or escaping. An attacker can exploit this to execute arbitrary shell commands by providing a payload like `test; rm -rf /`.",
+      "title": "Command Injection in archive()",
+      "body": "The `archive` function interpolates the `name` parameter directly into a shell command via `execSync`. This allows an attacker to execute arbitrary shell commands by injecting characters like `;` or `&` into `name`.",
       "file": "src/files.js",
       "line_start": 12,
       "line_end": 14,
       "confidence": 1,
-      "recommendation": "Use `execFileSync` instead of `execSync` and pass arguments as an array to prevent shell interpretation. Alternatively, use a native Node.js library for creating tar archives."
+      "recommendation": "Use `child_process.execFileSync` or `spawnSync` with an array of arguments instead of a single shell string to prevent shell interpolation."
     },
     {
       "severity": "critical",
-      "title": "Path Traversal Vulnerability in readUpload",
-      "body": "The `readUpload` function constructs a file path by joining a root directory with the `name` parameter without verifying the final resolved path. An attacker can read arbitrary files by using directory traversal payloads (e.g., `../../etc/passwd`). This vulnerability also applies to the `archive` function.",
+      "title": "Path Traversal in readUpload()",
+      "body": "The `readUpload` function joins `ROOT` and `name` without validating that the final resolved path stays within `ROOT`. An attacker can use `../` in `name` to read arbitrary files from the filesystem.",
       "file": "src/files.js",
       "line_start": 7,
       "line_end": 10,
       "confidence": 1,
-      "recommendation": "Ensure the `name` parameter does not contain path separators, and verify that the final resolved absolute path is strictly within the `ROOT` directory (e.g., using `target.startsWith(ROOT)`) before operating on it."
+      "recommendation": "Ensure the resolved path starts with `ROOT` using `path.resolve`, or sanitize `name` by using `path.basename(name)`."
     },
     {
       "severity": "medium",
-      "title": "Missing Error Handling in readUpload",
-      "body": "`fs.readFileSync` throws a synchronous exception if the file does not exist or lacks read permissions. Without a try-catch block, this unhandled exception may crash the application depending on the caller's context.",
-      "file": "src/files.js",
-      "line_start": 8,
-      "line_end": 9,
-      "confidence": 0.95,
-      "recommendation": "Wrap `fs.readFileSync` in a try-catch block to handle missing files or access errors gracefully."
-    },
-    {
-      "severity": "medium",
-      "title": "Unsafe integer parsing and missing bounds check in pickPage",
-      "body": "If `body.page` is missing or a non-numeric string, `parseInt` returns `NaN`, leading to `pages[NaN]` which yields `undefined`. There is also no bounds checking, so a negative or overly large integer will also return `undefined`, potentially causing downstream errors.",
+      "title": "Missing Validation in pickPage()",
+      "body": "The `pickPage` function parses `body.page` without checking if the result is `NaN` or out of bounds for the `pages` array, which can lead to runtime errors or undefined behavior.",
       "file": "src/files.js",
       "line_start": 16,
       "line_end": 19,
       "confidence": 0.9,
-      "recommendation": "Verify that `parseInt(body.page)` is a valid number using `Number.isNaN()` and ensure it falls within the valid index range of the `pages` array before accessing the element."
+      "recommendation": "Validate that `body.page` is a valid number, handle the `NaN` case, and ensure the resulting index is within the bounds of `pages`."
     }
   ],
-  "latencyMs": 27202,
-  "engineVersion": "0.55.1",
+  "latencyMs": 25775,
+  "engineVersion": "0.56.0",
+  "engineObserved": null,
   "samples": [
     {
       "verdict": "needs-attention",
-      "summary": "Critical security vulnerabilities including command injection and path traversal, along with missing input validation.",
+      "summary": "Critical security vulnerabilities including path traversal and command injection, along with event loop blocking operations.",
       "findings": [
         {
           "severity": "critical",
-          "title": "Command Injection in archive()",
-          "body": "The `name` parameter is directly interpolated into a shell command string passed to `execSync`. If `name` contains shell metacharacters (e.g., `name; rm -rf /`), an attacker can execute arbitrary commands on the host system.",
-          "file": "src/files.js",
-          "line_start": 12,
-          "line_end": 14,
-          "confidence": 1,
-          "recommendation": "Use `execFileSync('tar', ['-czf', `${name}.tar.gz`, path.join(ROOT, name)])` to pass arguments safely as an array, bypassing shell interpretation."
-        },
-        {
-          "severity": "high",
-          "title": "Path Traversal in readUpload() and archive()",
-          "body": "The `name` parameter is concatenated with `ROOT` using `path.join()`, but there is no check to ensure the resolved path stays within `/srv/uploads`. An attacker can supply `../` to access arbitrary files on the filesystem.",
-          "file": "src/files.js",
-          "line_start": 7,
-          "line_end": 14,
-          "confidence": 1,
-          "recommendation": "After resolving the absolute path, verify it resides within the intended directory (e.g., `if (!target.startsWith(ROOT + path.sep)) throw Error('Invalid path')`)."
-        },
-        {
-          "severity": "medium",
-          "title": "Unsafe array indexing in pickPage()",
-          "body": "The function parses `body.page` using `parseInt()` but fails to validate the result. If `body.page` is missing or invalid, `page` becomes `NaN`. Without bounds checking, this can result in accessing invalid indices or returning `undefined`.",
-          "file": "src/files.js",
-          "line_start": 16,
-          "line_end": 19,
-          "confidence": 0.9,
-          "recommendation": "Ensure `page` is a valid number (`!isNaN(page)`) and verify it falls within the safe bounds of `0 <= page < pages.length`."
-        }
-      ],
-      "latencyMs": 23671
-    },
-    {
-      "verdict": "needs-attention",
-      "summary": "Critical command injection and high-severity path traversal vulnerabilities detected due to unsafe handling of input.",
-      "findings": [
-        {
-          "severity": "critical",
-          "title": "Command Injection in archive function",
-          "body": "The `name` parameter is directly interpolated into a shell command and executed using `execSync`. An attacker can provide malicious input (e.g., `file.txt; id`) to achieve arbitrary command execution on the host system.",
-          "file": "src/files.js",
-          "line_start": 12,
-          "line_end": 14,
-          "confidence": 1,
-          "recommendation": "Use `execFileSync` from `child_process` to pass arguments as a strict array, thereby bypassing shell evaluation. Additionally, validate `name` to ensure it does not start with a hyphen to prevent argument injection into the `tar` command."
-        },
-        {
-          "severity": "high",
-          "title": "Path Traversal vulnerability in readUpload",
-          "body": "The `name` parameter is passed directly to `path.join()` without validation. If `name` contains directory traversal sequences (e.g., `../../../etc/passwd`), it allows an attacker to read arbitrary files anywhere on the filesystem, bypassing the `/srv/uploads` boundary.",
+          "title": "Path Traversal in readUpload",
+          "body": "The `name` argument is joined with `ROOT` without verifying that the resolved path stays within the `ROOT` directory bounds. An attacker can supply `../` sequences to read arbitrary files on the host filesystem.",
           "file": "src/files.js",
           "line_start": 7,
           "line_end": 10,
           "confidence": 1,
-          "recommendation": "Validate the resolved path to ensure it strictly starts with the target `ROOT` directory. Alternatively, if subdirectories are not required, sanitize the input using `path.basename(name)`."
+          "recommendation": "Validate the resolved path using `target.startsWith(ROOT)` (ensuring trailing slashes are handled) to prevent directory traversal attacks."
+        },
+        {
+          "severity": "critical",
+          "title": "Command Injection in archive",
+          "body": "The `name` parameter is interpolated directly into a shell command string passed to `execSync`. This allows arbitrary shell command execution if the parameter contains shell metacharacters like `;`, `&`, or `$()`.",
+          "file": "src/files.js",
+          "line_start": 12,
+          "line_end": 14,
+          "confidence": 1,
+          "recommendation": "Use `child_process.execFileSync` or `spawnSync` and pass arguments as an array, avoiding the shell entirely."
+        },
+        {
+          "severity": "high",
+          "title": "Synchronous Blocking I/O",
+          "body": "The code uses synchronous methods `readFileSync` and `execSync`. If this file is used in a web server context, these blocking operations will halt the Node.js event loop, leading to immediate performance degradation and Denial of Service (DoS).",
+          "file": "src/files.js",
+          "line_start": 9,
+          "line_end": 13,
+          "confidence": 0.95,
+          "recommendation": "Switch to asynchronous alternatives: `fs.promises.readFile` and `child_process.spawn` or `child_process.execFile`."
         },
         {
           "severity": "medium",
-          "title": "Missing null/undefined checks in pickPage",
-          "body": "The function attempts to read `body.page` without verifying if `body` exists. If `body` is null or undefined, this will throw an unhandled `TypeError`. It also fails to validate if the result of `parseInt` is `NaN` or an out-of-bounds index.",
+          "title": "Missing Input Validation in pickPage",
+          "body": "`parseInt(body.page)` can return `NaN` or an out-of-bounds integer. Returning `pages[NaN]` or an out-of-bounds index evaluates to `undefined` without proper error handling or bounds checking, which could lead to downstream null reference errors.",
           "file": "src/files.js",
           "line_start": 16,
           "line_end": 19,
           "confidence": 0.95,
-          "recommendation": "Add checks to verify `body` exists and is an object. Validate that `page` parses to a valid number (`!isNaN`) and check array/object bounds before returning the element."
+          "recommendation": "Check if the parsed `page` is a valid integer (`Number.isInteger`) and verify it falls within `0` and `pages.length - 1` before accessing the array."
         }
       ],
-      "latencyMs": 25680
+      "latencyMs": 30610
     },
     {
       "verdict": "needs-attention",
-      "summary": "The code introduces critical security vulnerabilities including command injection and path traversal, alongside missing error handling.",
+      "summary": "Critical command injection and path traversal vulnerabilities discovered in file handling operations.",
       "findings": [
         {
           "severity": "critical",
-          "title": "Command Injection in archive function",
-          "body": "The `name` parameter is directly interpolated into a shell command string executed by `execSync` without any sanitization or escaping. An attacker can exploit this to execute arbitrary shell commands by providing a payload like `test; rm -rf /`.",
+          "title": "Command Injection in archive",
+          "body": "The `name` parameter is concatenated directly into a shell string passed to `execSync`. An attacker can pass specially crafted filenames (e.g., `\"; malicious_command; #`) to execute arbitrary code on the host system.",
           "file": "src/files.js",
           "line_start": 12,
           "line_end": 14,
           "confidence": 1,
-          "recommendation": "Use `execFileSync` instead of `execSync` and pass arguments as an array to prevent shell interpretation. Alternatively, use a native Node.js library for creating tar archives."
+          "recommendation": "Use `execFileSync` or `spawnSync` from `node:child_process` and pass arguments as an array to avoid invoking a shell, and sanitize `name`."
         },
         {
-          "severity": "critical",
-          "title": "Path Traversal Vulnerability in readUpload",
-          "body": "The `readUpload` function constructs a file path by joining a root directory with the `name` parameter without verifying the final resolved path. An attacker can read arbitrary files by using directory traversal payloads (e.g., `../../etc/passwd`). This vulnerability also applies to the `archive` function.",
+          "severity": "high",
+          "title": "Path Traversal in readUpload and archive",
+          "body": "The `name` parameter is used in `path.join(ROOT, name)` without validating the final resolved path. An attacker can provide input like `../../etc/passwd` to read or interact with files outside the intended `/srv/uploads` directory.",
           "file": "src/files.js",
           "line_start": 7,
-          "line_end": 10,
+          "line_end": 13,
           "confidence": 1,
-          "recommendation": "Ensure the `name` parameter does not contain path separators, and verify that the final resolved absolute path is strictly within the `ROOT` directory (e.g., using `target.startsWith(ROOT)`) before operating on it."
+          "recommendation": "Use `path.resolve` and verify that the resulting path strictly starts with the expected `ROOT` directory path before proceeding with filesystem operations."
         },
         {
           "severity": "medium",
-          "title": "Missing Error Handling in readUpload",
-          "body": "`fs.readFileSync` throws a synchronous exception if the file does not exist or lacks read permissions. Without a try-catch block, this unhandled exception may crash the application depending on the caller's context.",
+          "title": "Missing Error Handling for File Reads",
+          "body": "`fs.readFileSync` is called without a try-catch block. If the requested file does not exist, node will throw an error, immediately crashing the process.",
           "file": "src/files.js",
           "line_start": 8,
           "line_end": 9,
           "confidence": 0.95,
-          "recommendation": "Wrap `fs.readFileSync` in a try-catch block to handle missing files or access errors gracefully."
+          "recommendation": "Wrap `fs.readFileSync` in a try-catch block and handle `ENOENT` errors gracefully, returning an appropriate error response or null."
         },
         {
           "severity": "medium",
-          "title": "Unsafe integer parsing and missing bounds check in pickPage",
-          "body": "If `body.page` is missing or a non-numeric string, `parseInt` returns `NaN`, leading to `pages[NaN]` which yields `undefined`. There is also no bounds checking, so a negative or overly large integer will also return `undefined`, potentially causing downstream errors.",
+          "title": "Missing bounds and type checking in pickPage",
+          "body": "`parseInt(body.page)` is used directly as an index for `pages` without checking if it evaluates to `NaN` or falls outside the array bounds, risking application logic failures or undefined behavior.",
           "file": "src/files.js",
           "line_start": 16,
           "line_end": 19,
           "confidence": 0.9,
-          "recommendation": "Verify that `parseInt(body.page)` is a valid number using `Number.isNaN()` and ensure it falls within the valid index range of the `pages` array before accessing the element."
+          "recommendation": "Ensure `Number.isInteger(page)` is true and that the index is within `0` and `pages.length - 1` before accessing."
         }
       ],
-      "latencyMs": 27202
+      "latencyMs": 21806
+    },
+    {
+      "verdict": "needs-attention",
+      "summary": "The code contains critical security flaws including command injection and path traversal vulnerabilities.",
+      "findings": [
+        {
+          "severity": "critical",
+          "title": "Command Injection in archive()",
+          "body": "The `archive` function interpolates the `name` parameter directly into a shell command via `execSync`. This allows an attacker to execute arbitrary shell commands by injecting characters like `;` or `&` into `name`.",
+          "file": "src/files.js",
+          "line_start": 12,
+          "line_end": 14,
+          "confidence": 1,
+          "recommendation": "Use `child_process.execFileSync` or `spawnSync` with an array of arguments instead of a single shell string to prevent shell interpolation."
+        },
+        {
+          "severity": "critical",
+          "title": "Path Traversal in readUpload()",
+          "body": "The `readUpload` function joins `ROOT` and `name` without validating that the final resolved path stays within `ROOT`. An attacker can use `../` in `name` to read arbitrary files from the filesystem.",
+          "file": "src/files.js",
+          "line_start": 7,
+          "line_end": 10,
+          "confidence": 1,
+          "recommendation": "Ensure the resolved path starts with `ROOT` using `path.resolve`, or sanitize `name` by using `path.basename(name)`."
+        },
+        {
+          "severity": "medium",
+          "title": "Missing Validation in pickPage()",
+          "body": "The `pickPage` function parses `body.page` without checking if the result is `NaN` or out of bounds for the `pages` array, which can lead to runtime errors or undefined behavior.",
+          "file": "src/files.js",
+          "line_start": 16,
+          "line_end": 19,
+          "confidence": 0.9,
+          "recommendation": "Validate that `body.page` is a valid number, handle the `NaN` case, and ensure the resulting index is within the bounds of `pages`."
+        }
+      ],
+      "latencyMs": 25775
     }
   ],
-  "raw": "{\n  \"session_id\": \"167fdf40-34b8-4751-b9fa-15b48ef4f0d3\",\n  \"response\": \"{\\n  \\\"verdict\\\": \\\"needs-attention\\\",\\n  \\\"summary\\\": \\\"The code introduces critical security vulnerabilities including command injection and path traversal, alongside missing error handling.\\\",\\n  \\\"findings\\\": [\\n    {\\n      \\\"severity\\\": \\\"critical\\\",\\n      \\\"title\\\": \\\"Command Injection in archive function\\\",\\n      \\\"body\\\": \\\"The `name` parameter is directly interpolated into a shell command string executed by `execSync` without any sanitization or escaping. An attacker can exploit this to execute arbitrary shell commands by providing a payload like `test; rm -rf /`.\\\",\\n      \\\"file\\\": \\\"src/files.js\\\",\\n      \\\"line_start\\\": 12,\\n      \\\"line_end\\\": 14,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Use `execFileSync` instead of `execSync` and pass arguments as an array to prevent shell interpretation. Alternatively, use a native Node.js library for creating tar archives.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"critical\\\",\\n      \\\"title\\\": \\\"Path Traversal Vulnerability in readUpload\\\",\\n      \\\"body\\\": \\\"The `readUpload` function constructs a file path by joining a root directory with the `name` parameter without verifying the final resolved path. An attacker can read arbitrary files by using directory traversal payloads (e.g., `../../etc/passwd`). This vulnerability also applies to the `archive` function.\\\",\\n      \\\"file\\\": \\\"src/files.js\\\",\\n      \\\"line_start\\\": 7,\\n      \\\"line_end\\\": 10,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Ensure the `name` parameter does not contain path separators, and verify that the final resolved absolute path is strictly within the `ROOT` directory (e.g., using `target.startsWith(ROOT)`) before operating on it.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"medium\\\",\\n      \\\"title\\\": \\\"Missing Error Handling in readUpload\\\",\\n      \\\"body\\\": \\\"`fs.readFileSync` throws a synchronous exception if the file does not exist or lacks read permissions. Without a try-catch block, this unhandled exception may crash the application depending on the caller's context.\\\",\\n      \\\"file\\\": \\\"src/files.js\\\",\\n      \\\"line_start\\\": 8,\\n      \\\"line_end\\\": 9,\\n      \\\"confidence\\\": 0.95,\\n      \\\"recommendation\\\": \\\"Wrap `fs.readFileSync` in a try-catch block to handle missing files or access errors gracefully.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"medium\\\",\\n      \\\"title\\\": \\\"Unsafe integer parsing and missing bounds check in pickPage\\\",\\n      \\\"body\\\": \\\"If `body.page` is missing or a non-numeric string, `parseInt` returns `NaN`, leading to `pages[NaN]` which yields `undefined`. There is also no bounds checking, so a negative or overly large integer will also return `undefined`, potentially causing downstream errors.\\\",\\n      \\\"file\\\": \\\"src/files.js\\\",\\n      \\\"line_start\\\": 16,\\n      \\\"line_end\\\": 19,\\n      \\\"confidence\\\": 0.9,\\n      \\\"recommendation\\\": \\\"Verify that `parseInt(body.page)` is a valid number using `Number.isNaN()` and ensure it falls within the valid index range of the `pages` array before accessing the element.\\\"\\n    }\\n  ],\\n  \\\"next_steps\\\": [\\n    \\\"Refactor 'archive' to use execFileSync with an array of arguments to prevent command injection.\\\",\\n    \\\"Implement strict path validation in 'readUpload' and 'archive' to prevent directory traversal.\\\",\\n    \\\"Add try/catch error handling around fs.readFileSync.\\\",\\n    \\\"Add type and boundary validation in the 'pickPage' function.\\\"\\n  ]\\n}\",\n  \"stats\": {\n    \"models\": {\n      \"gemini-3.1-pro-preview\": {\n        \"api\": {\n          \"totalRequests\": 1,\n          \"totalErrors\": 0,\n          \"totalLatencyMs\": 25504,\n          \"errorsByType\": {}\n        },\n        \"tokens\": {\n          \"input\": 5082,\n          \"prompt\": 17301,\n          \"candidates\": 802,\n          \"total\": 20272,\n          \"cached\": 12219,\n          \"thoughts\": 2169,\n          \"tool\": 0\n        },\n        \"roles\": {\n          \"main\": {\n            \"totalRequests\": 1"
+  "raw": "{\n  \"session_id\": \"3d8401ac-7aa6-4705-aeb1-313c37c46df7\",\n  \"response\": \"{\\n  \\\"verdict\\\": \\\"needs-attention\\\",\\n  \\\"summary\\\": \\\"The code contains critical security flaws including command injection and path traversal vulnerabilities.\\\",\\n  \\\"findings\\\": [\\n    {\\n      \\\"severity\\\": \\\"critical\\\",\\n      \\\"title\\\": \\\"Command Injection in archive()\\\",\\n      \\\"body\\\": \\\"The `archive` function interpolates the `name` parameter directly into a shell command via `execSync`. This allows an attacker to execute arbitrary shell commands by injecting characters like `;` or `&` into `name`.\\\",\\n      \\\"file\\\": \\\"src/files.js\\\",\\n      \\\"line_start\\\": 12,\\n      \\\"line_end\\\": 14,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Use `child_process.execFileSync` or `spawnSync` with an array of arguments instead of a single shell string to prevent shell interpolation.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"critical\\\",\\n      \\\"title\\\": \\\"Path Traversal in readUpload()\\\",\\n      \\\"body\\\": \\\"The `readUpload` function joins `ROOT` and `name` without validating that the final resolved path stays within `ROOT`. An attacker can use `../` in `name` to read arbitrary files from the filesystem.\\\",\\n      \\\"file\\\": \\\"src/files.js\\\",\\n      \\\"line_start\\\": 7,\\n      \\\"line_end\\\": 10,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Ensure the resolved path starts with `ROOT` using `path.resolve`, or sanitize `name` by using `path.basename(name)`.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"medium\\\",\\n      \\\"title\\\": \\\"Missing Validation in pickPage()\\\",\\n      \\\"body\\\": \\\"The `pickPage` function parses `body.page` without checking if the result is `NaN` or out of bounds for the `pages` array, which can lead to runtime errors or undefined behavior.\\\",\\n      \\\"file\\\": \\\"src/files.js\\\",\\n      \\\"line_start\\\": 16,\\n      \\\"line_end\\\": 19,\\n      \\\"confidence\\\": 0.9,\\n      \\\"recommendation\\\": \\\"Validate that `body.page` is a valid number, handle the `NaN` case, and ensure the resulting index is within the bounds of `pages`.\\\"\\n    }\\n  ],\\n  \\\"next_steps\\\": [\\n    \\\"Replace execSync with execFileSync in archive()\\\",\\n    \\\"Add path traversal checks or basename sanitation in readUpload()\\\",\\n    \\\"Add type checking and array bounds checking in pickPage()\\\"\\n  ]\\n}\",\n  \"stats\": {\n    \"models\": {\n      \"gemini-3.1-pro-preview\": {\n        \"api\": {\n          \"totalRequests\": 1,\n          \"totalErrors\": 0,\n          \"totalLatencyMs\": 24149,\n          \"errorsByType\": {}\n        },\n        \"tokens\": {\n          \"input\": 5958,\n          \"prompt\": 18180,\n          \"candidates\": 522,\n          \"total\": 20866,\n          \"cached\": 12222,\n          \"thoughts\": 2164,\n          \"tool\": 0\n        },\n        \"roles\": {\n          \"main\": {\n            \"totalRequests\": 1,\n            \"totalErrors\": 0,\n            \"totalLatencyMs\": 24149,\n            \"tokens\": {\n              \"input\": 5958,\n              \"prompt\": 18180,\n              \"candidates\": 522,\n              \"total\": 20866,\n              \"cached\": 12222,\n              \"thoughts\": 2164,\n              \"tool\": 0\n            }\n          }\n        }\n      }\n    },\n    \"tools\": {\n      \"totalCalls\": 0,\n      \"totalSuccess\": 0,\n      \"totalFail\": 0,\n      \"totalDurationMs\": 0,\n      \"totalDecisions\": {\n        \"accept\": 0,\n        \"reject\": 0,\n        \"modify\": 0,\n        \"auto_accept\": 0\n      },\n      \"byName\": {}\n    },\n    \"files\": {\n      \"totalLinesAdded\": 0,\n      \"totalLinesRemoved\": 0\n    }\n  }\n}"
 }

--- a/bench/cassettes/repo-context/agy.adversarial.json
+++ b/bench/cassettes/repo-context/agy.adversarial.json
@@ -1,0 +1,156 @@
+{
+  "caseId": "repo-context",
+  "cell": "agy.adversarial",
+  "recordedAt": "2026-08-24T11:23:49.108Z",
+  "verdict": "needs-attention",
+  "summary": "This change introduces an undeclared dependency on jsonwebtoken, unvalidated JWT secret usage, and commits ephemeral runner state.",
+  "findings": [
+    {
+      "severity": "critical",
+      "title": "Undeclared dependency 'jsonwebtoken' causes runtime failure",
+      "body": "src/token.js requires 'jsonwebtoken', but this package is not declared in package.json dependencies. Clean installations and production builds will fail at runtime with MODULE_NOT_FOUND when requiring this module.",
+      "file": "src/token.js",
+      "line_start": 1,
+      "line_end": 1,
+      "confidence": 1,
+      "recommendation": "Add 'jsonwebtoken' with an appropriate version constraint to dependencies in package.json."
+    },
+    {
+      "severity": "high",
+      "title": "Unvalidated JWT_SECRET compromises token signing and reliability",
+      "body": "jwt.sign is called directly with process.env.JWT_SECRET without checking if the environment variable is set. If unset, token issuance will throw an unhandled runtime error or sign with an invalid/empty secret, breaking authentication integrity.",
+      "file": "src/token.js",
+      "line_start": 3,
+      "line_end": 5,
+      "confidence": 0.95,
+      "recommendation": "Validate that process.env.JWT_SECRET is non-empty before signing, throwing an explicit configuration error if it is missing."
+    },
+    {
+      "severity": "medium",
+      "title": "Ephemeral job runner state committed to repository",
+      "body": ".omc/state/job.json contains local process state (jobId and pid) that was staged into version control. Committing transient runner artifacts pollutes git history and may cause state conflicts across environments.",
+      "file": ".omc/state/job.json",
+      "line_start": 1,
+      "line_end": 1,
+      "confidence": 0.95,
+      "recommendation": "Unstage and delete .omc/state/job.json from git and add .omc/ to .gitignore."
+    }
+  ],
+  "latencyMs": 41774,
+  "engineVersion": "1.1.19",
+  "engineObserved": "agy",
+  "samples": [
+    {
+      "verdict": "needs-attention",
+      "summary": "Do not ship: src/token.js introduces an undeclared dependency on jsonwebtoken, lacks validation for JWT_SECRET, and commits transient local state.",
+      "findings": [
+        {
+          "severity": "critical",
+          "title": "Missing jsonwebtoken dependency in package.json",
+          "body": "src/token.js requires the 'jsonwebtoken' module, but package.json only declares 'express' under dependencies. Any clean installation or production deployment will immediately fail with MODULE_NOT_FOUND upon requiring this module or invoking issue().",
+          "file": "src/token.js",
+          "line_start": 1,
+          "line_end": 1,
+          "confidence": 1,
+          "recommendation": "Add 'jsonwebtoken' to the dependencies in package.json."
+        },
+        {
+          "severity": "high",
+          "title": "Missing guard for undefined JWT_SECRET",
+          "body": "issue() directly passes process.env.JWT_SECRET to jwt.sign without checking if the environment variable is configured. If JWT_SECRET is unset, jwt.sign throws a synchronous error ('secretOrPrivateKey must have a value') at runtime during token generation.",
+          "file": "src/token.js",
+          "line_start": 3,
+          "line_end": 5,
+          "confidence": 0.95,
+          "recommendation": "Assert that process.env.JWT_SECRET is defined with sufficient entropy before signing, or fail fast on service startup if missing."
+        },
+        {
+          "severity": "low",
+          "title": "Stray local runtime state committed",
+          "body": "The file .omc/state/job.json contains transient local execution state (jobId, status, pid). Committing execution state artifacts to version control pollutes the repository and creates merge conflicts.",
+          "file": ".omc/state/job.json",
+          "line_start": 1,
+          "line_end": 1,
+          "confidence": 1,
+          "recommendation": "Remove .omc/state/job.json from git staging and ignore the .omc/ directory in .gitignore."
+        }
+      ],
+      "latencyMs": 35618
+    },
+    {
+      "verdict": "needs-attention",
+      "summary": "The change introduces an undeclared dependency, lacks secret validation, and commits transient runtime state.",
+      "findings": [
+        {
+          "severity": "critical",
+          "title": "Undeclared jsonwebtoken dependency",
+          "body": "src/token.js requires jsonwebtoken, but jsonwebtoken is not declared in package.json dependencies. Deploying this change to fresh environments or CI containers will result in MODULE_NOT_FOUND runtime crashes.",
+          "file": "src/token.js",
+          "line_start": 1,
+          "line_end": 1,
+          "confidence": 1,
+          "recommendation": "Add jsonwebtoken to package.json dependencies and update the package lockfile."
+        },
+        {
+          "severity": "high",
+          "title": "Missing JWT_SECRET configuration validation",
+          "body": "issue() passes process.env.JWT_SECRET directly to jwt.sign without verifying that it is set. If JWT_SECRET is undefined, jwt.sign throws a runtime error ('secretOrPrivateKey must have a value'), causing unhandled exceptions during token issuance.",
+          "file": "src/token.js",
+          "line_start": 3,
+          "line_end": 5,
+          "confidence": 0.95,
+          "recommendation": "Assert that process.env.JWT_SECRET is defined and non-empty before signing tokens or fail fast at startup."
+        },
+        {
+          "severity": "medium",
+          "title": "Transient runtime state file committed",
+          "body": "The commit introduces .omc/state/job.json, which contains ephemeral job metadata (jobId, status, pid). Tracking local runtime state files in version control pollutes the repository and risks state collisions across environments.",
+          "file": ".omc/state/job.json",
+          "line_start": 1,
+          "line_end": 1,
+          "confidence": 1,
+          "recommendation": "Remove .omc/state/job.json from git and ignore the .omc/ directory in .gitignore."
+        }
+      ],
+      "latencyMs": 45513
+    },
+    {
+      "verdict": "needs-attention",
+      "summary": "This change introduces an undeclared dependency on jsonwebtoken, unvalidated JWT secret usage, and commits ephemeral runner state.",
+      "findings": [
+        {
+          "severity": "critical",
+          "title": "Undeclared dependency 'jsonwebtoken' causes runtime failure",
+          "body": "src/token.js requires 'jsonwebtoken', but this package is not declared in package.json dependencies. Clean installations and production builds will fail at runtime with MODULE_NOT_FOUND when requiring this module.",
+          "file": "src/token.js",
+          "line_start": 1,
+          "line_end": 1,
+          "confidence": 1,
+          "recommendation": "Add 'jsonwebtoken' with an appropriate version constraint to dependencies in package.json."
+        },
+        {
+          "severity": "high",
+          "title": "Unvalidated JWT_SECRET compromises token signing and reliability",
+          "body": "jwt.sign is called directly with process.env.JWT_SECRET without checking if the environment variable is set. If unset, token issuance will throw an unhandled runtime error or sign with an invalid/empty secret, breaking authentication integrity.",
+          "file": "src/token.js",
+          "line_start": 3,
+          "line_end": 5,
+          "confidence": 0.95,
+          "recommendation": "Validate that process.env.JWT_SECRET is non-empty before signing, throwing an explicit configuration error if it is missing."
+        },
+        {
+          "severity": "medium",
+          "title": "Ephemeral job runner state committed to repository",
+          "body": ".omc/state/job.json contains local process state (jobId and pid) that was staged into version control. Committing transient runner artifacts pollutes git history and may cause state conflicts across environments.",
+          "file": ".omc/state/job.json",
+          "line_start": 1,
+          "line_end": 1,
+          "confidence": 0.95,
+          "recommendation": "Unstage and delete .omc/state/job.json from git and add .omc/ to .gitignore."
+        }
+      ],
+      "latencyMs": 41774
+    }
+  ],
+  "raw": "{\n  \"review\": \"Adversarial Review\",\n  \"target\": {\n    \"mode\": \"working-tree\",\n    \"label\": \"working tree diff\",\n    \"explicit\": true\n  },\n  \"engine\": \"agy\",\n  \"gemini\": {\n    \"status\": 0,\n    \"stdout\": \"{\\n  \\\"verdict\\\": \\\"needs-attention\\\",\\n  \\\"summary\\\": \\\"This change introduces an undeclared dependency on jsonwebtoken, unvalidated JWT secret usage, and commits ephemeral runner state.\\\",\\n  \\\"findings\\\": [\\n    {\\n      \\\"severity\\\": \\\"critical\\\",\\n      \\\"title\\\": \\\"Undeclared dependency 'jsonwebtoken' causes runtime failure\\\",\\n      \\\"body\\\": \\\"src/token.js requires 'jsonwebtoken', but this package is not declared in package.json dependencies. Clean installations and production builds will fail at runtime with MODULE_NOT_FOUND when requiring this module.\\\",\\n      \\\"file\\\": \\\"src/token.js\\\",\\n      \\\"line_start\\\": 1,\\n      \\\"line_end\\\": 1,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Add 'jsonwebtoken' with an appropriate version constraint to dependencies in package.json.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"high\\\",\\n      \\\"title\\\": \\\"Unvalidated JWT_SECRET compromises token signing and reliability\\\",\\n      \\\"body\\\": \\\"jwt.sign is called directly with process.env.JWT_SECRET without checking if the environment variable is set. If unset, token issuance will throw an unhandled runtime error or sign with an invalid/empty secret, breaking authentication integrity.\\\",\\n      \\\"file\\\": \\\"src/token.js\\\",\\n      \\\"line_start\\\": 3,\\n      \\\"line_end\\\": 5,\\n      \\\"confidence\\\": 0.95,\\n      \\\"recommendation\\\": \\\"Validate that process.env.JWT_SECRET is non-empty before signing, throwing an explicit configuration error if it is missing.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"medium\\\",\\n      \\\"title\\\": \\\"Ephemeral job runner state committed to repository\\\",\\n      \\\"body\\\": \\\".omc/state/job.json contains local process state (jobId and pid) that was staged into version control. Committing transient runner artifacts pollutes git history and may cause state conflicts across environments.\\\",\\n      \\\"file\\\": \\\".omc/state/job.json\\\",\\n      \\\"line_start\\\": 1,\\n      \\\"line_end\\\": 1,\\n      \\\"confidence\\\": 0.95,\\n      \\\"recommendation\\\": \\\"Unstage and delete .omc/state/job.json from git and add .omc/ to .gitignore.\\\"\\n    }\\n  ],\\n  \\\"next_steps\\\": [\\n    \\\"Add jsonwebtoken to package.json dependencies.\\\",\\n    \\\"Add guard checks for process.env.JWT_SECRET in src/token.js.\\\",\\n    \\\"Remove .omc/state/job.json from git and ignore .omc in .gitignore.\\\"\\n  ]\\n}\",\n    \"stderr\": \"\"\n  },\n  \"result\": {\n    \"verdict\": \"needs-attention\",\n    \"summary\": \"This change introduces an undeclared dependency on jsonwebtoken, unvalidated JWT secret usage, and commits ephemeral runner state.\",\n    \"findings\": [\n      {\n        \"severity\": \"critical\",\n        \"title\": \"Undeclared dependency 'jsonwebtoken' causes runtime failure\",\n        \"body\": \"src/token.js requires 'jsonwebtoken', but this package is not declared in package.json dependencies. Clean installations and production builds will fail at runtime with MODULE_NOT_FOUND when requiring this module.\",\n        \"file\": \"src/token.js\",\n        \"line_start\": 1,\n        \"line_end\": 1,\n        \"confidence\": 1,\n        \"recommendation\": \"Add 'jsonwebtoken' with an appropriate version constraint to dependencies in package.json.\"\n      },\n      {\n        \"severity\": \"high\",\n        \"title\": \"Unvalidated JWT_SECRET compromises token signing and reliability\",\n        \"body\": \"jwt.sign is called directly with process.env.JWT_SECRET without checking if the environment variable is set. If unset, token issuance will throw an unhandled runtime error or sign with an invalid/empty secret, breaking authentication integrity.\",\n        \"file\": \"src/token.js\",\n        \"line_start\": 3,\n        \"line_end\": 5,\n        \"confidence\": 0.95,\n        \"recommendation\": \"Validate that process.env.JWT_SECRET is non-empty before signing, throwing an explicit configuration error if it is missing.\"\n      },\n      {\n"
+}

--- a/bench/cassettes/repo-context/agy.deep.json
+++ b/bench/cassettes/repo-context/agy.deep.json
@@ -1,72 +1,110 @@
 {
   "caseId": "repo-context",
   "cell": "agy.deep",
-  "recordedAt": "2026-08-19T03:23:20.325Z",
+  "recordedAt": "2026-08-24T09:47:57.255Z",
   "verdict": "needs-attention",
-  "summary": "Undeclared dependency on jsonwebtoken, missing JWT_SECRET validation, and committed runtime state file require fixes.",
+  "summary": "Undeclared dependency on jsonwebtoken, unvalidated JWT secret, and stray runtime state file committed.",
   "findings": [
     {
-      "severity": "critical",
-      "title": "Undeclared dependency on jsonwebtoken",
-      "body": "src/token.js requires 'jsonwebtoken', but the package is missing from dependencies in package.json, which will cause MODULE_NOT_FOUND runtime crashes in production.",
+      "severity": "high",
+      "title": "Undeclared dependency 'jsonwebtoken'",
+      "body": "src/token.js imports 'jsonwebtoken', but this package is not declared under dependencies in package.json, which will cause MODULE_NOT_FOUND runtime errors in clean environments.",
       "file": "src/token.js",
       "line_start": 1,
       "line_end": 1,
       "confidence": 1,
-      "recommendation": "Add 'jsonwebtoken' to dependencies in package.json."
+      "recommendation": "Add 'jsonwebtoken' to dependencies in package.json (e.g. run npm install jsonwebtoken)."
     },
     {
       "severity": "high",
-      "title": "Unchecked JWT_SECRET environment variable",
-      "body": "issue() passes process.env.JWT_SECRET directly to jwt.sign() without validating that it is set. If JWT_SECRET is undefined, jwt.sign() throws a synchronous runtime exception.",
+      "title": "Missing validation for JWT_SECRET environment variable",
+      "body": "src/token.js calls jwt.sign using process.env.JWT_SECRET without checking if it is set. If JWT_SECRET is undefined, jwt.sign will throw an unhandled error at runtime.",
       "file": "src/token.js",
       "line_start": 3,
       "line_end": 5,
       "confidence": 0.95,
-      "recommendation": "Validate that process.env.JWT_SECRET is defined and non-empty before attempting to sign tokens, throwing an explicit configuration error if missing."
+      "recommendation": "Validate that process.env.JWT_SECRET is defined before signing or throw an explicit configuration error."
     },
     {
-      "severity": "low",
-      "title": "Committed runtime state file",
-      "body": ".omc/state/job.json contains transient process and job metadata (jobId, status, pid) that should not be tracked in version control.",
+      "severity": "medium",
+      "title": "Ephemeral job state file committed to source control",
+      "body": ".omc/state/job.json contains local process state (jobId, status, pid) and should not be tracked in version control.",
       "file": ".omc/state/job.json",
       "line_start": 1,
       "line_end": 1,
-      "confidence": 0.95,
+      "confidence": 1,
       "recommendation": "Remove .omc/state/job.json from git tracking and add .omc/ to .gitignore."
     }
   ],
-  "latencyMs": 28459,
-  "engineVersion": "1.1.14",
+  "latencyMs": 26296,
+  "engineVersion": "1.1.19",
+  "engineObserved": "agy",
   "samples": [
     {
       "verdict": "needs-attention",
-      "summary": "The changes introduce an undeclared dependency, unvalidated environment secret usage, and committed runtime state files.",
+      "summary": "The changes introduce an undeclared dependency, unvalidated JWT secret access, and a committed runtime state artifact.",
       "findings": [
         {
-          "severity": "critical",
-          "title": "Undeclared jsonwebtoken dependency",
-          "body": "src/token.js requires `jsonwebtoken`, but this package is not declared in `package.json` dependencies. This will cause `MODULE_NOT_FOUND` runtime crashes in fresh environments or production builds.",
+          "severity": "high",
+          "title": "Undeclared 'jsonwebtoken' dependency",
+          "body": "src/token.js requires 'jsonwebtoken', but the package is not declared in package.json dependencies, causing MODULE_NOT_FOUND errors on fresh installs and production builds.",
           "file": "src/token.js",
           "line_start": 1,
           "line_end": 1,
           "confidence": 1,
-          "recommendation": "Add `jsonwebtoken` to the `dependencies` section in `package.json`."
+          "recommendation": "Add 'jsonwebtoken' to dependencies in package.json by running `npm install jsonwebtoken`."
         },
         {
           "severity": "high",
-          "title": "Unvalidated JWT_SECRET environment variable",
-          "body": "In `src/token.js`, `jwt.sign()` uses `process.env.JWT_SECRET` without verifying that it is defined. If the environment variable is missing, `jwt.sign()` will throw an uncaught error at runtime or fail securely signing tokens.",
+          "title": "Missing JWT_SECRET environment variable check",
+          "body": "issue() calls jwt.sign() directly with process.env.JWT_SECRET. If JWT_SECRET is unset, jwt.sign() throws a synchronous runtime exception ('secretOrPrivateKey must have a value') when issuing tokens.",
           "file": "src/token.js",
           "line_start": 3,
           "line_end": 5,
           "confidence": 0.95,
-          "recommendation": "Assert that `process.env.JWT_SECRET` is set and non-empty before calling `jwt.sign()`, throwing a clear configuration error if unset."
+          "recommendation": "Validate that process.env.JWT_SECRET is defined before signing, or validate required environment variables at application startup."
         },
         {
-          "severity": "medium",
-          "title": "Transient runtime state file added to git",
-          "body": "`.omc/state/job.json` contains transient local process metadata (job ID, pid, status) that should not be tracked in version control.",
+          "severity": "low",
+          "title": "Runtime state file committed to repository",
+          "body": ".omc/state/job.json is an internal runtime job state file (storing PID and job status) that should not be committed to version control.",
+          "file": ".omc/state/job.json",
+          "line_start": 1,
+          "line_end": 1,
+          "confidence": 0.95,
+          "recommendation": "Remove .omc/state/job.json from git staging/tracking and add .omc/ to .gitignore."
+        }
+      ],
+      "latencyMs": 42567
+    },
+    {
+      "verdict": "needs-attention",
+      "summary": "Identified undeclared `jsonwebtoken` dependency, missing `JWT_SECRET` environment variable validation, and a stray runtime state file.",
+      "findings": [
+        {
+          "severity": "high",
+          "title": "Undeclared `jsonwebtoken` dependency",
+          "body": "`src/token.js` imports `jsonwebtoken`, but the package is not declared in `package.json` `dependencies`. Running this code in a clean environment will result in a runtime `MODULE_NOT_FOUND` error.",
+          "file": "src/token.js",
+          "line_start": 1,
+          "line_end": 1,
+          "confidence": 1,
+          "recommendation": "Add `jsonwebtoken` to `dependencies` in `package.json`."
+        },
+        {
+          "severity": "high",
+          "title": "Unvalidated `process.env.JWT_SECRET`",
+          "body": "`issue()` passes `process.env.JWT_SECRET` directly to `jwt.sign()` without asserting that the environment variable is configured. If undefined, `jwt.sign()` will throw an error at runtime.",
+          "file": "src/token.js",
+          "line_start": 3,
+          "line_end": 5,
+          "confidence": 0.95,
+          "recommendation": "Validate that `process.env.JWT_SECRET` is defined and non-empty before signing, throwing a clear configuration error if missing."
+        },
+        {
+          "severity": "low",
+          "title": "Ephemeral runtime state file tracked in git",
+          "body": "`.omc/state/job.json` contains ephemeral execution state (`jobId`, `pid`, `status`). Committing local runner state into version control can cause merge conflicts and clutter history.",
           "file": ".omc/state/job.json",
           "line_start": 1,
           "line_end": 1,
@@ -74,82 +112,45 @@
           "recommendation": "Remove `.omc/state/job.json` from git and add `.omc/` to `.gitignore`."
         }
       ],
-      "latencyMs": 27868
+      "latencyMs": 25072
     },
     {
       "verdict": "needs-attention",
-      "summary": "The change introduces an undeclared dependency on jsonwebtoken, unvalidated JWT secret access, and a committed ephemeral tool state file.",
+      "summary": "Undeclared dependency on jsonwebtoken, unvalidated JWT secret, and stray runtime state file committed.",
       "findings": [
         {
           "severity": "high",
-          "title": "Undeclared dependency on jsonwebtoken",
-          "body": "src/token.js requires jsonwebtoken, but the package is not listed in dependencies in package.json. Importing or running this module in clean or production environments will fail with a MODULE_NOT_FOUND error.",
+          "title": "Undeclared dependency 'jsonwebtoken'",
+          "body": "src/token.js imports 'jsonwebtoken', but this package is not declared under dependencies in package.json, which will cause MODULE_NOT_FOUND runtime errors in clean environments.",
           "file": "src/token.js",
           "line_start": 1,
           "line_end": 1,
           "confidence": 1,
-          "recommendation": "Add jsonwebtoken to dependencies in package.json by running npm install jsonwebtoken."
+          "recommendation": "Add 'jsonwebtoken' to dependencies in package.json (e.g. run npm install jsonwebtoken)."
+        },
+        {
+          "severity": "high",
+          "title": "Missing validation for JWT_SECRET environment variable",
+          "body": "src/token.js calls jwt.sign using process.env.JWT_SECRET without checking if it is set. If JWT_SECRET is undefined, jwt.sign will throw an unhandled error at runtime.",
+          "file": "src/token.js",
+          "line_start": 3,
+          "line_end": 5,
+          "confidence": 0.95,
+          "recommendation": "Validate that process.env.JWT_SECRET is defined before signing or throw an explicit configuration error."
         },
         {
           "severity": "medium",
-          "title": "Unvalidated JWT secret environment variable",
-          "body": "src/token.js passes process.env.JWT_SECRET directly to jwt.sign without verifying it is present. If the environment variable is unset, jwt.sign throws a runtime error (or generates insecure tokens depending on configuration).",
-          "file": "src/token.js",
-          "line_start": 3,
-          "line_end": 5,
-          "confidence": 0.95,
-          "recommendation": "Validate that process.env.JWT_SECRET is defined and non-empty before signing, throwing an explicit descriptive error if missing."
-        },
-        {
-          "severity": "low",
-          "title": "Transient job state file tracked in git",
-          "body": ".omc/state/job.json contains ephemeral process metadata (jobId, status, pid) from a local execution run and should not be committed to version control.",
+          "title": "Ephemeral job state file committed to source control",
+          "body": ".omc/state/job.json contains local process state (jobId, status, pid) and should not be tracked in version control.",
           "file": ".omc/state/job.json",
           "line_start": 1,
           "line_end": 1,
           "confidence": 1,
-          "recommendation": "Remove .omc/state/job.json from git staging/tracking and add .omc/ to .gitignore."
-        }
-      ],
-      "latencyMs": 29434
-    },
-    {
-      "verdict": "needs-attention",
-      "summary": "Undeclared dependency on jsonwebtoken, missing JWT_SECRET validation, and committed runtime state file require fixes.",
-      "findings": [
-        {
-          "severity": "critical",
-          "title": "Undeclared dependency on jsonwebtoken",
-          "body": "src/token.js requires 'jsonwebtoken', but the package is missing from dependencies in package.json, which will cause MODULE_NOT_FOUND runtime crashes in production.",
-          "file": "src/token.js",
-          "line_start": 1,
-          "line_end": 1,
-          "confidence": 1,
-          "recommendation": "Add 'jsonwebtoken' to dependencies in package.json."
-        },
-        {
-          "severity": "high",
-          "title": "Unchecked JWT_SECRET environment variable",
-          "body": "issue() passes process.env.JWT_SECRET directly to jwt.sign() without validating that it is set. If JWT_SECRET is undefined, jwt.sign() throws a synchronous runtime exception.",
-          "file": "src/token.js",
-          "line_start": 3,
-          "line_end": 5,
-          "confidence": 0.95,
-          "recommendation": "Validate that process.env.JWT_SECRET is defined and non-empty before attempting to sign tokens, throwing an explicit configuration error if missing."
-        },
-        {
-          "severity": "low",
-          "title": "Committed runtime state file",
-          "body": ".omc/state/job.json contains transient process and job metadata (jobId, status, pid) that should not be tracked in version control.",
-          "file": ".omc/state/job.json",
-          "line_start": 1,
-          "line_end": 1,
-          "confidence": 0.95,
           "recommendation": "Remove .omc/state/job.json from git tracking and add .omc/ to .gitignore."
         }
       ],
-      "latencyMs": 28459
+      "latencyMs": 26296
     }
   ],
-  "raw": "{\n  \"review\": \"Review\",\n  \"target\": {\n    \"mode\": \"working-tree\",\n    \"label\": \"working tree diff\",\n    \"explicit\": true\n  },\n  \"gemini\": {\n    \"status\": 0,\n    \"stdout\": \"{\\n  \\\"verdict\\\": \\\"needs-attention\\\",\\n  \\\"summary\\\": \\\"Undeclared dependency on jsonwebtoken, missing JWT_SECRET validation, and committed runtime state file require fixes.\\\",\\n  \\\"findings\\\": [\\n    {\\n      \\\"severity\\\": \\\"critical\\\",\\n      \\\"title\\\": \\\"Undeclared dependency on jsonwebtoken\\\",\\n      \\\"body\\\": \\\"src/token.js requires 'jsonwebtoken', but the package is missing from dependencies in package.json, which will cause MODULE_NOT_FOUND runtime crashes in production.\\\",\\n      \\\"file\\\": \\\"src/token.js\\\",\\n      \\\"line_start\\\": 1,\\n      \\\"line_end\\\": 1,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Add 'jsonwebtoken' to dependencies in package.json.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"high\\\",\\n      \\\"title\\\": \\\"Unchecked JWT_SECRET environment variable\\\",\\n      \\\"body\\\": \\\"issue() passes process.env.JWT_SECRET directly to jwt.sign() without validating that it is set. If JWT_SECRET is undefined, jwt.sign() throws a synchronous runtime exception.\\\",\\n      \\\"file\\\": \\\"src/token.js\\\",\\n      \\\"line_start\\\": 3,\\n      \\\"line_end\\\": 5,\\n      \\\"confidence\\\": 0.95,\\n      \\\"recommendation\\\": \\\"Validate that process.env.JWT_SECRET is defined and non-empty before attempting to sign tokens, throwing an explicit configuration error if missing.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"low\\\",\\n      \\\"title\\\": \\\"Committed runtime state file\\\",\\n      \\\"body\\\": \\\".omc/state/job.json contains transient process and job metadata (jobId, status, pid) that should not be tracked in version control.\\\",\\n      \\\"file\\\": \\\".omc/state/job.json\\\",\\n      \\\"line_start\\\": 1,\\n      \\\"line_end\\\": 1,\\n      \\\"confidence\\\": 0.95,\\n      \\\"recommendation\\\": \\\"Remove .omc/state/job.json from git tracking and add .omc/ to .gitignore.\\\"\\n    }\\n  ],\\n  \\\"next_steps\\\": [\\n    \\\"Install and add jsonwebtoken to package.json dependencies.\\\",\\n    \\\"Add environment variable validation for JWT_SECRET in src/token.js.\\\",\\n    \\\"Delete .omc/state/job.json and add .omc/ to .gitignore.\\\"\\n  ]\\n}\",\n    \"stderr\": \"\"\n  },\n  \"result\": {\n    \"verdict\": \"needs-attention\",\n    \"summary\": \"Undeclared dependency on jsonwebtoken, missing JWT_SECRET validation, and committed runtime state file require fixes.\",\n    \"findings\": [\n      {\n        \"severity\": \"critical\",\n        \"title\": \"Undeclared dependency on jsonwebtoken\",\n        \"body\": \"src/token.js requires 'jsonwebtoken', but the package is missing from dependencies in package.json, which will cause MODULE_NOT_FOUND runtime crashes in production.\",\n        \"file\": \"src/token.js\",\n        \"line_start\": 1,\n        \"line_end\": 1,\n        \"confidence\": 1,\n        \"recommendation\": \"Add 'jsonwebtoken' to dependencies in package.json.\"\n      },\n      {\n        \"severity\": \"high\",\n        \"title\": \"Unchecked JWT_SECRET environment variable\",\n        \"body\": \"issue() passes process.env.JWT_SECRET directly to jwt.sign() without validating that it is set. If JWT_SECRET is undefined, jwt.sign() throws a synchronous runtime exception.\",\n        \"file\": \"src/token.js\",\n        \"line_start\": 3,\n        \"line_end\": 5,\n        \"confidence\": 0.95,\n        \"recommendation\": \"Validate that process.env.JWT_SECRET is defined and non-empty before attempting to sign tokens, throwing an explicit configuration error if missing.\"\n      },\n      {\n        \"severity\": \"low\",\n        \"title\": \"Committed runtime state file\",\n        \"body\": \".omc/state/job.json contains transient process and job metadata (jobId, status, pid) that should not be tracked in version control.\",\n        \"file\": \".omc/state/job.json\",\n        \"line_start\": 1,\n        \"line_end\": 1,\n        \"confidence\": 0.95,\n        \"recommendation\": \"Remove .omc/state/job.json from git tracking and add .omc/ to .gitignore.\"\n      }\n    ],\n    \"next_steps\": [\n      \"Install and add jsonwebtoken t"
+  "raw": "{\n  \"review\": \"Review\",\n  \"target\": {\n    \"mode\": \"working-tree\",\n    \"label\": \"working tree diff\",\n    \"explicit\": true\n  },\n  \"engine\": \"agy\",\n  \"gemini\": {\n    \"status\": 0,\n    \"stdout\": \"{\\n  \\\"verdict\\\": \\\"needs-attention\\\",\\n  \\\"summary\\\": \\\"Undeclared dependency on jsonwebtoken, unvalidated JWT secret, and stray runtime state file committed.\\\",\\n  \\\"findings\\\": [\\n    {\\n      \\\"severity\\\": \\\"high\\\",\\n      \\\"title\\\": \\\"Undeclared dependency 'jsonwebtoken'\\\",\\n      \\\"body\\\": \\\"src/token.js imports 'jsonwebtoken', but this package is not declared under dependencies in package.json, which will cause MODULE_NOT_FOUND runtime errors in clean environments.\\\",\\n      \\\"file\\\": \\\"src/token.js\\\",\\n      \\\"line_start\\\": 1,\\n      \\\"line_end\\\": 1,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Add 'jsonwebtoken' to dependencies in package.json (e.g. run npm install jsonwebtoken).\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"high\\\",\\n      \\\"title\\\": \\\"Missing validation for JWT_SECRET environment variable\\\",\\n      \\\"body\\\": \\\"src/token.js calls jwt.sign using process.env.JWT_SECRET without checking if it is set. If JWT_SECRET is undefined, jwt.sign will throw an unhandled error at runtime.\\\",\\n      \\\"file\\\": \\\"src/token.js\\\",\\n      \\\"line_start\\\": 3,\\n      \\\"line_end\\\": 5,\\n      \\\"confidence\\\": 0.95,\\n      \\\"recommendation\\\": \\\"Validate that process.env.JWT_SECRET is defined before signing or throw an explicit configuration error.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"medium\\\",\\n      \\\"title\\\": \\\"Ephemeral job state file committed to source control\\\",\\n      \\\"body\\\": \\\".omc/state/job.json contains local process state (jobId, status, pid) and should not be tracked in version control.\\\",\\n      \\\"file\\\": \\\".omc/state/job.json\\\",\\n      \\\"line_start\\\": 1,\\n      \\\"line_end\\\": 1,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Remove .omc/state/job.json from git tracking and add .omc/ to .gitignore.\\\"\\n    }\\n  ],\\n  \\\"next_steps\\\": [\\n    \\\"Install and add jsonwebtoken to package.json dependencies.\\\",\\n    \\\"Add guard check for process.env.JWT_SECRET in src/token.js.\\\",\\n    \\\"Remove .omc/state/job.json and ignore .omc in .gitignore.\\\"\\n  ]\\n}\",\n    \"stderr\": \"\"\n  },\n  \"result\": {\n    \"verdict\": \"needs-attention\",\n    \"summary\": \"Undeclared dependency on jsonwebtoken, unvalidated JWT secret, and stray runtime state file committed.\",\n    \"findings\": [\n      {\n        \"severity\": \"high\",\n        \"title\": \"Undeclared dependency 'jsonwebtoken'\",\n        \"body\": \"src/token.js imports 'jsonwebtoken', but this package is not declared under dependencies in package.json, which will cause MODULE_NOT_FOUND runtime errors in clean environments.\",\n        \"file\": \"src/token.js\",\n        \"line_start\": 1,\n        \"line_end\": 1,\n        \"confidence\": 1,\n        \"recommendation\": \"Add 'jsonwebtoken' to dependencies in package.json (e.g. run npm install jsonwebtoken).\"\n      },\n      {\n        \"severity\": \"high\",\n        \"title\": \"Missing validation for JWT_SECRET environment variable\",\n        \"body\": \"src/token.js calls jwt.sign using process.env.JWT_SECRET without checking if it is set. If JWT_SECRET is undefined, jwt.sign will throw an unhandled error at runtime.\",\n        \"file\": \"src/token.js\",\n        \"line_start\": 3,\n        \"line_end\": 5,\n        \"confidence\": 0.95,\n        \"recommendation\": \"Validate that process.env.JWT_SECRET is defined before signing or throw an explicit configuration error.\"\n      },\n      {\n        \"severity\": \"medium\",\n        \"title\": \"Ephemeral job state file committed to source control\",\n        \"body\": \".omc/state/job.json contains local process state (jobId, status, pid) and should not be tracked in version control.\",\n        \"file\": \".omc/state/job.json\",\n        \"line_start\": 1,\n        \"line_end\": 1,\n        \"confidence\": 1,\n        \"recommendation\": \"Remove .omc/state/job.json from git tracking and add .omc/ to .gitignore.\"\n      }\n    ],\n    \"next_steps\": [\n      \"Install and add jso"
 }

--- a/bench/cassettes/repo-context/agy.model.json
+++ b/bench/cassettes/repo-context/agy.model.json
@@ -1,75 +1,116 @@
 {
   "caseId": "repo-context",
   "cell": "agy.model",
-  "recordedAt": "2026-08-19T03:20:21.493Z",
+  "recordedAt": "2026-08-24T05:04:18.964Z",
   "verdict": "needs-attention",
-  "summary": "Token generation relies on process.env.JWT_SECRET without validation, leading to runtime failures or insecure signing if unconfigured.",
+  "summary": "JWT signing secret is used without any existence or strength check, and runtime state containing a PID is committed to source control.",
   "findings": [
     {
       "severity": "high",
-      "title": "Unvalidated JWT_SECRET environment variable",
-      "body": "jwt.sign directly uses process.env.JWT_SECRET without checking if it is defined. If the environment variable is missing or empty, jsonwebtoken throws an unhandled error ('secretOrPrivateKey must have a value'), causing token generation to fail unexpectedly.",
+      "title": "No guard on undefined JWT_SECRET",
+      "body": "process.env.JWT_SECRET is passed directly to jwt.sign() with no prior check. If the environment variable is unset, the value is `undefined`. While modern jsonwebtoken (v8+) throws for an undefined secret with HS256, the resulting error is an opaque library exception ('secretOrPrivateKey must have a value') rather than a clear configuration error, and there is no try/catch or fail-fast validation. In older library versions or if the algorithm were ever changed to 'none', this could silently produce unsigned tokens—a catastrophic auth bypass.",
       "file": "src/token.js",
       "line_start": 4,
       "line_end": 4,
-      "confidence": 0.95,
-      "recommendation": "Validate that process.env.JWT_SECRET is defined and non-empty before signing, throwing a clear error or enforcing startup environment checks, and specify an explicit signing algorithm."
+      "confidence": 0.92,
+      "recommendation": "Validate the secret at module load time: `const secret = process.env.JWT_SECRET; if (!secret) throw new Error('JWT_SECRET env var is required');` and pass `secret` to jwt.sign(). This fails fast on startup instead of on the first token request."
+    },
+    {
+      "severity": "medium",
+      "title": "Runtime state file with PID committed to version control",
+      "body": ".omc/state/job.json contains a hardcoded process ID (4242) and runtime job status. Committing runtime state means every developer or CI clone inherits a stale PID reference, the file will generate constant merge noise, and internal process metadata is leaked into the repository history.",
+      "file": ".omc/state/job.json",
+      "line_start": 1,
+      "line_end": 1,
+      "confidence": 0.85,
+      "recommendation": "Add `.omc/state/` to .gitignore and remove the file from tracking with `git rm --cached .omc/state/job.json`. Generate this file at runtime only."
     }
   ],
-  "latencyMs": 18495,
-  "engineVersion": "1.1.14",
+  "latencyMs": 49967,
+  "engineVersion": "1.1.19",
+  "engineObserved": null,
   "samples": [
     {
       "verdict": "needs-attention",
-      "summary": "The token issuance function lacks validation for the secret key environment variable, causing runtime exceptions if unset.",
+      "summary": "JWT signing secret is never validated, allowing tokens signed with an undefined or empty key, and runtime state containing a PID is committed to version control.",
       "findings": [
         {
-          "severity": "high",
-          "title": "Unvalidated JWT secret key",
-          "body": "process.env.JWT_SECRET is passed directly to jwt.sign without checking if it is defined. If the environment variable is missing or empty, jwt.sign throws a runtime error or risks signing tokens with an invalid key.",
+          "severity": "critical",
+          "title": "JWT_SECRET used without validation — tokens may be signed with empty/undefined key",
+          "body": "process.env.JWT_SECRET is passed directly to jwt.sign() with no existence or length check. If the env var is unset, jwt.sign() throws an opaque error at call time rather than at startup. Worse, if JWT_SECRET is set to an empty string, jsonwebtoken silently accepts it and produces a token signed with a zero-length secret, which any party can forge. This is an authentication bypass.",
           "file": "src/token.js",
           "line_start": 4,
           "line_end": 4,
           "confidence": 0.95,
-          "recommendation": "Validate that process.env.JWT_SECRET is defined and non-empty prior to signing, throwing a clear configuration error if missing."
+          "recommendation": "Guard at module load: const secret = process.env.JWT_SECRET; if (!secret) throw new Error('JWT_SECRET env var must be set and non-empty'); — then use the validated `secret` in jwt.sign()."
+        },
+        {
+          "severity": "medium",
+          "title": "Runtime state file with PID committed to repository",
+          "body": ".omc/state/job.json contains a process ID (4242) and transient job status. Committing machine-local runtime state to version control causes spurious diffs, merge conflicts, and leaks host information. It will also be stale on any other checkout.",
+          "file": ".omc/state/job.json",
+          "line_start": 1,
+          "line_end": 1,
+          "confidence": 0.85,
+          "recommendation": "Add .omc/state/ to .gitignore and remove this file from tracking (git rm --cached)."
         }
       ],
-      "latencyMs": 18450
+      "latencyMs": 43395
     },
     {
       "verdict": "needs-attention",
-      "summary": "Token signing lacks validation for the JWT_SECRET environment variable, leading to unhandled runtime errors if unset.",
+      "summary": "JWT signing secret is used without any existence check, and runtime state is committed to version control.",
       "findings": [
         {
-          "severity": "high",
-          "title": "Unchecked JWT_SECRET environment variable",
-          "body": "jwt.sign is called with process.env.JWT_SECRET without verifying that the secret exists. If the environment variable is missing, jsonwebtoken throws a synchronous error ('\"secretOrPrivateKey\" must have a value'), causing unhandled exceptions during token issuance.",
-          "file": "src/token.js",
-          "line_start": 3,
-          "line_end": 5,
-          "confidence": 0.95,
-          "recommendation": "Validate that process.env.JWT_SECRET is present and non-empty before signing, throwing a clear configuration error if it is not configured."
-        }
-      ],
-      "latencyMs": 19571
-    },
-    {
-      "verdict": "needs-attention",
-      "summary": "Token generation relies on process.env.JWT_SECRET without validation, leading to runtime failures or insecure signing if unconfigured.",
-      "findings": [
-        {
-          "severity": "high",
-          "title": "Unvalidated JWT_SECRET environment variable",
-          "body": "jwt.sign directly uses process.env.JWT_SECRET without checking if it is defined. If the environment variable is missing or empty, jsonwebtoken throws an unhandled error ('secretOrPrivateKey must have a value'), causing token generation to fail unexpectedly.",
+          "severity": "critical",
+          "title": "JWT_SECRET used without validation — undefined secret risks unsigned or weakly-signed tokens",
+          "body": "jwt.sign() receives process.env.JWT_SECRET directly. If the environment variable is unset, the value is undefined. Behaviour then depends on the jsonwebtoken library version: modern versions (≥9) throw an opaque error, but older versions could silently produce an unsigned (alg:none) or empty-secret-signed token, which any attacker can forge. Even in the throwing case, the caller gets no meaningful error context and the failure is unhandled.",
           "file": "src/token.js",
           "line_start": 4,
           "line_end": 4,
           "confidence": 0.95,
-          "recommendation": "Validate that process.env.JWT_SECRET is defined and non-empty before signing, throwing a clear error or enforcing startup environment checks, and specify an explicit signing algorithm."
+          "recommendation": "Validate the secret at module load time: const SECRET = process.env.JWT_SECRET; if (!SECRET) throw new Error('JWT_SECRET environment variable is required'); and pass SECRET to jwt.sign()."
+        },
+        {
+          "severity": "medium",
+          "title": "Runtime state file with ephemeral PID committed to repository",
+          "body": ".omc/state/job.json contains a process ID (4242) and runtime job status. PIDs are machine-specific and ephemeral; committing this file pollutes version history with per-run artefacts, causes needless merge conflicts, and may leak internal operational details. This is almost certainly meant to be a local-only runtime file.",
+          "file": ".omc/state/job.json",
+          "line_start": 1,
+          "line_end": 1,
+          "confidence": 0.9,
+          "recommendation": "Add .omc/state/ (or the entire .omc/ directory) to .gitignore and remove this file from tracking with git rm --cached."
         }
       ],
-      "latencyMs": 18495
+      "latencyMs": 47393
+    },
+    {
+      "verdict": "needs-attention",
+      "summary": "JWT signing secret is used without any existence or strength check, and runtime state containing a PID is committed to source control.",
+      "findings": [
+        {
+          "severity": "high",
+          "title": "No guard on undefined JWT_SECRET",
+          "body": "process.env.JWT_SECRET is passed directly to jwt.sign() with no prior check. If the environment variable is unset, the value is `undefined`. While modern jsonwebtoken (v8+) throws for an undefined secret with HS256, the resulting error is an opaque library exception ('secretOrPrivateKey must have a value') rather than a clear configuration error, and there is no try/catch or fail-fast validation. In older library versions or if the algorithm were ever changed to 'none', this could silently produce unsigned tokens—a catastrophic auth bypass.",
+          "file": "src/token.js",
+          "line_start": 4,
+          "line_end": 4,
+          "confidence": 0.92,
+          "recommendation": "Validate the secret at module load time: `const secret = process.env.JWT_SECRET; if (!secret) throw new Error('JWT_SECRET env var is required');` and pass `secret` to jwt.sign(). This fails fast on startup instead of on the first token request."
+        },
+        {
+          "severity": "medium",
+          "title": "Runtime state file with PID committed to version control",
+          "body": ".omc/state/job.json contains a hardcoded process ID (4242) and runtime job status. Committing runtime state means every developer or CI clone inherits a stale PID reference, the file will generate constant merge noise, and internal process metadata is leaked into the repository history.",
+          "file": ".omc/state/job.json",
+          "line_start": 1,
+          "line_end": 1,
+          "confidence": 0.85,
+          "recommendation": "Add `.omc/state/` to .gitignore and remove the file from tracking with `git rm --cached .omc/state/job.json`. Generate this file at runtime only."
+        }
+      ],
+      "latencyMs": 49967
     }
   ],
-  "raw": "{\"conversation_id\":\"e5e7cf3a-6022-4d7e-9000-b828fb916ec3\",\"status\":\"SUCCESS\",\"response\":\"{\\n  \\\"verdict\\\": \\\"needs-attention\\\",\\n  \\\"summary\\\": \\\"Token generation relies on process.env.JWT_SECRET without validation, leading to runtime failures or insecure signing if unconfigured.\\\",\\n  \\\"findings\\\": [\\n    {\\n      \\\"severity\\\": \\\"high\\\",\\n      \\\"title\\\": \\\"Unvalidated JWT_SECRET environment variable\\\",\\n      \\\"body\\\": \\\"jwt.sign directly uses process.env.JWT_SECRET without checking if it is defined. If the environment variable is missing or empty, jsonwebtoken throws an unhandled error ('secretOrPrivateKey must have a value'), causing token generation to fail unexpectedly.\\\",\\n      \\\"file\\\": \\\"src/token.js\\\",\\n      \\\"line_start\\\": 4,\\n      \\\"line_end\\\": 4,\\n      \\\"confidence\\\": 0.95,\\n      \\\"recommendation\\\": \\\"Validate that process.env.JWT_SECRET is defined and non-empty before signing, throwing a clear error or enforcing startup environment checks, and specify an explicit signing algorithm.\\\"\\n    }\\n  ],\\n  \\\"next_steps\\\": [\\n    \\\"Add an environment variable guard check for JWT_SECRET in src/token.js or during app initialization.\\\",\\n    \\\"Explicitly set algorithm (e.g., 'HS256') in jwt.sign options to avoid relying on library defaults.\\\"\\n  ]\\n}\\n\",\"duration_seconds\":14.0636541,\"num_turns\":1,\"usage\":{\"input_tokens\":18972,\"output_tokens\":1369,\"thinking_tokens\":1108,\"cache_read_tokens\":0,\"total_tokens\":20341}}\n"
+  "raw": "{\"conversation_id\":\"2783ab69-a0f0-4919-bf13-47037cf62129\",\"status\":\"SUCCESS\",\"response\":\"{\\\"verdict\\\":\\\"needs-attention\\\",\\\"summary\\\":\\\"JWT signing secret is used without any existence or strength check, and runtime state containing a PID is committed to source control.\\\",\\\"findings\\\":[{\\\"severity\\\":\\\"high\\\",\\\"title\\\":\\\"No guard on undefined JWT_SECRET\\\",\\\"body\\\":\\\"process.env.JWT_SECRET is passed directly to jwt.sign() with no prior check. If the environment variable is unset, the value is `undefined`. While modern jsonwebtoken (v8+) throws for an undefined secret with HS256, the resulting error is an opaque library exception ('secretOrPrivateKey must have a value') rather than a clear configuration error, and there is no try/catch or fail-fast validation. In older library versions or if the algorithm were ever changed to 'none', this could silently produce unsigned tokens—a catastrophic auth bypass.\\\",\\\"file\\\":\\\"src/token.js\\\",\\\"line_start\\\":4,\\\"line_end\\\":4,\\\"confidence\\\":0.92,\\\"recommendation\\\":\\\"Validate the secret at module load time: `const secret = process.env.JWT_SECRET; if (!secret) throw new Error('JWT_SECRET env var is required');` and pass `secret` to jwt.sign(). This fails fast on startup instead of on the first token request.\\\"},{\\\"severity\\\":\\\"medium\\\",\\\"title\\\":\\\"Runtime state file with PID committed to version control\\\",\\\"body\\\":\\\".omc/state/job.json contains a hardcoded process ID (4242) and runtime job status. Committing runtime state means every developer or CI clone inherits a stale PID reference, the file will generate constant merge noise, and internal process metadata is leaked into the repository history.\\\",\\\"file\\\":\\\".omc/state/job.json\\\",\\\"line_start\\\":1,\\\"line_end\\\":1,\\\"confidence\\\":0.85,\\\"recommendation\\\":\\\"Add `.omc/state/` to .gitignore and remove the file from tracking with `git rm --cached .omc/state/job.json`. Generate this file at runtime only.\\\"}],\\\"next_steps\\\":[\\\"Add a fail-fast check for JWT_SECRET at module load time in src/token.js\\\",\\\"Add .omc/state/ to .gitignore and remove the tracked state file from the repository\\\"]}\\n\",\"duration_seconds\":45.7332332,\"num_turns\":1,\"usage\":{\"input_tokens\":22503,\"output_tokens\":1181,\"thinking_tokens\":0,\"cache_read_tokens\":0,\"total_tokens\":23684}}\n"
 }

--- a/bench/cassettes/repo-context/agy.shallow.json
+++ b/bench/cassettes/repo-context/agy.shallow.json
@@ -1,0 +1,96 @@
+{
+  "caseId": "repo-context",
+  "cell": "agy.shallow",
+  "recordedAt": "2026-08-24T15:32:17.664Z",
+  "verdict": "needs-attention",
+  "summary": "JWT issuance lacks validation for the secret environment variable and a transient state file is tracked in git.",
+  "findings": [
+    {
+      "severity": "medium",
+      "title": "Missing validation for JWT_SECRET environment variable",
+      "body": "In src/token.js (lines 3-5), issue() passes process.env.JWT_SECRET directly into jwt.sign() without checking if it is defined. If the environment variable is unset, jwt.sign() throws a synchronous runtime exception ('secretOrPrivateKey must have a value').",
+      "file": "src/token.js",
+      "line_start": 3,
+      "line_end": 5,
+      "confidence": 0.95,
+      "recommendation": "Assert that process.env.JWT_SECRET is defined before calling jwt.sign, or fail fast with a descriptive configuration error."
+    },
+    {
+      "severity": "low",
+      "title": "Ephemeral runtime state file committed to repository",
+      "body": "In .omc/state/job.json (line 1), a runtime execution state file containing a process ID (pid: 4242) and job status is tracked, which can cause repository pollution and merge conflicts across different environments.",
+      "file": ".omc/state/job.json",
+      "line_start": 1,
+      "line_end": 1,
+      "confidence": 0.9,
+      "recommendation": "Remove .omc/state/job.json from git and add .omc/ to .gitignore."
+    }
+  ],
+  "latencyMs": 17230,
+  "engineVersion": "1.1.19",
+  "engineObserved": "agy",
+  "samples": [
+    {
+      "verdict": "needs-attention",
+      "summary": "Token generation lacks validation for the JWT_SECRET environment variable.",
+      "findings": [
+        {
+          "severity": "medium",
+          "title": "Missing validation for JWT_SECRET environment variable",
+          "body": "In src/token.js, issue() passes process.env.JWT_SECRET directly to jwt.sign() without verifying that the variable is defined. If JWT_SECRET is unset or empty, jwt.sign() throws a runtime error, causing token issuance to fail without a clear configuration error.",
+          "file": "src/token.js",
+          "line_start": 3,
+          "line_end": 5,
+          "confidence": 0.95,
+          "recommendation": "Validate that process.env.JWT_SECRET is defined and non-empty before calling jwt.sign(), throwing a descriptive error or failing fast at startup if it is missing."
+        }
+      ],
+      "latencyMs": 17542
+    },
+    {
+      "verdict": "needs-attention",
+      "summary": "The token issuing function lacks validation for the JWT_SECRET environment variable, causing synchronous runtime failures when unset.",
+      "findings": [
+        {
+          "severity": "high",
+          "title": "Missing validation for JWT_SECRET environment variable",
+          "body": "In src/token.js, jwt.sign is called with process.env.JWT_SECRET without ensuring the environment variable is defined. If JWT_SECRET is unset or empty, jsonwebtoken throws a synchronous error ('secretOrPrivateKey must have a value'), leading to uncaught runtime exceptions during token generation.",
+          "file": "src/token.js",
+          "line_start": 3,
+          "line_end": 5,
+          "confidence": 0.95,
+          "recommendation": "Validate that process.env.JWT_SECRET is defined and non-empty before invoking jwt.sign, or enforce configuration existence during application startup."
+        }
+      ],
+      "latencyMs": 19337
+    },
+    {
+      "verdict": "needs-attention",
+      "summary": "JWT issuance lacks validation for the secret environment variable and a transient state file is tracked in git.",
+      "findings": [
+        {
+          "severity": "medium",
+          "title": "Missing validation for JWT_SECRET environment variable",
+          "body": "In src/token.js (lines 3-5), issue() passes process.env.JWT_SECRET directly into jwt.sign() without checking if it is defined. If the environment variable is unset, jwt.sign() throws a synchronous runtime exception ('secretOrPrivateKey must have a value').",
+          "file": "src/token.js",
+          "line_start": 3,
+          "line_end": 5,
+          "confidence": 0.95,
+          "recommendation": "Assert that process.env.JWT_SECRET is defined before calling jwt.sign, or fail fast with a descriptive configuration error."
+        },
+        {
+          "severity": "low",
+          "title": "Ephemeral runtime state file committed to repository",
+          "body": "In .omc/state/job.json (line 1), a runtime execution state file containing a process ID (pid: 4242) and job status is tracked, which can cause repository pollution and merge conflicts across different environments.",
+          "file": ".omc/state/job.json",
+          "line_start": 1,
+          "line_end": 1,
+          "confidence": 0.9,
+          "recommendation": "Remove .omc/state/job.json from git and add .omc/ to .gitignore."
+        }
+      ],
+      "latencyMs": 17230
+    }
+  ],
+  "raw": "{\n  \"review\": \"Review\",\n  \"target\": {\n    \"mode\": \"working-tree\",\n    \"label\": \"working tree diff\",\n    \"explicit\": true\n  },\n  \"engine\": \"agy\",\n  \"gemini\": {\n    \"status\": 0,\n    \"stdout\": \"{\\n  \\\"verdict\\\": \\\"needs-attention\\\",\\n  \\\"summary\\\": \\\"JWT issuance lacks validation for the secret environment variable and a transient state file is tracked in git.\\\",\\n  \\\"findings\\\": [\\n    {\\n      \\\"severity\\\": \\\"medium\\\",\\n      \\\"title\\\": \\\"Missing validation for JWT_SECRET environment variable\\\",\\n      \\\"body\\\": \\\"In src/token.js (lines 3-5), issue() passes process.env.JWT_SECRET directly into jwt.sign() without checking if it is defined. If the environment variable is unset, jwt.sign() throws a synchronous runtime exception ('secretOrPrivateKey must have a value').\\\",\\n      \\\"file\\\": \\\"src/token.js\\\",\\n      \\\"line_start\\\": 3,\\n      \\\"line_end\\\": 5,\\n      \\\"confidence\\\": 0.95,\\n      \\\"recommendation\\\": \\\"Assert that process.env.JWT_SECRET is defined before calling jwt.sign, or fail fast with a descriptive configuration error.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"low\\\",\\n      \\\"title\\\": \\\"Ephemeral runtime state file committed to repository\\\",\\n      \\\"body\\\": \\\"In .omc/state/job.json (line 1), a runtime execution state file containing a process ID (pid: 4242) and job status is tracked, which can cause repository pollution and merge conflicts across different environments.\\\",\\n      \\\"file\\\": \\\".omc/state/job.json\\\",\\n      \\\"line_start\\\": 1,\\n      \\\"line_end\\\": 1,\\n      \\\"confidence\\\": 0.9,\\n      \\\"recommendation\\\": \\\"Remove .omc/state/job.json from git and add .omc/ to .gitignore.\\\"\\n    }\\n  ],\\n  \\\"next_steps\\\": [\\n    \\\"Validate process.env.JWT_SECRET prior to invoking jwt.sign().\\\",\\n    \\\"Untrack .omc/state/job.json and ignore the .omc directory in .gitignore.\\\"\\n  ]\\n}\",\n    \"stderr\": \"\"\n  },\n  \"result\": {\n    \"verdict\": \"needs-attention\",\n    \"summary\": \"JWT issuance lacks validation for the secret environment variable and a transient state file is tracked in git.\",\n    \"findings\": [\n      {\n        \"severity\": \"medium\",\n        \"title\": \"Missing validation for JWT_SECRET environment variable\",\n        \"body\": \"In src/token.js (lines 3-5), issue() passes process.env.JWT_SECRET directly into jwt.sign() without checking if it is defined. If the environment variable is unset, jwt.sign() throws a synchronous runtime exception ('secretOrPrivateKey must have a value').\",\n        \"file\": \"src/token.js\",\n        \"line_start\": 3,\n        \"line_end\": 5,\n        \"confidence\": 0.95,\n        \"recommendation\": \"Assert that process.env.JWT_SECRET is defined before calling jwt.sign, or fail fast with a descriptive configuration error.\"\n      },\n      {\n        \"severity\": \"low\",\n        \"title\": \"Ephemeral runtime state file committed to repository\",\n        \"body\": \"In .omc/state/job.json (line 1), a runtime execution state file containing a process ID (pid: 4242) and job status is tracked, which can cause repository pollution and merge conflicts across different environments.\",\n        \"file\": \".omc/state/job.json\",\n        \"line_start\": 1,\n        \"line_end\": 1,\n        \"confidence\": 0.9,\n        \"recommendation\": \"Remove .omc/state/job.json from git and add .omc/ to .gitignore.\"\n      }\n    ],\n    \"next_steps\": [\n      \"Validate process.env.JWT_SECRET prior to invoking jwt.sign().\",\n      \"Untrack .omc/state/job.json and ignore the .omc directory in .gitignore.\"\n    ]\n  }\n}\n"
+}

--- a/bench/cassettes/repo-context/codex.adversarial.json
+++ b/bench/cassettes/repo-context/codex.adversarial.json
@@ -1,0 +1,146 @@
+{
+  "caseId": "repo-context",
+  "cell": "codex.adversarial",
+  "recordedAt": "2026-08-24T11:15:07.090Z",
+  "verdict": "needs-attention",
+  "summary": "Do not ship: the diff includes stale process state and a JWT issuer that accepts weak signing configuration and unrestricted claims.",
+  "findings": [
+    {
+      "severity": "high",
+      "title": "JWT signing accepts any non-empty secret without strength validation",
+      "body": "`issue()` signs authentication tokens directly with `JWT_SECRET`. `jsonwebtoken` rejects a missing secret, but accepts short or predictable non-empty values; a misconfigured deployment can therefore start successfully while issuing forgeable HS256 tokens. The impact depends on how these tokens are trusted, but compromise of authorization claims would be severe.",
+      "file": "src/token.js",
+      "line_start": 4,
+      "line_end": 4,
+      "confidence": 0.9,
+      "recommendation": "Validate `JWT_SECRET` during application startup, require cryptographically random key material of an enforced minimum strength, and fail startup before serving requests when validation fails."
+    },
+    {
+      "severity": "medium",
+      "title": "Token issuer permits callers to inject arbitrary authorization and reserved claims",
+      "body": "The entire caller-supplied object is signed without an allowlist or normalization. If any caller can derive this payload from request or profile data, it can mint claims such as elevated roles, `sub`, `aud`, or `iss` under the server's signature. That trust-boundary exposure is an inference because callers are not included in the context, but this API does not enforce the invariant itself.",
+      "file": "src/token.js",
+      "line_start": 3,
+      "line_end": 4,
+      "confidence": 0.76,
+      "recommendation": "Construct the signed payload from an explicit allowlist of server-controlled claims, reject reserved claims from caller input, and set and verify fixed issuer, audience, subject, and algorithm values."
+    },
+    {
+      "severity": "medium",
+      "title": "Repository contains non-portable live process state",
+      "body": "The new state file permanently records a job as `running` with PID 4242. That PID and lifecycle state become stale as soon as the originating process exits or the checkout moves to another machine. Any recovery or orchestration code trusting this file could falsely suppress work or act on an unrelated process that later reuses the PID.",
+      "file": ".omc/state/job.json",
+      "line_start": 1,
+      "line_end": 1,
+      "confidence": 0.98,
+      "recommendation": "Remove the runtime state file from the change and ignore `.omc/state/` or the specific generated artifact; recreate job state at runtime with liveness and ownership validation."
+    }
+  ],
+  "latencyMs": 35683,
+  "engineVersion": "codex-cli 0.149.0",
+  "engineObserved": null,
+  "samples": [
+    {
+      "verdict": "needs-attention",
+      "summary": "Do not ship: the change persists stale runtime state and exposes an unrestricted JWT-signing primitive without validating its signing configuration.",
+      "findings": [
+        {
+          "severity": "high",
+          "title": "Arbitrary caller-supplied claims are signed without an allowlist",
+          "body": "`issue` signs the entire supplied payload unchanged. Any caller that passes request-derived or otherwise insufficiently trusted data can mint reserved or authorization-sensitive claims such as `sub`, `role`, `scope`, `aud`, or `iss`. The repository context does not show callers, so exploitability is inferred, but this API establishes no trust boundary itself.",
+          "file": "src/token.js",
+          "line_start": 3,
+          "line_end": 4,
+          "confidence": 0.86,
+          "recommendation": "Accept explicit trusted fields instead of an arbitrary payload, construct claims internally, and set/validate issuer, audience, subject, and algorithm consistently with verification."
+        },
+        {
+          "severity": "medium",
+          "title": "Missing JWT secret fails only during token issuance",
+          "body": "`process.env.JWT_SECRET` is passed directly to `jwt.sign`. If the variable is missing or empty in any deployment, issuance throws synchronously on the live request path, creating an authentication outage without an actionable startup failure.",
+          "file": "src/token.js",
+          "line_start": 4,
+          "line_end": 4,
+          "confidence": 0.98,
+          "recommendation": "Validate `JWT_SECRET` at startup, reject empty or inadequate values, and fail deployment with a clear configuration error before serving requests."
+        },
+        {
+          "severity": "medium",
+          "title": "Ephemeral process state is included in the deliverable",
+          "body": "The file records job `task-123` as running under PID 4242. That PID and status describe one local execution and will be stale elsewhere; tooling that consumes this state may falsely treat the job as active or target an unrelated process after PID reuse.",
+          "file": ".omc/state/job.json",
+          "line_start": 1,
+          "line_end": 1,
+          "confidence": 0.94,
+          "recommendation": "Remove the runtime state file from the change and ignore `.omc/state/` (or the specific generated file) unless the repository explicitly requires a sanitized state fixture."
+        }
+      ],
+      "latencyMs": 25428
+    },
+    {
+      "verdict": "needs-attention",
+      "summary": "Do not ship: token issuance has a latent configuration-dependent outage path, and the diff includes host-specific live-job state.",
+      "findings": [
+        {
+          "severity": "high",
+          "title": "JWT configuration failure is deferred into the request path",
+          "body": "`issue()` reads `JWT_SECRET` only when signing and does not validate that it exists or has an acceptable value. If the variable is missing or empty, `jsonwebtoken.sign` throws synchronously when a token is requested, turning deployment misconfiguration into a user-visible authentication outage instead of a startup failure. No local error handling or configuration guard is present in this module.",
+          "file": "src/token.js",
+          "line_start": 3,
+          "line_end": 4,
+          "confidence": 0.98,
+          "recommendation": "Validate `JWT_SECRET` during application startup, reject missing or invalid secrets before serving traffic, and add tests covering absent-secret behavior and successful issuance."
+        },
+        {
+          "severity": "medium",
+          "title": "Host-specific running-job state is being added to the repository",
+          "body": "This file records a concrete PID and claims the job is currently running. Those values describe ephemeral process state on one machine and become stale immediately on another checkout or after process exit. If the state consumer trusts this file, it can attach to, signal, or suppress work based on unrelated PID 4242; at minimum, source control will repeatedly distribute false operational state. The exact consumer impact is inferred because its implementation is not included.",
+          "file": ".omc/state/job.json",
+          "line_start": 1,
+          "line_end": 1,
+          "confidence": 0.91,
+          "recommendation": "Remove the runtime state file from the change, ignore `.omc/state/` or the specific state artifact, and have the consumer verify process identity/liveness rather than trusting persisted PID status."
+        }
+      ],
+      "latencyMs": 30692
+    },
+    {
+      "verdict": "needs-attention",
+      "summary": "Do not ship: the diff includes stale process state and a JWT issuer that accepts weak signing configuration and unrestricted claims.",
+      "findings": [
+        {
+          "severity": "high",
+          "title": "JWT signing accepts any non-empty secret without strength validation",
+          "body": "`issue()` signs authentication tokens directly with `JWT_SECRET`. `jsonwebtoken` rejects a missing secret, but accepts short or predictable non-empty values; a misconfigured deployment can therefore start successfully while issuing forgeable HS256 tokens. The impact depends on how these tokens are trusted, but compromise of authorization claims would be severe.",
+          "file": "src/token.js",
+          "line_start": 4,
+          "line_end": 4,
+          "confidence": 0.9,
+          "recommendation": "Validate `JWT_SECRET` during application startup, require cryptographically random key material of an enforced minimum strength, and fail startup before serving requests when validation fails."
+        },
+        {
+          "severity": "medium",
+          "title": "Token issuer permits callers to inject arbitrary authorization and reserved claims",
+          "body": "The entire caller-supplied object is signed without an allowlist or normalization. If any caller can derive this payload from request or profile data, it can mint claims such as elevated roles, `sub`, `aud`, or `iss` under the server's signature. That trust-boundary exposure is an inference because callers are not included in the context, but this API does not enforce the invariant itself.",
+          "file": "src/token.js",
+          "line_start": 3,
+          "line_end": 4,
+          "confidence": 0.76,
+          "recommendation": "Construct the signed payload from an explicit allowlist of server-controlled claims, reject reserved claims from caller input, and set and verify fixed issuer, audience, subject, and algorithm values."
+        },
+        {
+          "severity": "medium",
+          "title": "Repository contains non-portable live process state",
+          "body": "The new state file permanently records a job as `running` with PID 4242. That PID and lifecycle state become stale as soon as the originating process exits or the checkout moves to another machine. Any recovery or orchestration code trusting this file could falsely suppress work or act on an unrelated process that later reuses the PID.",
+          "file": ".omc/state/job.json",
+          "line_start": 1,
+          "line_end": 1,
+          "confidence": 0.98,
+          "recommendation": "Remove the runtime state file from the change and ignore `.omc/state/` or the specific generated artifact; recreate job state at runtime with liveness and ownership validation."
+        }
+      ],
+      "latencyMs": 35683
+    }
+  ],
+  "raw": "{\n  \"review\": \"Adversarial Review\",\n  \"target\": {\n    \"mode\": \"working-tree\",\n    \"label\": \"working tree diff\",\n    \"explicit\": true\n  },\n  \"threadId\": \"01a0337a-b24f-7312-91a5-7bc3f20180e0\",\n  \"context\": {\n    \"repoRoot\": \"C:/Users/arcobaleno/AppData/Local/Temp/bench-repo-context-1RXLNu\",\n    \"branch\": \"main\",\n    \"summary\": \"Reviewing 0 staged, 2 unstaged, and 0 untracked file(s).\"\n  },\n  \"codex\": {\n    \"status\": 0,\n    \"stderr\": \"\",\n    \"stdout\": \"{\\\"verdict\\\":\\\"needs-attention\\\",\\\"summary\\\":\\\"Do not ship: the diff includes stale process state and a JWT issuer that accepts weak signing configuration and unrestricted claims.\\\",\\\"findings\\\":[{\\\"severity\\\":\\\"high\\\",\\\"title\\\":\\\"JWT signing accepts any non-empty secret without strength validation\\\",\\\"body\\\":\\\"`issue()` signs authentication tokens directly with `JWT_SECRET`. `jsonwebtoken` rejects a missing secret, but accepts short or predictable non-empty values; a misconfigured deployment can therefore start successfully while issuing forgeable HS256 tokens. The impact depends on how these tokens are trusted, but compromise of authorization claims would be severe.\\\",\\\"file\\\":\\\"src/token.js\\\",\\\"line_start\\\":4,\\\"line_end\\\":4,\\\"confidence\\\":0.9,\\\"recommendation\\\":\\\"Validate `JWT_SECRET` during application startup, require cryptographically random key material of an enforced minimum strength, and fail startup before serving requests when validation fails.\\\"},{\\\"severity\\\":\\\"medium\\\",\\\"title\\\":\\\"Token issuer permits callers to inject arbitrary authorization and reserved claims\\\",\\\"body\\\":\\\"The entire caller-supplied object is signed without an allowlist or normalization. If any caller can derive this payload from request or profile data, it can mint claims such as elevated roles, `sub`, `aud`, or `iss` under the server's signature. That trust-boundary exposure is an inference because callers are not included in the context, but this API does not enforce the invariant itself.\\\",\\\"file\\\":\\\"src/token.js\\\",\\\"line_start\\\":3,\\\"line_end\\\":4,\\\"confidence\\\":0.76,\\\"recommendation\\\":\\\"Construct the signed payload from an explicit allowlist of server-controlled claims, reject reserved claims from caller input, and set and verify fixed issuer, audience, subject, and algorithm values.\\\"},{\\\"severity\\\":\\\"medium\\\",\\\"title\\\":\\\"Repository contains non-portable live process state\\\",\\\"body\\\":\\\"The new state file permanently records a job as `running` with PID 4242. That PID and lifecycle state become stale as soon as the originating process exits or the checkout moves to another machine. Any recovery or orchestration code trusting this file could falsely suppress work or act on an unrelated process that later reuses the PID.\\\",\\\"file\\\":\\\".omc/state/job.json\\\",\\\"line_start\\\":1,\\\"line_end\\\":1,\\\"confidence\\\":0.98,\\\"recommendation\\\":\\\"Remove the runtime state file from the change and ignore `.omc/state/` or the specific generated artifact; recreate job state at runtime with liveness and ownership validation.\\\"}],\\\"next_steps\\\":[\\\"Remove the generated job-state artifact.\\\",\\\"Harden the JWT configuration and claim boundary, then add tests for weak secrets and injected privileged or reserved claims.\\\"]}\",\n    \"reasoning\": []\n  },\n  \"result\": {\n    \"verdict\": \"needs-attention\",\n    \"summary\": \"Do not ship: the diff includes stale process state and a JWT issuer that accepts weak signing configuration and unrestricted claims.\",\n    \"findings\": [\n      {\n        \"severity\": \"high\",\n        \"title\": \"JWT signing accepts any non-empty secret without strength validation\",\n        \"body\": \"`issue()` signs authentication tokens directly with `JWT_SECRET`. `jsonwebtoken` rejects a missing secret, but accepts short or predictable non-empty values; a misconfigured deployment can therefore start successfully while issuing forgeable HS256 tokens. The impact depends on how these tokens are trusted, but compromise of authorization claims would be severe.\",\n        \"file\": \"src/token.js\",\n        \"line_start\": 4,\n        \"li"
+}

--- a/bench/cassettes/repo-context/codex.model.json
+++ b/bench/cassettes/repo-context/codex.model.json
@@ -1,115 +1,96 @@
 {
   "caseId": "repo-context",
   "cell": "codex.model",
-  "recordedAt": "2026-08-19T03:19:24.977Z",
+  "recordedAt": "2026-08-24T04:44:46.517Z",
   "verdict": "needs-attention",
-  "summary": "Token issuance can fail at runtime without configuration validation, and committed runtime state can misidentify an unrelated process as an active job.",
+  "summary": "The diff commits live runtime state and adds token issuance without validating its signing secret.",
   "findings": [
     {
-      "severity": "medium",
-      "title": "JWT secret is used without startup validation",
-      "body": "issue() passes process.env.JWT_SECRET directly to jwt.sign; when the variable is absent, token issuance throws synchronously, leaving callers to encounter an avoidable runtime failure instead of a clear configuration error.",
-      "file": "src/token.js",
-      "line_start": 4,
-      "line_end": 4,
-      "confidence": 0.99,
-      "recommendation": "Validate JWT_SECRET at application startup, require a non-empty suitably strong value, and fail with an explicit configuration error before serving requests."
-    },
-    {
-      "severity": "medium",
-      "title": "Ephemeral job state is committed with a live status and fixed PID",
-      "body": "The new state file declares task-123 as running under PID 4242. On another machine or later checkout, that PID may be stale or belong to an unrelated process, so consumers trusting this file could report a nonexistent job or act on the wrong process.",
+      "severity": "high",
+      "title": "Runtime job state is committed as active",
+      "body": "The new state file records a hard-coded running job and PID. Any code that consumes this persisted state can treat a nonexistent task as active or target an unrelated process if PID 4242 is reused, disrupting job recovery or process management.",
       "file": ".omc/state/job.json",
       "line_start": 1,
       "line_end": 1,
+      "confidence": 0.97,
+      "recommendation": "Remove the runtime state file from version control and ignore `.omc/state/`; create and validate job state only at runtime, including checking process identity before acting on a stored PID."
+    },
+    {
+      "severity": "medium",
+      "title": "Missing JWT secret validation",
+      "body": "Token issuance passes `process.env.JWT_SECRET` directly to `jwt.sign`. If the variable is absent or empty, issuance throws synchronously with no controlled configuration error, potentially turning authentication requests into unhandled failures.",
+      "file": "src/token.js",
+      "line_start": 3,
+      "line_end": 4,
       "confidence": 0.96,
-      "recommendation": "Remove the runtime state file from version control, ignore generated .omc/state data, and create state dynamically with PID identity and liveness validation."
+      "recommendation": "Validate `JWT_SECRET` during application startup and fail with an explicit configuration error before serving requests; ensure callers convert signing failures into controlled responses."
     }
   ],
-  "latencyMs": 17229,
-  "engineVersion": "codex-cli 0.147.0",
+  "latencyMs": 20153,
+  "engineVersion": "codex-cli 0.149.0",
+  "engineObserved": null,
   "samples": [
     {
       "verdict": "needs-attention",
-      "summary": "The diff commits stale runtime state and adds token issuance without explicit secret validation.",
-      "findings": [
-        {
-          "severity": "medium",
-          "title": "Runtime job state is committed as active",
-          "body": "The newly tracked state file declares task-123 as running under PID 4242, but both status and PID are ephemeral machine state. A checkout can therefore begin with a false active-job record, potentially blocking new work or causing any state consumer to target an unrelated reused PID.",
-          "file": ".omc/state/job.json",
-          "line_start": 1,
-          "line_end": 1,
-          "confidence": 0.96,
-          "recommendation": "Remove the runtime state file from version control, add the state path to the appropriate ignore file, and create job state only at runtime with stale-PID validation."
-        },
-        {
-          "severity": "medium",
-          "title": "JWT secret is used without configuration validation",
-          "body": "issue passes process.env.JWT_SECRET directly to jwt.sign. If the variable is missing or invalid, token issuance fails at runtime with a library exception and no clear configuration error at startup; this leaves an incomplete failure path in every caller relying on this function.",
-          "file": "src/token.js",
-          "line_start": 3,
-          "line_end": 4,
-          "confidence": 0.93,
-          "recommendation": "Validate JWT_SECRET once during application initialization, reject missing or insufficient configuration with a clear error, and inject the validated secret into the token issuer."
-        }
-      ],
-      "latencyMs": 17835
-    },
-    {
-      "verdict": "needs-attention",
-      "summary": "Token issuance can fail at runtime when JWT configuration is absent, and committed transient job state can become immediately stale.",
+      "summary": "Token issuance can fail at runtime because the signing secret is used without validation.",
       "findings": [
         {
           "severity": "medium",
           "title": "Missing JWT secret validation",
-          "body": "issue() passes process.env.JWT_SECRET directly to jwt.sign; when the variable is missing, jsonwebtoken throws synchronously, leaving token issuance to fail with an unhandled configuration error at runtime.",
-          "file": "src/token.js",
-          "line_start": 3,
-          "line_end": 4,
-          "confidence": 0.99,
-          "recommendation": "Validate JWT_SECRET during application startup, reject empty or inadequate values, and fail with an explicit configuration error before serving requests."
-        },
-        {
-          "severity": "medium",
-          "title": "Transient running-job state is committed",
-          "body": "The repository now records a job as running with hard-coded PID 4242. After checkout or process termination this state is stale, so automation that trusts it may treat a nonexistent or unrelated process as the active job.",
-          "file": ".omc/state/job.json",
-          "line_start": 1,
-          "line_end": 1,
-          "confidence": 0.94,
-          "recommendation": "Remove the runtime state file from version control, ignore .omc/state artifacts, and generate and validate job/PID state at runtime."
-        }
-      ],
-      "latencyMs": 17946
-    },
-    {
-      "verdict": "needs-attention",
-      "summary": "Token issuance can fail at runtime without configuration validation, and committed runtime state can misidentify an unrelated process as an active job.",
-      "findings": [
-        {
-          "severity": "medium",
-          "title": "JWT secret is used without startup validation",
-          "body": "issue() passes process.env.JWT_SECRET directly to jwt.sign; when the variable is absent, token issuance throws synchronously, leaving callers to encounter an avoidable runtime failure instead of a clear configuration error.",
+          "body": "issue() passes process.env.JWT_SECRET directly to jwt.sign without checking that it is configured and non-empty; a missing secret causes token issuance to throw at runtime, potentially breaking every authentication request instead of producing a clear startup/configuration failure.",
           "file": "src/token.js",
           "line_start": 4,
           "line_end": 4,
           "confidence": 0.99,
-          "recommendation": "Validate JWT_SECRET at application startup, require a non-empty suitably strong value, and fail with an explicit configuration error before serving requests."
-        },
+          "recommendation": "Validate JWT_SECRET during application startup and fail fast with a clear configuration error; keep issue() unreachable until a non-empty secret is available."
+        }
+      ],
+      "latencyMs": 19265
+    },
+    {
+      "verdict": "needs-attention",
+      "summary": "JWT issuance depends on an unvalidated runtime secret and can fail or produce weakly protected tokens.",
+      "findings": [
         {
-          "severity": "medium",
-          "title": "Ephemeral job state is committed with a live status and fixed PID",
-          "body": "The new state file declares task-123 as running under PID 4242. On another machine or later checkout, that PID may be stale or belong to an unrelated process, so consumers trusting this file could report a nonexistent job or act on the wrong process.",
+          "severity": "high",
+          "title": "JWT secret is not validated",
+          "body": "src/token.js passes process.env.JWT_SECRET directly to jwt.sign without verifying that it exists and has sufficient entropy. A missing value causes token issuance to throw at runtime, while a weak configured value permits attackers to forge valid tokens.",
+          "file": "src/token.js",
+          "line_start": 4,
+          "line_end": 4,
+          "confidence": 0.98,
+          "recommendation": "Validate JWT_SECRET during application startup, fail with a clear configuration error when absent, and enforce an appropriately strong secret; pass the validated value into this module."
+        }
+      ],
+      "latencyMs": 20942
+    },
+    {
+      "verdict": "needs-attention",
+      "summary": "The diff commits live runtime state and adds token issuance without validating its signing secret.",
+      "findings": [
+        {
+          "severity": "high",
+          "title": "Runtime job state is committed as active",
+          "body": "The new state file records a hard-coded running job and PID. Any code that consumes this persisted state can treat a nonexistent task as active or target an unrelated process if PID 4242 is reused, disrupting job recovery or process management.",
           "file": ".omc/state/job.json",
           "line_start": 1,
           "line_end": 1,
+          "confidence": 0.97,
+          "recommendation": "Remove the runtime state file from version control and ignore `.omc/state/`; create and validate job state only at runtime, including checking process identity before acting on a stored PID."
+        },
+        {
+          "severity": "medium",
+          "title": "Missing JWT secret validation",
+          "body": "Token issuance passes `process.env.JWT_SECRET` directly to `jwt.sign`. If the variable is absent or empty, issuance throws synchronously with no controlled configuration error, potentially turning authentication requests into unhandled failures.",
+          "file": "src/token.js",
+          "line_start": 3,
+          "line_end": 4,
           "confidence": 0.96,
-          "recommendation": "Remove the runtime state file from version control, ignore generated .omc/state data, and create state dynamically with PID identity and liveness validation."
+          "recommendation": "Validate `JWT_SECRET` during application startup and fail with an explicit configuration error before serving requests; ensure callers convert signing failures into controlled responses."
         }
       ],
-      "latencyMs": 17229
+      "latencyMs": 20153
     }
   ],
-  "raw": "{\"verdict\":\"needs-attention\",\"summary\":\"Token issuance can fail at runtime without configuration validation, and committed runtime state can misidentify an unrelated process as an active job.\",\"findings\":[{\"severity\":\"medium\",\"title\":\"JWT secret is used without startup validation\",\"body\":\"issue() passes process.env.JWT_SECRET directly to jwt.sign; when the variable is absent, token issuance throws synchronously, leaving callers to encounter an avoidable runtime failure instead of a clear configuration error.\",\"file\":\"src/token.js\",\"line_start\":4,\"line_end\":4,\"confidence\":0.99,\"recommendation\":\"Validate JWT_SECRET at application startup, require a non-empty suitably strong value, and fail with an explicit configuration error before serving requests.\"},{\"severity\":\"medium\",\"title\":\"Ephemeral job state is committed with a live status and fixed PID\",\"body\":\"The new state file declares task-123 as running under PID 4242. On another machine or later checkout, that PID may be stale or belong to an unrelated process, so consumers trusting this file could report a nonexistent job or act on the wrong process.\",\"file\":\".omc/state/job.json\",\"line_start\":1,\"line_end\":1,\"confidence\":0.96,\"recommendation\":\"Remove the runtime state file from version control, ignore generated .omc/state data, and create state dynamically with PID identity and liveness validation.\"}],\"next_steps\":[\"Add startup validation for JWT_SECRET and test the missing-secret path.\",\"Remove the committed job state and add the generated state path to the appropriate ignore configuration.\"]}\n"
+  "raw": "{\"verdict\":\"needs-attention\",\"summary\":\"The diff commits live runtime state and adds token issuance without validating its signing secret.\",\"findings\":[{\"severity\":\"high\",\"title\":\"Runtime job state is committed as active\",\"body\":\"The new state file records a hard-coded running job and PID. Any code that consumes this persisted state can treat a nonexistent task as active or target an unrelated process if PID 4242 is reused, disrupting job recovery or process management.\",\"file\":\".omc/state/job.json\",\"line_start\":1,\"line_end\":1,\"confidence\":0.97,\"recommendation\":\"Remove the runtime state file from version control and ignore `.omc/state/`; create and validate job state only at runtime, including checking process identity before acting on a stored PID.\"},{\"severity\":\"medium\",\"title\":\"Missing JWT secret validation\",\"body\":\"Token issuance passes `process.env.JWT_SECRET` directly to `jwt.sign`. If the variable is absent or empty, issuance throws synchronously with no controlled configuration error, potentially turning authentication requests into unhandled failures.\",\"file\":\"src/token.js\",\"line_start\":3,\"line_end\":4,\"confidence\":0.96,\"recommendation\":\"Validate `JWT_SECRET` during application startup and fail with an explicit configuration error before serving requests; ensure callers convert signing failures into controlled responses.\"}],\"next_steps\":[\"Remove and ignore the runtime state artifact.\",\"Add startup validation for `JWT_SECRET` and test missing-secret behavior.\"]}\n"
 }

--- a/bench/cassettes/repo-context/gemini.deep.json
+++ b/bench/cassettes/repo-context/gemini.deep.json
@@ -1,155 +1,136 @@
 {
   "caseId": "repo-context",
   "cell": "gemini.deep",
-  "recordedAt": "2026-08-19T12:10:51.341Z",
+  "recordedAt": "2026-08-24T10:53:40.860Z",
   "verdict": "needs-attention",
-  "summary": "Found an undeclared dependency on jsonwebtoken, a lack of JWT secret validation, and tracked ephemeral process files in git.",
+  "summary": "Undeclared dependencies and missing environment variable safety checks in token generation.",
   "findings": [
     {
-      "severity": "high",
-      "title": "Undeclared dependency 'jsonwebtoken' in package.json",
-      "body": "The module 'src/token.js' imports and uses the 'jsonwebtoken' package, but it is not listed in the 'dependencies' of package.json. This will cause clean installations or production deployments to fail with a 'Cannot find module' error.",
+      "severity": "critical",
+      "title": "Undeclared Dependency 'jsonwebtoken'",
+      "body": "The module 'jsonwebtoken' is imported in src/token.js but not declared as a dependency in package.json. This will cause a runtime crash with 'Error: Cannot find module 'jsonwebtoken'' when the application attempts to load src/token.js.",
       "file": "package.json",
       "line_start": 5,
       "line_end": 7,
       "confidence": 1,
-      "recommendation": "Run 'npm install jsonwebtoken' or manually add 'jsonwebtoken' (e.g., '^9.0.0') to the dependencies section in package.json."
+      "recommendation": "Add \"jsonwebtoken\": \"^9.0.2\" to the dependencies object in package.json."
     },
     {
-      "severity": "medium",
-      "title": "Missing validation for process.env.JWT_SECRET",
-      "body": "In 'src/token.js', 'jwt.sign' is called with 'process.env.JWT_SECRET' without validating that it is set. If this environment variable is missing, the signing call will throw an unhandled 'secretOrPrivateKey must have a value' exception at runtime.",
+      "severity": "high",
+      "title": "Missing check for process.env.JWT_SECRET",
+      "body": "The 'issue' function in src/token.js invokes jwt.sign with process.env.JWT_SECRET without checking if the environment variable is set. If JWT_SECRET is undefined, jwt.sign will throw a synchronous 'secretOrPrivateKey must have a value' error, which could crash the application or cause unhandled exceptions.",
       "file": "src/token.js",
       "line_start": 3,
       "line_end": 5,
-      "confidence": 0.95,
-      "recommendation": "Add a check to ensure 'process.env.JWT_SECRET' is defined before calling 'jwt.sign', or throw a clear initialization error if it is not set."
-    },
-    {
-      "severity": "low",
-      "title": "Committing ephemeral state file .omc/state/job.json",
-      "body": "The file '.omc/state/job.json' contains runtime-specific job information (such as pid and running status). Tracking active process/runner state in git leads to noisy commits, potential merge conflicts, and leakage of transient local environment details.",
-      "file": ".omc/state/job.json",
-      "line_start": 1,
-      "line_end": 1,
       "confidence": 1,
-      "recommendation": "Remove '.omc/state/job.json' from git tracking and create a '.gitignore' file that excludes '.omc/' or '.omc/state/'."
+      "recommendation": "Add an assertion at startup or inside the 'issue' function to ensure process.env.JWT_SECRET is defined before attempting to sign tokens."
     }
   ],
-  "latencyMs": 31736,
-  "engineVersion": "0.55.1",
+  "latencyMs": 26687,
+  "engineVersion": "0.56.0",
+  "engineObserved": "gemini",
   "samples": [
     {
       "verdict": "needs-attention",
-      "summary": "Identified undeclared dependency on jsonwebtoken, missing validation of process.env.JWT_SECRET, and accidental staging of a transient runtime state file.",
-      "findings": [
-        {
-          "severity": "high",
-          "title": "Undeclared dependency on jsonwebtoken in package.json",
-          "body": "The new file `src/token.js` imports the `jsonwebtoken` library via `require('jsonwebtoken')`, but this dependency is not declared in `package.json`. At runtime, attempting to load this file will fail with a `Cannot find module 'jsonwebtoken'` exception, causing the application to crash.",
-          "file": "package.json",
-          "line_start": 5,
-          "line_end": 7,
-          "confidence": 1,
-          "recommendation": "Add `\"jsonwebtoken\"` with an appropriate version range (e.g., `\"^9.0.0\"`) to the `\"dependencies\"` block in `package.json`."
-        },
-        {
-          "severity": "medium",
-          "title": "Missing validation of JWT_SECRET environment variable",
-          "body": "In `src/token.js`, the function `issue(payload)` directly accesses `process.env.JWT_SECRET` to sign tokens. If `process.env.JWT_SECRET` is undefined or not set, `jwt.sign()` will synchronously throw a fatal `Error: secretOrPrivateKey must have a value`. Without error handling, this will cause unhandled promise rejections or process crashes in the calling code.",
-          "file": "src/token.js",
-          "line_start": 3,
-          "line_end": 5,
-          "confidence": 1,
-          "recommendation": "Add validation to check if `process.env.JWT_SECRET` is defined before calling `jwt.sign()`. For example:\n\n```js\nfunction issue(payload) {\n  if (!process.env.JWT_SECRET) {\n    throw new Error('JWT_SECRET environment variable is not defined');\n  }\n  return jwt.sign(payload, process.env.JWT_SECRET, { expiresIn: '1h' });\n}\n```"
-        },
-        {
-          "severity": "low",
-          "title": "Staging of transient job state file",
-          "body": "The local/runtime job state file `.omc/state/job.json` containing active execution state (`\"status\": \"running\"`, `\"pid\": 4242`) has been added/staged for tracking in git. Committing dynamic process state files to source control is bad practice as it causes git history pollution and potential merge conflicts.",
-          "file": ".omc/state/job.json",
-          "line_start": 1,
-          "line_end": 1,
-          "confidence": 1,
-          "recommendation": "Unstage `.omc/state/job.json` using `git reset HEAD .omc/state/job.json`, and add `.omc/` or `.omc/state/` to the project's `.gitignore` file to prevent accidental future commits of transient state."
-        }
-      ],
-      "latencyMs": 36148
-    },
-    {
-      "verdict": "needs-attention",
-      "summary": "The code has a missing runtime dependency, lacks environment variable validation, and contains a runtime state file that should be gitignored.",
+      "summary": "Undeclared 'jsonwebtoken' dependency and missing validation for the mandatory JWT_SECRET environment variable will cause runtime failures in production.",
       "findings": [
         {
           "severity": "critical",
-          "title": "Missing 'jsonwebtoken' dependency in package.json",
-          "body": "The file `src/token.js` requires the `jsonwebtoken` module, but it is not listed in `package.json` under `dependencies`. This will result in a runtime `Cannot find module 'jsonwebtoken'` crash.",
-          "file": "src/token.js",
-          "line_start": 1,
-          "line_end": 1,
-          "confidence": 1,
-          "recommendation": "Add `jsonwebtoken` to the `dependencies` block in `package.json` (e.g., by running `npm install jsonwebtoken`)."
-        },
-        {
-          "severity": "high",
-          "title": "Missing validation for process.env.JWT_SECRET",
-          "body": "In `src/token.js`, `process.env.JWT_SECRET` is passed directly to `jwt.sign()` without validation. If the environment variable is not defined, `jwt.sign()` will throw a synchronous error: 'secretOrPrivateKey must have a value'.",
-          "file": "src/token.js",
-          "line_start": 3,
-          "line_end": 5,
-          "confidence": 1,
-          "recommendation": "Validate that `process.env.JWT_SECRET` is defined and has sufficient entropy before calling `jwt.sign()`, throwing a clear initialization or configuration error if it is missing."
-        },
-        {
-          "severity": "low",
-          "title": "Runtime state file (.omc/state/job.json) is tracked",
-          "body": "The state file `.omc/state/job.json` contains transient, machine-specific execution state (like `pid` and status 'running'). This file should not be committed to the repository.",
-          "file": ".omc/state/job.json",
-          "line_start": 1,
-          "line_end": 1,
-          "confidence": 1,
-          "recommendation": "Remove `.omc/state/job.json` from Git tracking and add `.omc/` or `.omc/state/` to a `.gitignore` file to prevent tracking of dynamic runtime state."
-        }
-      ],
-      "latencyMs": 27264
-    },
-    {
-      "verdict": "needs-attention",
-      "summary": "Found an undeclared dependency on jsonwebtoken, a lack of JWT secret validation, and tracked ephemeral process files in git.",
-      "findings": [
-        {
-          "severity": "high",
-          "title": "Undeclared dependency 'jsonwebtoken' in package.json",
-          "body": "The module 'src/token.js' imports and uses the 'jsonwebtoken' package, but it is not listed in the 'dependencies' of package.json. This will cause clean installations or production deployments to fail with a 'Cannot find module' error.",
+          "title": "Undeclared dependency on 'jsonwebtoken' in package.json",
+          "body": "The newly added file 'src/token.js' imports 'jsonwebtoken', but the package.json dependency manifest does not list 'jsonwebtoken' as a dependency. This will cause a MODULE_NOT_FOUND error and runtime failure in production or after any clean npm installation.",
           "file": "package.json",
           "line_start": 5,
           "line_end": 7,
           "confidence": 1,
-          "recommendation": "Run 'npm install jsonwebtoken' or manually add 'jsonwebtoken' (e.g., '^9.0.0') to the dependencies section in package.json."
+          "recommendation": "Add 'jsonwebtoken' to the dependencies object in package.json."
         },
         {
-          "severity": "medium",
-          "title": "Missing validation for process.env.JWT_SECRET",
-          "body": "In 'src/token.js', 'jwt.sign' is called with 'process.env.JWT_SECRET' without validating that it is set. If this environment variable is missing, the signing call will throw an unhandled 'secretOrPrivateKey must have a value' exception at runtime.",
+          "severity": "high",
+          "title": "Missing validation for mandatory JWT_SECRET environment variable",
+          "body": "In 'src/token.js', jwt.sign is called using 'process.env.JWT_SECRET' without any prior validation. If the environment variable JWT_SECRET is not configured, jwt.sign will throw a synchronous error ('secretOrPrivateKey must have a value') which is unhandled and can crash the application process.",
           "file": "src/token.js",
-          "line_start": 3,
-          "line_end": 5,
-          "confidence": 0.95,
-          "recommendation": "Add a check to ensure 'process.env.JWT_SECRET' is defined before calling 'jwt.sign', or throw a clear initialization error if it is not set."
+          "line_start": 4,
+          "line_end": 4,
+          "confidence": 1,
+          "recommendation": "Assert that process.env.JWT_SECRET is defined and non-empty during application initialization or before calling jwt.sign, raising a descriptive configuration error if missing."
         },
         {
           "severity": "low",
-          "title": "Committing ephemeral state file .omc/state/job.json",
-          "body": "The file '.omc/state/job.json' contains runtime-specific job information (such as pid and running status). Tracking active process/runner state in git leads to noisy commits, potential merge conflicts, and leakage of transient local environment details.",
+          "title": "Stray runtime state file tracked by Git",
+          "body": "The file '.omc/state/job.json' stores ephemeral execution state (including pid and running status). Committing or tracking local runner state in git is an anti-pattern as it causes merge conflicts and pollutes the repository with environment-specific information.",
+          "file": ".omc/state/job.json",
+          "line_start": 1,
+          "line_end": 1,
+          "confidence": 0.95,
+          "recommendation": "Remove '.omc/state/job.json' from git tracking and add '.omc/' to the repository's .gitignore file."
+        }
+      ],
+      "latencyMs": 33886
+    },
+    {
+      "verdict": "needs-attention",
+      "summary": "Identified a missing dependency (jsonwebtoken), an unvalidated environment variable for JWT signing, and an ephemeral runtime state file staged for commit.",
+      "findings": [
+        {
+          "severity": "high",
+          "title": "Missing jsonwebtoken dependency in package.json",
+          "body": "The new file src/token.js imports 'jsonwebtoken', which is not listed as a dependency in package.json. This will cause a runtime crash ('Cannot find module') in environments where dependencies are freshly installed.",
+          "file": "package.json",
+          "line_start": 5,
+          "line_end": 7,
+          "confidence": 1,
+          "recommendation": "Install and add 'jsonwebtoken' to package.json, for example by running 'npm install jsonwebtoken'."
+        },
+        {
+          "severity": "medium",
+          "title": "Unvalidated JWT secret environment variable",
+          "body": "The issue() function in src/token.js uses process.env.JWT_SECRET without checking if it is defined. If the environment variable is missing, jwt.sign() will synchronously throw a 'secretOrPrivateKey must have a value' error.",
+          "file": "src/token.js",
+          "line_start": 3,
+          "line_end": 5,
+          "confidence": 1,
+          "recommendation": "Assert that process.env.JWT_SECRET is defined at application startup, or throw a clear configuration error if it is missing."
+        },
+        {
+          "severity": "low",
+          "title": "Ephemeral runtime state file tracked in git",
+          "body": "The file .omc/state/job.json contains active runtime process info (status 'running', pid 4242) and is being tracked. Committing state or process files pollutes the repository and leaks local system details.",
           "file": ".omc/state/job.json",
           "line_start": 1,
           "line_end": 1,
           "confidence": 1,
-          "recommendation": "Remove '.omc/state/job.json' from git tracking and create a '.gitignore' file that excludes '.omc/' or '.omc/state/'."
+          "recommendation": "Create a .gitignore file containing '.omc/', and remove the file from git tracking using 'git rm --cached .omc/state/job.json'."
         }
       ],
-      "latencyMs": 31736
+      "latencyMs": 31747
+    },
+    {
+      "verdict": "needs-attention",
+      "summary": "Undeclared dependencies and missing environment variable safety checks in token generation.",
+      "findings": [
+        {
+          "severity": "critical",
+          "title": "Undeclared Dependency 'jsonwebtoken'",
+          "body": "The module 'jsonwebtoken' is imported in src/token.js but not declared as a dependency in package.json. This will cause a runtime crash with 'Error: Cannot find module 'jsonwebtoken'' when the application attempts to load src/token.js.",
+          "file": "package.json",
+          "line_start": 5,
+          "line_end": 7,
+          "confidence": 1,
+          "recommendation": "Add \"jsonwebtoken\": \"^9.0.2\" to the dependencies object in package.json."
+        },
+        {
+          "severity": "high",
+          "title": "Missing check for process.env.JWT_SECRET",
+          "body": "The 'issue' function in src/token.js invokes jwt.sign with process.env.JWT_SECRET without checking if the environment variable is set. If JWT_SECRET is undefined, jwt.sign will throw a synchronous 'secretOrPrivateKey must have a value' error, which could crash the application or cause unhandled exceptions.",
+          "file": "src/token.js",
+          "line_start": 3,
+          "line_end": 5,
+          "confidence": 1,
+          "recommendation": "Add an assertion at startup or inside the 'issue' function to ensure process.env.JWT_SECRET is defined before attempting to sign tokens."
+        }
+      ],
+      "latencyMs": 26687
     }
   ],
-  "raw": "{\n  \"review\": \"Review\",\n  \"target\": {\n    \"mode\": \"working-tree\",\n    \"label\": \"working tree diff\",\n    \"explicit\": true\n  },\n  \"gemini\": {\n    \"status\": 0,\n    \"stdout\": \"{\\n  \\\"verdict\\\": \\\"needs-attention\\\",\\n  \\\"summary\\\": \\\"Found an undeclared dependency on jsonwebtoken, a lack of JWT secret validation, and tracked ephemeral process files in git.\\\",\\n  \\\"findings\\\": [\\n    {\\n      \\\"severity\\\": \\\"high\\\",\\n      \\\"title\\\": \\\"Undeclared dependency 'jsonwebtoken' in package.json\\\",\\n      \\\"body\\\": \\\"The module 'src/token.js' imports and uses the 'jsonwebtoken' package, but it is not listed in the 'dependencies' of package.json. This will cause clean installations or production deployments to fail with a 'Cannot find module' error.\\\",\\n      \\\"file\\\": \\\"package.json\\\",\\n      \\\"line_start\\\": 5,\\n      \\\"line_end\\\": 7,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Run 'npm install jsonwebtoken' or manually add 'jsonwebtoken' (e.g., '^9.0.0') to the dependencies section in package.json.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"medium\\\",\\n      \\\"title\\\": \\\"Missing validation for process.env.JWT_SECRET\\\",\\n      \\\"body\\\": \\\"In 'src/token.js', 'jwt.sign' is called with 'process.env.JWT_SECRET' without validating that it is set. If this environment variable is missing, the signing call will throw an unhandled 'secretOrPrivateKey must have a value' exception at runtime.\\\",\\n      \\\"file\\\": \\\"src/token.js\\\",\\n      \\\"line_start\\\": 3,\\n      \\\"line_end\\\": 5,\\n      \\\"confidence\\\": 0.95,\\n      \\\"recommendation\\\": \\\"Add a check to ensure 'process.env.JWT_SECRET' is defined before calling 'jwt.sign', or throw a clear initialization error if it is not set.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"low\\\",\\n      \\\"title\\\": \\\"Committing ephemeral state file .omc/state/job.json\\\",\\n      \\\"body\\\": \\\"The file '.omc/state/job.json' contains runtime-specific job information (such as pid and running status). Tracking active process/runner state in git leads to noisy commits, potential merge conflicts, and leakage of transient local environment details.\\\",\\n      \\\"file\\\": \\\".omc/state/job.json\\\",\\n      \\\"line_start\\\": 1,\\n      \\\"line_end\\\": 1,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Remove '.omc/state/job.json' from git tracking and create a '.gitignore' file that excludes '.omc/' or '.omc/state/'.\\\"\\n    }\\n  ],\\n  \\\"next_steps\\\": [\\n    \\\"Add 'jsonwebtoken' to package.json dependencies.\\\",\\n    \\\"Add startup or runtime validation for 'process.env.JWT_SECRET' in 'src/token.js'.\\\",\\n    \\\"Remove '.omc/state/job.json' from git tracking and configure '.gitignore' to ignore the '.omc/' directory.\\\"\\n  ]\\n}\",\n    \"stderr\": \"Warning: True color (24-bit) support not detected. Using a terminal with true color enabled will result in a better visual experience.\\nRipgrep is not available. Falling back to GrepTool.\\n\"\n  },\n  \"result\": {\n    \"verdict\": \"needs-attention\",\n    \"summary\": \"Found an undeclared dependency on jsonwebtoken, a lack of JWT secret validation, and tracked ephemeral process files in git.\",\n    \"findings\": [\n      {\n        \"severity\": \"high\",\n        \"title\": \"Undeclared dependency 'jsonwebtoken' in package.json\",\n        \"body\": \"The module 'src/token.js' imports and uses the 'jsonwebtoken' package, but it is not listed in the 'dependencies' of package.json. This will cause clean installations or production deployments to fail with a 'Cannot find module' error.\",\n        \"file\": \"package.json\",\n        \"line_start\": 5,\n        \"line_end\": 7,\n        \"confidence\": 1,\n        \"recommendation\": \"Run 'npm install jsonwebtoken' or manually add 'jsonwebtoken' (e.g., '^9.0.0') to the dependencies section in package.json.\"\n      },\n      {\n        \"severity\": \"medium\",\n        \"title\": \"Missing validation for process.env.JWT_SECRET\",\n        \"body\": \"In 'src/token.js', 'jwt.sign' is called with 'process.env.JWT_SECRET' without validating that it is set. If this environment variable is missing, the signing call w"
+  "raw": "{\n  \"review\": \"Review\",\n  \"target\": {\n    \"mode\": \"working-tree\",\n    \"label\": \"working tree diff\",\n    \"explicit\": true\n  },\n  \"engine\": \"gemini\",\n  \"gemini\": {\n    \"status\": 0,\n    \"stdout\": \"{\\n  \\\"verdict\\\": \\\"needs-attention\\\",\\n  \\\"summary\\\": \\\"Undeclared dependencies and missing environment variable safety checks in token generation.\\\",\\n  \\\"findings\\\": [\\n    {\\n      \\\"severity\\\": \\\"critical\\\",\\n      \\\"title\\\": \\\"Undeclared Dependency 'jsonwebtoken'\\\",\\n      \\\"body\\\": \\\"The module 'jsonwebtoken' is imported in src/token.js but not declared as a dependency in package.json. This will cause a runtime crash with 'Error: Cannot find module 'jsonwebtoken'' when the application attempts to load src/token.js.\\\",\\n      \\\"file\\\": \\\"package.json\\\",\\n      \\\"line_start\\\": 5,\\n      \\\"line_end\\\": 7,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Add \\\\\\\"jsonwebtoken\\\\\\\": \\\\\\\"^9.0.2\\\\\\\" to the dependencies object in package.json.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"high\\\",\\n      \\\"title\\\": \\\"Missing check for process.env.JWT_SECRET\\\",\\n      \\\"body\\\": \\\"The 'issue' function in src/token.js invokes jwt.sign with process.env.JWT_SECRET without checking if the environment variable is set. If JWT_SECRET is undefined, jwt.sign will throw a synchronous 'secretOrPrivateKey must have a value' error, which could crash the application or cause unhandled exceptions.\\\",\\n      \\\"file\\\": \\\"src/token.js\\\",\\n      \\\"line_start\\\": 3,\\n      \\\"line_end\\\": 5,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Add an assertion at startup or inside the 'issue' function to ensure process.env.JWT_SECRET is defined before attempting to sign tokens.\\\"\\n    }\\n  ],\\n  \\\"next_steps\\\": [\\n    \\\"Run 'npm install jsonwebtoken' to declare the dependency in package.json.\\\",\\n    \\\"Add validation logic in src/token.js to guarantee process.env.JWT_SECRET is present before signing.\\\"\\n  ]\\n}\",\n    \"stderr\": \"Warning: 256-color support not detected. Using a terminal with at least 256-color support is recommended for a better visual experience.\\nRipgrep is not available. Falling back to GrepTool.\\n\"\n  },\n  \"result\": {\n    \"verdict\": \"needs-attention\",\n    \"summary\": \"Undeclared dependencies and missing environment variable safety checks in token generation.\",\n    \"findings\": [\n      {\n        \"severity\": \"critical\",\n        \"title\": \"Undeclared Dependency 'jsonwebtoken'\",\n        \"body\": \"The module 'jsonwebtoken' is imported in src/token.js but not declared as a dependency in package.json. This will cause a runtime crash with 'Error: Cannot find module 'jsonwebtoken'' when the application attempts to load src/token.js.\",\n        \"file\": \"package.json\",\n        \"line_start\": 5,\n        \"line_end\": 7,\n        \"confidence\": 1,\n        \"recommendation\": \"Add \\\"jsonwebtoken\\\": \\\"^9.0.2\\\" to the dependencies object in package.json.\"\n      },\n      {\n        \"severity\": \"high\",\n        \"title\": \"Missing check for process.env.JWT_SECRET\",\n        \"body\": \"The 'issue' function in src/token.js invokes jwt.sign with process.env.JWT_SECRET without checking if the environment variable is set. If JWT_SECRET is undefined, jwt.sign will throw a synchronous 'secretOrPrivateKey must have a value' error, which could crash the application or cause unhandled exceptions.\",\n        \"file\": \"src/token.js\",\n        \"line_start\": 3,\n        \"line_end\": 5,\n        \"confidence\": 1,\n        \"recommendation\": \"Add an assertion at startup or inside the 'issue' function to ensure process.env.JWT_SECRET is defined before attempting to sign tokens.\"\n      }\n    ],\n    \"next_steps\": [\n      \"Run 'npm install jsonwebtoken' to declare the dependency in package.json.\",\n      \"Add validation logic in src/token.js to guarantee process.env.JWT_SECRET is present before signing.\"\n    ]\n  }\n}\n"
 }

--- a/bench/cassettes/repo-context/gemini.model.json
+++ b/bench/cassettes/repo-context/gemini.model.json
@@ -1,115 +1,116 @@
 {
   "caseId": "repo-context",
   "cell": "gemini.model",
-  "recordedAt": "2026-08-19T09:08:56.233Z",
+  "recordedAt": "2026-08-24T10:45:10.318Z",
   "verdict": "needs-attention",
-  "summary": "The diff commits a local process state file to version control and lacks critical environment variable validation for JWT signing.",
+  "summary": "Missing validation for cryptographic secrets and accidental commit of runtime state.",
   "findings": [
     {
-      "severity": "medium",
-      "title": "Version controlling dynamic state file",
-      "body": "The commit introduces a `.omc/state/job.json` file containing a specific process ID and 'running' status. Dynamic state files must not be tracked in version control, as they leak local execution state and will cause constant git conflicts.",
-      "file": ".omc/state/job.json",
-      "line_start": 1,
-      "line_end": 1,
-      "confidence": 1,
-      "recommendation": "Remove this file from the commit, delete it from the repository, and add the `.omc/state/` directory to `.gitignore`."
-    },
-    {
       "severity": "high",
-      "title": "Missing validation for JWT_SECRET",
-      "body": "The `jwt.sign` function directly consumes `process.env.JWT_SECRET` without checking if it is defined. If the environment variable is missing, the `jsonwebtoken` library will throw an unhandled synchronous exception ('secretOrPrivateKey must have a value'), resulting in runtime application crashes when attempting to issue tokens.",
+      "title": "Unvalidated JWT_SECRET leads to runtime crash",
+      "body": "The function uses process.env.JWT_SECRET directly without checking if it is defined. If the environment variable is missing, jwt.sign will throw a synchronous exception ('secretOrPrivateKey must have a value'), which can crash the application.",
       "file": "src/token.js",
       "line_start": 4,
       "line_end": 4,
       "confidence": 0.95,
-      "recommendation": "Add a check to verify `process.env.JWT_SECRET` is defined and non-empty before issuing the token. Consider failing fast at application startup rather than at token issuance time."
+      "recommendation": "Validate that process.env.JWT_SECRET is defined (ideally at application startup) and fail fast with a clear configuration error before it can crash at runtime."
+    },
+    {
+      "severity": "medium",
+      "title": "Committing runtime state to version control",
+      "body": "A runtime state file containing a specific process ID (4242) and job status is being committed. Ephemeral state files should not be tracked in version control as they pollute the repository and cause dirty working trees.",
+      "file": ".omc/state/job.json",
+      "line_start": 1,
+      "line_end": 1,
+      "confidence": 0.99,
+      "recommendation": "Remove this file from the commit and add the .omc/state/ directory to .gitignore."
     }
   ],
-  "latencyMs": 21964,
-  "engineVersion": "0.55.1",
+  "latencyMs": 24514,
+  "engineVersion": "0.56.0",
+  "engineObserved": null,
   "samples": [
     {
       "verdict": "needs-attention",
-      "summary": "Missing validation for JWT_SECRET and accidental commit of transient runtime state.",
+      "summary": "Missing JWT secret validation can cause runtime crashes, and transient state was accidentally committed.",
       "findings": [
         {
           "severity": "high",
           "title": "Missing validation for JWT_SECRET",
-          "body": "The issue function uses process.env.JWT_SECRET directly without verifying that it is defined. If the environment variable is missing, jwt.sign will either throw a runtime error or sign the token using an undefined/empty value, which can lead to critical security vulnerabilities where tokens can be easily forged.",
+          "body": "The function uses process.env.JWT_SECRET directly without checking if it is defined. If the environment variable is missing, jwt.sign will throw a runtime exception ('secretOrPrivateKey must have a value'), causing the token issuance to fail and potentially crashing the application.",
           "file": "src/token.js",
           "line_start": 3,
           "line_end": 5,
           "confidence": 0.95,
-          "recommendation": "Throw an explicit error if process.env.JWT_SECRET is undefined or falsy before attempting to sign the token."
+          "recommendation": "Validate that process.env.JWT_SECRET is defined (ideally at module load time or application startup) and throw a clear, descriptive error if it is missing."
         },
         {
-          "severity": "low",
-          "title": "Transient state file committed to repository",
-          "body": "The file .omc/state/job.json contains local process state (a PID and a running job status). Committing local runtime state causes dirty working trees for other developers and merge conflicts.",
+          "severity": "medium",
+          "title": "Accidental commit of transient runtime state",
+          "body": "The file .omc/state/job.json contains a hardcoded PID (4242) and a 'running' status. This strongly indicates it is a local, ephemeral runtime state file that was accidentally tracked by git.",
           "file": ".omc/state/job.json",
           "line_start": 1,
           "line_end": 1,
           "confidence": 0.9,
-          "recommendation": "Remove this file from the commit and add the .omc/state/ directory to .gitignore."
+          "recommendation": "Remove this file from the commit and add '.omc/state/' to .gitignore to prevent local runtime states from leaking into version control."
         }
       ],
-      "latencyMs": 16888
+      "latencyMs": 21838
     },
     {
       "verdict": "needs-attention",
-      "summary": "The changes introduce runtime risks by not validating the JWT secret and accidentally check in ephemeral process state.",
+      "summary": "Missing validation for required secret environment variables and accidental tracking of ephemeral state.",
       "findings": [
-        {
-          "severity": "high",
-          "title": "Missing validation for JWT_SECRET environment variable",
-          "body": "The token issuing function relies directly on process.env.JWT_SECRET without checking if it is defined. If the environment variable is missing, jwt.sign throws a synchronous error, causing a runtime crash. It should fail fast during initialization or explicitly handle the missing secret.",
-          "file": "src/token.js",
-          "line_start": 3,
-          "line_end": 5,
-          "confidence": 0.95,
-          "recommendation": "Validate that process.env.JWT_SECRET is defined and not empty at the top level of the module to fail fast on startup."
-        },
-        {
-          "severity": "medium",
-          "title": "Ephemeral job state checked into version control",
-          "body": "The file .omc/state/job.json contains runtime process state (pid: 4242, status: running). Committing ephemeral runtime state pollutes the repository and will cause continuous merge conflicts.",
-          "file": ".omc/state/job.json",
-          "line_start": 1,
-          "line_end": 1,
-          "confidence": 0.98,
-          "recommendation": "Remove this file from the commit and add .omc/state/ to .gitignore."
-        }
-      ],
-      "latencyMs": 24950
-    },
-    {
-      "verdict": "needs-attention",
-      "summary": "The diff commits a local process state file to version control and lacks critical environment variable validation for JWT signing.",
-      "findings": [
-        {
-          "severity": "medium",
-          "title": "Version controlling dynamic state file",
-          "body": "The commit introduces a `.omc/state/job.json` file containing a specific process ID and 'running' status. Dynamic state files must not be tracked in version control, as they leak local execution state and will cause constant git conflicts.",
-          "file": ".omc/state/job.json",
-          "line_start": 1,
-          "line_end": 1,
-          "confidence": 1,
-          "recommendation": "Remove this file from the commit, delete it from the repository, and add the `.omc/state/` directory to `.gitignore`."
-        },
         {
           "severity": "high",
           "title": "Missing validation for JWT_SECRET",
-          "body": "The `jwt.sign` function directly consumes `process.env.JWT_SECRET` without checking if it is defined. If the environment variable is missing, the `jsonwebtoken` library will throw an unhandled synchronous exception ('secretOrPrivateKey must have a value'), resulting in runtime application crashes when attempting to issue tokens.",
+          "body": "The token issuance logic implicitly assumes `process.env.JWT_SECRET` is defined. If this environment variable is missing in a production environment, `jwt.sign()` will throw a synchronous error ('secretOrPrivateKey must have a value'), causing an unhandled exception that crashes the process during token issuance.",
+          "file": "src/token.js",
+          "line_start": 3,
+          "line_end": 5,
+          "confidence": 1,
+          "recommendation": "Validate the existence of `process.env.JWT_SECRET` at application startup or before calling `jwt.sign`, throwing a descriptive error if it is missing."
+        },
+        {
+          "severity": "medium",
+          "title": "Committing ephemeral job state to version control",
+          "body": "The diff adds a dynamically generated job state file (`.omc/state/job.json`) containing a specific PID and 'running' status. Committing ephemeral local state causes repository churn, inevitable merge conflicts, and leaks local execution context.",
+          "file": ".omc/state/job.json",
+          "line_start": 1,
+          "line_end": 2,
+          "confidence": 0.95,
+          "recommendation": "Remove this file from version control (e.g., `git rm --cached`) and ensure the `.omc/state/` directory is added to `.gitignore`."
+        }
+      ],
+      "latencyMs": 21920
+    },
+    {
+      "verdict": "needs-attention",
+      "summary": "Missing validation for cryptographic secrets and accidental commit of runtime state.",
+      "findings": [
+        {
+          "severity": "high",
+          "title": "Unvalidated JWT_SECRET leads to runtime crash",
+          "body": "The function uses process.env.JWT_SECRET directly without checking if it is defined. If the environment variable is missing, jwt.sign will throw a synchronous exception ('secretOrPrivateKey must have a value'), which can crash the application.",
           "file": "src/token.js",
           "line_start": 4,
           "line_end": 4,
           "confidence": 0.95,
-          "recommendation": "Add a check to verify `process.env.JWT_SECRET` is defined and non-empty before issuing the token. Consider failing fast at application startup rather than at token issuance time."
+          "recommendation": "Validate that process.env.JWT_SECRET is defined (ideally at application startup) and fail fast with a clear configuration error before it can crash at runtime."
+        },
+        {
+          "severity": "medium",
+          "title": "Committing runtime state to version control",
+          "body": "A runtime state file containing a specific process ID (4242) and job status is being committed. Ephemeral state files should not be tracked in version control as they pollute the repository and cause dirty working trees.",
+          "file": ".omc/state/job.json",
+          "line_start": 1,
+          "line_end": 1,
+          "confidence": 0.99,
+          "recommendation": "Remove this file from the commit and add the .omc/state/ directory to .gitignore."
         }
       ],
-      "latencyMs": 21964
+      "latencyMs": 24514
     }
   ],
-  "raw": "{\n  \"session_id\": \"f69a7a83-a612-4a35-8bd6-1733da531d30\",\n  \"response\": \"{\\n  \\\"verdict\\\": \\\"needs-attention\\\",\\n  \\\"summary\\\": \\\"The diff commits a local process state file to version control and lacks critical environment variable validation for JWT signing.\\\",\\n  \\\"findings\\\": [\\n    {\\n      \\\"severity\\\": \\\"medium\\\",\\n      \\\"title\\\": \\\"Version controlling dynamic state file\\\",\\n      \\\"body\\\": \\\"The commit introduces a `.omc/state/job.json` file containing a specific process ID and 'running' status. Dynamic state files must not be tracked in version control, as they leak local execution state and will cause constant git conflicts.\\\",\\n      \\\"file\\\": \\\".omc/state/job.json\\\",\\n      \\\"line_start\\\": 1,\\n      \\\"line_end\\\": 1,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Remove this file from the commit, delete it from the repository, and add the `.omc/state/` directory to `.gitignore`.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"high\\\",\\n      \\\"title\\\": \\\"Missing validation for JWT_SECRET\\\",\\n      \\\"body\\\": \\\"The `jwt.sign` function directly consumes `process.env.JWT_SECRET` without checking if it is defined. If the environment variable is missing, the `jsonwebtoken` library will throw an unhandled synchronous exception ('secretOrPrivateKey must have a value'), resulting in runtime application crashes when attempting to issue tokens.\\\",\\n      \\\"file\\\": \\\"src/token.js\\\",\\n      \\\"line_start\\\": 4,\\n      \\\"line_end\\\": 4,\\n      \\\"confidence\\\": 0.95,\\n      \\\"recommendation\\\": \\\"Add a check to verify `process.env.JWT_SECRET` is defined and non-empty before issuing the token. Consider failing fast at application startup rather than at token issuance time.\\\"\\n    }\\n  ],\\n  \\\"next_steps\\\": [\\n    \\\"Revert the addition of .omc/state/job.json and update .gitignore.\\\",\\n    \\\"Add explicit validation for process.env.JWT_SECRET in src/token.js to prevent runtime crashes.\\\"\\n  ]\\n}\",\n  \"stats\": {\n    \"models\": {\n      \"gemini-3.1-pro-preview\": {\n        \"api\": {\n          \"totalRequests\": 1,\n          \"totalErrors\": 0,\n          \"totalLatencyMs\": 20261,\n          \"errorsByType\": {}\n        },\n        \"tokens\": {\n          \"input\": 5059,\n          \"prompt\": 17278,\n          \"candidates\": 407,\n          \"total\": 19504,\n          \"cached\": 12219,\n          \"thoughts\": 1819,\n          \"tool\": 0\n        },\n        \"roles\": {\n          \"main\": {\n            \"totalRequests\": 1,\n            \"totalErrors\": 0,\n            \"totalLatencyMs\": 20261,\n            \"tokens\": {\n              \"input\": 5059,\n              \"prompt\": 17278,\n              \"candidates\": 407,\n              \"total\": 19504,\n              \"cached\": 12219,\n              \"thoughts\": 1819,\n              \"tool\": 0\n            }\n          }\n        }\n      }\n    },\n    \"tools\": {\n      \"totalCalls\": 0,\n      \"totalSuccess\": 0,\n      \"totalFail\": 0,\n      \"totalDurationMs\": 0,\n      \"totalDecisions\": {\n        \"accept\": 0,\n        \"reject\": 0,\n        \"modify\": 0,\n        \"auto_accept\": 0\n      },\n      \"byName\": {}\n    },\n    \"files\": {\n      \"totalLinesAdded\": 0,\n      \"totalLinesRemoved\": 0\n    }\n  }\n}"
+  "raw": "{\n  \"session_id\": \"515c65da-02e1-45ad-b3f2-71dd31bb2bd3\",\n  \"response\": \"{\\n  \\\"verdict\\\": \\\"needs-attention\\\",\\n  \\\"summary\\\": \\\"Missing validation for cryptographic secrets and accidental commit of runtime state.\\\",\\n  \\\"findings\\\": [\\n    {\\n      \\\"severity\\\": \\\"high\\\",\\n      \\\"title\\\": \\\"Unvalidated JWT_SECRET leads to runtime crash\\\",\\n      \\\"body\\\": \\\"The function uses process.env.JWT_SECRET directly without checking if it is defined. If the environment variable is missing, jwt.sign will throw a synchronous exception ('secretOrPrivateKey must have a value'), which can crash the application.\\\",\\n      \\\"file\\\": \\\"src/token.js\\\",\\n      \\\"line_start\\\": 4,\\n      \\\"line_end\\\": 4,\\n      \\\"confidence\\\": 0.95,\\n      \\\"recommendation\\\": \\\"Validate that process.env.JWT_SECRET is defined (ideally at application startup) and fail fast with a clear configuration error before it can crash at runtime.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"medium\\\",\\n      \\\"title\\\": \\\"Committing runtime state to version control\\\",\\n      \\\"body\\\": \\\"A runtime state file containing a specific process ID (4242) and job status is being committed. Ephemeral state files should not be tracked in version control as they pollute the repository and cause dirty working trees.\\\",\\n      \\\"file\\\": \\\".omc/state/job.json\\\",\\n      \\\"line_start\\\": 1,\\n      \\\"line_end\\\": 1,\\n      \\\"confidence\\\": 0.99,\\n      \\\"recommendation\\\": \\\"Remove this file from the commit and add the .omc/state/ directory to .gitignore.\\\"\\n    }\\n  ],\\n  \\\"next_steps\\\": [\\n    \\\"Add startup validation for all required environment variables, including JWT_SECRET.\\\",\\n    \\\"Remove .omc/state/job.json from git index and update .gitignore.\\\"\\n  ]\\n}\",\n  \"stats\": {\n    \"models\": {\n      \"gemini-3.1-pro-preview\": {\n        \"api\": {\n          \"totalRequests\": 1,\n          \"totalErrors\": 0,\n          \"totalLatencyMs\": 22853,\n          \"errorsByType\": {}\n        },\n        \"tokens\": {\n          \"input\": 18163,\n          \"prompt\": 18163,\n          \"candidates\": 379,\n          \"total\": 20524,\n          \"cached\": 0,\n          \"thoughts\": 1982,\n          \"tool\": 0\n        },\n        \"roles\": {\n          \"main\": {\n            \"totalRequests\": 1,\n            \"totalErrors\": 0,\n            \"totalLatencyMs\": 22853,\n            \"tokens\": {\n              \"input\": 18163,\n              \"prompt\": 18163,\n              \"candidates\": 379,\n              \"total\": 20524,\n              \"cached\": 0,\n              \"thoughts\": 1982,\n              \"tool\": 0\n            }\n          }\n        }\n      }\n    },\n    \"tools\": {\n      \"totalCalls\": 0,\n      \"totalSuccess\": 0,\n      \"totalFail\": 0,\n      \"totalDurationMs\": 0,\n      \"totalDecisions\": {\n        \"accept\": 0,\n        \"reject\": 0,\n        \"modify\": 0,\n        \"auto_accept\": 0\n      },\n      \"byName\": {}\n    },\n    \"files\": {\n      \"totalLinesAdded\": 0,\n      \"totalLinesRemoved\": 0\n    }\n  }\n}"
 }

--- a/bench/cassettes/stale-duplicate/agy.deep.json
+++ b/bench/cassettes/stale-duplicate/agy.deep.json
@@ -1,0 +1,86 @@
+{
+  "caseId": "stale-duplicate",
+  "cell": "agy.deep",
+  "recordedAt": "2026-08-24T14:43:50.543Z",
+  "verdict": "needs-attention",
+  "summary": "Missing maxBatch configuration causes worker chunking to evaluate to NaN, producing empty chunks and losing all batch items.",
+  "findings": [
+    {
+      "severity": "critical",
+      "title": "Undefined maxBatch in config causes chunking loop failure and data loss",
+      "body": "src/worker.js relies on config.maxBatch to slice batch IDs into chunks, but config/default.json does not define maxBatch. In JavaScript, accessing this undefined property causes i + config.maxBatch to produce NaN. As a result, ids.slice(0, NaN) returns [] and i becomes NaN, terminating the loop after a single iteration and returning [[]] as chunks regardless of the input.",
+      "file": "src/worker.js",
+      "line_start": 7,
+      "line_end": 9,
+      "confidence": 1,
+      "recommendation": "Define maxBatch in config/default.json and specify a fallback or validation in src/worker.js (e.g., const maxBatch = config.maxBatch ?? 100)."
+    }
+  ],
+  "latencyMs": 37088,
+  "engineVersion": "1.1.19",
+  "engineObserved": "agy",
+  "samples": [
+    {
+      "verdict": "needs-attention",
+      "summary": "Missing maxBatch configuration causes drain() in worker.js to slice with undefined bounds and drop all items.",
+      "findings": [
+        {
+          "severity": "critical",
+          "title": "Undefined config.maxBatch causes chunking failure and data loss in worker.js",
+          "body": "config.maxBatch is referenced in src/worker.js (lines 7-9) to chunk validated batch IDs, but maxBatch is not defined in config/default.json. Consequently, config.maxBatch is undefined at runtime, causing ids.slice(i, i + config.maxBatch) to evaluate to ids.slice(0, NaN) which returns [] and i += config.maxBatch to become NaN. This terminates the loop after a single iteration and silently discards all IDs.",
+          "file": "src/worker.js",
+          "line_start": 7,
+          "line_end": 9,
+          "confidence": 1,
+          "recommendation": "Add the maxBatch property to config/default.json and specify a fallback in src/worker.js (e.g., const maxBatch = config.maxBatch || 100)."
+        }
+      ],
+      "latencyMs": 37566
+    },
+    {
+      "verdict": "needs-attention",
+      "summary": "Worker chunking fails due to undefined config.maxBatch dropping all batch items, and legacy v1 validate logic remains a stale duplicate unpatched against missing IDs.",
+      "findings": [
+        {
+          "severity": "critical",
+          "title": "Undefined config.maxBatch causes chunking failure and data loss in worker",
+          "body": "src/worker.js references config.maxBatch in the chunking loop at lines 7-9, but maxBatch is not defined in config/default.json. Because config.maxBatch is undefined, ids.slice(0, NaN) yields an empty array and i becomes NaN, immediately terminating the loop and returning chunks: [[]], discarding all items in the batch.",
+          "file": "src/worker.js",
+          "line_start": 7,
+          "line_end": 9,
+          "confidence": 1,
+          "recommendation": "Define maxBatch in config/default.json and add fallback validation in src/worker.js (e.g. const maxBatch = Number(config.maxBatch) || 100)."
+        },
+        {
+          "severity": "medium",
+          "title": "Stale duplicate validation in v1 missing null-safe filtering for batch items",
+          "body": "The fix to skip entries with missing IDs was applied to src/api/v2/validate.js, but src/api/v1/validate.js remains a stale duplicate that calls batch.map((item) => String(item.id)). If legacy clients send batch items that are null, undefined, or missing an id property, v1 will throw a TypeError and abort processing the entire batch.",
+          "file": "src/api/v1/validate.js",
+          "line_start": 10,
+          "line_end": 10,
+          "confidence": 0.95,
+          "recommendation": "Update src/api/v1/validate.js to filter out null or missing id items matching v2, or consolidate shared validation logic into a common helper."
+        }
+      ],
+      "latencyMs": 48340
+    },
+    {
+      "verdict": "needs-attention",
+      "summary": "Missing maxBatch configuration causes worker chunking to evaluate to NaN, producing empty chunks and losing all batch items.",
+      "findings": [
+        {
+          "severity": "critical",
+          "title": "Undefined maxBatch in config causes chunking loop failure and data loss",
+          "body": "src/worker.js relies on config.maxBatch to slice batch IDs into chunks, but config/default.json does not define maxBatch. In JavaScript, accessing this undefined property causes i + config.maxBatch to produce NaN. As a result, ids.slice(0, NaN) returns [] and i becomes NaN, terminating the loop after a single iteration and returning [[]] as chunks regardless of the input.",
+          "file": "src/worker.js",
+          "line_start": 7,
+          "line_end": 9,
+          "confidence": 1,
+          "recommendation": "Define maxBatch in config/default.json and specify a fallback or validation in src/worker.js (e.g., const maxBatch = config.maxBatch ?? 100)."
+        }
+      ],
+      "latencyMs": 37088
+    }
+  ],
+  "raw": "{\n  \"review\": \"Review\",\n  \"target\": {\n    \"mode\": \"working-tree\",\n    \"label\": \"working tree diff\",\n    \"explicit\": true\n  },\n  \"engine\": \"agy\",\n  \"gemini\": {\n    \"status\": 0,\n    \"stdout\": \"{\\n  \\\"verdict\\\": \\\"needs-attention\\\",\\n  \\\"summary\\\": \\\"Missing maxBatch configuration causes worker chunking to evaluate to NaN, producing empty chunks and losing all batch items.\\\",\\n  \\\"findings\\\": [\\n    {\\n      \\\"severity\\\": \\\"critical\\\",\\n      \\\"title\\\": \\\"Undefined maxBatch in config causes chunking loop failure and data loss\\\",\\n      \\\"body\\\": \\\"src/worker.js relies on config.maxBatch to slice batch IDs into chunks, but config/default.json does not define maxBatch. In JavaScript, accessing this undefined property causes i + config.maxBatch to produce NaN. As a result, ids.slice(0, NaN) returns [] and i becomes NaN, terminating the loop after a single iteration and returning [[]] as chunks regardless of the input.\\\",\\n      \\\"file\\\": \\\"src/worker.js\\\",\\n      \\\"line_start\\\": 7,\\n      \\\"line_end\\\": 9,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Define maxBatch in config/default.json and specify a fallback or validation in src/worker.js (e.g., const maxBatch = config.maxBatch ?? 100).\\\"\\n    }\\n  ],\\n  \\\"next_steps\\\": [\\n    \\\"Add maxBatch to config/default.json\\\",\\n    \\\"Add unit tests covering drain() in src/worker.js with various batch sizes\\\"\\n  ]\\n}\",\n    \"stderr\": \"\"\n  },\n  \"result\": {\n    \"verdict\": \"needs-attention\",\n    \"summary\": \"Missing maxBatch configuration causes worker chunking to evaluate to NaN, producing empty chunks and losing all batch items.\",\n    \"findings\": [\n      {\n        \"severity\": \"critical\",\n        \"title\": \"Undefined maxBatch in config causes chunking loop failure and data loss\",\n        \"body\": \"src/worker.js relies on config.maxBatch to slice batch IDs into chunks, but config/default.json does not define maxBatch. In JavaScript, accessing this undefined property causes i + config.maxBatch to produce NaN. As a result, ids.slice(0, NaN) returns [] and i becomes NaN, terminating the loop after a single iteration and returning [[]] as chunks regardless of the input.\",\n        \"file\": \"src/worker.js\",\n        \"line_start\": 7,\n        \"line_end\": 9,\n        \"confidence\": 1,\n        \"recommendation\": \"Define maxBatch in config/default.json and specify a fallback or validation in src/worker.js (e.g., const maxBatch = config.maxBatch ?? 100).\"\n      }\n    ],\n    \"next_steps\": [\n      \"Add maxBatch to config/default.json\",\n      \"Add unit tests covering drain() in src/worker.js with various batch sizes\"\n    ]\n  }\n}\n"
+}

--- a/bench/cassettes/stale-duplicate/agy.model.json
+++ b/bench/cassettes/stale-duplicate/agy.model.json
@@ -1,0 +1,65 @@
+{
+  "caseId": "stale-duplicate",
+  "cell": "agy.model",
+  "recordedAt": "2026-08-24T14:41:46.366Z",
+  "verdict": "needs-attention",
+  "summary": "The batch chunking loop in drain() unsafely assumes config.maxBatch is a positive integer, creating a risk of an infinite loop or data loss.",
+  "findings": [
+    {
+      "severity": "high",
+      "title": "Unvalidated loop step risks infinite loop",
+      "body": "In src/worker.js, drain() increments the loop index via `i += config.maxBatch` without verifying that config.maxBatch is a positive integer. If config.maxBatch is 0 or negative, non-empty batches trigger an infinite loop that hangs the Node.js event loop. If config.maxBatch is undefined or NaN, i becomes NaN and the loop terminates prematurely, returning incomplete or empty chunks.",
+      "file": "src/worker.js",
+      "line_start": 7,
+      "line_end": 9,
+      "confidence": 0.9,
+      "recommendation": "Validate that config.maxBatch is an integer greater than 0 before entering the loop (or supply a safe default/throw a configuration error if invalid)."
+    }
+  ],
+  "latencyMs": 41932,
+  "engineVersion": "1.1.19",
+  "engineObserved": null,
+  "samples": [
+    {
+      "verdict": "needs-attention",
+      "summary": "The batch chunking loop in worker.js unsafely assumes config.maxBatch is a positive integer, risking an infinite loop or silent data loss.",
+      "findings": [
+        {
+          "severity": "high",
+          "title": "Unsafe loop increment with unvalidated config.maxBatch",
+          "body": "In drain(), the chunking loop uses `i += config.maxBatch` without verifying that `config.maxBatch` is a positive integer. If `config.maxBatch` is 0 or negative, the loop will never terminate and will freeze the process. If `config.maxBatch` is undefined or NaN, `i` becomes `NaN`, causing `i < ids.length` to evaluate to false and silently returning empty chunks.",
+          "file": "src/worker.js",
+          "line_start": 7,
+          "line_end": 9,
+          "confidence": 0.95,
+          "recommendation": "Validate that `config.maxBatch` is a positive integer greater than 0 before running the loop, or provide a safe default value."
+        }
+      ],
+      "latencyMs": 27768
+    },
+    {
+      "verdict": "approve",
+      "summary": "The changes safely filter out items with missing or nullish IDs and correctly chunk the validated IDs for queue processing.",
+      "findings": [],
+      "latencyMs": 35069
+    },
+    {
+      "verdict": "needs-attention",
+      "summary": "The batch chunking loop in drain() unsafely assumes config.maxBatch is a positive integer, creating a risk of an infinite loop or data loss.",
+      "findings": [
+        {
+          "severity": "high",
+          "title": "Unvalidated loop step risks infinite loop",
+          "body": "In src/worker.js, drain() increments the loop index via `i += config.maxBatch` without verifying that config.maxBatch is a positive integer. If config.maxBatch is 0 or negative, non-empty batches trigger an infinite loop that hangs the Node.js event loop. If config.maxBatch is undefined or NaN, i becomes NaN and the loop terminates prematurely, returning incomplete or empty chunks.",
+          "file": "src/worker.js",
+          "line_start": 7,
+          "line_end": 9,
+          "confidence": 0.9,
+          "recommendation": "Validate that config.maxBatch is an integer greater than 0 before entering the loop (or supply a safe default/throw a configuration error if invalid)."
+        }
+      ],
+      "latencyMs": 41932
+    }
+  ],
+  "raw": "{\"conversation_id\":\"042d88c2-6819-4503-b5f8-b7199a81d7b6\",\"status\":\"SUCCESS\",\"response\":\"{\\n  \\\"verdict\\\": \\\"needs-attention\\\",\\n  \\\"summary\\\": \\\"The batch chunking loop in drain() unsafely assumes config.maxBatch is a positive integer, creating a risk of an infinite loop or data loss.\\\",\\n  \\\"findings\\\": [\\n    {\\n      \\\"severity\\\": \\\"high\\\",\\n      \\\"title\\\": \\\"Unvalidated loop step risks infinite loop\\\",\\n      \\\"body\\\": \\\"In src/worker.js, drain() increments the loop index via `i += config.maxBatch` without verifying that config.maxBatch is a positive integer. If config.maxBatch is 0 or negative, non-empty batches trigger an infinite loop that hangs the Node.js event loop. If config.maxBatch is undefined or NaN, i becomes NaN and the loop terminates prematurely, returning incomplete or empty chunks.\\\",\\n      \\\"file\\\": \\\"src/worker.js\\\",\\n      \\\"line_start\\\": 7,\\n      \\\"line_end\\\": 9,\\n      \\\"confidence\\\": 0.9,\\n      \\\"recommendation\\\": \\\"Validate that config.maxBatch is an integer greater than 0 before entering the loop (or supply a safe default/throw a configuration error if invalid).\\\"\\n    }\\n  ],\\n  \\\"next_steps\\\": [\\n    \\\"Add validation or a safe fallback for config.maxBatch in src/worker.js before chunking.\\\",\\n    \\\"Add unit tests for drain() verifying chunking behavior with various batch sizes and configuration values.\\\"\\n  ]\\n}\\n\",\"duration_seconds\":37.690064,\"num_turns\":1,\"usage\":{\"input_tokens\":19177,\"output_tokens\":11512,\"thinking_tokens\":11251,\"cache_read_tokens\":0,\"total_tokens\":30689}}\n"
+}

--- a/bench/cassettes/stale-duplicate/agy.shallow.json
+++ b/bench/cassettes/stale-duplicate/agy.shallow.json
@@ -1,0 +1,54 @@
+{
+  "caseId": "stale-duplicate",
+  "cell": "agy.shallow",
+  "recordedAt": "2026-08-24T15:27:51.675Z",
+  "verdict": "needs-attention",
+  "summary": "Unvalidated batch configuration in worker chunking logic can cause infinite loops or silent data loss.",
+  "findings": [
+    {
+      "severity": "medium",
+      "title": "Unvalidated `config.maxBatch` allows infinite loop or silent batch drop",
+      "body": "In `src/worker.js`, `drain()` increments the loop counter using `i += config.maxBatch`. If `config.maxBatch` is non-positive (<= 0), the loop will never advance and will hang the process on non-empty batches. If `config.maxBatch` is undefined or not a number, `i` evaluates to `NaN`, causing the loop condition `i < ids.length` to immediately evaluate to false and return an empty `chunks` array, silently dropping all batch items.",
+      "file": "src/worker.js",
+      "line_start": 7,
+      "line_end": 9,
+      "confidence": 0.95,
+      "recommendation": "Validate that `config.maxBatch` is a positive integer (e.g., `const maxBatch = Number.isInteger(config?.maxBatch) && config.maxBatch > 0 ? config.maxBatch : throw new Error('Invalid maxBatch')`) before running the chunking loop."
+    }
+  ],
+  "latencyMs": 22864,
+  "engineVersion": "1.1.19",
+  "engineObserved": "agy",
+  "samples": [
+    {
+      "verdict": "approve",
+      "summary": "The batch validation correctly filters invalid IDs and worker chunking is implemented cleanly.",
+      "findings": [],
+      "latencyMs": 26299
+    },
+    {
+      "verdict": "approve",
+      "summary": "The batch validation filtering and worker chunking implementation are correct and introduce no material defects.",
+      "findings": [],
+      "latencyMs": 26479
+    },
+    {
+      "verdict": "needs-attention",
+      "summary": "Unvalidated batch configuration in worker chunking logic can cause infinite loops or silent data loss.",
+      "findings": [
+        {
+          "severity": "medium",
+          "title": "Unvalidated `config.maxBatch` allows infinite loop or silent batch drop",
+          "body": "In `src/worker.js`, `drain()` increments the loop counter using `i += config.maxBatch`. If `config.maxBatch` is non-positive (<= 0), the loop will never advance and will hang the process on non-empty batches. If `config.maxBatch` is undefined or not a number, `i` evaluates to `NaN`, causing the loop condition `i < ids.length` to immediately evaluate to false and return an empty `chunks` array, silently dropping all batch items.",
+          "file": "src/worker.js",
+          "line_start": 7,
+          "line_end": 9,
+          "confidence": 0.95,
+          "recommendation": "Validate that `config.maxBatch` is a positive integer (e.g., `const maxBatch = Number.isInteger(config?.maxBatch) && config.maxBatch > 0 ? config.maxBatch : throw new Error('Invalid maxBatch')`) before running the chunking loop."
+        }
+      ],
+      "latencyMs": 22864
+    }
+  ],
+  "raw": "{\n  \"review\": \"Review\",\n  \"target\": {\n    \"mode\": \"working-tree\",\n    \"label\": \"working tree diff\",\n    \"explicit\": true\n  },\n  \"engine\": \"agy\",\n  \"gemini\": {\n    \"status\": 0,\n    \"stdout\": \"{\\n  \\\"verdict\\\": \\\"needs-attention\\\",\\n  \\\"summary\\\": \\\"Unvalidated batch configuration in worker chunking logic can cause infinite loops or silent data loss.\\\",\\n  \\\"findings\\\": [\\n    {\\n      \\\"severity\\\": \\\"medium\\\",\\n      \\\"title\\\": \\\"Unvalidated `config.maxBatch` allows infinite loop or silent batch drop\\\",\\n      \\\"body\\\": \\\"In `src/worker.js`, `drain()` increments the loop counter using `i += config.maxBatch`. If `config.maxBatch` is non-positive (<= 0), the loop will never advance and will hang the process on non-empty batches. If `config.maxBatch` is undefined or not a number, `i` evaluates to `NaN`, causing the loop condition `i < ids.length` to immediately evaluate to false and return an empty `chunks` array, silently dropping all batch items.\\\",\\n      \\\"file\\\": \\\"src/worker.js\\\",\\n      \\\"line_start\\\": 7,\\n      \\\"line_end\\\": 9,\\n      \\\"confidence\\\": 0.95,\\n      \\\"recommendation\\\": \\\"Validate that `config.maxBatch` is a positive integer (e.g., `const maxBatch = Number.isInteger(config?.maxBatch) && config.maxBatch > 0 ? config.maxBatch : throw new Error('Invalid maxBatch')`) before running the chunking loop.\\\"\\n    }\\n  ],\\n  \\\"next_steps\\\": [\\n    \\\"Add validation or fallback handling for `config.maxBatch` in `src/worker.js`.\\\",\\n    \\\"Add unit test cases for `drain()` handling edge cases of missing or invalid `config.maxBatch` values.\\\"\\n  ]\\n}\",\n    \"stderr\": \"\"\n  },\n  \"result\": {\n    \"verdict\": \"needs-attention\",\n    \"summary\": \"Unvalidated batch configuration in worker chunking logic can cause infinite loops or silent data loss.\",\n    \"findings\": [\n      {\n        \"severity\": \"medium\",\n        \"title\": \"Unvalidated `config.maxBatch` allows infinite loop or silent batch drop\",\n        \"body\": \"In `src/worker.js`, `drain()` increments the loop counter using `i += config.maxBatch`. If `config.maxBatch` is non-positive (<= 0), the loop will never advance and will hang the process on non-empty batches. If `config.maxBatch` is undefined or not a number, `i` evaluates to `NaN`, causing the loop condition `i < ids.length` to immediately evaluate to false and return an empty `chunks` array, silently dropping all batch items.\",\n        \"file\": \"src/worker.js\",\n        \"line_start\": 7,\n        \"line_end\": 9,\n        \"confidence\": 0.95,\n        \"recommendation\": \"Validate that `config.maxBatch` is a positive integer (e.g., `const maxBatch = Number.isInteger(config?.maxBatch) && config.maxBatch > 0 ? config.maxBatch : throw new Error('Invalid maxBatch')`) before running the chunking loop.\"\n      }\n    ],\n    \"next_steps\": [\n      \"Add validation or fallback handling for `config.maxBatch` in `src/worker.js`.\",\n      \"Add unit test cases for `drain()` handling edge cases of missing or invalid `config.maxBatch` values.\"\n    ]\n  }\n}\n"
+}

--- a/bench/cassettes/stale-duplicate/codex.adversarial.json
+++ b/bench/cassettes/stale-duplicate/codex.adversarial.json
@@ -1,0 +1,76 @@
+{
+  "caseId": "stale-duplicate",
+  "cell": "codex.adversarial",
+  "recordedAt": "2026-08-24T23:29:39.435Z",
+  "verdict": "needs-attention",
+  "summary": "Do not ship: the new worker silently drops every ID in non-empty batches.",
+  "findings": [
+    {
+      "severity": "high",
+      "title": "Missing maxBatch causes valid IDs to be discarded",
+      "body": "config/default.json does not define maxBatch. Therefore the first slice uses NaN as its end index and produces [], after which i becomes NaN and the loop exits. Reproduced with two valid IDs: drain([{id:'a'},{id:'b'}]) returned {\"queue\":\"ingest\",\"chunks\":[[]]}. Downstream processing would silently lose the entire batch.",
+      "file": "src/worker.js",
+      "line_start": 7,
+      "line_end": 8,
+      "confidence": 1,
+      "recommendation": "Define maxBatch as a positive integer, reject missing or invalid values at startup, and add a test proving a non-empty batch preserves every ID across chunks."
+    }
+  ],
+  "latencyMs": 74192,
+  "engineVersion": "codex-cli 0.149.0",
+  "engineObserved": null,
+  "samples": [
+    {
+      "verdict": "needs-attention",
+      "summary": "Do not ship: the new worker silently discards every non-empty batch because its chunk size is undefined.",
+      "findings": [
+        {
+          "severity": "high",
+          "title": "Missing maxBatch configuration produces an empty chunk and drops all IDs",
+          "body": "`config/default.json` defines `queueName` and `retryDelayMs` but no `maxBatch`. Therefore `i + config.maxBatch` becomes `NaN`, `ids.slice(0, NaN)` yields an empty array, and the loop terminates after one iteration. This was reproduced with two valid IDs: `drain([{id:1},{id:2}])` returned `{\"queue\":\"ingest\",\"chunks\":[[]]}`. Any caller treating this result as successfully drained can lose the entire batch without an exception.",
+          "file": "src/worker.js",
+          "line_start": 7,
+          "line_end": 8,
+          "confidence": 1,
+          "recommendation": "Define and validate a positive integer `maxBatch` before processing, and add tests asserting that non-empty input preserves every ID across chunks and that missing, zero, negative, or non-numeric chunk sizes fail explicitly."
+        }
+      ],
+      "latencyMs": 42047
+    },
+    {
+      "verdict": "needs-attention",
+      "summary": "Do not ship: the new worker silently discards every non-empty batch.",
+      "findings": [
+        {
+          "severity": "high",
+          "title": "Missing maxBatch produces an empty chunk and drops all IDs",
+          "body": "config/default.json does not define maxBatch. At runtime, slice(0, undefined) becomes slice(0, 0), so the first chunk is empty; then i += undefined makes i NaN and terminates the loop. Direct execution of drain([{id:1},{id:2}]) returned {\"queue\":\"ingest\",\"chunks\":[[]]}, losing both validated IDs without an error.",
+          "file": "src/worker.js",
+          "line_start": 7,
+          "line_end": 8,
+          "confidence": 1,
+          "recommendation": "Define maxBatch as a positive integer, validate it before entering the loop, fail fast on invalid configuration, and add a test asserting that a non-empty batch preserves every ID across chunks."
+        }
+      ],
+      "latencyMs": 47737
+    },
+    {
+      "verdict": "needs-attention",
+      "summary": "Do not ship: the new worker silently drops every ID in non-empty batches.",
+      "findings": [
+        {
+          "severity": "high",
+          "title": "Missing maxBatch causes valid IDs to be discarded",
+          "body": "config/default.json does not define maxBatch. Therefore the first slice uses NaN as its end index and produces [], after which i becomes NaN and the loop exits. Reproduced with two valid IDs: drain([{id:'a'},{id:'b'}]) returned {\"queue\":\"ingest\",\"chunks\":[[]]}. Downstream processing would silently lose the entire batch.",
+          "file": "src/worker.js",
+          "line_start": 7,
+          "line_end": 8,
+          "confidence": 1,
+          "recommendation": "Define maxBatch as a positive integer, reject missing or invalid values at startup, and add a test proving a non-empty batch preserves every ID across chunks."
+        }
+      ],
+      "latencyMs": 74192
+    }
+  ],
+  "raw": "{\n  \"review\": \"Adversarial Review\",\n  \"target\": {\n    \"mode\": \"working-tree\",\n    \"label\": \"working tree diff\",\n    \"explicit\": true\n  },\n  \"threadId\": \"01a0361a-9b74-7573-8817-39e39ec3e900\",\n  \"context\": {\n    \"repoRoot\": \"C:/Users/arcobaleno/AppData/Local/Temp/bench-stale-duplicate-AYQEBP\",\n    \"branch\": \"main\",\n    \"summary\": \"Reviewing 0 staged, 2 unstaged, and 0 untracked file(s).\"\n  },\n  \"codex\": {\n    \"status\": 0,\n    \"stderr\": \"\",\n    \"stdout\": \"{\\\"verdict\\\":\\\"needs-attention\\\",\\\"summary\\\":\\\"Do not ship: the new worker silently drops every ID in non-empty batches.\\\",\\\"findings\\\":[{\\\"severity\\\":\\\"high\\\",\\\"title\\\":\\\"Missing maxBatch causes valid IDs to be discarded\\\",\\\"body\\\":\\\"config/default.json does not define maxBatch. Therefore the first slice uses NaN as its end index and produces [], after which i becomes NaN and the loop exits. Reproduced with two valid IDs: drain([{id:'a'},{id:'b'}]) returned {\\\\\\\"queue\\\\\\\":\\\\\\\"ingest\\\\\\\",\\\\\\\"chunks\\\\\\\":[[]]}. Downstream processing would silently lose the entire batch.\\\",\\\"file\\\":\\\"src/worker.js\\\",\\\"line_start\\\":7,\\\"line_end\\\":8,\\\"confidence\\\":1,\\\"recommendation\\\":\\\"Define maxBatch as a positive integer, reject missing or invalid values at startup, and add a test proving a non-empty batch preserves every ID across chunks.\\\"}],\\\"next_steps\\\":[\\\"Fix and validate maxBatch, then rerun the working-tree review.\\\"]}\",\n    \"reasoning\": []\n  },\n  \"result\": {\n    \"verdict\": \"needs-attention\",\n    \"summary\": \"Do not ship: the new worker silently drops every ID in non-empty batches.\",\n    \"findings\": [\n      {\n        \"severity\": \"high\",\n        \"title\": \"Missing maxBatch causes valid IDs to be discarded\",\n        \"body\": \"config/default.json does not define maxBatch. Therefore the first slice uses NaN as its end index and produces [], after which i becomes NaN and the loop exits. Reproduced with two valid IDs: drain([{id:'a'},{id:'b'}]) returned {\\\"queue\\\":\\\"ingest\\\",\\\"chunks\\\":[[]]}. Downstream processing would silently lose the entire batch.\",\n        \"file\": \"src/worker.js\",\n        \"line_start\": 7,\n        \"line_end\": 8,\n        \"confidence\": 1,\n        \"recommendation\": \"Define maxBatch as a positive integer, reject missing or invalid values at startup, and add a test proving a non-empty batch preserves every ID across chunks.\"\n      }\n    ],\n    \"next_steps\": [\n      \"Fix and validate maxBatch, then rerun the working-tree review.\"\n    ]\n  },\n  \"rawOutput\": \"{\\\"verdict\\\":\\\"needs-attention\\\",\\\"summary\\\":\\\"Do not ship: the new worker silently drops every ID in non-empty batches.\\\",\\\"findings\\\":[{\\\"severity\\\":\\\"high\\\",\\\"title\\\":\\\"Missing maxBatch causes valid IDs to be discarded\\\",\\\"body\\\":\\\"config/default.json does not define maxBatch. Therefore the first slice uses NaN as its end index and produces [], after which i becomes NaN and the loop exits. Reproduced with two valid IDs: drain([{id:'a'},{id:'b'}]) returned {\\\\\\\"queue\\\\\\\":\\\\\\\"ingest\\\\\\\",\\\\\\\"chunks\\\\\\\":[[]]}. Downstream processing would silently lose the entire batch.\\\",\\\"file\\\":\\\"src/worker.js\\\",\\\"line_start\\\":7,\\\"line_end\\\":8,\\\"confidence\\\":1,\\\"recommendation\\\":\\\"Define maxBatch as a positive integer, reject missing or invalid values at startup, and add a test proving a non-empty batch preserves every ID across chunks.\\\"}],\\\"next_steps\\\":[\\\"Fix and validate maxBatch, then rerun the working-tree review.\\\"]}\",\n  \"parseError\": null,\n  \"reasoningSummary\": []\n}\n"
+}

--- a/bench/cassettes/stale-duplicate/codex.model.json
+++ b/bench/cassettes/stale-duplicate/codex.model.json
@@ -1,0 +1,76 @@
+{
+  "caseId": "stale-duplicate",
+  "cell": "codex.model",
+  "recordedAt": "2026-08-24T23:24:47.507Z",
+  "verdict": "needs-attention",
+  "summary": "Chunking can hang indefinitely when maxBatch is not a positive finite integer.",
+  "findings": [
+    {
+      "severity": "medium",
+      "title": "Invalid maxBatch causes a non-terminating drain loop",
+      "body": "The loop assumes config.maxBatch is a positive finite number. If it is 0, negative, NaN, or otherwise invalid, i may never advance toward ids.length, causing drain() to loop indefinitely and consume memory or CPU.",
+      "file": "src/worker.js",
+      "line_start": 7,
+      "line_end": 9,
+      "confidence": 0.98,
+      "recommendation": "Validate config.maxBatch before the loop as a positive finite integer and fail fast with a clear configuration error."
+    }
+  ],
+  "latencyMs": 23869,
+  "engineVersion": "codex-cli 0.149.0",
+  "engineObserved": null,
+  "samples": [
+    {
+      "verdict": "needs-attention",
+      "summary": "The worker can hang indefinitely when maxBatch is zero or negative.",
+      "findings": [
+        {
+          "severity": "high",
+          "title": "Unvalidated chunk size can cause an infinite loop",
+          "body": "The loop increments i by config.maxBatch without verifying that it is a positive integer. A zero value prevents i from advancing, while a negative value moves it away from the termination condition, causing drain() to loop indefinitely and consume memory whenever ids is nonempty.",
+          "file": "src/worker.js",
+          "line_start": 7,
+          "line_end": 9,
+          "confidence": 0.99,
+          "recommendation": "Validate config.maxBatch before the loop and throw a configuration error unless it is a positive integer."
+        }
+      ],
+      "latencyMs": 20635
+    },
+    {
+      "verdict": "needs-attention",
+      "summary": "Chunking trusts an unvalidated configuration value that can hang the worker or silently lose the batch.",
+      "findings": [
+        {
+          "severity": "high",
+          "title": "Invalid maxBatch can hang or discard work",
+          "body": "The loop uses config.maxBatch as both its increment and slice width without verifying that it is a positive integer. A value of 0 or a negative value makes the loop non-terminating for any non-empty batch; a missing, non-numeric, or fractional value can produce empty or inconsistent chunks and silently omit IDs.",
+          "file": "src/worker.js",
+          "line_start": 6,
+          "line_end": 8,
+          "confidence": 0.99,
+          "recommendation": "Validate maxBatch before the loop with Number.isInteger(config.maxBatch) && config.maxBatch > 0, and throw a clear configuration error when invalid."
+        }
+      ],
+      "latencyMs": 18304
+    },
+    {
+      "verdict": "needs-attention",
+      "summary": "Chunking can hang indefinitely when maxBatch is not a positive finite integer.",
+      "findings": [
+        {
+          "severity": "medium",
+          "title": "Invalid maxBatch causes a non-terminating drain loop",
+          "body": "The loop assumes config.maxBatch is a positive finite number. If it is 0, negative, NaN, or otherwise invalid, i may never advance toward ids.length, causing drain() to loop indefinitely and consume memory or CPU.",
+          "file": "src/worker.js",
+          "line_start": 7,
+          "line_end": 9,
+          "confidence": 0.98,
+          "recommendation": "Validate config.maxBatch before the loop as a positive finite integer and fail fast with a clear configuration error."
+        }
+      ],
+      "latencyMs": 23869
+    }
+  ],
+  "raw": "{\"verdict\":\"needs-attention\",\"summary\":\"Chunking can hang indefinitely when maxBatch is not a positive finite integer.\",\"findings\":[{\"severity\":\"medium\",\"title\":\"Invalid maxBatch causes a non-terminating drain loop\",\"body\":\"The loop assumes config.maxBatch is a positive finite number. If it is 0, negative, NaN, or otherwise invalid, i may never advance toward ids.length, causing drain() to loop indefinitely and consume memory or CPU.\",\"file\":\"src/worker.js\",\"line_start\":7,\"line_end\":9,\"confidence\":0.98,\"recommendation\":\"Validate config.maxBatch before the loop as a positive finite integer and fail fast with a clear configuration error.\"}],\"next_steps\":[\"Add maxBatch validation and tests covering zero, negative, non-numeric, and valid values.\"]}\n"
+}

--- a/bench/cassettes/vacuous-tests/agy.adversarial.json
+++ b/bench/cassettes/vacuous-tests/agy.adversarial.json
@@ -1,0 +1,196 @@
+{
+  "caseId": "vacuous-tests",
+  "cell": "agy.adversarial",
+  "recordedAt": "2026-08-24T11:27:47.789Z",
+  "verdict": "needs-attention",
+  "summary": "The test suite introduces vacuous tests without assertions, deterministic failure from unseeded state, unhandled async assertion escapes, and skipped core coverage.",
+  "findings": [
+    {
+      "severity": "high",
+      "title": "Async assertion in process.nextTick escapes test runner lifecycle and hides failures",
+      "body": "The test function runs synchronously and returns immediately without awaiting or returning a Promise. The assertion inside `process.nextTick` executes after `node:test` has already marked the test as passed. Additionally, no deletion or expiration function is invoked after `sessions.set('abc', ...)`, leaving `sessions.size` at 1 and causing an uncaught exception outside the test lifecycle when the callback executes.",
+      "file": "test/session.test.js",
+      "line_start": 20,
+      "line_end": 25,
+      "confidence": 0.98,
+      "recommendation": "Invoke the deletion logic directly and perform assertions synchronously within the test scope without using un-awaited nextTick callbacks."
+    },
+    {
+      "severity": "high",
+      "title": "Deterministic assertion failure caused by unseeded session state",
+      "body": "The test calls `render()` against an empty `sessions` Map without setting up expired and fresh session records. `render()` returns an empty array, resulting in `indexOf('expired')` and `indexOf('fresh')` both returning `-1`. Evaluating `-1 < -1` yields `false`, causing `assert.ok` to throw an AssertionError every time the test runs.",
+      "file": "test/session.test.js",
+      "line_start": 10,
+      "line_end": 13,
+      "confidence": 0.99,
+      "recommendation": "Seed the `sessions` Map with both an expired and a fresh session before calling `render()`, and clear the Map in an afterEach hook to avoid test pollution."
+    },
+    {
+      "severity": "medium",
+      "title": "Vacuous test with missing assertions and valid payload under malformed test description",
+      "body": "The test titled 'parseSession handles a malformed payload' passes a valid JSON string ('{\"id\":\"abc\",\"expiresAt\":0}') and contains no assertions or `assert.throws` checks. The test produces false confidence by passing vacuously without validating error handling or parsed output.",
+      "file": "test/session.test.js",
+      "line_start": 6,
+      "line_end": 8,
+      "confidence": 0.95,
+      "recommendation": "Pass actual malformed inputs (e.g., truncated JSON or invalid types) and assert expected return values or error throwing behavior with `assert.throws`."
+    },
+    {
+      "severity": "low",
+      "title": "Skipped test disables verification of session expiration logic",
+      "body": "`test.skip` is used on the `expire()` test, bypassing automated verification of session deletion behavior in CI.",
+      "file": "test/session.test.js",
+      "line_start": 15,
+      "line_end": 18,
+      "confidence": 0.95,
+      "recommendation": "Change `test.skip` to `test` so the core deletion behavior is actively tested."
+    }
+  ],
+  "latencyMs": 122195,
+  "engineVersion": "1.1.19",
+  "engineObserved": "agy",
+  "samples": [
+    {
+      "verdict": "needs-attention",
+      "summary": "The test suite contains vacuous tests, unawaited asynchronous assertions that mask failures, and skipped core coverage, creating false confidence.",
+      "findings": [
+        {
+          "severity": "high",
+          "title": "Unawaited asynchronous assertion in synchronous test creates vacuous pass and leaks state",
+          "body": "In test/session.test.js lines 20-25, the test function is synchronous and completes before the process.nextTick callback executes. In node:test, assertions inside unawaited nextTick callbacks run outside the test runner's lifecycle, so failure cannot fail the test. Furthermore, no deletion logic (expire) is called after sessions.set(), meaning sessions.size is actually 1 rather than 0, yet the test passes while polluting the global sessions map.",
+          "file": "test/session.test.js",
+          "line_start": 20,
+          "line_end": 25,
+          "confidence": 1,
+          "recommendation": "Invoke the expire() function under test, assert the store size synchronously (or await an async operation if asynchronous), and clean up the shared sessions Map before/after each test."
+        },
+        {
+          "severity": "high",
+          "title": "Order assertion evaluates -1 < -1 on unseeded store and fails or depends on cross-test pollution",
+          "body": "In test/session.test.js lines 10-13, render() is called on an unseeded sessions store. If the store is empty, render() returns [] where lines.indexOf('expired') and lines.indexOf('fresh') are both -1, causing assert.ok(-1 < -1) to throw an AssertionError. If it passes, it only does so due to shared state pollution from other tests, and render() itself does not sort entries.",
+          "file": "test/session.test.js",
+          "line_start": 10,
+          "line_end": 13,
+          "confidence": 0.95,
+          "recommendation": "Seed the sessions store with explicit expired and fresh session records within the test, test the rendered output ordering deterministically, and isolate state with beforeEach/afterEach hooks."
+        },
+        {
+          "severity": "medium",
+          "title": "Test for malformed payload provides valid JSON and contains zero assertions",
+          "body": "In test/session.test.js lines 6-8, the test titled 'parseSession handles a malformed payload' passes valid JSON ('{\"id\":\"abc\",\"expiresAt\":0}') and contains no assert calls. It does not verify error handling for malformed input (such as invalid JSON syntax or missing schema fields) and will never detect parsing regressions.",
+          "file": "test/session.test.js",
+          "line_start": 6,
+          "line_end": 8,
+          "confidence": 0.95,
+          "recommendation": "Pass actual malformed JSON strings or invalid data structures and assert that parseSession throws a SyntaxError or handles validation errors as expected."
+        },
+        {
+          "severity": "medium",
+          "title": "Skipped test disables verification of core session expiration",
+          "body": "In test/session.test.js lines 15-18, test.skip disables the only test verifying that expire() successfully deletes sessions from the sessions map. Expiration regressions will not be caught during test execution.",
+          "file": "test/session.test.js",
+          "line_start": 15,
+          "line_end": 18,
+          "confidence": 0.9,
+          "recommendation": "Remove test.skip, enable the test, and ensure test state is properly isolated."
+        }
+      ],
+      "latencyMs": 53576
+    },
+    {
+      "verdict": "needs-attention",
+      "summary": "The test suite contains vacuous tests without assertions, unawaited asynchronous callbacks producing false passes, flawed ordering logic, and skipped core test coverage.",
+      "findings": [
+        {
+          "severity": "high",
+          "title": "Unawaited nextTick assertion causes false-positive test completion and unhandled errors",
+          "body": "The test function runs synchronously while placing its assertion inside process.nextTick without returning a Promise or taking a completion callback. node:test marks the test as passed immediately before the callback executes. Furthermore, no deletion logic is called, leaving sessions.size at 1 and causing an asynchronous unhandled exception outside test lifecycle tracking.",
+          "file": "test/session.test.js",
+          "line_start": 20,
+          "line_end": 25,
+          "confidence": 1,
+          "recommendation": "Invoke expire('abc') synchronously, assert sessions.size === 0 in the main test body without process.nextTick, and clear session state in an afterEach teardown."
+        },
+        {
+          "severity": "high",
+          "title": "Flawed ordering assertion produces false positives and crashes on empty state",
+          "body": "The test asserts lines.indexOf('expired') < lines.indexOf('fresh') without populating the sessions map. When the store is empty, both indexOf calls return -1, causing -1 < -1 to evaluate to false and fail. If only 'fresh' exists in the store, indexOf('expired') returns -1, which evaluates as less than 0 and creates a false positive even when expired sessions are missing.",
+          "file": "test/session.test.js",
+          "line_start": 10,
+          "line_end": 13,
+          "confidence": 1,
+          "recommendation": "Seed the sessions map with both an expired and a fresh session, and assert deep equality on the rendered output array (e.g., assert.deepEqual(render(), ['expired', 'fresh']))."
+        },
+        {
+          "severity": "medium",
+          "title": "Malformed payload test supplies valid JSON and contains no assertions",
+          "body": "The test titled 'parseSession handles a malformed payload' supplies a valid JSON string ('{\"id\":\"abc\",\"expiresAt\":0}') rather than a malformed payload, and performs no assertions on return value or exception handling. It provides false confidence that invalid inputs are handled safely.",
+          "file": "test/session.test.js",
+          "line_start": 6,
+          "line_end": 8,
+          "confidence": 0.95,
+          "recommendation": "Pass invalid JSON or malformed schema inputs to parseSession and assert that it throws or returns a sanitized fallback value."
+        },
+        {
+          "severity": "medium",
+          "title": "Core session expiration test is skipped",
+          "body": "The unit test verifying that expire() successfully removes an entry from the sessions store is disabled using test.skip, leaving the primary deletion path without active automated test coverage.",
+          "file": "test/session.test.js",
+          "line_start": 15,
+          "line_end": 18,
+          "confidence": 1,
+          "recommendation": "Remove test.skip to enable the expire() test and ensure it runs as part of the standard test suite."
+        }
+      ],
+      "latencyMs": 61828
+    },
+    {
+      "verdict": "needs-attention",
+      "summary": "The test suite introduces vacuous tests without assertions, deterministic failure from unseeded state, unhandled async assertion escapes, and skipped core coverage.",
+      "findings": [
+        {
+          "severity": "high",
+          "title": "Async assertion in process.nextTick escapes test runner lifecycle and hides failures",
+          "body": "The test function runs synchronously and returns immediately without awaiting or returning a Promise. The assertion inside `process.nextTick` executes after `node:test` has already marked the test as passed. Additionally, no deletion or expiration function is invoked after `sessions.set('abc', ...)`, leaving `sessions.size` at 1 and causing an uncaught exception outside the test lifecycle when the callback executes.",
+          "file": "test/session.test.js",
+          "line_start": 20,
+          "line_end": 25,
+          "confidence": 0.98,
+          "recommendation": "Invoke the deletion logic directly and perform assertions synchronously within the test scope without using un-awaited nextTick callbacks."
+        },
+        {
+          "severity": "high",
+          "title": "Deterministic assertion failure caused by unseeded session state",
+          "body": "The test calls `render()` against an empty `sessions` Map without setting up expired and fresh session records. `render()` returns an empty array, resulting in `indexOf('expired')` and `indexOf('fresh')` both returning `-1`. Evaluating `-1 < -1` yields `false`, causing `assert.ok` to throw an AssertionError every time the test runs.",
+          "file": "test/session.test.js",
+          "line_start": 10,
+          "line_end": 13,
+          "confidence": 0.99,
+          "recommendation": "Seed the `sessions` Map with both an expired and a fresh session before calling `render()`, and clear the Map in an afterEach hook to avoid test pollution."
+        },
+        {
+          "severity": "medium",
+          "title": "Vacuous test with missing assertions and valid payload under malformed test description",
+          "body": "The test titled 'parseSession handles a malformed payload' passes a valid JSON string ('{\"id\":\"abc\",\"expiresAt\":0}') and contains no assertions or `assert.throws` checks. The test produces false confidence by passing vacuously without validating error handling or parsed output.",
+          "file": "test/session.test.js",
+          "line_start": 6,
+          "line_end": 8,
+          "confidence": 0.95,
+          "recommendation": "Pass actual malformed inputs (e.g., truncated JSON or invalid types) and assert expected return values or error throwing behavior with `assert.throws`."
+        },
+        {
+          "severity": "low",
+          "title": "Skipped test disables verification of session expiration logic",
+          "body": "`test.skip` is used on the `expire()` test, bypassing automated verification of session deletion behavior in CI.",
+          "file": "test/session.test.js",
+          "line_start": 15,
+          "line_end": 18,
+          "confidence": 0.95,
+          "recommendation": "Change `test.skip` to `test` so the core deletion behavior is actively tested."
+        }
+      ],
+      "latencyMs": 122195
+    }
+  ],
+  "raw": "{\n  \"review\": \"Adversarial Review\",\n  \"target\": {\n    \"mode\": \"working-tree\",\n    \"label\": \"working tree diff\",\n    \"explicit\": true\n  },\n  \"engine\": \"agy\",\n  \"gemini\": {\n    \"status\": 1,\n    \"stdout\": \"{\\n  \\\"verdict\\\": \\\"needs-attention\\\",\\n  \\\"summary\\\": \\\"The test suite introduces vacuous tests without assertions, deterministic failure from unseeded state, unhandled async assertion escapes, and skipped core coverage.\\\",\\n  \\\"findings\\\": [\\n    {\\n      \\\"severity\\\": \\\"high\\\",\\n      \\\"title\\\": \\\"Async assertion in process.nextTick escapes test runner lifecycle and hides failures\\\",\\n      \\\"body\\\": \\\"The test function runs synchronously and returns immediately without awaiting or returning a Promise. The assertion inside `process.nextTick` executes after `node:test` has already marked the test as passed. Additionally, no deletion or expiration function is invoked after `sessions.set('abc', ...)`, leaving `sessions.size` at 1 and causing an uncaught exception outside the test lifecycle when the callback executes.\\\",\\n      \\\"file\\\": \\\"test/session.test.js\\\",\\n      \\\"line_start\\\": 20,\\n      \\\"line_end\\\": 25,\\n      \\\"confidence\\\": 0.98,\\n      \\\"recommendation\\\": \\\"Invoke the deletion logic directly and perform assertions synchronously within the test scope without using un-awaited nextTick callbacks.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"high\\\",\\n      \\\"title\\\": \\\"Deterministic assertion failure caused by unseeded session state\\\",\\n      \\\"body\\\": \\\"The test calls `render()` against an empty `sessions` Map without setting up expired and fresh session records. `render()` returns an empty array, resulting in `indexOf('expired')` and `indexOf('fresh')` both returning `-1`. Evaluating `-1 < -1` yields `false`, causing `assert.ok` to throw an AssertionError every time the test runs.\\\",\\n      \\\"file\\\": \\\"test/session.test.js\\\",\\n      \\\"line_start\\\": 10,\\n      \\\"line_end\\\": 13,\\n      \\\"confidence\\\": 0.99,\\n      \\\"recommendation\\\": \\\"Seed the `sessions` Map with both an expired and a fresh session before calling `render()`, and clear the Map in an afterEach hook to avoid test pollution.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"medium\\\",\\n      \\\"title\\\": \\\"Vacuous test with missing assertions and valid payload under malformed test description\\\",\\n      \\\"body\\\": \\\"The test titled 'parseSession handles a malformed payload' passes a valid JSON string ('{\\\\\\\"id\\\\\\\":\\\\\\\"abc\\\\\\\",\\\\\\\"expiresAt\\\\\\\":0}') and contains no assertions or `assert.throws` checks. The test produces false confidence by passing vacuously without validating error handling or parsed output.\\\",\\n      \\\"file\\\": \\\"test/session.test.js\\\",\\n      \\\"line_start\\\": 6,\\n      \\\"line_end\\\": 8,\\n      \\\"confidence\\\": 0.95,\\n      \\\"recommendation\\\": \\\"Pass actual malformed inputs (e.g., truncated JSON or invalid types) and assert expected return values or error throwing behavior with `assert.throws`.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"low\\\",\\n      \\\"title\\\": \\\"Skipped test disables verification of session expiration logic\\\",\\n      \\\"body\\\": \\\"`test.skip` is used on the `expire()` test, bypassing automated verification of session deletion behavior in CI.\\\",\\n      \\\"file\\\": \\\"test/session.test.js\\\",\\n      \\\"line_start\\\": 15,\\n      \\\"line_end\\\": 18,\\n      \\\"confidence\\\": 0.95,\\n      \\\"recommendation\\\": \\\"Change `test.skip` to `test` so the core deletion behavior is actively tested.\\\"\\n    }\\n  ],\\n  \\\"next_steps\\\": [\\n    \\\"Fix the asynchronous nextTick assertion and add actual session deletion in test/session.test.js.\\\",\\n    \\\"Seed test data for fresh and expired sessions before calling render(), and clean up session state after each test.\\\",\\n    \\\"Supply malformed payloads with explicit assert.throws assertions in parseSession error tests.\\\",\\n    \\\"Enable the skipped expire() test.\\\"\\n  ]\\n}\",\n    \"stderr\": \"\"\n  },\n  \"result\": {\n    \"verdict\": \"needs-attention\",\n    \"summary\": \"The test suite introduces vacuous tests without assertions, deterministic fai"
+}

--- a/bench/cassettes/vacuous-tests/agy.deep.json
+++ b/bench/cassettes/vacuous-tests/agy.deep.json
@@ -1,195 +1,196 @@
 {
   "caseId": "vacuous-tests",
   "cell": "agy.deep",
-  "recordedAt": "2026-08-19T08:33:21.204Z",
+  "recordedAt": "2026-08-24T09:49:24.105Z",
   "verdict": "needs-attention",
-  "summary": "The newly added test suite contains failing assertions, an unhandled asynchronous failure that crashes the process, and vacuous or skipped test cases.",
+  "summary": "The test suite contains skipped, vacuous, and improperly synchronized tests that fail to validate session parsing, ordering, and deletion.",
   "findings": [
     {
       "severity": "high",
-      "title": "Uncaught async assertion and missing session deletion",
-      "body": "In test/session.test.js lines 20-25, the test 'deleting a session empties the store' places its assertion inside an unawaited process.nextTick callback without returning a Promise or handling async completion. Furthermore, no deletion or expire() call is performed after setting the session, leaving sessions.size as 1 and causing an AssertionError to throw after the test runner finishes, crashing with an uncaughtException.",
+      "title": "Asynchronous assertion in synchronous test passes vacuously without executing deletion",
+      "body": "The test schedules an assertion inside process.nextTick within a synchronous test function, causing the test runner to complete and pass before the callback runs. Furthermore, neither expire() nor sessions.delete() is called after setting the session, so the session is never actually deleted.",
       "file": "test/session.test.js",
       "line_start": 20,
       "line_end": 25,
       "confidence": 1,
-      "recommendation": "Invoke expire('abc') or sessions.delete('abc') and perform assert.equal(sessions.size, 0) synchronously within the test body rather than inside process.nextTick."
-    },
-    {
-      "severity": "high",
-      "title": "Failing test due to unseeded sessions map and invalid index check",
-      "body": "In test/session.test.js lines 10-13, the test 'an expired session is listed before a fresh one' calls render() without populating the sessions store with both expired and fresh session records. Because render() returns an empty array, lines.indexOf('expired') and lines.indexOf('fresh') both evaluate to -1, making the condition -1 < -1 false and causing assert.ok() to throw an AssertionError.",
-      "file": "test/session.test.js",
-      "line_start": 10,
-      "line_end": 13,
-      "confidence": 1,
-      "recommendation": "Seed sessions with both an expired session (e.g., expiresAt in the past) and a fresh session (expiresAt in the future) before calling render(), and assert that both are found at non-negative indices in the expected relative order."
+      "recommendation": "Invoke expire('abc') or the deletion logic directly, remove process.nextTick (or return a Promise), and assert that sessions.size === 0."
     },
     {
       "severity": "medium",
-      "title": "Vacuous test with no assertions and valid JSON payload",
-      "body": "In test/session.test.js lines 6-8, 'parseSession handles a malformed payload' supplies valid JSON and contains no assert calls, meaning neither malformed payload rejection nor valid return value structures are actually tested.",
+      "title": "render() ordering test relies on unseeded state and flawed indexOf comparison",
+      "body": "The test executes render() without seeding the sessions Map with both fresh and expired sessions. When an expired session is missing, lines.indexOf('expired') returns -1, which evaluates to less than index 0 (a fresh session at index 0), yielding a false positive. It also leaks/depends on shared global state.",
+      "file": "test/session.test.js",
+      "line_start": 10,
+      "line_end": 13,
+      "confidence": 0.95,
+      "recommendation": "Explicitly populate sessions with both fresh and expired entries before calling render(), clean up state after the test, and assert exact list ordering."
+    },
+    {
+      "severity": "medium",
+      "title": "parseSession malformed payload test lacks invalid inputs and assertions",
+      "body": "The test passes valid JSON ('{\"id\":\"abc\",\"expiresAt\":0}') rather than a malformed payload and contains no assertion checks. It fails to verify error handling or return values when invalid payloads are provided.",
       "file": "test/session.test.js",
       "line_start": 6,
       "line_end": 8,
-      "confidence": 1,
-      "recommendation": "Update the test to pass invalid JSON and assert that it throws using assert.throws(() => parseSession('{bad json}'), SyntaxError), and add a separate test asserting the return object structure for valid JSON."
+      "confidence": 0.95,
+      "recommendation": "Pass actual malformed JSON and assert that parseSession throws or handles the error as expected, and add assertions for valid parsing."
     },
     {
       "severity": "low",
-      "title": "Skipped test leaves expire function unverified",
-      "body": "In test/session.test.js lines 15-18, the test for expire() is marked with test.skip, leaving the deletion behavior untested in the active test suite.",
+      "title": "expire() test is skipped",
+      "body": "The test for expire() is disabled with test.skip, leaving core session expiration logic unverified in the test suite.",
       "file": "test/session.test.js",
       "line_start": 15,
       "line_end": 18,
-      "confidence": 0.95,
-      "recommendation": "Enable the test by replacing test.skip with test, and ensure sessions state is cleaned up between test runs."
+      "confidence": 1,
+      "recommendation": "Enable the test by replacing test.skip with test and ensure sessions state is reset before and after running."
     }
   ],
-  "latencyMs": 27086,
-  "engineVersion": "1.1.15",
+  "latencyMs": 28128,
+  "engineVersion": "1.1.19",
+  "engineObserved": "agy",
   "samples": [
     {
       "verdict": "needs-attention",
-      "summary": "The test suite contains unhandled asynchronous assertion failures, failing ordering assertions on empty state, vacuous test cases, and a skipped core test.",
+      "summary": "The test suite contains unawaited asynchronous assertions, vacuous test cases with missing assertions, and flawed comparison logic that can yield false positives.",
       "findings": [
         {
           "severity": "high",
-          "title": "Asynchronous assertion in synchronous test escapes runner and causes unhandled error",
-          "body": "In test/session.test.js (lines 20-25), the test function is synchronous but executes its assertion inside process.nextTick(). The test runner marks the test as passed before the callback executes. When the callback runs, sessions.size is 1 (because no deletion was performed), causing an assertion failure outside the test lifecycle as an unhandled exception.",
+          "title": "Unawaited asynchronous assertion in synchronous test",
+          "body": "In test/session.test.js (lines 20-25), the assertion is wrapped inside process.nextTick within a synchronous node:test test case. The test runner marks the test as passed immediately when the synchronous function returns, before nextTick runs. Any assertion failure inside nextTick will trigger an uncaught exception outside the test lifecycle rather than failing the test case. In addition, no session deletion operation is performed prior to checking sessions.size.",
           "file": "test/session.test.js",
           "line_start": 20,
           "line_end": 25,
           "confidence": 1,
-          "recommendation": "Execute assertions synchronously after explicitly invoking expire('abc'), or return a Promise/use async handling if testing asynchronous behaviour."
-        },
-        {
-          "severity": "high",
-          "title": "Ordering test runs on unpopulated sessions Map and fails assertion",
-          "body": "In test/session.test.js (lines 10-13), render() is called without populating the sessions Map. It returns an empty array, resulting in indexOf('expired') and indexOf('fresh') both returning -1. The expression -1 < -1 evaluates to false, causing assert.ok to throw an AssertionError when the test executes.",
-          "file": "test/session.test.js",
-          "line_start": 10,
-          "line_end": 13,
-          "confidence": 1,
-          "recommendation": "Populate sessions with both an expired and a fresh session before calling render(), and assert that both items exist in the output array in addition to checking their relative order."
+          "recommendation": "Remove process.nextTick, invoke the session deletion method (e.g. expire() or sessions.delete()), and synchronously assert that sessions.size equals 0."
         },
         {
           "severity": "medium",
-          "title": "Malformed payload test provides valid JSON and lacks assertions",
-          "body": "In test/session.test.js (lines 6-8), the test titled 'parseSession handles a malformed payload' supplies valid JSON ('{\"id\":\"abc\",\"expiresAt\":0}') and contains no assertions. It does not test malformed payloads or verify the function's return value or error handling.",
+          "title": "Malformed payload test uses valid JSON and lacks assertions",
+          "body": "In test/session.test.js (lines 6-8), the test titled 'parseSession handles a malformed payload' provides a valid JSON string ('{\"id\":\"abc\",\"expiresAt\":0}') and does not assert anything about the function's return value or thrown exceptions, making the test vacuous.",
           "file": "test/session.test.js",
           "line_start": 6,
           "line_end": 8,
           "confidence": 0.95,
-          "recommendation": "Pass actual invalid input (e.g. invalid JSON strings) and assert expected error handling using assert.throws()."
+          "recommendation": "Pass an invalid payload and verify expected behavior using assert.throws() or by asserting the parsed output."
+        },
+        {
+          "severity": "medium",
+          "title": "Flawed indexOf comparison allows false positives when substring is missing",
+          "body": "In test/session.test.js (lines 10-13), assert.ok(lines.indexOf(\"expired\") < lines.indexOf(\"fresh\")) evaluates to true if 'expired' is absent (-1) and 'fresh' is found at index 0 or higher (-1 < 0). The test also relies on ambient state without seeding expired and fresh sessions first.",
+          "file": "test/session.test.js",
+          "line_start": 10,
+          "line_end": 13,
+          "confidence": 0.95,
+          "recommendation": "Populate sessions with test data before calling render(), verify that both indexOf values are not equal to -1, and then compare their positions."
+        },
+        {
+          "severity": "low",
+          "title": "Skipped test leaves expire() unverified",
+          "body": "In test/session.test.js (lines 15-18), test.skip is used on the expire() test, preventing it from executing in the test suite.",
+          "file": "test/session.test.js",
+          "line_start": 15,
+          "line_end": 18,
+          "confidence": 0.9,
+          "recommendation": "Remove .skip from test.skip to enable the test and ensure expire() passes verification."
+        }
+      ],
+      "latencyMs": 24621
+    },
+    {
+      "verdict": "needs-attention",
+      "summary": "The test suite contains a failing assertion from unseeded state, an asynchronous unhandled exception due to improper callback usage, and vacuous or skipped test cases.",
+      "findings": [
+        {
+          "severity": "high",
+          "title": "Unseeded session store causes immediate test failure on render assertion",
+          "body": "In test/session.test.js, the test 'an expired session is listed before a fresh one' invokes render() on an empty sessions Map. Both lines.indexOf('expired') and lines.indexOf('fresh') evaluate to -1, causing assert.ok(-1 < -1) to throw an AssertionError and fail test execution.",
+          "file": "test/session.test.js",
+          "line_start": 10,
+          "line_end": 13,
+          "confidence": 1,
+          "recommendation": "Seed the sessions Map with an expired session and a fresh session prior to calling render(), and ensure test state is cleared after execution."
+        },
+        {
+          "severity": "high",
+          "title": "Asynchronous callback in synchronous test triggers uncaughtException after completion",
+          "body": "In test/session.test.js, the test 'deleting a session empties the store' performs assertions inside process.nextTick without returning a Promise or using async/await. The test runner marks the test finished prematurely, and the subsequent callback execution asserts 1 === 0 (since no deletion function was called), resulting in an uncaughtException outside the test lifecycle.",
+          "file": "test/session.test.js",
+          "line_start": 20,
+          "line_end": 25,
+          "confidence": 1,
+          "recommendation": "Invoke expire('abc') or sessions.delete('abc') and perform the assert.equal(sessions.size, 0) check synchronously within the test function."
+        },
+        {
+          "severity": "medium",
+          "title": "Malformed payload test lacks assertions and supplies valid JSON",
+          "body": "In test/session.test.js, 'parseSession handles a malformed payload' passes valid JSON ('{\"id\":\"abc\",\"expiresAt\":0}') rather than malformed input and contains no assertions, leaving error handling unverified.",
+          "file": "test/session.test.js",
+          "line_start": 6,
+          "line_end": 8,
+          "confidence": 1,
+          "recommendation": "Pass an invalid JSON string to parseSession and wrap the call in assert.throws() to assert appropriate error handling."
         },
         {
           "severity": "low",
           "title": "Core session expiration test is skipped",
-          "body": "In test/session.test.js (lines 15-18), test.skip is used on the test verifying expire() functionality, leaving the expiration logic unverified during test suite runs.",
+          "body": "In test/session.test.js, test.skip is used for 'expire() removes the session', leaving the expire function unverified during test runs.",
           "file": "test/session.test.js",
           "line_start": 15,
           "line_end": 18,
           "confidence": 1,
-          "recommendation": "Remove .skip from test.skip to ensure expire() is continuously validated."
+          "recommendation": "Enable the test by replacing test.skip with test and adding beforeEach/afterEach hooks to reset sessions state."
         }
       ],
-      "latencyMs": 32224
+      "latencyMs": 33069
     },
     {
       "verdict": "needs-attention",
-      "summary": "The test suite contains a broken test assertion, an unawaited callback causing unhandled runtime exceptions, a vacuous test lacking assertions, and a skipped test case.",
+      "summary": "The test suite contains skipped, vacuous, and improperly synchronized tests that fail to validate session parsing, ordering, and deletion.",
       "findings": [
         {
           "severity": "high",
-          "title": "Unawaited asynchronous assertion triggers unhandled exception and passes vacuously",
-          "body": "The test schedules an assertion inside process.nextTick without returning a Promise or handling completion. The test runner records a pass before the callback runs, and when the callback executes it throws an unhandled AssertionError because sessions.size is 1 instead of 0 (no deletion function was called).",
+          "title": "Asynchronous assertion in synchronous test passes vacuously without executing deletion",
+          "body": "The test schedules an assertion inside process.nextTick within a synchronous test function, causing the test runner to complete and pass before the callback runs. Furthermore, neither expire() nor sessions.delete() is called after setting the session, so the session is never actually deleted.",
           "file": "test/session.test.js",
           "line_start": 20,
           "line_end": 25,
           "confidence": 1,
-          "recommendation": "Invoke expire('abc') synchronously and assert assert.equal(sessions.size, 0) directly without process.nextTick."
-        },
-        {
-          "severity": "high",
-          "title": "Failing test due to unpopulated state and flawed indexOf ordering comparison",
-          "body": "The test calls render() without populating sessions. Because sessions is empty, render() returns [], causing both indexOf calls to return -1 and failing the assertion. Furthermore, comparing indexOf directly is fragile because -1 < 0 evaluates to true when 'expired' is missing but 'fresh' is present.",
-          "file": "test/session.test.js",
-          "line_start": 10,
-          "line_end": 13,
-          "confidence": 1,
-          "recommendation": "Seed sessions with both an expired and a fresh session fixture and assert the rendered output array directly (e.g. assert.deepEqual(render(), ['expired', 'fresh']))."
+          "recommendation": "Invoke expire('abc') or the deletion logic directly, remove process.nextTick (or return a Promise), and assert that sessions.size === 0."
         },
         {
           "severity": "medium",
-          "title": "Malformed payload test lacks assertions and tests valid JSON",
-          "body": "The test 'parseSession handles a malformed payload' supplies valid JSON and contains no assertion. It does not verify error handling or fallback behavior when given genuinely malformed input.",
-          "file": "test/session.test.js",
-          "line_start": 6,
-          "line_end": 8,
-          "confidence": 1,
-          "recommendation": "Pass invalid JSON or incomplete input and assert expected error handling with assert.throws(() => parseSession('invalid-json'))."
-        },
-        {
-          "severity": "low",
-          "title": "Skipped test leaves session expiration logic untested",
-          "body": "The test for expire() is skipped using test.skip, leaving the expiration function without active automated test coverage.",
-          "file": "test/session.test.js",
-          "line_start": 15,
-          "line_end": 18,
-          "confidence": 0.95,
-          "recommendation": "Remove .skip from test.skip to enable verification of expire()."
-        }
-      ],
-      "latencyMs": 29260
-    },
-    {
-      "verdict": "needs-attention",
-      "summary": "The newly added test suite contains failing assertions, an unhandled asynchronous failure that crashes the process, and vacuous or skipped test cases.",
-      "findings": [
-        {
-          "severity": "high",
-          "title": "Uncaught async assertion and missing session deletion",
-          "body": "In test/session.test.js lines 20-25, the test 'deleting a session empties the store' places its assertion inside an unawaited process.nextTick callback without returning a Promise or handling async completion. Furthermore, no deletion or expire() call is performed after setting the session, leaving sessions.size as 1 and causing an AssertionError to throw after the test runner finishes, crashing with an uncaughtException.",
-          "file": "test/session.test.js",
-          "line_start": 20,
-          "line_end": 25,
-          "confidence": 1,
-          "recommendation": "Invoke expire('abc') or sessions.delete('abc') and perform assert.equal(sessions.size, 0) synchronously within the test body rather than inside process.nextTick."
-        },
-        {
-          "severity": "high",
-          "title": "Failing test due to unseeded sessions map and invalid index check",
-          "body": "In test/session.test.js lines 10-13, the test 'an expired session is listed before a fresh one' calls render() without populating the sessions store with both expired and fresh session records. Because render() returns an empty array, lines.indexOf('expired') and lines.indexOf('fresh') both evaluate to -1, making the condition -1 < -1 false and causing assert.ok() to throw an AssertionError.",
+          "title": "render() ordering test relies on unseeded state and flawed indexOf comparison",
+          "body": "The test executes render() without seeding the sessions Map with both fresh and expired sessions. When an expired session is missing, lines.indexOf('expired') returns -1, which evaluates to less than index 0 (a fresh session at index 0), yielding a false positive. It also leaks/depends on shared global state.",
           "file": "test/session.test.js",
           "line_start": 10,
           "line_end": 13,
-          "confidence": 1,
-          "recommendation": "Seed sessions with both an expired session (e.g., expiresAt in the past) and a fresh session (expiresAt in the future) before calling render(), and assert that both are found at non-negative indices in the expected relative order."
+          "confidence": 0.95,
+          "recommendation": "Explicitly populate sessions with both fresh and expired entries before calling render(), clean up state after the test, and assert exact list ordering."
         },
         {
           "severity": "medium",
-          "title": "Vacuous test with no assertions and valid JSON payload",
-          "body": "In test/session.test.js lines 6-8, 'parseSession handles a malformed payload' supplies valid JSON and contains no assert calls, meaning neither malformed payload rejection nor valid return value structures are actually tested.",
+          "title": "parseSession malformed payload test lacks invalid inputs and assertions",
+          "body": "The test passes valid JSON ('{\"id\":\"abc\",\"expiresAt\":0}') rather than a malformed payload and contains no assertion checks. It fails to verify error handling or return values when invalid payloads are provided.",
           "file": "test/session.test.js",
           "line_start": 6,
           "line_end": 8,
-          "confidence": 1,
-          "recommendation": "Update the test to pass invalid JSON and assert that it throws using assert.throws(() => parseSession('{bad json}'), SyntaxError), and add a separate test asserting the return object structure for valid JSON."
+          "confidence": 0.95,
+          "recommendation": "Pass actual malformed JSON and assert that parseSession throws or handles the error as expected, and add assertions for valid parsing."
         },
         {
           "severity": "low",
-          "title": "Skipped test leaves expire function unverified",
-          "body": "In test/session.test.js lines 15-18, the test for expire() is marked with test.skip, leaving the deletion behavior untested in the active test suite.",
+          "title": "expire() test is skipped",
+          "body": "The test for expire() is disabled with test.skip, leaving core session expiration logic unverified in the test suite.",
           "file": "test/session.test.js",
           "line_start": 15,
           "line_end": 18,
-          "confidence": 0.95,
-          "recommendation": "Enable the test by replacing test.skip with test, and ensure sessions state is cleaned up between test runs."
+          "confidence": 1,
+          "recommendation": "Enable the test by replacing test.skip with test and ensure sessions state is reset before and after running."
         }
       ],
-      "latencyMs": 27086
+      "latencyMs": 28128
     }
   ],
-  "raw": "{\n  \"review\": \"Review\",\n  \"target\": {\n    \"mode\": \"working-tree\",\n    \"label\": \"working tree diff\",\n    \"explicit\": true\n  },\n  \"gemini\": {\n    \"status\": 0,\n    \"stdout\": \"{\\n  \\\"verdict\\\": \\\"needs-attention\\\",\\n  \\\"summary\\\": \\\"The newly added test suite contains failing assertions, an unhandled asynchronous failure that crashes the process, and vacuous or skipped test cases.\\\",\\n  \\\"findings\\\": [\\n    {\\n      \\\"severity\\\": \\\"high\\\",\\n      \\\"title\\\": \\\"Uncaught async assertion and missing session deletion\\\",\\n      \\\"body\\\": \\\"In test/session.test.js lines 20-25, the test 'deleting a session empties the store' places its assertion inside an unawaited process.nextTick callback without returning a Promise or handling async completion. Furthermore, no deletion or expire() call is performed after setting the session, leaving sessions.size as 1 and causing an AssertionError to throw after the test runner finishes, crashing with an uncaughtException.\\\",\\n      \\\"file\\\": \\\"test/session.test.js\\\",\\n      \\\"line_start\\\": 20,\\n      \\\"line_end\\\": 25,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Invoke expire('abc') or sessions.delete('abc') and perform assert.equal(sessions.size, 0) synchronously within the test body rather than inside process.nextTick.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"high\\\",\\n      \\\"title\\\": \\\"Failing test due to unseeded sessions map and invalid index check\\\",\\n      \\\"body\\\": \\\"In test/session.test.js lines 10-13, the test 'an expired session is listed before a fresh one' calls render() without populating the sessions store with both expired and fresh session records. Because render() returns an empty array, lines.indexOf('expired') and lines.indexOf('fresh') both evaluate to -1, making the condition -1 < -1 false and causing assert.ok() to throw an AssertionError.\\\",\\n      \\\"file\\\": \\\"test/session.test.js\\\",\\n      \\\"line_start\\\": 10,\\n      \\\"line_end\\\": 13,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Seed sessions with both an expired session (e.g., expiresAt in the past) and a fresh session (expiresAt in the future) before calling render(), and assert that both are found at non-negative indices in the expected relative order.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"medium\\\",\\n      \\\"title\\\": \\\"Vacuous test with no assertions and valid JSON payload\\\",\\n      \\\"body\\\": \\\"In test/session.test.js lines 6-8, 'parseSession handles a malformed payload' supplies valid JSON and contains no assert calls, meaning neither malformed payload rejection nor valid return value structures are actually tested.\\\",\\n      \\\"file\\\": \\\"test/session.test.js\\\",\\n      \\\"line_start\\\": 6,\\n      \\\"line_end\\\": 8,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Update the test to pass invalid JSON and assert that it throws using assert.throws(() => parseSession('{bad json}'), SyntaxError), and add a separate test asserting the return object structure for valid JSON.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"low\\\",\\n      \\\"title\\\": \\\"Skipped test leaves expire function unverified\\\",\\n      \\\"body\\\": \\\"In test/session.test.js lines 15-18, the test for expire() is marked with test.skip, leaving the deletion behavior untested in the active test suite.\\\",\\n      \\\"file\\\": \\\"test/session.test.js\\\",\\n      \\\"line_start\\\": 15,\\n      \\\"line_end\\\": 18,\\n      \\\"confidence\\\": 0.95,\\n      \\\"recommendation\\\": \\\"Enable the test by replacing test.skip with test, and ensure sessions state is cleaned up between test runs.\\\"\\n    }\\n  ],\\n  \\\"next_steps\\\": [\\n    \\\"Seed test data before calling render() in test/session.test.js\\\",\\n    \\\"Remove process.nextTick and execute deletion assertions synchronously in test/session.test.js\\\",\\n    \\\"Add assert.throws to verify malformed input handling in parseSession tests\\\",\\n    \\\"Unskip test.skip on expire() and verify the full test suite passes with node --test\\\"\\n  ]\\n}\",\n    \"stderr\": \"\"\n  },\n  \"result\": {\n    \"verdict\": \"needs-attention\",\n    \"summary\": \"The newly "
+  "raw": "{\n  \"review\": \"Review\",\n  \"target\": {\n    \"mode\": \"working-tree\",\n    \"label\": \"working tree diff\",\n    \"explicit\": true\n  },\n  \"engine\": \"agy\",\n  \"gemini\": {\n    \"status\": 0,\n    \"stdout\": \"{\\n  \\\"verdict\\\": \\\"needs-attention\\\",\\n  \\\"summary\\\": \\\"The test suite contains skipped, vacuous, and improperly synchronized tests that fail to validate session parsing, ordering, and deletion.\\\",\\n  \\\"findings\\\": [\\n    {\\n      \\\"severity\\\": \\\"high\\\",\\n      \\\"title\\\": \\\"Asynchronous assertion in synchronous test passes vacuously without executing deletion\\\",\\n      \\\"body\\\": \\\"The test schedules an assertion inside process.nextTick within a synchronous test function, causing the test runner to complete and pass before the callback runs. Furthermore, neither expire() nor sessions.delete() is called after setting the session, so the session is never actually deleted.\\\",\\n      \\\"file\\\": \\\"test/session.test.js\\\",\\n      \\\"line_start\\\": 20,\\n      \\\"line_end\\\": 25,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Invoke expire('abc') or the deletion logic directly, remove process.nextTick (or return a Promise), and assert that sessions.size === 0.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"medium\\\",\\n      \\\"title\\\": \\\"render() ordering test relies on unseeded state and flawed indexOf comparison\\\",\\n      \\\"body\\\": \\\"The test executes render() without seeding the sessions Map with both fresh and expired sessions. When an expired session is missing, lines.indexOf('expired') returns -1, which evaluates to less than index 0 (a fresh session at index 0), yielding a false positive. It also leaks/depends on shared global state.\\\",\\n      \\\"file\\\": \\\"test/session.test.js\\\",\\n      \\\"line_start\\\": 10,\\n      \\\"line_end\\\": 13,\\n      \\\"confidence\\\": 0.95,\\n      \\\"recommendation\\\": \\\"Explicitly populate sessions with both fresh and expired entries before calling render(), clean up state after the test, and assert exact list ordering.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"medium\\\",\\n      \\\"title\\\": \\\"parseSession malformed payload test lacks invalid inputs and assertions\\\",\\n      \\\"body\\\": \\\"The test passes valid JSON ('{\\\\\\\"id\\\\\\\":\\\\\\\"abc\\\\\\\",\\\\\\\"expiresAt\\\\\\\":0}') rather than a malformed payload and contains no assertion checks. It fails to verify error handling or return values when invalid payloads are provided.\\\",\\n      \\\"file\\\": \\\"test/session.test.js\\\",\\n      \\\"line_start\\\": 6,\\n      \\\"line_end\\\": 8,\\n      \\\"confidence\\\": 0.95,\\n      \\\"recommendation\\\": \\\"Pass actual malformed JSON and assert that parseSession throws or handles the error as expected, and add assertions for valid parsing.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"low\\\",\\n      \\\"title\\\": \\\"expire() test is skipped\\\",\\n      \\\"body\\\": \\\"The test for expire() is disabled with test.skip, leaving core session expiration logic unverified in the test suite.\\\",\\n      \\\"file\\\": \\\"test/session.test.js\\\",\\n      \\\"line_start\\\": 15,\\n      \\\"line_end\\\": 18,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Enable the test by replacing test.skip with test and ensure sessions state is reset before and after running.\\\"\\n    }\\n  ],\\n  \\\"next_steps\\\": [\\n    \\\"Fix test/session.test.js to seed and clean up the shared sessions Map around each test case.\\\",\\n    \\\"Correct the deletion test to invoke expire() and assert synchronously.\\\",\\n    \\\"Add assertions for malformed input in parseSession and unskip the expire() test.\\\"\\n  ]\\n}\",\n    \"stderr\": \"\"\n  },\n  \"result\": {\n    \"verdict\": \"needs-attention\",\n    \"summary\": \"The test suite contains skipped, vacuous, and improperly synchronized tests that fail to validate session parsing, ordering, and deletion.\",\n    \"findings\": [\n      {\n        \"severity\": \"high\",\n        \"title\": \"Asynchronous assertion in synchronous test passes vacuously without executing deletion\",\n        \"body\": \"The test schedules an assertion inside process.nextTick within a synchronous test function, causing the test runner to complete and pass before "
 }

--- a/bench/cassettes/vacuous-tests/agy.model.json
+++ b/bench/cassettes/vacuous-tests/agy.model.json
@@ -1,155 +1,136 @@
 {
   "caseId": "vacuous-tests",
   "cell": "agy.model",
-  "recordedAt": "2026-08-19T08:30:38.456Z",
+  "recordedAt": "2026-08-24T09:40:54.525Z",
   "verdict": "needs-attention",
-  "summary": "The test suite contains asynchronous assertion leakage, flawed index comparison logic causing false positives, and missing assertions.",
+  "summary": "The test suite contains an unawaited async assertion in a synchronous test runner callback and an unsafe indexOf comparison that can falsely pass.",
   "findings": [
     {
       "severity": "high",
-      "title": "Asynchronous assertion in synchronous test escapes test runner lifecycle",
-      "body": "The test function is synchronous and completes before the process.nextTick callback executes. Consequently, any assertion failure throws as an unhandled exception outside the test lifecycle instead of registering as a test failure, and no deletion operation is performed before asserting the size.",
+      "title": "Unbounded async assertion in synchronous test",
+      "body": "The test callback is synchronous, so the test runner marks the test as passed before process.nextTick executes. If the assertion fails, it will throw an unhandled error outside the test runner scope. Additionally, no deletion logic is invoked prior to asserting sessions.size.",
       "file": "test/session.test.js",
       "line_start": 20,
       "line_end": 25,
       "confidence": 0.95,
-      "recommendation": "Return a Promise or await the async operation, and invoke the deletion function before asserting store size."
+      "recommendation": "Return a Promise or use an async function to properly await the async operation, and invoke the session deletion logic before asserting sessions.size."
     },
     {
       "severity": "medium",
-      "title": "indexOf comparison yields false positive when substring is missing",
-      "body": "If 'expired' is absent from lines, indexOf returns -1. If 'fresh' is found at index >= 0, the comparison -1 < lines.indexOf('fresh') evaluates to true, causing the assertion to pass even when 'expired' is not present.",
+      "title": "Unsafe indexOf comparison yields false positive when substring is missing",
+      "body": "Evaluating lines.indexOf('expired') < lines.indexOf('fresh') resolves to true if 'expired' is missing (-1) and 'fresh' is found at index 0 or higher, allowing the test to pass even when 'expired' is omitted.",
       "file": "test/session.test.js",
       "line_start": 10,
       "line_end": 13,
-      "confidence": 0.95,
-      "recommendation": "Verify that both 'expired' and 'fresh' exist in lines (indexOf !== -1) before comparing their positions."
-    },
-    {
-      "severity": "low",
-      "title": "Malformed payload test passes valid JSON and lacks assertions",
-      "body": "The test titled for malformed payload testing supplies valid JSON and contains no assertions to verify error handling or return values.",
-      "file": "test/session.test.js",
-      "line_start": 6,
-      "line_end": 8,
       "confidence": 0.9,
-      "recommendation": "Pass invalid JSON input and assert expected error handling using assert.throws or return value checks."
+      "recommendation": "Assert that both lines.indexOf('expired') and lines.indexOf('fresh') are not equal to -1 before asserting their relative ordering."
     }
   ],
-  "latencyMs": 24400,
-  "engineVersion": "1.1.15",
+  "latencyMs": 26989,
+  "engineVersion": "1.1.19",
+  "engineObserved": null,
   "samples": [
     {
       "verdict": "needs-attention",
-      "summary": "The test suite contains unhandled asynchronous assertions, false-positive index assertions, and incomplete test cases.",
+      "summary": "The test suite contains unhandled asynchronous assertions, flawed index comparisons that produce false positives, and missing error-handling assertions.",
       "findings": [
         {
           "severity": "high",
-          "title": "Unhandled asynchronous assertion escapes test lifecycle",
-          "body": "The test performs assertions inside `process.nextTick()` without returning a Promise or accepting a callback parameter. The test runner marks the test as passed before the assertion runs, and no deletion logic is invoked prior to asserting `sessions.size === 0`.",
-          "file": "test/session.test.js",
-          "line_start": 20,
-          "line_end": 25,
-          "confidence": 0.95,
-          "recommendation": "Make the test function async (or return a Promise), invoke the deletion/expiration logic, and await the operation before asserting that the store is empty."
-        },
-        {
-          "severity": "medium",
-          "title": "Flawed indexOf comparison produces false positives",
-          "body": "At line 12, `lines.indexOf('expired') < lines.indexOf('fresh')` evaluates to true if 'expired' is missing from `lines` (returning -1) and 'fresh' is found at index 0 or higher, allowing the test to pass when expired sessions are omitted.",
-          "file": "test/session.test.js",
-          "line_start": 10,
-          "line_end": 13,
-          "confidence": 0.9,
-          "recommendation": "Assert that both `lines.indexOf('expired') !== -1` and `lines.indexOf('fresh') !== -1` before checking relative ordering."
-        },
-        {
-          "severity": "medium",
-          "title": "Malformed payload test provides valid JSON without assertions",
-          "body": "The test claims to handle a malformed payload but passes a well-formed JSON string with no assertion checking the returned result or verifying error handling.",
-          "file": "test/session.test.js",
-          "line_start": 6,
-          "line_end": 8,
-          "confidence": 0.85,
-          "recommendation": "Pass an actual malformed payload (e.g. invalid JSON or invalid schema) and assert that `parseSession` throws or returns an expected error/fallback value."
-        }
-      ],
-      "latencyMs": 23288
-    },
-    {
-      "verdict": "needs-attention",
-      "summary": "The test suite contains unawaited asynchronous assertions, false-positive index comparisons, and vacuous test cases lacking assertions.",
-      "findings": [
-        {
-          "severity": "high",
-          "title": "Unawaited asynchronous assertion and missing deletion call",
-          "body": "The test function runs synchronously while placing the assertion inside process.nextTick. In node:test, the test completes immediately with a pass before the callback runs. Additionally, no deletion or expiration function is invoked after adding the session, so the deferred assertion would fail outside the test lifecycle as an uncaught exception.",
+          "title": "Unawaited asynchronous assertion in synchronous test",
+          "body": "The test function is synchronous, causing node:test to complete before process.nextTick executes. If the assertion fails, it throws outside the test context as an uncaught exception rather than a test failure, and the test can falsely pass.",
           "file": "test/session.test.js",
           "line_start": 20,
           "line_end": 25,
           "confidence": 1,
-          "recommendation": "Invoke the session deletion logic and make the test asynchronous (e.g. returning a Promise or using async/await) so node:test properly tracks the assertion."
+          "recommendation": "Return a Promise or make the test async to ensure asynchronous operations and assertions are awaited before the test finishes."
         },
         {
           "severity": "medium",
-          "title": "Unsafe indexOf comparison creates false-positive test pass",
-          "body": "Comparing indexOf results directly with '<' allows the assertion to pass if 'expired' is missing from the output (-1) and 'fresh' is found at index 0 or greater (-1 < 0 is true).",
+          "title": "Substr comparison permits false positive when substring is missing",
+          "body": "If 'expired' is not present in lines, indexOf('expired') returns -1. If 'fresh' is present at index >= 0, -1 < lines.indexOf('fresh') evaluates to true, falsely passing the test even when expired sessions are omitted.",
           "file": "test/session.test.js",
           "line_start": 10,
           "line_end": 13,
           "confidence": 0.95,
-          "recommendation": "Verify that both indices are not -1 before comparing their relative positions, or assert the exact expected structure of rendered lines."
+          "recommendation": "Verify both substrings exist (index !== -1) before asserting lines.indexOf('expired') < lines.indexOf('fresh')."
         },
         {
           "severity": "medium",
-          "title": "Malformed payload test lacks assertions and passes valid JSON",
-          "body": "The test intended for malformed payloads passes a well-formed JSON string and contains no assertions (such as assert.throws or checking error return values), leaving the failure path untested.",
+          "title": "Malformed payload test uses valid JSON without assertions",
+          "body": "The test passes valid JSON ('{\"id\":\"abc\",\"expiresAt\":0}') rather than a malformed payload and does not assert return values or expected error handling via assert.throws.",
           "file": "test/session.test.js",
           "line_start": 6,
           "line_end": 8,
           "confidence": 0.9,
-          "recommendation": "Pass genuinely malformed input (e.g. invalid JSON syntax or invalid schema types) and assert the expected error or fallback behavior."
+          "recommendation": "Pass an invalid payload string and use assert.throws or assert error return values to verify malformed input handling."
         }
       ],
-      "latencyMs": 22927
+      "latencyMs": 24683
     },
     {
       "verdict": "needs-attention",
-      "summary": "The test suite contains asynchronous assertion leakage, flawed index comparison logic causing false positives, and missing assertions.",
+      "summary": "The test suite contains un-awaited asynchronous assertions causing false-positive passes, an unreliable indexOf comparison, and an unasserted test with valid JSON representing a malformed case.",
       "findings": [
         {
           "severity": "high",
-          "title": "Asynchronous assertion in synchronous test escapes test runner lifecycle",
-          "body": "The test function is synchronous and completes before the process.nextTick callback executes. Consequently, any assertion failure throws as an unhandled exception outside the test lifecycle instead of registering as a test failure, and no deletion operation is performed before asserting the size.",
+          "title": "Un-awaited asynchronous assertion causes test false positive",
+          "body": "The test executes assertions inside `process.nextTick` without returning a Promise or using a completion callback. The test runner marks the test as passed immediately, leaving the assertion to execute out-of-band and potentially throwing unhandled errors.",
+          "file": "test/session.test.js",
+          "line_start": 20,
+          "line_end": 25,
+          "confidence": 1,
+          "recommendation": "Convert the test function to return a Promise or use `async`/`await` when asserting asynchronous operations."
+        },
+        {
+          "severity": "medium",
+          "title": "Index comparison allows false-positive pass when target is missing",
+          "body": "Comparing `lines.indexOf('expired') < lines.indexOf('fresh')` evaluates to true if 'expired' is missing (`-1`) and 'fresh' is found at index 0 or later, leading to false-positive test passes.",
+          "file": "test/session.test.js",
+          "line_start": 10,
+          "line_end": 13,
+          "confidence": 0.95,
+          "recommendation": "Explicitly assert that both 'expired' and 'fresh' exist (`index !== -1`) before comparing relative order."
+        },
+        {
+          "severity": "medium",
+          "title": "Malformed payload test uses valid JSON and lacks assertions",
+          "body": "The test titled 'parseSession handles a malformed payload' supplies a valid JSON string ('{\"id\":\"abc\",\"expiresAt\":0}') and contains no assertions or expectations verifying error handling or fallback behavior.",
+          "file": "test/session.test.js",
+          "line_start": 6,
+          "line_end": 8,
+          "confidence": 0.95,
+          "recommendation": "Pass an invalid payload (e.g., malformed JSON syntax or missing required fields) and assert the expected error or return value."
+        }
+      ],
+      "latencyMs": 24011
+    },
+    {
+      "verdict": "needs-attention",
+      "summary": "The test suite contains an unawaited async assertion in a synchronous test runner callback and an unsafe indexOf comparison that can falsely pass.",
+      "findings": [
+        {
+          "severity": "high",
+          "title": "Unbounded async assertion in synchronous test",
+          "body": "The test callback is synchronous, so the test runner marks the test as passed before process.nextTick executes. If the assertion fails, it will throw an unhandled error outside the test runner scope. Additionally, no deletion logic is invoked prior to asserting sessions.size.",
           "file": "test/session.test.js",
           "line_start": 20,
           "line_end": 25,
           "confidence": 0.95,
-          "recommendation": "Return a Promise or await the async operation, and invoke the deletion function before asserting store size."
+          "recommendation": "Return a Promise or use an async function to properly await the async operation, and invoke the session deletion logic before asserting sessions.size."
         },
         {
           "severity": "medium",
-          "title": "indexOf comparison yields false positive when substring is missing",
-          "body": "If 'expired' is absent from lines, indexOf returns -1. If 'fresh' is found at index >= 0, the comparison -1 < lines.indexOf('fresh') evaluates to true, causing the assertion to pass even when 'expired' is not present.",
+          "title": "Unsafe indexOf comparison yields false positive when substring is missing",
+          "body": "Evaluating lines.indexOf('expired') < lines.indexOf('fresh') resolves to true if 'expired' is missing (-1) and 'fresh' is found at index 0 or higher, allowing the test to pass even when 'expired' is omitted.",
           "file": "test/session.test.js",
           "line_start": 10,
           "line_end": 13,
-          "confidence": 0.95,
-          "recommendation": "Verify that both 'expired' and 'fresh' exist in lines (indexOf !== -1) before comparing their positions."
-        },
-        {
-          "severity": "low",
-          "title": "Malformed payload test passes valid JSON and lacks assertions",
-          "body": "The test titled for malformed payload testing supplies valid JSON and contains no assertions to verify error handling or return values.",
-          "file": "test/session.test.js",
-          "line_start": 6,
-          "line_end": 8,
           "confidence": 0.9,
-          "recommendation": "Pass invalid JSON input and assert expected error handling using assert.throws or return value checks."
+          "recommendation": "Assert that both lines.indexOf('expired') and lines.indexOf('fresh') are not equal to -1 before asserting their relative ordering."
         }
       ],
-      "latencyMs": 24400
+      "latencyMs": 26989
     }
   ],
-  "raw": "{\"conversation_id\":\"cb24c46a-76a8-4b1a-9771-94bf5f851682\",\"status\":\"SUCCESS\",\"response\":\"{\\n  \\\"verdict\\\": \\\"needs-attention\\\",\\n  \\\"summary\\\": \\\"The test suite contains asynchronous assertion leakage, flawed index comparison logic causing false positives, and missing assertions.\\\",\\n  \\\"findings\\\": [\\n    {\\n      \\\"severity\\\": \\\"high\\\",\\n      \\\"title\\\": \\\"Asynchronous assertion in synchronous test escapes test runner lifecycle\\\",\\n      \\\"body\\\": \\\"The test function is synchronous and completes before the process.nextTick callback executes. Consequently, any assertion failure throws as an unhandled exception outside the test lifecycle instead of registering as a test failure, and no deletion operation is performed before asserting the size.\\\",\\n      \\\"file\\\": \\\"test/session.test.js\\\",\\n      \\\"line_start\\\": 20,\\n      \\\"line_end\\\": 25,\\n      \\\"confidence\\\": 0.95,\\n      \\\"recommendation\\\": \\\"Return a Promise or await the async operation, and invoke the deletion function before asserting store size.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"medium\\\",\\n      \\\"title\\\": \\\"indexOf comparison yields false positive when substring is missing\\\",\\n      \\\"body\\\": \\\"If 'expired' is absent from lines, indexOf returns -1. If 'fresh' is found at index \\u003e= 0, the comparison -1 \\u003c lines.indexOf('fresh') evaluates to true, causing the assertion to pass even when 'expired' is not present.\\\",\\n      \\\"file\\\": \\\"test/session.test.js\\\",\\n      \\\"line_start\\\": 10,\\n      \\\"line_end\\\": 13,\\n      \\\"confidence\\\": 0.95,\\n      \\\"recommendation\\\": \\\"Verify that both 'expired' and 'fresh' exist in lines (indexOf !== -1) before comparing their positions.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"low\\\",\\n      \\\"title\\\": \\\"Malformed payload test passes valid JSON and lacks assertions\\\",\\n      \\\"body\\\": \\\"The test titled for malformed payload testing supplies valid JSON and contains no assertions to verify error handling or return values.\\\",\\n      \\\"file\\\": \\\"test/session.test.js\\\",\\n      \\\"line_start\\\": 6,\\n      \\\"line_end\\\": 8,\\n      \\\"confidence\\\": 0.9,\\n      \\\"recommendation\\\": \\\"Pass invalid JSON input and assert expected error handling using assert.throws or return value checks.\\\"\\n    }\\n  ],\\n  \\\"next_steps\\\": [\\n    \\\"Refactor asynchronous tests in test/session.test.js to return promises or use async/await.\\\",\\n    \\\"Add explicit index boundary checks to relative ordering assertions in render tests.\\\",\\n    \\\"Add malformed input test cases with appropriate assert.throws assertions.\\\"\\n  ]\\n}\\n\",\"duration_seconds\":20.4497043,\"num_turns\":1,\"usage\":{\"input_tokens\":19072,\"output_tokens\":4594,\"thinking_tokens\":4051,\"cache_read_tokens\":0,\"total_tokens\":23666}}\n"
+  "raw": "{\"conversation_id\":\"f08e1686-81b8-4ca9-93a3-3fe82c5459e2\",\"status\":\"SUCCESS\",\"response\":\"{\\n  \\\"verdict\\\": \\\"needs-attention\\\",\\n  \\\"summary\\\": \\\"The test suite contains an unawaited async assertion in a synchronous test runner callback and an unsafe indexOf comparison that can falsely pass.\\\",\\n  \\\"findings\\\": [\\n    {\\n      \\\"severity\\\": \\\"high\\\",\\n      \\\"title\\\": \\\"Unbounded async assertion in synchronous test\\\",\\n      \\\"body\\\": \\\"The test callback is synchronous, so the test runner marks the test as passed before process.nextTick executes. If the assertion fails, it will throw an unhandled error outside the test runner scope. Additionally, no deletion logic is invoked prior to asserting sessions.size.\\\",\\n      \\\"file\\\": \\\"test/session.test.js\\\",\\n      \\\"line_start\\\": 20,\\n      \\\"line_end\\\": 25,\\n      \\\"confidence\\\": 0.95,\\n      \\\"recommendation\\\": \\\"Return a Promise or use an async function to properly await the async operation, and invoke the session deletion logic before asserting sessions.size.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"medium\\\",\\n      \\\"title\\\": \\\"Unsafe indexOf comparison yields false positive when substring is missing\\\",\\n      \\\"body\\\": \\\"Evaluating lines.indexOf('expired') \\u003c lines.indexOf('fresh') resolves to true if 'expired' is missing (-1) and 'fresh' is found at index 0 or higher, allowing the test to pass even when 'expired' is omitted.\\\",\\n      \\\"file\\\": \\\"test/session.test.js\\\",\\n      \\\"line_start\\\": 10,\\n      \\\"line_end\\\": 13,\\n      \\\"confidence\\\": 0.9,\\n      \\\"recommendation\\\": \\\"Assert that both lines.indexOf('expired') and lines.indexOf('fresh') are not equal to -1 before asserting their relative ordering.\\\"\\n    }\\n  ],\\n  \\\"next_steps\\\": [\\n    \\\"Refactor the asynchronous test in test/session.test.js to properly invoke deletion and await assertions within the test lifecycle.\\\",\\n    \\\"Update the render test to check that both 'expired' and 'fresh' exist in the output before comparing their indices.\\\"\\n  ]\\n}\\n\",\"duration_seconds\":23.5141759,\"num_turns\":1,\"usage\":{\"input_tokens\":19039,\"output_tokens\":4304,\"thinking_tokens\":3898,\"cache_read_tokens\":0,\"total_tokens\":23343}}\n"
 }

--- a/bench/cassettes/vacuous-tests/agy.shallow.json
+++ b/bench/cassettes/vacuous-tests/agy.shallow.json
@@ -1,0 +1,166 @@
+{
+  "caseId": "vacuous-tests",
+  "cell": "agy.shallow",
+  "recordedAt": "2026-08-24T15:33:17.643Z",
+  "verdict": "needs-attention",
+  "summary": "The test suite contains unhandled asynchronous assertions causing false passes/uncaught exceptions, invalid order assertions, and incomplete test coverage.",
+  "findings": [
+    {
+      "severity": "high",
+      "title": "Asynchronous assertion in process.nextTick causes uncaught exception and false test pass",
+      "body": "The test on lines 20-25 completes synchronously before the process.nextTick callback executes. Furthermore, no deletion or expiration function is invoked after populating the session store. When nextTick fires, assert.equal(sessions.size, 0) fails outside the test runner execution context, triggering an uncaught exception while previously registering a false positive test pass.",
+      "file": "test/session.test.js",
+      "line_start": 20,
+      "line_end": 25,
+      "confidence": 0.95,
+      "recommendation": "Invoke the deletion logic (e.g. expire('abc') or sessions.delete('abc')) and assert store state synchronously within the test execution scope instead of deferring to process.nextTick."
+    },
+    {
+      "severity": "medium",
+      "title": "Flawed indexOf comparison allows false positive test passes",
+      "body": "On lines 10-13, lines.indexOf('expired') < lines.indexOf('fresh') evaluates to true if 'expired' is not present in lines (returning -1) and 'fresh' is found at index >= 0. This masks missing expired session output.",
+      "file": "test/session.test.js",
+      "line_start": 10,
+      "line_end": 13,
+      "confidence": 0.95,
+      "recommendation": "Assert that both 'expired' and 'fresh' exist (e.g. assert.notEqual(lines.indexOf(...), -1)) before checking their relative index ordering."
+    },
+    {
+      "severity": "low",
+      "title": "Malformed payload test lacks assertions and tests valid JSON",
+      "body": "The test 'parseSession handles a malformed payload' on lines 6-8 passes valid JSON ('{\"id\":\"abc\",\"expiresAt\":0}') and does not assert return values or verify that invalid input is handled.",
+      "file": "test/session.test.js",
+      "line_start": 6,
+      "line_end": 8,
+      "confidence": 0.9,
+      "recommendation": "Pass actual malformed payloads (e.g. invalid JSON strings, missing fields, or malformed data types) and assert the expected error handling behavior."
+    }
+  ],
+  "latencyMs": 19067,
+  "engineVersion": "1.1.19",
+  "engineObserved": "agy",
+  "samples": [
+    {
+      "verdict": "needs-attention",
+      "summary": "The test suite contains an unawaited async assertion causing unhandled exceptions, a faulty indexOf comparison allowing false positives, and a skipped test.",
+      "findings": [
+        {
+          "severity": "high",
+          "title": "Unawaited callback in process.nextTick causes test to pass prematurely and throw unhandled error",
+          "body": "In test/session.test.js (lines 20-25), the test callback is synchronous and finishes before process.nextTick runs. Furthermore, sessions.delete is never invoked, so assert.equal(sessions.size, 0) fails asynchronously outside the test execution context, triggering an uncaught exception.",
+          "file": "test/session.test.js",
+          "line_start": 20,
+          "line_end": 25,
+          "confidence": 0.95,
+          "recommendation": "Return a Promise or wrap async execution properly, call the deletion logic being tested, and clear shared session state."
+        },
+        {
+          "severity": "medium",
+          "title": "Comparison of indexOf results produces false positive when item is absent",
+          "body": "In test/session.test.js (lines 10-13), lines.indexOf(\"expired\") < lines.indexOf(\"fresh\") evaluates to true if 'expired' is not found (-1) and 'fresh' is found at index 0 or higher. Also, the test invokes render() without populating sessions beforehand.",
+          "file": "test/session.test.js",
+          "line_start": 10,
+          "line_end": 13,
+          "confidence": 0.9,
+          "recommendation": "Explicitly assert that both 'expired' and 'fresh' exist (indexOf !== -1) before comparing relative positions, and populate test fixture data before rendering."
+        },
+        {
+          "severity": "low",
+          "title": "Core expiration test is skipped",
+          "body": "In test/session.test.js (lines 15-18), test.skip is used for expire(), leaving session removal untested in test runs.",
+          "file": "test/session.test.js",
+          "line_start": 15,
+          "line_end": 18,
+          "confidence": 0.9,
+          "recommendation": "Remove test.skip, verify expire() implementation, and ensure sessions state is cleaned up after testing."
+        }
+      ],
+      "latencyMs": 20883
+    },
+    {
+      "verdict": "needs-attention",
+      "summary": "New session test suite contains unhandled asynchronous assertions, false-positive index checks, an unasserted malformed payload test, and a skipped test case.",
+      "findings": [
+        {
+          "severity": "high",
+          "title": "Asynchronous assertion in synchronous test causes unhandled errors",
+          "body": "In test/session.test.js, the test function is synchronous but performs assert.equal inside process.nextTick. In node:test, synchronous tests complete immediately upon return, causing deferred assertions to run after the test has passed and throw unhandled exceptions outside the test context. Furthermore, no deletion or expiration logic is executed before asserting size.",
+          "file": "test/session.test.js",
+          "line_start": 20,
+          "line_end": 25,
+          "confidence": 0.95,
+          "recommendation": "Convert the test to async or return a Promise, invoke the deletion logic, and await the store update before asserting sessions.size === 0."
+        },
+        {
+          "severity": "medium",
+          "title": "Missing substring index comparison yields false positive test passes",
+          "body": "In test/session.test.js, comparing lines.indexOf('expired') < lines.indexOf('fresh') will evaluate to true if 'expired' is absent (-1) and 'fresh' is present at index >= 0 (since -1 < index), producing a false pass when expired entries are missing from render().",
+          "file": "test/session.test.js",
+          "line_start": 10,
+          "line_end": 13,
+          "confidence": 0.95,
+          "recommendation": "Assert that both lines.indexOf('expired') >= 0 and lines.indexOf('fresh') >= 0 before asserting their relative index ordering."
+        },
+        {
+          "severity": "medium",
+          "title": "Malformed payload test uses valid JSON and lacks assertions",
+          "body": "The test named 'parseSession handles a malformed payload' passes a syntactically valid JSON string ('{\"id\":\"abc\",\"expiresAt\":0}') and contains no assertions to verify return value or error handling behaviour.",
+          "file": "test/session.test.js",
+          "line_start": 6,
+          "line_end": 8,
+          "confidence": 0.9,
+          "recommendation": "Pass a genuinely malformed payload (such as invalid JSON or non-string input) and assert expected error throwing (e.g. assert.throws) or fallback return handling."
+        },
+        {
+          "severity": "low",
+          "title": "Skipped test case left in newly added test suite",
+          "body": "test.skip('expire() removes the session') disables verification of the expire() helper, leaving session expiration untested.",
+          "file": "test/session.test.js",
+          "line_start": 15,
+          "line_end": 18,
+          "confidence": 0.9,
+          "recommendation": "Enable the test by removing .skip and ensure expire('abc') passes against the session store."
+        }
+      ],
+      "latencyMs": 19044
+    },
+    {
+      "verdict": "needs-attention",
+      "summary": "The test suite contains unhandled asynchronous assertions causing false passes/uncaught exceptions, invalid order assertions, and incomplete test coverage.",
+      "findings": [
+        {
+          "severity": "high",
+          "title": "Asynchronous assertion in process.nextTick causes uncaught exception and false test pass",
+          "body": "The test on lines 20-25 completes synchronously before the process.nextTick callback executes. Furthermore, no deletion or expiration function is invoked after populating the session store. When nextTick fires, assert.equal(sessions.size, 0) fails outside the test runner execution context, triggering an uncaught exception while previously registering a false positive test pass.",
+          "file": "test/session.test.js",
+          "line_start": 20,
+          "line_end": 25,
+          "confidence": 0.95,
+          "recommendation": "Invoke the deletion logic (e.g. expire('abc') or sessions.delete('abc')) and assert store state synchronously within the test execution scope instead of deferring to process.nextTick."
+        },
+        {
+          "severity": "medium",
+          "title": "Flawed indexOf comparison allows false positive test passes",
+          "body": "On lines 10-13, lines.indexOf('expired') < lines.indexOf('fresh') evaluates to true if 'expired' is not present in lines (returning -1) and 'fresh' is found at index >= 0. This masks missing expired session output.",
+          "file": "test/session.test.js",
+          "line_start": 10,
+          "line_end": 13,
+          "confidence": 0.95,
+          "recommendation": "Assert that both 'expired' and 'fresh' exist (e.g. assert.notEqual(lines.indexOf(...), -1)) before checking their relative index ordering."
+        },
+        {
+          "severity": "low",
+          "title": "Malformed payload test lacks assertions and tests valid JSON",
+          "body": "The test 'parseSession handles a malformed payload' on lines 6-8 passes valid JSON ('{\"id\":\"abc\",\"expiresAt\":0}') and does not assert return values or verify that invalid input is handled.",
+          "file": "test/session.test.js",
+          "line_start": 6,
+          "line_end": 8,
+          "confidence": 0.9,
+          "recommendation": "Pass actual malformed payloads (e.g. invalid JSON strings, missing fields, or malformed data types) and assert the expected error handling behavior."
+        }
+      ],
+      "latencyMs": 19067
+    }
+  ],
+  "raw": "{\n  \"review\": \"Review\",\n  \"target\": {\n    \"mode\": \"working-tree\",\n    \"label\": \"working tree diff\",\n    \"explicit\": true\n  },\n  \"engine\": \"agy\",\n  \"gemini\": {\n    \"status\": 0,\n    \"stdout\": \"{\\n  \\\"verdict\\\": \\\"needs-attention\\\",\\n  \\\"summary\\\": \\\"The test suite contains unhandled asynchronous assertions causing false passes/uncaught exceptions, invalid order assertions, and incomplete test coverage.\\\",\\n  \\\"findings\\\": [\\n    {\\n      \\\"severity\\\": \\\"high\\\",\\n      \\\"title\\\": \\\"Asynchronous assertion in process.nextTick causes uncaught exception and false test pass\\\",\\n      \\\"body\\\": \\\"The test on lines 20-25 completes synchronously before the process.nextTick callback executes. Furthermore, no deletion or expiration function is invoked after populating the session store. When nextTick fires, assert.equal(sessions.size, 0) fails outside the test runner execution context, triggering an uncaught exception while previously registering a false positive test pass.\\\",\\n      \\\"file\\\": \\\"test/session.test.js\\\",\\n      \\\"line_start\\\": 20,\\n      \\\"line_end\\\": 25,\\n      \\\"confidence\\\": 0.95,\\n      \\\"recommendation\\\": \\\"Invoke the deletion logic (e.g. expire('abc') or sessions.delete('abc')) and assert store state synchronously within the test execution scope instead of deferring to process.nextTick.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"medium\\\",\\n      \\\"title\\\": \\\"Flawed indexOf comparison allows false positive test passes\\\",\\n      \\\"body\\\": \\\"On lines 10-13, lines.indexOf('expired') < lines.indexOf('fresh') evaluates to true if 'expired' is not present in lines (returning -1) and 'fresh' is found at index >= 0. This masks missing expired session output.\\\",\\n      \\\"file\\\": \\\"test/session.test.js\\\",\\n      \\\"line_start\\\": 10,\\n      \\\"line_end\\\": 13,\\n      \\\"confidence\\\": 0.95,\\n      \\\"recommendation\\\": \\\"Assert that both 'expired' and 'fresh' exist (e.g. assert.notEqual(lines.indexOf(...), -1)) before checking their relative index ordering.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"low\\\",\\n      \\\"title\\\": \\\"Malformed payload test lacks assertions and tests valid JSON\\\",\\n      \\\"body\\\": \\\"The test 'parseSession handles a malformed payload' on lines 6-8 passes valid JSON ('{\\\\\\\"id\\\\\\\":\\\\\\\"abc\\\\\\\",\\\\\\\"expiresAt\\\\\\\":0}') and does not assert return values or verify that invalid input is handled.\\\",\\n      \\\"file\\\": \\\"test/session.test.js\\\",\\n      \\\"line_start\\\": 6,\\n      \\\"line_end\\\": 8,\\n      \\\"confidence\\\": 0.9,\\n      \\\"recommendation\\\": \\\"Pass actual malformed payloads (e.g. invalid JSON strings, missing fields, or malformed data types) and assert the expected error handling behavior.\\\"\\n    }\\n  ],\\n  \\\"next_steps\\\": [\\n    \\\"Fix test/session.test.js line 20-25 by calling the deletion function and removing the detached process.nextTick callback.\\\",\\n    \\\"Update the ordering assertions in test/session.test.js to verify substring existence before checking position.\\\",\\n    \\\"Add explicit assertions for malformed payload handling and unskip test.skip on line 15.\\\"\\n  ]\\n}\",\n    \"stderr\": \"\"\n  },\n  \"result\": {\n    \"verdict\": \"needs-attention\",\n    \"summary\": \"The test suite contains unhandled asynchronous assertions causing false passes/uncaught exceptions, invalid order assertions, and incomplete test coverage.\",\n    \"findings\": [\n      {\n        \"severity\": \"high\",\n        \"title\": \"Asynchronous assertion in process.nextTick causes uncaught exception and false test pass\",\n        \"body\": \"The test on lines 20-25 completes synchronously before the process.nextTick callback executes. Furthermore, no deletion or expiration function is invoked after populating the session store. When nextTick fires, assert.equal(sessions.size, 0) fails outside the test runner execution context, triggering an uncaught exception while previously registering a false positive test pass.\",\n        \"file\": \"test/session.test.js\",\n        \"line_start\": 20,\n        \"line_end\": 25,\n        \"confidence\": 0.95,\n        \"recommendation\": \"Invoke the dele"
+}

--- a/bench/cassettes/vacuous-tests/codex.adversarial.json
+++ b/bench/cassettes/vacuous-tests/codex.adversarial.json
@@ -1,0 +1,186 @@
+{
+  "caseId": "vacuous-tests",
+  "cell": "codex.adversarial",
+  "recordedAt": "2026-08-24T11:16:46.744Z",
+  "verdict": "needs-attention",
+  "summary": "No-ship: the added suite can pass without verifying session parsing, expiration, or deletion, so it provides misleading regression coverage.",
+  "findings": [
+    {
+      "severity": "high",
+      "title": "Deletion test completes before its assertion and never deletes anything",
+      "body": "The test inserts a session, schedules the only assertion with process.nextTick(), and returns immediately. node:test can mark the test passed before that callback runs; any later failure is not reliably attributed to this test. More fundamentally, no deletion or expiration operation is invoked, so sessions.size cannot become zero from the shown code. This creates a false-positive test for the behavior named by the test.",
+      "file": "test/session.test.js",
+      "line_start": 20,
+      "line_end": 25,
+      "confidence": 0.99,
+      "recommendation": "Invoke the actual deletion operation and synchronously assert the resulting store state, or return/await a Promise that resolves only after the asynchronous deletion and assertion complete. Clear or recreate the store during setup to isolate the test."
+    },
+    {
+      "severity": "high",
+      "title": "The only direct expire() behavior test is permanently disabled",
+      "body": "test.skip prevents the assertion for expire(\"abc\") from running. A broken, missing, or throwing expire implementation therefore does not fail the suite, leaving the core expiration behavior entirely unprotected.",
+      "file": "test/session.test.js",
+      "line_start": 15,
+      "line_end": 18,
+      "confidence": 1,
+      "recommendation": "Remove test.skip, assert both the return value and that sessions no longer contains \"abc\", and isolate store state before and after the test."
+    },
+    {
+      "severity": "medium",
+      "title": "Render ordering assertion passes when expected output is missing",
+      "body": "indexOf returns -1 when a marker is absent. The comparison can therefore pass when \"expired\" is missing but \"fresh\" exists because -1 is less than the fresh index. The test also does not arrange expired and fresh sessions, so its result depends on ambient module state.",
+      "file": "test/session.test.js",
+      "line_start": 10,
+      "line_end": 13,
+      "confidence": 0.98,
+      "recommendation": "Arrange both session records explicitly, assert each marker index is non-negative, then assert the expired index is lower than the fresh index."
+    },
+    {
+      "severity": "medium",
+      "title": "Malformed-payload test has no observable assertion and uses valid JSON",
+      "body": "The supplied payload is syntactically valid JSON, and the test neither checks a returned value nor expects a specific exception or state change. Any implementation that silently returns an invalid result or mishandles the intended malformed condition can still pass.",
+      "file": "test/session.test.js",
+      "line_start": 6,
+      "line_end": 8,
+      "confidence": 0.97,
+      "recommendation": "Use an actually malformed or contract-invalid payload and assert the required outcome explicitly, such as assert.throws(), a defined fallback value, or unchanged session state."
+    }
+  ],
+  "latencyMs": 32725,
+  "engineVersion": "codex-cli 0.149.0",
+  "engineObserved": null,
+  "samples": [
+    {
+      "verdict": "needs-attention",
+      "summary": "Do not ship: the new tests can pass without exercising or proving the session behaviors they claim to cover.",
+      "findings": [
+        {
+          "severity": "high",
+          "title": "Deletion behavior is never exercised or awaited",
+          "body": "The test inserts a session but never invokes deletion. Its assertion runs in an unreturned `process.nextTick` callback after the test body has completed, so it cannot reliably determine this test's result. Any unrelated asynchronous store mutation could satisfy it, while a failure may be reported outside the originating test. This leaves session deletion entirely unverified.",
+          "file": "test/session.test.js",
+          "line_start": 19,
+          "line_end": 24,
+          "confidence": 0.99,
+          "recommendation": "Call the actual deletion operation, await or return all asynchronous work, and assert both its result and that the specific session key was removed before the test completes."
+        },
+        {
+          "severity": "medium",
+          "title": "Malformed-payload test has no observable expectation",
+          "body": "The test only calls `parseSession`; it passes for any non-throwing behavior, including returning corrupt or unsafe session data. The supplied payload is also syntactically valid JSON, so the test does not establish what makes it malformed or what rejection/sanitization behavior is required.",
+          "file": "test/session.test.js",
+          "line_start": 5,
+          "line_end": 7,
+          "confidence": 0.99,
+          "recommendation": "Define the malformed condition and assert the exact safe outcome, such as a specific exception, null result, or rejected field set."
+        },
+        {
+          "severity": "medium",
+          "title": "Ordering assertion passes when the expired entry is missing",
+          "body": "`indexOf(\"expired\")` returns `-1` when the marker is absent. If `fresh` exists, `-1 < freshIndex` passes, so the test can report correct ordering even though no expired session was rendered. The test also does not seed either record, making it dependent on ambient singleton state.",
+          "file": "test/session.test.js",
+          "line_start": 9,
+          "line_end": 12,
+          "confidence": 0.98,
+          "recommendation": "Seed isolated expired and fresh sessions, assert both indexes are non-negative, then assert the expired index is lower; reset shared state before and after the test."
+        },
+        {
+          "severity": "medium",
+          "title": "The only direct expire test is permanently disabled",
+          "body": "The sole test that calls `expire(\"abc\")` is skipped, so regressions in the return value or removal behavior cannot fail the suite. Combined with the non-awaited deletion test, there is no effective coverage of expiration.",
+          "file": "test/session.test.js",
+          "line_start": 14,
+          "line_end": 17,
+          "confidence": 1,
+          "recommendation": "Remove `test.skip`, isolate the session store, and assert both `expire`'s return value and `sessions.has(\"abc\") === false`."
+        }
+      ],
+      "latencyMs": 32520
+    },
+    {
+      "verdict": "needs-attention",
+      "summary": "Do not ship: the new suite leaves the core expiration behavior skipped and contains tests that can pass without validating their stated behavior.",
+      "findings": [
+        {
+          "severity": "high",
+          "title": "Deletion assertion runs after the test has already completed",
+          "body": "The test returns immediately after scheduling `process.nextTick`, so the test runner is not given a Promise or callback to await. The assertion therefore executes outside the test lifecycle and may be reported as stray asynchronous activity rather than a failure of this test. The test also never calls `expire()` or any deletion operation, so it cannot demonstrate that deleting a session empties the store.",
+          "file": "test/session.test.js",
+          "line_start": 19,
+          "line_end": 24,
+          "confidence": 0.99,
+          "recommendation": "Perform the deletion inside the test, assert synchronously when possible, or return/await a Promise covering the asynchronous operation; also isolate and clear `sessions` before and after the test."
+        },
+        {
+          "severity": "high",
+          "title": "The only direct expiration test is disabled",
+          "body": "`test.skip` prevents the assertion for `expire(\"abc\")` from running. A regression where expiration fails, returns the wrong result, or leaves the session stored will not fail the suite—the central behavior named by this change remains unverified.",
+          "file": "test/session.test.js",
+          "line_start": 14,
+          "line_end": 17,
+          "confidence": 1,
+          "recommendation": "Enable the test and assert both the return value and `sessions.has(\"abc\") === false`, with store cleanup to prevent cross-test contamination."
+        },
+        {
+          "severity": "medium",
+          "title": "Malformed-payload test supplies valid JSON and asserts nothing",
+          "body": "The payload is syntactically valid JSON and the test has no assertion. It only proves that this particular valid input does not throw; it does not verify rejection, fallback behavior, normalization, or store integrity for malformed input. Incorrect parsing behavior can therefore pass unnoticed.",
+          "file": "test/session.test.js",
+          "line_start": 6,
+          "line_end": 8,
+          "confidence": 1,
+          "recommendation": "Use genuinely malformed or schema-invalid payloads and assert the required result or exception plus any expected lack of mutation to `sessions`."
+        }
+      ],
+      "latencyMs": 33302
+    },
+    {
+      "verdict": "needs-attention",
+      "summary": "No-ship: the added suite can pass without verifying session parsing, expiration, or deletion, so it provides misleading regression coverage.",
+      "findings": [
+        {
+          "severity": "high",
+          "title": "Deletion test completes before its assertion and never deletes anything",
+          "body": "The test inserts a session, schedules the only assertion with process.nextTick(), and returns immediately. node:test can mark the test passed before that callback runs; any later failure is not reliably attributed to this test. More fundamentally, no deletion or expiration operation is invoked, so sessions.size cannot become zero from the shown code. This creates a false-positive test for the behavior named by the test.",
+          "file": "test/session.test.js",
+          "line_start": 20,
+          "line_end": 25,
+          "confidence": 0.99,
+          "recommendation": "Invoke the actual deletion operation and synchronously assert the resulting store state, or return/await a Promise that resolves only after the asynchronous deletion and assertion complete. Clear or recreate the store during setup to isolate the test."
+        },
+        {
+          "severity": "high",
+          "title": "The only direct expire() behavior test is permanently disabled",
+          "body": "test.skip prevents the assertion for expire(\"abc\") from running. A broken, missing, or throwing expire implementation therefore does not fail the suite, leaving the core expiration behavior entirely unprotected.",
+          "file": "test/session.test.js",
+          "line_start": 15,
+          "line_end": 18,
+          "confidence": 1,
+          "recommendation": "Remove test.skip, assert both the return value and that sessions no longer contains \"abc\", and isolate store state before and after the test."
+        },
+        {
+          "severity": "medium",
+          "title": "Render ordering assertion passes when expected output is missing",
+          "body": "indexOf returns -1 when a marker is absent. The comparison can therefore pass when \"expired\" is missing but \"fresh\" exists because -1 is less than the fresh index. The test also does not arrange expired and fresh sessions, so its result depends on ambient module state.",
+          "file": "test/session.test.js",
+          "line_start": 10,
+          "line_end": 13,
+          "confidence": 0.98,
+          "recommendation": "Arrange both session records explicitly, assert each marker index is non-negative, then assert the expired index is lower than the fresh index."
+        },
+        {
+          "severity": "medium",
+          "title": "Malformed-payload test has no observable assertion and uses valid JSON",
+          "body": "The supplied payload is syntactically valid JSON, and the test neither checks a returned value nor expects a specific exception or state change. Any implementation that silently returns an invalid result or mishandles the intended malformed condition can still pass.",
+          "file": "test/session.test.js",
+          "line_start": 6,
+          "line_end": 8,
+          "confidence": 0.97,
+          "recommendation": "Use an actually malformed or contract-invalid payload and assert the required outcome explicitly, such as assert.throws(), a defined fallback value, or unchanged session state."
+        }
+      ],
+      "latencyMs": 32725
+    }
+  ],
+  "raw": "{\n  \"review\": \"Adversarial Review\",\n  \"target\": {\n    \"mode\": \"working-tree\",\n    \"label\": \"working tree diff\",\n    \"explicit\": true\n  },\n  \"threadId\": \"01a0337c-43b5-78e0-9e8b-cbcd0c814de3\",\n  \"context\": {\n    \"repoRoot\": \"C:/Users/arcobaleno/AppData/Local/Temp/bench-vacuous-tests-GazcWy\",\n    \"branch\": \"main\",\n    \"summary\": \"Reviewing 0 staged, 1 unstaged, and 0 untracked file(s).\"\n  },\n  \"codex\": {\n    \"status\": 0,\n    \"stderr\": \"\",\n    \"stdout\": \"{\\\"verdict\\\":\\\"needs-attention\\\",\\\"summary\\\":\\\"No-ship: the added suite can pass without verifying session parsing, expiration, or deletion, so it provides misleading regression coverage.\\\",\\\"findings\\\":[{\\\"severity\\\":\\\"high\\\",\\\"title\\\":\\\"Deletion test completes before its assertion and never deletes anything\\\",\\\"body\\\":\\\"The test inserts a session, schedules the only assertion with process.nextTick(), and returns immediately. node:test can mark the test passed before that callback runs; any later failure is not reliably attributed to this test. More fundamentally, no deletion or expiration operation is invoked, so sessions.size cannot become zero from the shown code. This creates a false-positive test for the behavior named by the test.\\\",\\\"file\\\":\\\"test/session.test.js\\\",\\\"line_start\\\":20,\\\"line_end\\\":25,\\\"confidence\\\":0.99,\\\"recommendation\\\":\\\"Invoke the actual deletion operation and synchronously assert the resulting store state, or return/await a Promise that resolves only after the asynchronous deletion and assertion complete. Clear or recreate the store during setup to isolate the test.\\\"},{\\\"severity\\\":\\\"high\\\",\\\"title\\\":\\\"The only direct expire() behavior test is permanently disabled\\\",\\\"body\\\":\\\"test.skip prevents the assertion for expire(\\\\\\\"abc\\\\\\\") from running. A broken, missing, or throwing expire implementation therefore does not fail the suite, leaving the core expiration behavior entirely unprotected.\\\",\\\"file\\\":\\\"test/session.test.js\\\",\\\"line_start\\\":15,\\\"line_end\\\":18,\\\"confidence\\\":1,\\\"recommendation\\\":\\\"Remove test.skip, assert both the return value and that sessions no longer contains \\\\\\\"abc\\\\\\\", and isolate store state before and after the test.\\\"},{\\\"severity\\\":\\\"medium\\\",\\\"title\\\":\\\"Render ordering assertion passes when expected output is missing\\\",\\\"body\\\":\\\"indexOf returns -1 when a marker is absent. The comparison can therefore pass when \\\\\\\"expired\\\\\\\" is missing but \\\\\\\"fresh\\\\\\\" exists because -1 is less than the fresh index. The test also does not arrange expired and fresh sessions, so its result depends on ambient module state.\\\",\\\"file\\\":\\\"test/session.test.js\\\",\\\"line_start\\\":10,\\\"line_end\\\":13,\\\"confidence\\\":0.98,\\\"recommendation\\\":\\\"Arrange both session records explicitly, assert each marker index is non-negative, then assert the expired index is lower than the fresh index.\\\"},{\\\"severity\\\":\\\"medium\\\",\\\"title\\\":\\\"Malformed-payload test has no observable assertion and uses valid JSON\\\",\\\"body\\\":\\\"The supplied payload is syntactically valid JSON, and the test neither checks a returned value nor expects a specific exception or state change. Any implementation that silently returns an invalid result or mishandles the intended malformed condition can still pass.\\\",\\\"file\\\":\\\"test/session.test.js\\\",\\\"line_start\\\":6,\\\"line_end\\\":8,\\\"confidence\\\":0.97,\\\"recommendation\\\":\\\"Use an actually malformed or contract-invalid payload and assert the required outcome explicitly, such as assert.throws(), a defined fallback value, or unchanged session state.\\\"}],\\\"next_steps\\\":[\\\"Replace the vacuous and skipped cases with isolated assertions, then run the complete test suite and confirm each test fails when its target behavior is deliberately broken.\\\"]}\",\n    \"reasoning\": []\n  },\n  \"result\": {\n    \"verdict\": \"needs-attention\",\n    \"summary\": \"No-ship: the added suite can pass without verifying session parsing, expiration, or deletion, so it provides misleading regression coverage.\",\n    \"findings\": [\n      {\n        \"severity\": \"high\",\n        \"title\": \"Deletio"
+}

--- a/bench/cassettes/vacuous-tests/codex.model.json
+++ b/bench/cassettes/vacuous-tests/codex.model.json
@@ -1,0 +1,166 @@
+{
+  "caseId": "vacuous-tests",
+  "cell": "codex.model",
+  "recordedAt": "2026-08-24T04:42:21.772Z",
+  "verdict": "needs-attention",
+  "summary": "The new tests can pass without exercising the intended session behavior and leave asynchronous failures outside the test lifecycle.",
+  "findings": [
+    {
+      "severity": "medium",
+      "title": "Deletion test neither deletes nor awaits its assertion",
+      "body": "The test inserts a session but never calls a deletion operation, then schedules its only assertion with process.nextTick without returning a promise or accepting a callback. The test therefore completes before verification; the assertion may become an uncaught asynchronous error, and no deletion path is actually tested.",
+      "file": "test/session.test.js",
+      "line_start": 20,
+      "line_end": 25,
+      "confidence": 0.99,
+      "recommendation": "Call the deletion API and assert the result and store size synchronously, or return/await a promise that resolves after the callback."
+    },
+    {
+      "severity": "medium",
+      "title": "Expired-session ordering assertion permits missing output",
+      "body": "Using indexOf positions does not establish that both labels exist. If \"expired\" is absent while \"fresh\" is present, -1 is less than the fresh index and the test passes despite missing the expired session entirely. The test also creates no sessions before rendering, making it dependent on external mutable state.",
+      "file": "test/session.test.js",
+      "line_start": 10,
+      "line_end": 13,
+      "confidence": 0.98,
+      "recommendation": "Arrange explicit expired and fresh sessions, assert both indices are non-negative, then assert the expired index is lower."
+    },
+    {
+      "severity": "low",
+      "title": "Malformed-payload test has no observable assertion",
+      "body": "The test supplies syntactically valid JSON and makes no assertion about the return value, thrown error, or session-store state. It only verifies that this particular payload does not throw, so malformed-input handling can remain broken unnoticed.",
+      "file": "test/session.test.js",
+      "line_start": 6,
+      "line_end": 8,
+      "confidence": 0.97,
+      "recommendation": "Provide genuinely malformed or schema-invalid input and assert the documented error, fallback result, and absence of unintended store mutation."
+    }
+  ],
+  "latencyMs": 25225,
+  "engineVersion": "codex-cli 0.149.0",
+  "engineObserved": null,
+  "samples": [
+    {
+      "verdict": "needs-attention",
+      "summary": "The new tests contain false-positive and order-dependent paths that do not reliably verify session behavior.",
+      "findings": [
+        {
+          "severity": "high",
+          "title": "Deletion test completes before its assertion runs",
+          "body": "The test schedules its only assertion with process.nextTick() but neither returns a promise nor accepts a test callback, so the test completes synchronously and can be reported as passing before the assertion executes. It also never invokes any deletion operation, making the expected empty store unsupported and potentially producing an uncaught asynchronous assertion later.",
+          "file": "test/session.test.js",
+          "line_start": 20,
+          "line_end": 25,
+          "confidence": 0.99,
+          "recommendation": "Invoke the session-deletion API in the test and assert the resulting store state synchronously, or await a promise that resolves after the scheduled operation before returning from the test."
+        },
+        {
+          "severity": "medium",
+          "title": "Malformed-payload test has no observable expectation",
+          "body": "The test calls parseSession but makes no assertion about its return value or error behavior. It passes for nearly any non-throwing implementation, including one that silently accepts the purportedly malformed payload, so it cannot detect the behavior named by the test.",
+          "file": "test/session.test.js",
+          "line_start": 6,
+          "line_end": 8,
+          "confidence": 0.98,
+          "recommendation": "Assert the required contract explicitly, such as assert.throws for rejection or deep equality against the expected validation result."
+        },
+        {
+          "severity": "medium",
+          "title": "Render-order test depends on unstated shared session state",
+          "body": "The test calls render() without inserting expired and fresh sessions. Its result therefore depends on module initialization or state left by other tests, making it order-dependent and unable to prove ordering for controlled inputs.",
+          "file": "test/session.test.js",
+          "line_start": 10,
+          "line_end": 13,
+          "confidence": 0.96,
+          "recommendation": "Clear the shared store, insert one known expired session and one known fresh session, then assert their positions in the rendered output and verify both markers are present."
+        },
+        {
+          "severity": "low",
+          "title": "Expire behavior is permanently excluded from the suite",
+          "body": "The only direct test of expire() is skipped, so regressions in its return value or removal behavior will not fail the test run.",
+          "file": "test/session.test.js",
+          "line_start": 15,
+          "line_end": 18,
+          "confidence": 0.99,
+          "recommendation": "Remove test.skip and isolate the shared session store before and after the test so expire() is exercised deterministically."
+        }
+      ],
+      "latencyMs": 26329
+    },
+    {
+      "verdict": "needs-attention",
+      "summary": "The new tests leave session deletion and malformed-payload behavior effectively unverified.",
+      "findings": [
+        {
+          "severity": "high",
+          "title": "Deletion test neither deletes nor awaits its assertion",
+          "body": "The test inserts a session but never calls expire() or any deletion operation, then schedules an assertion with process.nextTick without returning or awaiting completion. The test can finish before the assertion runs, so it does not reliably verify deletion and may produce asynchronous activity after test completion.",
+          "file": "test/session.test.js",
+          "line_start": 19,
+          "line_end": 24,
+          "confidence": 0.99,
+          "recommendation": "Call the deletion API directly and assert synchronously, or await a Promise that resolves after the scheduled operation before asserting the store size."
+        },
+        {
+          "severity": "medium",
+          "title": "Malformed-payload test uses valid JSON and has no assertion",
+          "body": "The supplied payload is syntactically valid and contains both expected-looking fields. With no assertion, the test only checks that this particular valid input does not throw and cannot verify rejection, fallback behavior, or the parsed result for an actually malformed payload.",
+          "file": "test/session.test.js",
+          "line_start": 6,
+          "line_end": 8,
+          "confidence": 0.98,
+          "recommendation": "Pass genuinely malformed or schema-invalid input and assert the documented error, return value, or recovery behavior."
+        },
+        {
+          "severity": "medium",
+          "title": "Core expiration behavior is permanently skipped",
+          "body": "The only test that directly calls expire() is marked skipped, leaving its return value and session-removal behavior uncovered while the active deletion test never invokes it.",
+          "file": "test/session.test.js",
+          "line_start": 15,
+          "line_end": 18,
+          "confidence": 0.99,
+          "recommendation": "Remove test.skip and assert both that expire(\"abc\") returns true and that sessions.has(\"abc\") is false afterward."
+        }
+      ],
+      "latencyMs": 24165
+    },
+    {
+      "verdict": "needs-attention",
+      "summary": "The new tests can pass without exercising the intended session behavior and leave asynchronous failures outside the test lifecycle.",
+      "findings": [
+        {
+          "severity": "medium",
+          "title": "Deletion test neither deletes nor awaits its assertion",
+          "body": "The test inserts a session but never calls a deletion operation, then schedules its only assertion with process.nextTick without returning a promise or accepting a callback. The test therefore completes before verification; the assertion may become an uncaught asynchronous error, and no deletion path is actually tested.",
+          "file": "test/session.test.js",
+          "line_start": 20,
+          "line_end": 25,
+          "confidence": 0.99,
+          "recommendation": "Call the deletion API and assert the result and store size synchronously, or return/await a promise that resolves after the callback."
+        },
+        {
+          "severity": "medium",
+          "title": "Expired-session ordering assertion permits missing output",
+          "body": "Using indexOf positions does not establish that both labels exist. If \"expired\" is absent while \"fresh\" is present, -1 is less than the fresh index and the test passes despite missing the expired session entirely. The test also creates no sessions before rendering, making it dependent on external mutable state.",
+          "file": "test/session.test.js",
+          "line_start": 10,
+          "line_end": 13,
+          "confidence": 0.98,
+          "recommendation": "Arrange explicit expired and fresh sessions, assert both indices are non-negative, then assert the expired index is lower."
+        },
+        {
+          "severity": "low",
+          "title": "Malformed-payload test has no observable assertion",
+          "body": "The test supplies syntactically valid JSON and makes no assertion about the return value, thrown error, or session-store state. It only verifies that this particular payload does not throw, so malformed-input handling can remain broken unnoticed.",
+          "file": "test/session.test.js",
+          "line_start": 6,
+          "line_end": 8,
+          "confidence": 0.97,
+          "recommendation": "Provide genuinely malformed or schema-invalid input and assert the documented error, fallback result, and absence of unintended store mutation."
+        }
+      ],
+      "latencyMs": 25225
+    }
+  ],
+  "raw": "{\"verdict\":\"needs-attention\",\"summary\":\"The new tests can pass without exercising the intended session behavior and leave asynchronous failures outside the test lifecycle.\",\"findings\":[{\"severity\":\"medium\",\"title\":\"Deletion test neither deletes nor awaits its assertion\",\"body\":\"The test inserts a session but never calls a deletion operation, then schedules its only assertion with process.nextTick without returning a promise or accepting a callback. The test therefore completes before verification; the assertion may become an uncaught asynchronous error, and no deletion path is actually tested.\",\"file\":\"test/session.test.js\",\"line_start\":20,\"line_end\":25,\"confidence\":0.99,\"recommendation\":\"Call the deletion API and assert the result and store size synchronously, or return/await a promise that resolves after the callback.\"},{\"severity\":\"medium\",\"title\":\"Expired-session ordering assertion permits missing output\",\"body\":\"Using indexOf positions does not establish that both labels exist. If \\\"expired\\\" is absent while \\\"fresh\\\" is present, -1 is less than the fresh index and the test passes despite missing the expired session entirely. The test also creates no sessions before rendering, making it dependent on external mutable state.\",\"file\":\"test/session.test.js\",\"line_start\":10,\"line_end\":13,\"confidence\":0.98,\"recommendation\":\"Arrange explicit expired and fresh sessions, assert both indices are non-negative, then assert the expired index is lower.\"},{\"severity\":\"low\",\"title\":\"Malformed-payload test has no observable assertion\",\"body\":\"The test supplies syntactically valid JSON and makes no assertion about the return value, thrown error, or session-store state. It only verifies that this particular payload does not throw, so malformed-input handling can remain broken unnoticed.\",\"file\":\"test/session.test.js\",\"line_start\":6,\"line_end\":8,\"confidence\":0.97,\"recommendation\":\"Provide genuinely malformed or schema-invalid input and assert the documented error, fallback result, and absence of unintended store mutation.\"}],\"next_steps\":[\"Rewrite the tests with explicit setup, synchronous or awaited assertions, and enable the skipped expire test.\"]}\n"
+}

--- a/bench/cassettes/vacuous-tests/gemini.model.json
+++ b/bench/cassettes/vacuous-tests/gemini.model.json
@@ -1,135 +1,156 @@
 {
   "caseId": "vacuous-tests",
   "cell": "gemini.model",
-  "recordedAt": "2026-08-19T09:10:17.333Z",
+  "recordedAt": "2026-08-24T10:46:21.199Z",
   "verdict": "needs-attention",
-  "summary": "The test suite contains a vacuous test with no assertions and an improperly managed asynchronous execution that escapes the test runner's lifecycle.",
+  "summary": "The test suite contains fundamentally flawed tests, including a vacuous test with no assertions and an improperly handled asynchronous callback that escapes the test runner scope.",
   "findings": [
     {
       "severity": "high",
       "title": "Vacuous test lacking assertions",
-      "body": "The test 'parseSession handles a malformed payload' invokes 'parseSession' but fails to assert any outcomes. This test will falsely pass unless the function synchronously throws an error, resulting in misleading test coverage.",
+      "body": "The test 'parseSession handles a malformed payload' invokes `parseSession` but does not assert anything about the result or potential thrown errors. This test will silently pass regardless of the function's correctness, failing to catch regressions.",
       "file": "test/session.test.js",
       "line_start": 6,
       "line_end": 8,
       "confidence": 1,
-      "recommendation": "Implement explicit assertions (such as 'assert.throws' or checking the return value) to validate how the function handles malformed payloads."
+      "recommendation": "Add appropriate `assert` statements (e.g., `assert.throws` if it should reject, or `assert.deepEqual` if it returns a specific error object or null)."
     },
     {
       "severity": "high",
-      "title": "Unawaited asynchronous execution escapes test scope",
-      "body": "The test 'deleting a session empties the store' schedules an assertion inside 'process.nextTick' but does not return a Promise or use a done callback. The node:test runner will mark the test as passed synchronously before the assertion executes. If the assertion fails later, it will trigger an unhandled exception.",
+      "title": "Un-awaited asynchronous assertion escapes test scope",
+      "body": "The test 'deleting a session empties the store' places its assertion inside a `process.nextTick` callback, but the test function itself returns synchronously. The test runner will conclude the test has passed before the assertion actually runs. If the assertion fails later, it will trigger an unhandled exception outside the test lifecycle.",
       "file": "test/session.test.js",
       "line_start": 20,
-      "line_end": 25,
+      "line_end": 24,
       "confidence": 1,
-      "recommendation": "Pass a 'done' callback to the test function and invoke it after the assertion, or return a Promise so the runner correctly waits for the asynchronous block to complete."
+      "recommendation": "Use the `done` callback provided by the `node:test` runner, or return a Promise that resolves when the `process.nextTick` callback completes."
+    },
+    {
+      "severity": "low",
+      "title": "Missing explicit setup/mocking before render",
+      "body": "The test 'an expired session is listed before a fresh one' calls `render()` without first adding any test data to the `sessions` store. It relies entirely on global state pollution from previous tests (which is also improperly managed).",
+      "file": "test/session.test.js",
+      "line_start": 10,
+      "line_end": 13,
+      "confidence": 0.9,
+      "recommendation": "Explicitly seed the `sessions` store with known mock data (one expired, one fresh session) within the test before calling `render()`."
     }
   ],
-  "latencyMs": 20496,
-  "engineVersion": "0.55.1",
+  "latencyMs": 23532,
+  "engineVersion": "0.56.0",
+  "engineObserved": null,
   "samples": [
     {
       "verdict": "needs-attention",
-      "summary": "The test suite contains fundamentally flawed tests, including unawaited async assertions and missing assertions.",
+      "summary": "The test suite contains multiple vacuous or falsely-passing tests due to missing assertions, flawed indexOf logic, and unhandled asynchronous execution.",
       "findings": [
+        {
+          "severity": "medium",
+          "title": "Missing assertion in parseSession test",
+          "body": "The test invokes `parseSession` but lacks any assertions. It will silently pass unless an exception is thrown, failing to verify how the malformed payload is actually handled.",
+          "file": "test/session.test.js",
+          "line_start": 6,
+          "line_end": 8,
+          "confidence": 1,
+          "recommendation": "Add assertions (e.g., `assert.deepEqual` or `assert.throws`) to verify the expected output or error for the malformed payload."
+        },
+        {
+          "severity": "high",
+          "title": "Unsafe index comparison allows false positives",
+          "body": "If 'expired' is not present in `lines`, `indexOf` returns -1. If 'fresh' is present (index >= 0), `-1 < index` is true, causing the test to pass even though the required 'expired' text is completely missing.",
+          "file": "test/session.test.js",
+          "line_start": 10,
+          "line_end": 13,
+          "confidence": 1,
+          "recommendation": "Assert that `indexOf(\"expired\") !== -1` and `indexOf(\"fresh\") !== -1` before comparing the two indices."
+        },
+        {
+          "severity": "high",
+          "title": "Unawaited asynchronous assertion",
+          "body": "The assertion inside `process.nextTick` is not awaited or tracked by the test framework. The test will complete synchronously and pass before the callback runs, leading to unhandled exceptions or false positives if the assertion fails.",
+          "file": "test/session.test.js",
+          "line_start": 20,
+          "line_end": 25,
+          "confidence": 1,
+          "recommendation": "Use the `done` callback argument provided by `node:test` (e.g., `test('...', (t, done) => { ... })`) or return a Promise that resolves after the assertion."
+        }
+      ],
+      "latencyMs": 26629
+    },
+    {
+      "verdict": "needs-attention",
+      "summary": "The new test file contains false positives due to missing assertions, unawaited asynchronous code, and flawed string index comparisons.",
+      "findings": [
+        {
+          "severity": "high",
+          "title": "Missing assertions in test",
+          "body": "The test 'parseSession handles a malformed payload' executes `parseSession` but makes no assertions about its return value or side effects. If the function is expected to handle it gracefully, the test doesn't verify the result. If it's expected to throw, it should use `assert.throws`.",
+          "file": "test/session.test.js",
+          "line_start": 6,
+          "line_end": 8,
+          "confidence": 1,
+          "recommendation": "Add explicit assertions (e.g., `assert.deepEqual` or `assert.throws`) to verify the expected behavior of `parseSession`."
+        },
+        {
+          "severity": "critical",
+          "title": "Flawed string index comparison",
+          "body": "Using `lines.indexOf(\"expired\") < lines.indexOf(\"fresh\")` can result in a false positive. If 'expired' is missing from `lines`, `indexOf` returns `-1`. If 'fresh' is found at index >= 0, `-1 < index` evaluates to true, causing the test to pass incorrectly.",
+          "file": "test/session.test.js",
+          "line_start": 10,
+          "line_end": 13,
+          "confidence": 1,
+          "recommendation": "Assert that both strings are present before comparing their indices, e.g., `assert.ok(indexExpired !== -1)`."
+        },
         {
           "severity": "critical",
           "title": "Unawaited asynchronous assertion",
-          "body": "The test 'deleting a session empties the store' uses `process.nextTick` to wrap its assertion, but does not return a Promise or use a test callback to await its completion. The test will exit synchronously (and pass) before the assertion ever runs. If the assertion fails later, it will cause an unhandled exception rather than a tracked test failure.",
+          "body": "The assertion inside `process.nextTick` runs after the synchronous execution of the test completes. This causes the test to pass immediately, and a later failure in the assertion will either be ignored or cause an unhandled process exception.",
           "file": "test/session.test.js",
           "line_start": 20,
           "line_end": 25,
           "confidence": 1,
-          "recommendation": "Use a `done` callback provided by the test runner (e.g., `test('...', (t, done) => { ... })`) or return a Promise so the test runner waits for the async assertion to execute."
-        },
-        {
-          "severity": "high",
-          "title": "Missing assertions in parseSession test",
-          "body": "The test 'parseSession handles a malformed payload' invokes the function but contains absolutely no assertions. This test will always pass as long as the function doesn't crash the process, making it a vacuous test that provides zero coverage guarantees.",
-          "file": "test/session.test.js",
-          "line_start": 6,
-          "line_end": 8,
-          "confidence": 1,
-          "recommendation": "Add specific assertions to verify the expected behavior, such as `assert.throws()` or checking the returned object/state."
-        },
-        {
-          "severity": "medium",
-          "title": "Missing test arrangement and fragile assertion",
-          "body": "The test 'an expired session is listed before a fresh one' calls `render()` without first inserting mock sessions. It either relies on polluted global state from other tests or operates on an empty store. Additionally, if the strings aren't found, `indexOf` returns -1, making the comparison `-1 < -1` (false) or potentially passing if only 'expired' is missing (`-1 < indexOf('fresh')`), leading to false confidence.",
-          "file": "test/session.test.js",
-          "line_start": 10,
-          "line_end": 13,
-          "confidence": 0.95,
-          "recommendation": "Explicitly populate the `sessions` store with predictable test data before calling `render()`, and assert that both strings are actually present (index > -1) before comparing their positions."
+          "recommendation": "Use the `done` callback provided by the node:test runner, or wrap the nextTick inside a Promise and `await` it."
         }
       ],
-      "latencyMs": 26819
+      "latencyMs": 20385
     },
     {
       "verdict": "needs-attention",
-      "summary": "The test suite contains a vacuous test with no assertions, tests with missing setup data, and an improperly synchronized asynchronous test that will falsely pass and crash the runner.",
-      "findings": [
-        {
-          "severity": "high",
-          "title": "Unsynchronized async assertion and missing deletion logic",
-          "body": "The test 'deleting a session empties the store' runs an assertion in `process.nextTick` but does not return a Promise or accept a callback, causing the test to complete synchronously before the assertion. Furthermore, no actual function is called to delete the session, meaning the assertion will fail out-of-band and likely crash the process.",
-          "file": "test/session.test.js",
-          "line_start": 20,
-          "line_end": 25,
-          "confidence": 1,
-          "recommendation": "Make the test function `async`, actually perform the session deletion before asserting, and remove the `process.nextTick` wrapper."
-        },
-        {
-          "severity": "medium",
-          "title": "Vacuous test with no assertions",
-          "body": "The test 'parseSession handles a malformed payload' invokes `parseSession` but does not assert the return value or catch expected exceptions. It will silently pass as long as `parseSession` does not throw an unexpected error.",
-          "file": "test/session.test.js",
-          "line_start": 6,
-          "line_end": 8,
-          "confidence": 1,
-          "recommendation": "Add assertions to verify the expected outcome of `parseSession`."
-        },
-        {
-          "severity": "medium",
-          "title": "Missing test setup for shared state",
-          "body": "The test 'an expired session is listed before a fresh one' calls `render()` without adding any sessions to the store. If both 'expired' and 'fresh' are not found, `indexOf` returns -1 for both, resulting in an `assert.ok(-1 < -1)` failure.",
-          "file": "test/session.test.js",
-          "line_start": 10,
-          "line_end": 13,
-          "confidence": 0.9,
-          "recommendation": "Populate the `sessions` state with mock 'expired' and 'fresh' items before calling `render()`."
-        }
-      ],
-      "latencyMs": 33484
-    },
-    {
-      "verdict": "needs-attention",
-      "summary": "The test suite contains a vacuous test with no assertions and an improperly managed asynchronous execution that escapes the test runner's lifecycle.",
+      "summary": "The test suite contains fundamentally flawed tests, including a vacuous test with no assertions and an improperly handled asynchronous callback that escapes the test runner scope.",
       "findings": [
         {
           "severity": "high",
           "title": "Vacuous test lacking assertions",
-          "body": "The test 'parseSession handles a malformed payload' invokes 'parseSession' but fails to assert any outcomes. This test will falsely pass unless the function synchronously throws an error, resulting in misleading test coverage.",
+          "body": "The test 'parseSession handles a malformed payload' invokes `parseSession` but does not assert anything about the result or potential thrown errors. This test will silently pass regardless of the function's correctness, failing to catch regressions.",
           "file": "test/session.test.js",
           "line_start": 6,
           "line_end": 8,
           "confidence": 1,
-          "recommendation": "Implement explicit assertions (such as 'assert.throws' or checking the return value) to validate how the function handles malformed payloads."
+          "recommendation": "Add appropriate `assert` statements (e.g., `assert.throws` if it should reject, or `assert.deepEqual` if it returns a specific error object or null)."
         },
         {
           "severity": "high",
-          "title": "Unawaited asynchronous execution escapes test scope",
-          "body": "The test 'deleting a session empties the store' schedules an assertion inside 'process.nextTick' but does not return a Promise or use a done callback. The node:test runner will mark the test as passed synchronously before the assertion executes. If the assertion fails later, it will trigger an unhandled exception.",
+          "title": "Un-awaited asynchronous assertion escapes test scope",
+          "body": "The test 'deleting a session empties the store' places its assertion inside a `process.nextTick` callback, but the test function itself returns synchronously. The test runner will conclude the test has passed before the assertion actually runs. If the assertion fails later, it will trigger an unhandled exception outside the test lifecycle.",
           "file": "test/session.test.js",
           "line_start": 20,
-          "line_end": 25,
+          "line_end": 24,
           "confidence": 1,
-          "recommendation": "Pass a 'done' callback to the test function and invoke it after the assertion, or return a Promise so the runner correctly waits for the asynchronous block to complete."
+          "recommendation": "Use the `done` callback provided by the `node:test` runner, or return a Promise that resolves when the `process.nextTick` callback completes."
+        },
+        {
+          "severity": "low",
+          "title": "Missing explicit setup/mocking before render",
+          "body": "The test 'an expired session is listed before a fresh one' calls `render()` without first adding any test data to the `sessions` store. It relies entirely on global state pollution from previous tests (which is also improperly managed).",
+          "file": "test/session.test.js",
+          "line_start": 10,
+          "line_end": 13,
+          "confidence": 0.9,
+          "recommendation": "Explicitly seed the `sessions` store with known mock data (one expired, one fresh session) within the test before calling `render()`."
         }
       ],
-      "latencyMs": 20496
+      "latencyMs": 23532
     }
   ],
-  "raw": "{\n  \"session_id\": \"0ff37620-fc22-44f8-8600-b05b33e3ad54\",\n  \"response\": \"{\\n  \\\"verdict\\\": \\\"needs-attention\\\",\\n  \\\"summary\\\": \\\"The test suite contains a vacuous test with no assertions and an improperly managed asynchronous execution that escapes the test runner's lifecycle.\\\",\\n  \\\"findings\\\": [\\n    {\\n      \\\"severity\\\": \\\"high\\\",\\n      \\\"title\\\": \\\"Vacuous test lacking assertions\\\",\\n      \\\"body\\\": \\\"The test 'parseSession handles a malformed payload' invokes 'parseSession' but fails to assert any outcomes. This test will falsely pass unless the function synchronously throws an error, resulting in misleading test coverage.\\\",\\n      \\\"file\\\": \\\"test/session.test.js\\\",\\n      \\\"line_start\\\": 6,\\n      \\\"line_end\\\": 8,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Implement explicit assertions (such as 'assert.throws' or checking the return value) to validate how the function handles malformed payloads.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"high\\\",\\n      \\\"title\\\": \\\"Unawaited asynchronous execution escapes test scope\\\",\\n      \\\"body\\\": \\\"The test 'deleting a session empties the store' schedules an assertion inside 'process.nextTick' but does not return a Promise or use a done callback. The node:test runner will mark the test as passed synchronously before the assertion executes. If the assertion fails later, it will trigger an unhandled exception.\\\",\\n      \\\"file\\\": \\\"test/session.test.js\\\",\\n      \\\"line_start\\\": 20,\\n      \\\"line_end\\\": 25,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Pass a 'done' callback to the test function and invoke it after the assertion, or return a Promise so the runner correctly waits for the asynchronous block to complete.\\\"\\n    }\\n  ],\\n  \\\"next_steps\\\": [\\n    \\\"Fix the vacuous test by adding assertions for the malformed payload.\\\",\\n    \\\"Correct the lifecycle of the async test using either a done callback or a Promise wrapper.\\\",\\n    \\\"Review the test suite for the reasoning behind the skipped 'expire() removes the session' test and implement it if necessary.\\\"\\n  ]\\n}\",\n  \"stats\": {\n    \"models\": {\n      \"gemini-3.1-pro-preview\": {\n        \"api\": {\n          \"totalRequests\": 1,\n          \"totalErrors\": 0,\n          \"totalLatencyMs\": 18790,\n          \"errorsByType\": {}\n        },\n        \"tokens\": {\n          \"input\": 5157,\n          \"prompt\": 17376,\n          \"candidates\": 413,\n          \"total\": 19348,\n          \"cached\": 12219,\n          \"thoughts\": 1559,\n          \"tool\": 0\n        },\n        \"roles\": {\n          \"main\": {\n            \"totalRequests\": 1,\n            \"totalErrors\": 0,\n            \"totalLatencyMs\": 18790,\n            \"tokens\": {\n              \"input\": 5157,\n              \"prompt\": 17376,\n              \"candidates\": 413,\n              \"total\": 19348,\n              \"cached\": 12219,\n              \"thoughts\": 1559,\n              \"tool\": 0\n            }\n          }\n        }\n      }\n    },\n    \"tools\": {\n      \"totalCalls\": 0,\n      \"totalSuccess\": 0,\n      \"totalFail\": 0,\n      \"totalDurationMs\": 0,\n      \"totalDecisions\": {\n        \"accept\": 0,\n        \"reject\": 0,\n        \"modify\": 0,\n        \"auto_accept\": 0\n      },\n      \"byName\": {}\n    },\n    \"files\": {\n      \"totalLinesAdded\": 0,\n      \"totalLinesRemoved\": 0\n    }\n  }\n}"
+  "raw": "{\n  \"session_id\": \"01be1310-a40b-4799-ab4a-a8fa422818c4\",\n  \"response\": \"{\\n  \\\"verdict\\\": \\\"needs-attention\\\",\\n  \\\"summary\\\": \\\"The test suite contains fundamentally flawed tests, including a vacuous test with no assertions and an improperly handled asynchronous callback that escapes the test runner scope.\\\",\\n  \\\"findings\\\": [\\n    {\\n      \\\"severity\\\": \\\"high\\\",\\n      \\\"title\\\": \\\"Vacuous test lacking assertions\\\",\\n      \\\"body\\\": \\\"The test 'parseSession handles a malformed payload' invokes `parseSession` but does not assert anything about the result or potential thrown errors. This test will silently pass regardless of the function's correctness, failing to catch regressions.\\\",\\n      \\\"file\\\": \\\"test/session.test.js\\\",\\n      \\\"line_start\\\": 6,\\n      \\\"line_end\\\": 8,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Add appropriate `assert` statements (e.g., `assert.throws` if it should reject, or `assert.deepEqual` if it returns a specific error object or null).\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"high\\\",\\n      \\\"title\\\": \\\"Un-awaited asynchronous assertion escapes test scope\\\",\\n      \\\"body\\\": \\\"The test 'deleting a session empties the store' places its assertion inside a `process.nextTick` callback, but the test function itself returns synchronously. The test runner will conclude the test has passed before the assertion actually runs. If the assertion fails later, it will trigger an unhandled exception outside the test lifecycle.\\\",\\n      \\\"file\\\": \\\"test/session.test.js\\\",\\n      \\\"line_start\\\": 20,\\n      \\\"line_end\\\": 24,\\n      \\\"confidence\\\": 1.0,\\n      \\\"recommendation\\\": \\\"Use the `done` callback provided by the `node:test` runner, or return a Promise that resolves when the `process.nextTick` callback completes.\\\"\\n    },\\n    {\\n      \\\"severity\\\": \\\"low\\\",\\n      \\\"title\\\": \\\"Missing explicit setup/mocking before render\\\",\\n      \\\"body\\\": \\\"The test 'an expired session is listed before a fresh one' calls `render()` without first adding any test data to the `sessions` store. It relies entirely on global state pollution from previous tests (which is also improperly managed).\\\",\\n      \\\"file\\\": \\\"test/session.test.js\\\",\\n      \\\"line_start\\\": 10,\\n      \\\"line_end\\\": 13,\\n      \\\"confidence\\\": 0.9,\\n      \\\"recommendation\\\": \\\"Explicitly seed the `sessions` store with known mock data (one expired, one fresh session) within the test before calling `render()`.\\\"\\n    }\\n  ],\\n  \\\"next_steps\\\": [\\n    \\\"Add explicit assertions to the 'parseSession' test.\\\",\\n    \\\"Refactor the 'deleting a session' test to properly await the asynchronous assertion using Promises or a done callback.\\\",\\n    \\\"Isolate test state by explicitly seeding the session store before testing 'render()'.\\\"\\n  ]\\n}\",\n  \"stats\": {\n    \"models\": {\n      \"gemini-3.1-pro-preview\": {\n        \"api\": {\n          \"totalRequests\": 1,\n          \"totalErrors\": 0,\n          \"totalLatencyMs\": 21923,\n          \"errorsByType\": {}\n        },\n        \"tokens\": {\n          \"input\": 18261,\n          \"prompt\": 18261,\n          \"candidates\": 596,\n          \"total\": 20390,\n          \"cached\": 0,\n          \"thoughts\": 1533,\n          \"tool\": 0\n        },\n        \"roles\": {\n          \"main\": {\n            \"totalRequests\": 1,\n            \"totalErrors\": 0,\n            \"totalLatencyMs\": 21923,\n            \"tokens\": {\n              \"input\": 18261,\n              \"prompt\": 18261,\n              \"candidates\": 596,\n              \"total\": 20390,\n              \"cached\": 0,\n              \"thoughts\": 1533,\n              \"tool\": 0\n            }\n          }\n        }\n      }\n    },\n    \"tools\": {\n      \"totalCalls\": 0,\n      \"totalSuccess\": 0,\n      \"totalFail\": 0,\n      \"totalDurationMs\": 0,\n      \"totalDecisions\": {\n        \"accept\": 0,\n        \"reject\": 0,\n        \"modify\": 0,\n        \"auto_accept\": 0\n      },\n      \"byName\": {}\n    },\n    \"files\": {\n      \"totalLinesAdded\": 0,\n      \"totalLinesRemoved\": 0\n    }\n  }\n}"
 }

--- a/bench/corpus/async-lifecycle/ground-truth.json
+++ b/bench/corpus/async-lifecycle/ground-truth.json
@@ -9,17 +9,7 @@
       "line_start": 26,
       "line_end": 28,
       "severity": "critical",
-      "match": {
-        "keywords": [
-          "swallow",
-          "ok: true",
-          "reports success",
-          "silently",
-          "catch block",
-          "hides the error",
-          "always returns"
-        ]
-      }
+      "match": { "all": ["runone"], "keywords": ["swallow", "ok: true", "reports success", "silently", "catch block", "hides the error", "always returns", "masks"] }
     },
     {
       "id": "handle-leak",
@@ -28,16 +18,7 @@
       "line_start": 6,
       "line_end": 10,
       "severity": "high",
-      "match": {
-        "keywords": [
-          "file handle",
-          "not closed",
-          "leak",
-          "finally",
-          "close()",
-          "descriptor"
-        ]
-      }
+      "match": { "all": ["openjob"], "keywords": ["file handle", "not closed", "leak", "finally", "close()", "descriptor"] }
     },
     {
       "id": "unbounded-interval",
@@ -46,15 +27,7 @@
       "line_start": 16,
       "line_end": 18,
       "severity": "medium",
-      "match": {
-        "keywords": [
-          "setinterval",
-          "never cleared",
-          "clearinterval",
-          "no handle",
-          "runs forever"
-        ]
-      }
+      "match": { "all": ["setinterval"], "keywords": ["never cleared", "clearinterval", "no handle", "runs forever", "cannot be stopped"] }
     },
     {
       "id": "floating-promise",
@@ -63,16 +36,7 @@
       "line_start": 17,
       "line_end": 17,
       "severity": "high",
-      "match": {
-        "keywords": [
-          "not awaited",
-          "floating promise",
-          "unhandled rejection",
-          "no await",
-          "no catch",
-          "promise is ignored"
-        ]
-      }
+      "match": { "all": ["appendfile"], "keywords": ["not awaited", "floating promise", "unhandled rejection", "no await", "no catch", "promise is ignored"] }
     },
     {
       "id": "unbounded-map",
@@ -81,16 +45,7 @@
       "line_start": 3,
       "line_end": 7,
       "severity": "medium",
-      "match": {
-        "keywords": [
-          "never removed",
-          "grows",
-          "unbounded",
-          "memory",
-          "delete",
-          "map is never"
-        ]
-      }
+      "match": { "all": ["handles"], "keywords": ["never removed", "grows", "unbounded", "delete", "never cleaned"] }
     }
   ],
   "allowed_extras": [

--- a/bench/corpus/auth-basic/ground-truth.json
+++ b/bench/corpus/auth-basic/ground-truth.json
@@ -9,7 +9,7 @@
       "line_start": 7,
       "line_end": 9,
       "severity": "critical",
-      "match": { "keywords": ["sql injection", "injection", "parameteriz", "concatenat"] }
+      "match": { "all": ["sql"], "keywords": ["injection", "parameteriz", "concatenat"] }
     },
     {
       "id": "hardcoded-secret",
@@ -18,7 +18,7 @@
       "line_start": 4,
       "line_end": 4,
       "severity": "high",
-      "match": { "keywords": ["hardcoded", "hard-coded", "hard coded", "secret in source", "jwt_secret"] }
+      "match": { "all": ["jwt_secret"], "keywords": ["hardcoded", "hard-coded", "hard coded", "secret in source", "in the source", "committed to source"] }
     },
     {
       "id": "null-check",
@@ -27,7 +27,7 @@
       "line_start": 14,
       "line_end": 15,
       "severity": "medium",
-      "match": { "keywords": ["null check", "null-check", "undefined", "may be null", "user could be", "missing check"] }
+      "match": { "all": ["finduser"], "keywords": ["null check", "null-check", "may be null", "could be null", "user could be", "missing check", "no row", "undefined"] }
     },
     {
       "id": "plaintext-compare",
@@ -36,7 +36,7 @@
       "line_start": 15,
       "line_end": 15,
       "severity": "high",
-      "match": { "keywords": ["plaintext", "plain text", "hash", "bcrypt", "constant-time", "timing attack"] }
+      "match": { "all": ["password"], "keywords": ["plaintext", "plain text", "hash", "bcrypt", "constant-time", "timing attack"] }
     },
     {
       "id": "json-parse",
@@ -45,7 +45,7 @@
       "line_start": 22,
       "line_end": 22,
       "severity": "high",
-      "match": { "keywords": ["json.parse", "unguarded", "try/catch", "throws", "malformed"] }
+      "match": { "all": ["json.parse"], "keywords": ["unguarded", "try/catch", "throws", "malformed", "invalid json"] }
     }
   ],
   "allowed_extras": [

--- a/bench/corpus/caller-contract/base/package.json
+++ b/bench/corpus/caller-contract/base/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "profile-service",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "express": "^4.18.0"
+  }
+}

--- a/bench/corpus/caller-contract/base/src/routes/admin.js
+++ b/bench/corpus/caller-contract/base/src/routes/admin.js
@@ -1,0 +1,11 @@
+const { findUser } = require("../store");
+
+function requireAdmin(req, res, next) {
+  const user = findUser(req.params.id);
+  if (user && user.role === "admin") {
+    return next();
+  }
+  return res.status(403).json({ error: "forbidden" });
+}
+
+module.exports = { requireAdmin };

--- a/bench/corpus/caller-contract/base/src/routes/profile.js
+++ b/bench/corpus/caller-contract/base/src/routes/profile.js
@@ -1,0 +1,11 @@
+const { findUser } = require("../store");
+
+function profileRoute(req, res) {
+  const user = findUser(req.params.id);
+  if (!user) {
+    return res.status(404).json({ error: "not found" });
+  }
+  return res.json({ id: user.id, name: user.name });
+}
+
+module.exports = { profileRoute };

--- a/bench/corpus/caller-contract/base/src/store.js
+++ b/bench/corpus/caller-contract/base/src/store.js
@@ -1,0 +1,11 @@
+const rows = [
+  { id: "u1", name: "Ada", role: "admin" },
+  { id: "u2", name: "Grace", role: "member" }
+];
+
+// Returns the user record, or null when there is no such id.
+function findUser(id) {
+  return rows.find((row) => row.id === id) || null;
+}
+
+module.exports = { findUser };

--- a/bench/corpus/caller-contract/ground-truth.json
+++ b/bench/corpus/caller-contract/ground-truth.json
@@ -9,9 +9,7 @@
       "line_start": 1,
       "line_end": 1,
       "severity": "high",
-      "match": {
-        "keywords": ["profile", "profileroute", "caller", "callers", "call site", "call sites", "not updated", "still expects", "return shape", "envelope"]
-      }
+      "match": { "all": ["profile"], "keywords": ["caller", "callers", "call site", "call sites", "not updated", "still expects", "return shape", "envelope"] }
     },
     {
       "id": "admin-check-always-passes",
@@ -20,9 +18,7 @@
       "line_start": 1,
       "line_end": 1,
       "severity": "critical",
-      "match": {
-        "keywords": ["requireadmin", "admin", "role", "always truthy", "always true", "authorization", "auth bypass", "forbidden"]
-      }
+      "match": { "all": ["admin"], "keywords": ["role", "always truthy", "always true", "authorization", "auth bypass", "forbidden"] }
     }
   ],
   "allowed_extras": [

--- a/bench/corpus/caller-contract/ground-truth.json
+++ b/bench/corpus/caller-contract/ground-truth.json
@@ -1,0 +1,35 @@
+{
+  "title": "caller-contract — a return shape changed and its callers were not",
+  "notes": "The diff touches only src/store.js, and read on its own it is a clean refactor: findUser now returns a result envelope instead of the record or null. Both planted defects live in files the diff never mentions, so a single-shot review over the diff cannot reach them — it has to go and read the callers. file is \"*\" so a finding citing any file matches on keyword.",
+  "planted": [
+    {
+      "id": "profile-caller-broken",
+      "category": "contract",
+      "file": "*",
+      "line_start": 1,
+      "line_end": 1,
+      "severity": "high",
+      "match": {
+        "keywords": ["profile", "profileroute", "caller", "callers", "call site", "call sites", "not updated", "still expects", "return shape", "envelope"]
+      }
+    },
+    {
+      "id": "admin-check-always-passes",
+      "category": "auth",
+      "file": "*",
+      "line_start": 1,
+      "line_end": 1,
+      "severity": "critical",
+      "match": {
+        "keywords": ["requireadmin", "admin", "role", "always truthy", "always true", "authorization", "auth bypass", "forbidden"]
+      }
+    }
+  ],
+  "allowed_extras": [
+    {
+      "id": "no-migration-note",
+      "file": "*",
+      "match": { "keywords": ["breaking change", "no callers updated in this commit", "semver"] }
+    }
+  ]
+}

--- a/bench/corpus/caller-contract/head/src/store.js
+++ b/bench/corpus/caller-contract/head/src/store.js
@@ -1,0 +1,15 @@
+const rows = [
+  { id: "u1", name: "Ada", role: "admin" },
+  { id: "u2", name: "Grace", role: "member" }
+];
+
+// Returns a result envelope so callers can tell "absent" from "lookup failed".
+function findUser(id) {
+  const row = rows.find((candidate) => candidate.id === id);
+  if (!row) {
+    return { ok: false, reason: "not-found" };
+  }
+  return { ok: true, user: row };
+}
+
+module.exports = { findUser };

--- a/bench/corpus/path-and-input/ground-truth.json
+++ b/bench/corpus/path-and-input/ground-truth.json
@@ -9,18 +9,7 @@
       "line_start": 8,
       "line_end": 9,
       "severity": "critical",
-      "match": {
-        "keywords": [
-          "path traversal",
-          "traversal",
-          "..",
-          "escape",
-          "outside",
-          "resolve",
-          "containment",
-          "directory traversal"
-        ]
-      }
+      "match": { "keywords": ["path traversal", "traversal", "directory traversal", "outside the root", "containment", "escape the root"] }
     },
     {
       "id": "command-injection",
@@ -29,16 +18,7 @@
       "line_start": 13,
       "line_end": 13,
       "severity": "critical",
-      "match": {
-        "keywords": [
-          "command injection",
-          "execsync",
-          "shell",
-          "interpolat",
-          "untrusted",
-          "execfile"
-        ]
-      }
+      "match": { "all": ["execsync"], "keywords": ["command injection", "shell", "interpolat", "untrusted", "execfile"] }
     },
     {
       "id": "parseint-radix",
@@ -47,17 +27,7 @@
       "line_start": 17,
       "line_end": 18,
       "severity": "medium",
-      "match": {
-        "keywords": [
-          "radix",
-          "parseint",
-          "nan",
-          "not validated",
-          "negative",
-          "out of range",
-          "undefined"
-        ]
-      }
+      "match": { "all": ["parseint"], "keywords": ["radix", "nan", "not validated", "negative", "out of range"] }
     },
     {
       "id": "unbounded-read",
@@ -66,16 +36,7 @@
       "line_start": 9,
       "line_end": 9,
       "severity": "medium",
-      "match": {
-        "keywords": [
-          "size limit",
-          "entire file",
-          "memory",
-          "large file",
-          "no limit",
-          "streaming"
-        ]
-      }
+      "match": { "all": ["readfilesync"], "keywords": ["size limit", "entire file", "large file", "no limit", "streaming"] }
     },
     {
       "id": "unhandled-enoent",
@@ -84,16 +45,7 @@
       "line_start": 7,
       "line_end": 9,
       "severity": "medium",
-      "match": {
-        "keywords": [
-          "enoent",
-          "missing file",
-          "throws",
-          "try/catch",
-          "does not exist",
-          "unhandled"
-        ]
-      }
+      "match": { "keywords": ["enoent", "no such file", "file does not exist", "missing file"] }
     }
   ],
   "allowed_extras": [

--- a/bench/corpus/repo-context/ground-truth.json
+++ b/bench/corpus/repo-context/ground-truth.json
@@ -9,7 +9,7 @@
       "line_start": 1,
       "line_end": 1,
       "severity": "high",
-      "match": { "keywords": ["jsonwebtoken", "undeclared", "not declared", "missing dependency", "not listed", "not in package.json"] }
+      "match": { "all": ["jsonwebtoken"], "keywords": ["undeclared", "not declared", "missing dependency", "not listed", "not in package.json"] }
     },
     {
       "id": "committed-state",
@@ -18,7 +18,7 @@
       "line_start": 1,
       "line_end": 1,
       "severity": "medium",
-      "match": { "keywords": [".omc/state", "runtime state", "should not be committed", "gitignore", "should be ignored", "untracked state"] }
+      "match": { "all": [".omc"], "keywords": ["runtime state", "should not be committed", "gitignore", "should be ignored", "untracked state"] }
     }
   ],
   "allowed_extras": []

--- a/bench/corpus/stale-duplicate/base/config/default.json
+++ b/bench/corpus/stale-duplicate/base/config/default.json
@@ -1,0 +1,4 @@
+{
+  "queueName": "ingest",
+  "retryDelayMs": 500
+}

--- a/bench/corpus/stale-duplicate/base/package.json
+++ b/bench/corpus/stale-duplicate/base/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "ingest-service",
+  "version": "2.3.0",
+  "private": true,
+  "dependencies": {}
+}

--- a/bench/corpus/stale-duplicate/base/src/api/v1/validate.js
+++ b/bench/corpus/stale-duplicate/base/src/api/v1/validate.js
@@ -1,0 +1,13 @@
+// v1 is still served for legacy clients; see README.
+function validateBatch(batch) {
+  if (!Array.isArray(batch)) {
+    throw new TypeError("batch must be an array");
+  }
+  // Size guard: reject anything unreasonably large.
+  if (batch.length > 1000) {
+    throw new RangeError("batch too large");
+  }
+  return batch.map((item) => String(item.id));
+}
+
+module.exports = { validateBatch };

--- a/bench/corpus/stale-duplicate/base/src/api/v2/validate.js
+++ b/bench/corpus/stale-duplicate/base/src/api/v2/validate.js
@@ -1,0 +1,12 @@
+function validateBatch(batch) {
+  if (!Array.isArray(batch)) {
+    throw new TypeError("batch must be an array");
+  }
+  // Size guard: reject anything unreasonably large.
+  if (batch.length > 1000) {
+    throw new RangeError("batch too large");
+  }
+  return batch.map((item) => String(item.id));
+}
+
+module.exports = { validateBatch };

--- a/bench/corpus/stale-duplicate/ground-truth.json
+++ b/bench/corpus/stale-duplicate/ground-truth.json
@@ -1,0 +1,35 @@
+{
+  "title": "stale-duplicate — the fix landed in one copy, and the new code reads a key nobody defined",
+  "notes": "The diff fixes a crash in src/api/v2/validate.js and adds src/worker.js. Both planted defects are invisible from the diff alone: the identical v1 copy that still crashes is never mentioned, and config/default.json — which has no maxBatch — is not part of the change. file is \"*\" so a finding citing any file matches on keyword.",
+  "planted": [
+    {
+      "id": "v1-copy-still-crashes",
+      "category": "duplication",
+      "file": "*",
+      "line_start": 1,
+      "line_end": 1,
+      "severity": "high",
+      "match": {
+        "keywords": ["v1", "api/v1", "duplicate", "copy", "same bug", "not applied", "legacy", "both versions"]
+      }
+    },
+    {
+      "id": "undefined-config-key",
+      "category": "config",
+      "file": "*",
+      "line_start": 1,
+      "line_end": 1,
+      "severity": "high",
+      "match": {
+        "keywords": ["maxbatch", "config", "default.json", "undefined", "not defined", "missing key", "nan"]
+      }
+    }
+  ],
+  "allowed_extras": [
+    {
+      "id": "worker-unreferenced",
+      "file": "*",
+      "match": { "keywords": ["worker.js", "never imported", "not wired", "unused module", "no entry point"] }
+    }
+  ]
+}

--- a/bench/corpus/stale-duplicate/ground-truth.json
+++ b/bench/corpus/stale-duplicate/ground-truth.json
@@ -9,9 +9,7 @@
       "line_start": 1,
       "line_end": 1,
       "severity": "high",
-      "match": {
-        "keywords": ["v1", "api/v1", "duplicate", "copy", "same bug", "not applied", "legacy", "both versions"]
-      }
+      "match": { "all": ["v1"], "keywords": ["duplicate", "copy", "same bug", "not applied", "legacy", "both versions"] }
     },
     {
       "id": "undefined-config-key",
@@ -20,9 +18,7 @@
       "line_start": 1,
       "line_end": 1,
       "severity": "high",
-      "match": {
-        "keywords": ["maxbatch", "config", "default.json", "undefined", "not defined", "missing key", "nan"]
-      }
+      "match": { "all": ["maxbatch"], "keywords": ["config", "default.json", "undefined", "not defined", "missing key", "nan"] }
     }
   ],
   "allowed_extras": [

--- a/bench/corpus/stale-duplicate/head/src/api/v2/validate.js
+++ b/bench/corpus/stale-duplicate/head/src/api/v2/validate.js
@@ -1,0 +1,13 @@
+function validateBatch(batch) {
+  if (!Array.isArray(batch)) {
+    throw new TypeError("batch must be an array");
+  }
+  // Size guard: reject anything unreasonably large. An entry with no id used to
+  // throw here, which took the whole batch down; skip those instead.
+  if (batch.length > 1000) {
+    throw new RangeError("batch too large");
+  }
+  return batch.filter((item) => item && item.id != null).map((item) => String(item.id));
+}
+
+module.exports = { validateBatch };

--- a/bench/corpus/stale-duplicate/head/src/worker.js
+++ b/bench/corpus/stale-duplicate/head/src/worker.js
@@ -1,0 +1,13 @@
+const config = require("../config/default.json");
+const { validateBatch } = require("./api/v2/validate");
+
+function drain(batch) {
+  const ids = validateBatch(batch);
+  const chunks = [];
+  for (let i = 0; i < ids.length; i += config.maxBatch) {
+    chunks.push(ids.slice(i, i + config.maxBatch));
+  }
+  return { queue: config.queueName, chunks };
+}
+
+module.exports = { drain };

--- a/bench/corpus/vacuous-tests/ground-truth.json
+++ b/bench/corpus/vacuous-tests/ground-truth.json
@@ -9,15 +9,7 @@
       "line_start": 6,
       "line_end": 7,
       "severity": "high",
-      "match": {
-        "keywords": [
-          "no assertion",
-          "asserts nothing",
-          "does not assert",
-          "always passes",
-          "no expectation"
-        ]
-      }
+      "match": { "all": ["parsesession"], "keywords": ["no assertion", "asserts nothing", "does not assert", "always passes", "no expectation"] }
     },
     {
       "id": "vacuous-ordering",
@@ -26,18 +18,7 @@
       "line_start": 11,
       "line_end": 12,
       "severity": "high",
-      "match": {
-        "keywords": [
-          "indexof",
-          "-1",
-          "not present",
-          "absent",
-          "empty",
-          "vacuous",
-          "passes when",
-          "missing element"
-        ]
-      }
+      "match": { "all": ["indexof"], "keywords": ["-1", "not present", "absent", "vacuous", "passes when", "missing element"] }
     },
     {
       "id": "permanent-skip",
@@ -46,15 +27,7 @@
       "line_start": 15,
       "line_end": 18,
       "severity": "medium",
-      "match": {
-        "keywords": [
-          "skip",
-          "never runs",
-          "disabled",
-          "not executed",
-          "unprotected"
-        ]
-      }
+      "match": { "all": ["test.skip"], "keywords": ["never runs", "disabled", "not executed", "skipped permanently", "unprotected"] }
     },
     {
       "id": "assertion-never-runs",
@@ -63,17 +36,7 @@
       "line_start": 22,
       "line_end": 24,
       "severity": "high",
-      "match": {
-        "keywords": [
-          "callback",
-          "nexttick",
-          "after the test",
-          "never runs",
-          "asynchronous",
-          "not awaited",
-          "test ends"
-        ]
-      }
+      "match": { "all": ["nexttick"], "keywords": ["callback", "after the test", "never runs", "asynchronous", "not awaited", "test ends"] }
     }
   ],
   "allowed_extras": [

--- a/bench/lib/adapters.mjs
+++ b/bench/lib/adapters.mjs
@@ -138,7 +138,7 @@ function resolveAgyBinary() {
   return agyBinaryCache;
 }
 
-function runAgyModel(promptText) {
+function runAgyModel(promptText, { spawnImpl = spawnSync } = {}) {
   return timed(() => {
     // AGY >=1.1.2 enters print mode from a piped prompt, so --print is omitted:
     // passing it here would make the next flag AGY's positional prompt.
@@ -155,7 +155,7 @@ function runAgyModel(promptText) {
     // an absolute .exe, so a planted `agy.bat` on PATH cannot take the call.
     const bin = resolveAgyBinary();
     if (!bin) return fail("agy: no agy executable on PATH");
-    const res = spawnSync(
+    const res = spawnImpl(
       bin,
       ["--disable-slash-commands", "--output-format", "json", "--print-timeout", printTimeout],
       { input: promptText, encoding: "utf8", timeout: TIMEOUT_MS }
@@ -165,7 +165,16 @@ function runAgyModel(promptText) {
     const envelope = extractJsonObject(res.stdout);
     const text = envelope?.response ?? envelope?.result?.response ?? res.stdout;
     const review = normalizeReview(extractJsonObject(text));
-    if (!review) return fail(`agy: could not parse review JSON (${(res.stderr || "").slice(0, 160)})`);
+    // AGY reports a refused run inside the envelope's `error`, with nothing on
+    // stderr — so echoing stderr alone printed `could not parse review JSON ()`
+    // and hid the reason. That cost three recording attempts on 2026-08-24, when
+    // the real answer was `Individual quota reached ... Resets in 94h2m50s` and the
+    // cell looked like a parser or model defect instead of a spent account. Same
+    // lesson as the codex branch below, which learned it from its own usage limit.
+    if (!review) {
+      const reason = envelope?.error ?? envelope?.result?.error ?? res.stderr ?? "";
+      return fail(`agy: could not parse review JSON (${String(reason).slice(0, 160)})`);
+    }
     return { ok: true, ...review, raw: res.stdout?.slice(0, 4000) };
   });
 }
@@ -234,12 +243,12 @@ export function assertExpectedEngine(payload, expected) {
 // the two lines that invoke `assertExpectedEngine` left every test green — the
 // helper was correct and unreachable, which is the same shape as the defect this
 // whole check exists to prevent.
-export function runCompanionReview(companionPath, repoDir, extraArgs, expectEngine = null, { spawnImpl = spawnSync } = {}) {
+export function runCompanionReview(companionPath, repoDir, extraArgs, expectEngine = null, { spawnImpl = spawnSync, subcommand = "review" } = {}) {
   return timed(() => {
     if (!companionPath) return fail("companion path not configured");
     const res = spawnImpl(
       process.execPath,
-      [companionPath, "review", "--scope", "working-tree", "--json", ...extraArgs, "--cwd", repoDir],
+      [companionPath, subcommand, "--scope", "working-tree", "--json", ...extraArgs, "--cwd", repoDir],
       { cwd: repoDir, encoding: "utf8", timeout: TIMEOUT_MS, env: companionSpawnEnv() }
     );
     if (res.error) return fail(`companion spawn: ${res.error.message}`);
@@ -272,9 +281,19 @@ function dispatchCell(cell, ctx) {
       return runCompanionReview(CODEX_COMPANION, ctx.repoDir, []);
     case "agy.deep":
       return runCompanionReview(GEMINI_COMPANION, ctx.repoDir, ["--deep", "--engine", "agy"], "agy");
+    case "gemini.adversarial":
+      return runCompanionReview(GEMINI_COMPANION, ctx.repoDir, ["--deep", "--engine", "gemini"], "gemini", { subcommand: "adversarial-review" });
+    case "agy.adversarial":
+      return runCompanionReview(GEMINI_COMPANION, ctx.repoDir, ["--deep", "--engine", "agy"], "agy", { subcommand: "adversarial-review" });
+    case "codex.adversarial":
+      // codex's `review` maps to its built-in reviewer, whose --json payload has no
+      // `result` at all (openai/codex-plugin-cc#679). `adversarial-review` is the
+      // codex path that emits schema-shaped findings, which is why the adversarial
+      // axis can carry a codex reading while `codex.native` cannot.
+      return runCompanionReview(CODEX_COMPANION, ctx.repoDir, [], null, { subcommand: "adversarial-review" });
     default:
       return fail(`unknown cell ${cell}`);
   }
 }
 
-export const _internal = { extractJsonObject, normalizeReview, geminiInnerText, companionSpawnEnv, assertExpectedEngine, runCompanionReview };
+export const _internal = { extractJsonObject, normalizeReview, geminiInnerText, companionSpawnEnv, assertExpectedEngine, runCompanionReview, runAgyModel };

--- a/bench/lib/adapters.mjs
+++ b/bench/lib/adapters.mjs
@@ -284,6 +284,12 @@ function dispatchCell(cell, ctx) {
       return runCompanionReview(CODEX_COMPANION, ctx.repoDir, []);
     case "agy.deep":
       return runCompanionReview(GEMINI_COMPANION, ctx.repoDir, ["--deep", "--engine", "agy"], "agy");
+    // No --deep: same prompt template, same embedded diff, no tools, no workspace.
+    // The control end for splitting the harness lift.
+    case "gemini.shallow":
+      return runCompanionReview(GEMINI_COMPANION, ctx.repoDir, ["--engine", "gemini"], "gemini");
+    case "agy.shallow":
+      return runCompanionReview(GEMINI_COMPANION, ctx.repoDir, ["--engine", "agy"], "agy");
     case "gemini.adversarial":
       return runCompanionReview(GEMINI_COMPANION, ctx.repoDir, ["--deep", "--engine", "gemini"], "gemini", { subcommand: "adversarial-review" });
     case "agy.adversarial":

--- a/bench/lib/adapters.mjs
+++ b/bench/lib/adapters.mjs
@@ -138,7 +138,7 @@ function resolveAgyBinary() {
   return agyBinaryCache;
 }
 
-function runAgyModel(promptText, { spawnImpl = spawnSync } = {}) {
+function runAgyModel(promptText, { spawnImpl = spawnSync, resolveBinaryImpl = resolveAgyBinary } = {}) {
   return timed(() => {
     // AGY >=1.1.2 enters print mode from a piped prompt, so --print is omitted:
     // passing it here would make the next flag AGY's positional prompt.
@@ -153,7 +153,10 @@ function runAgyModel(promptText, { spawnImpl = spawnSync } = {}) {
     // cell reported ETIMEDOUT. Spawned directly with a resolved path it answers in
     // ~9s. That also matches what the plugin insists on for agy (engine.mjs:51):
     // an absolute .exe, so a planted `agy.bat` on PATH cannot take the call.
-    const bin = resolveAgyBinary();
+    // Seam, for the same reason spawnImpl is one: the binary lookup runs before any
+    // of the envelope handling below, so a machine without agy on PATH — every CI
+    // runner — exits here and never reaches the behaviour a test means to pin.
+    const bin = resolveBinaryImpl();
     if (!bin) return fail("agy: no agy executable on PATH");
     const res = spawnImpl(
       bin,

--- a/bench/lib/cells.mjs
+++ b/bench/lib/cells.mjs
@@ -1,14 +1,25 @@
-// The benchmark cells. Two axes fall out of these:
-//   model axis   = compare the two "model-isolated" cells (same neutral prompt+diff, no tools)
-//   harness axis = compare the two "agentic" cells (each tool's own repo-exploring reviewer)
+// The benchmark cells. Three axes fall out of these:
+//   model axis       = the "model-isolated" cells (same neutral prompt+diff, no tools)
+//   harness axis     = the "plugin-native" cells (each tool's own default reviewer)
+//   adversarial axis = the "plugin-adversarial" cells (each tool's adversarial reviewer)
 // and the within-tool "single-shot -> agentic" delta is the harness lift.
+//
+// The adversarial axis is separate rather than folded into the harness axis, because
+// the prompts are not interchangeable: this plugin's `review.md` asks for a pragmatic
+// review and `adversarial-review.md` asks the model to break confidence in the change.
+// On a corpus scored mostly on recall, the second wins by construction. Putting an
+// adversarial reading in the same column as a pragmatic one would be a column stating
+// what it is supposed to hold rather than what it holds.
 export const CELLS = {
   "gemini.model": { tool: "gemini", track: "model-isolated", harness: "single-shot", label: "Gemini (model, single-shot)" },
   "codex.model": { tool: "codex", track: "model-isolated", harness: "single-shot", label: "Codex (model, single-shot)" },
   "agy.model": { tool: "agy", track: "model-isolated", harness: "single-shot", label: "AGY (model, single-shot)" },
   "gemini.deep": { tool: "gemini", track: "plugin-native", harness: "agentic", label: "Gemini (--deep, agentic)" },
   "codex.native": { tool: "codex", track: "plugin-native", harness: "agentic", label: "Codex (native review, agentic)" },
-  "agy.deep": { tool: "agy", track: "plugin-native", harness: "agentic", label: "AGY (--deep, agentic)" }
+  "agy.deep": { tool: "agy", track: "plugin-native", harness: "agentic", label: "AGY (--deep, agentic)" },
+  "gemini.adversarial": { tool: "gemini", track: "plugin-adversarial", harness: "agentic", label: "Gemini (adversarial, agentic)" },
+  "codex.adversarial": { tool: "codex", track: "plugin-adversarial", harness: "agentic", label: "Codex (adversarial, agentic)" },
+  "agy.adversarial": { tool: "agy", track: "plugin-adversarial", harness: "agentic", label: "AGY (adversarial, agentic)" }
 };
 
 export const CELL_IDS = Object.keys(CELLS);

--- a/bench/lib/cells.mjs
+++ b/bench/lib/cells.mjs
@@ -4,6 +4,14 @@
 //   adversarial axis = the "plugin-adversarial" cells (each tool's adversarial reviewer)
 // and the within-tool "single-shot -> agentic" delta is the harness lift.
 //
+// The "plugin-shallow" cells are a control, not an axis. They run the plugin's own
+// review without --deep: the same `prompts/review.md`, the same diff embedded in
+// REVIEW_INPUT, no tools and no workspace. That splits the harness lift, which
+// otherwise spans a prompt change and an exploration change at once, into the two
+// halves it is made of — `*.model -> *.shallow` is the prompt, `*.shallow -> *.deep`
+// is the exploration. They are deliberately outside every axis ranking: their only
+// job is to be a fixed end for those two deltas.
+//
 // The adversarial axis is separate rather than folded into the harness axis, because
 // the prompts are not interchangeable: this plugin's `review.md` asks for a pragmatic
 // review and `adversarial-review.md` asks the model to break confidence in the change.
@@ -24,6 +32,8 @@ export const CELLS = {
   "gemini.deep": { tool: "gemini", track: "plugin-native", harness: "agentic", label: "Gemini (--deep, agentic)" },
   "codex.native": { tool: "codex", track: "plugin-native", harness: "agentic", label: "Codex (native review, agentic)" },
   "agy.deep": { tool: "agy", track: "plugin-native", harness: "agentic", label: "AGY (--deep, agentic)" },
+  "gemini.shallow": { tool: "gemini", track: "plugin-shallow", harness: "single-shot", label: "Gemini (plugin review, no --deep)" },
+  "agy.shallow": { tool: "agy", track: "plugin-shallow", harness: "single-shot", label: "AGY (plugin review, no --deep)" },
   "gemini.adversarial": { tool: "gemini", track: "plugin-adversarial", harness: "agentic", label: "Gemini (adversarial, agentic)" },
   "codex.adversarial": { tool: "codex", track: "plugin-adversarial", harness: "agentic", label: "Codex (adversarial, agentic)" },
   "agy.adversarial": { tool: "agy", track: "plugin-adversarial", harness: "agentic", label: "AGY (adversarial, agentic)" }

--- a/bench/lib/cells.mjs
+++ b/bench/lib/cells.mjs
@@ -7,9 +7,16 @@
 // The adversarial axis is separate rather than folded into the harness axis, because
 // the prompts are not interchangeable: this plugin's `review.md` asks for a pragmatic
 // review and `adversarial-review.md` asks the model to break confidence in the change.
-// On a corpus scored mostly on recall, the second wins by construction. Putting an
-// adversarial reading in the same column as a pragmatic one would be a column stating
-// what it is supposed to hold rather than what it holds.
+// Putting an adversarial reading in the same column as a pragmatic one would be a
+// column stating what it is supposed to hold rather than what it holds.
+//
+// The separation was argued before it was measured, and the prediction was wrong in
+// direction. The guess was that a prompt asking the model to break confidence would
+// trade precision for recall on a composite weighted `recall*70`. Measured on agy,
+// 1.1.19, five cases x3: recall 0.81 -> 0.77, precision 0.91 -> 0.92, false positives
+// 1.67 -> 1.33. The adversarial prompt made the reviewer more conservative, not more
+// aggressive. The axis stays separate because the prompts still are not
+// interchangeable, which is a fact about the prompts rather than about the scores.
 export const CELLS = {
   "gemini.model": { tool: "gemini", track: "model-isolated", harness: "single-shot", label: "Gemini (model, single-shot)" },
   "codex.model": { tool: "codex", track: "model-isolated", harness: "single-shot", label: "Codex (model, single-shot)" },

--- a/bench/lib/cells.mjs
+++ b/bench/lib/cells.mjs
@@ -12,6 +12,11 @@
 // is the exploration. They are deliberately outside every axis ranking: their only
 // job is to be a fixed end for those two deltas.
 //
+// `needsRepo` is declared rather than inferred. It used to be read off
+// `harness === "agentic"`, which is true of every cell that runs a companion — until
+// these two, which run one without exploring. Inferring it left them with no
+// materialized repository and a `--cwd` pointing at nothing.
+//
 // The adversarial axis is separate rather than folded into the harness axis, because
 // the prompts are not interchangeable: this plugin's `review.md` asks for a pragmatic
 // review and `adversarial-review.md` asks the model to break confidence in the change.
@@ -32,8 +37,8 @@ export const CELLS = {
   "gemini.deep": { tool: "gemini", track: "plugin-native", harness: "agentic", label: "Gemini (--deep, agentic)" },
   "codex.native": { tool: "codex", track: "plugin-native", harness: "agentic", label: "Codex (native review, agentic)" },
   "agy.deep": { tool: "agy", track: "plugin-native", harness: "agentic", label: "AGY (--deep, agentic)" },
-  "gemini.shallow": { tool: "gemini", track: "plugin-shallow", harness: "single-shot", label: "Gemini (plugin review, no --deep)" },
-  "agy.shallow": { tool: "agy", track: "plugin-shallow", harness: "single-shot", label: "AGY (plugin review, no --deep)" },
+  "gemini.shallow": { tool: "gemini", track: "plugin-shallow", harness: "single-shot", needsRepo: true, label: "Gemini (plugin review, no --deep)" },
+  "agy.shallow": { tool: "agy", track: "plugin-shallow", harness: "single-shot", needsRepo: true, label: "AGY (plugin review, no --deep)" },
   "gemini.adversarial": { tool: "gemini", track: "plugin-adversarial", harness: "agentic", label: "Gemini (adversarial, agentic)" },
   "codex.adversarial": { tool: "codex", track: "plugin-adversarial", harness: "agentic", label: "Codex (adversarial, agentic)" },
   "agy.adversarial": { tool: "agy", track: "plugin-adversarial", harness: "agentic", label: "AGY (adversarial, agentic)" }

--- a/bench/lib/report.mjs
+++ b/bench/lib/report.mjs
@@ -27,10 +27,29 @@ function aggregateByCell(rows) {
   return out;
 }
 
+// The first cassette's provenance used to stand for the whole cell, which is fine
+// only while every case in it was recorded against the same version. It stops being
+// fine the moment one case fails to re-record: `agy.model` came back four cases on
+// 1.1.19 and one still on 1.1.15, and the table printed `1.1.19` for all five. That
+// is the same failure the `gemini.deep` mix-up was — a column stating what it was
+// supposed to be rather than what it holds — so a cell whose cassettes disagree now
+// carries every version it actually has.
 function provenanceByCell(rows) {
   const out = {};
   for (const cell of CELL_IDS) {
-    out[cell] = rows.find((r) => r.cell === cell && r.provenance)?.provenance ?? null;
+    const own = rows.filter((r) => r.cell === cell && r.provenance);
+    if (own.length === 0) {
+      out[cell] = null;
+      continue;
+    }
+    const counts = new Map();
+    for (const r of own) {
+      const v = r.provenance.engineVersion ?? null;
+      counts.set(v, (counts.get(v) ?? 0) + 1);
+    }
+    out[cell] = counts.size > 1
+      ? { ...own[0].provenance, otherVersions: [...counts].slice(1).map(([version, cases]) => ({ version, cases })) }
+      : own[0].provenance;
   }
   return out;
 }
@@ -50,8 +69,14 @@ function spreadByCell(rows) {
   return out;
 }
 
+const AXIS_TRACKS = {
+  model: "model-isolated",
+  harness: "plugin-native",
+  adversarial: "plugin-adversarial"
+};
+
 function cellsOn(axis) {
-  const key = axis === "model" ? "model-isolated" : "plugin-native";
+  const key = AXIS_TRACKS[axis];
   return CELL_IDS.filter((c) => CELLS[c].track === key);
 }
 
@@ -63,7 +88,10 @@ function describeSource(p) {
   // composite averaged over five read identically without it, and on this corpus
   // they are not comparable.
   const n = Number.isFinite(p.samples) && p.samples > 1 ? ` ×${p.samples}` : "";
-  return p.engineVersion ? `live ${day} · ${p.engineVersion}${n}` : `live ${day}${n}`;
+  const mixed = Array.isArray(p.otherVersions) && p.otherVersions.length
+    ? ` · ${p.otherVersions.map((o) => `${o.cases} case${o.cases === 1 ? "" : "s"} on ${o.version ?? "unknown"}`).join(", ")}`
+    : "";
+  return p.engineVersion ? `live ${day} · ${p.engineVersion}${n}${mixed}` : `live ${day}${n}${mixed}`;
 }
 
 // A seeded cassette is an illustration, not a measurement, so it cannot win an
@@ -154,6 +182,7 @@ export function buildScorecard(rows, meta = {}) {
   const spreads = spreadByCell(rows);
   const modelAxis = axisVerdict(cellsOn("model"), agg, prov, spreads);
   const harnessAxis = axisVerdict(cellsOn("harness"), agg, prov, spreads);
+  const adversarialAxis = axisVerdict(cellsOn("adversarial"), agg, prov, spreads);
   const lifts = harnessLifts(agg, prov, spreads);
 
   const lines = [];
@@ -167,6 +196,7 @@ export function buildScorecard(rows, meta = {}) {
   lines.push("|---|---|---|");
   lines.push(`| **Model** (single-shot, tools off) | **${modelAxis.name}** | ${modelAxis.note} |`);
   lines.push(`| **Harness** (agentic reviewers) | **${harnessAxis.name}** | ${harnessAxis.note} |`);
+  lines.push(`| **Adversarial** (agentic, adversarial prompt) | **${adversarialAxis.name}** | ${adversarialAxis.note} |`);
   for (const l of lifts) {
     if (l.lift == null) continue;
     const note = l.seeded

--- a/bench/lib/score.mjs
+++ b/bench/lib/score.mjs
@@ -3,7 +3,7 @@
 // (see bench/review-output.schema.json), so one scorer grades both.
 //
 // finding:  { severity, title, body, file, line_start, line_end, confidence, recommendation }
-// planted:  { id, category, file, line_start, line_end, severity, match: { keywords: [...] } }
+// planted:  { id, category, file, line_start, line_end, severity, match: { keywords: [...], all?: [...] } }
 // extra:    { id, file?, match: { keywords: [...] } }   // a legitimate "unique catch", not a false positive
 // truth:    { planted: [planted...], allowed_extras: [extra...] }
 
@@ -22,9 +22,28 @@ function rangesOverlap(aStart, aEnd, bStart, bEnd, tol = 0) {
   return aStart - tol <= bEnd && bStart <= aEnd + tol;
 }
 
-function keywordsHit(finding, keywords) {
-  if (!Array.isArray(keywords) || keywords.length === 0) return false;
-  const hay = `${finding.title ?? ""} ${finding.body ?? ""}`.toLowerCase();
+function haystack(finding) {
+  return `${finding.title ?? ""} ${finding.body ?? ""}`.toLowerCase();
+}
+
+// `match.keywords` is any-of: the reviewer's wording for the claim is free.
+// `match.all` is every-of: the subject the finding has to actually be about.
+//
+// The split exists because a wildcard defect (`file: "*"`) is matched on words
+// alone, and a subject word is a word every finding about that area writes down.
+// `repo-context` listed the bare module name among its any-of keywords, so a
+// finding about an unvalidated secret — which mentioned the module only in
+// passing — was credited with catching a missing manifest entry. Put the subject
+// in `all` and the claim in `keywords`, and a finding has to carry both.
+function keywordsHit(finding, keywords, required) {
+  const hay = haystack(finding);
+  if (Array.isArray(required) && required.length > 0) {
+    if (!required.every((k) => hay.includes(String(k).toLowerCase()))) return false;
+    // `all` on its own is a complete rule; `keywords` narrows it when present.
+    if (!Array.isArray(keywords) || keywords.length === 0) return true;
+  } else if (!Array.isArray(keywords) || keywords.length === 0) {
+    return false;
+  }
   return keywords.some((k) => hay.includes(String(k).toLowerCase()));
 }
 
@@ -46,7 +65,7 @@ function fileMatches(findingFile, declaredFile) {
 
 function matchQuality(finding, planted, lineTolerance) {
   if (!fileMatches(finding.file, planted.file)) return 0;
-  if (keywordsHit(finding, planted.match?.keywords)) return 2;
+  if (keywordsHit(finding, planted.match?.keywords, planted.match?.all)) return 2;
   if (planted.file === "*" || !planted.file) return 0; // wildcard defects are keyword-only
   const lineOk = rangesOverlap(
     finding.line_start,
@@ -64,7 +83,7 @@ export function findingMatchesPlanted(finding, planted, { lineTolerance = 0 } = 
 
 function findingMatchesExtra(finding, extra) {
   if (extra.file && normalizeFile(finding.file) !== normalizeFile(extra.file)) return false;
-  return keywordsHit(finding, extra.match?.keywords);
+  return keywordsHit(finding, extra.match?.keywords, extra.match?.all);
 }
 
 function severityCalibration(plantedSeverity, findingSeverity) {

--- a/bench/run-bench.mjs
+++ b/bench/run-bench.mjs
@@ -58,7 +58,7 @@ function spreadOf(scores) {
 
 function liveCell({ caseId, cell, promptText, repeats, truth }) {
   let repoCtx = null;
-  const needsRepo = CELLS[cell]?.harness === "agentic";
+  const needsRepo = CELLS[cell]?.needsRepo ?? CELLS[cell]?.harness === "agentic";
   try {
     const scores = [];
     const results = [];

--- a/bench/run-bench.test.mjs
+++ b/bench/run-bench.test.mjs
@@ -487,3 +487,93 @@ test("a companion that cannot say which engine ran is a failure, not a pass", ()
 
   assert.equal(adapters.assertExpectedEngine({ engine: null }, null), null, "a cell with no expectation is unaffected");
 });
+
+test("a refused AGY run reports the reason AGY gave, not an empty parenthesis", () => {
+  // AGY puts a refusal in the envelope's `error` and leaves stderr empty. The
+  // failure message used to echo stderr alone, so a spent account read as
+  // `could not parse review JSON ()` — indistinguishable from a parser bug, and
+  // diagnosed as one for three recording attempts.
+  const quotaEnvelope = {
+    conversation_id: "5504cb18",
+    status: "ERROR",
+    response: "",
+    error: "Individual quota reached. Please upgrade your subscription to increase your limits. Resets in 94h2m50s."
+  };
+  const stub = () => ({ status: 1, stdout: JSON.stringify(quotaEnvelope), stderr: "" });
+
+  const refused = adapters.runAgyModel("review this", { spawnImpl: stub });
+  assert.equal(refused.ok, false, "an envelope carrying no review is still a failure");
+  assert.match(String(refused.error), /Individual quota reached/);
+});
+
+test("a cell whose cases were recorded on different versions says so", () => {
+  // Taking the first cassette's version to stand for the cell is how a table states
+  // what a column is supposed to hold rather than what it holds. `agy.model` really
+  // did end up four cases on 1.1.19 and one on 1.1.15 after a re-record was refused.
+  const row = (caseId, engineVersion) => ({
+    caseId,
+    cell: "agy.model",
+    status: "ok",
+    score: { composite: 90, recall: 1, precision: 1, falsePositives: 0, bonus: 0, severityExactRate: 1, missed: [] },
+    latencyMs: 1000,
+    provenance: { seeded: false, recordedAt: "2026-08-24T00:00:00.000Z", engineVersion, samples: 3 }
+  });
+
+  const mixed = buildScorecard([row("c1", "1.1.19"), row("c2", "1.1.19"), row("c3", "1.1.15")]);
+  assert.match(mixed.markdown, /1\.1\.19 ×3 · 1 case on 1\.1\.15/);
+
+  const uniform = buildScorecard([row("c1", "1.1.19"), row("c2", "1.1.19")]);
+  assert.doesNotMatch(uniform.markdown, /case on/, "a cell recorded on one version says nothing extra");
+});
+
+test("the adversarial cells run their tool's adversarial subcommand, not review", () => {
+  // The whole reason the adversarial axis exists is that these are a different
+  // reviewer, so a cell that quietly ran `review` would make the axis a duplicate
+  // of the harness one under a different name.
+  const seen = [];
+  const stub = (_bin, args) => {
+    seen.push(args);
+    return {
+      status: 0,
+      stdout: JSON.stringify({ engine: "agy", result: { verdict: "approve", summary: "s", findings: [] } }),
+      stderr: ""
+    };
+  };
+
+  adapters.runCompanionReview("/companion.mjs", "/repo", ["--deep"], "agy", {
+    spawnImpl: stub,
+    subcommand: "adversarial-review"
+  });
+  assert.equal(seen[0][1], "adversarial-review");
+
+  adapters.runCompanionReview("/companion.mjs", "/repo", ["--deep"], "agy", { spawnImpl: stub });
+  assert.equal(seen[1][1], "review", "the default stays what every existing cell passes");
+});
+
+test("the scorecard carries an adversarial axis of its own", () => {
+  // Folding these into the harness axis would rank a prompt that asks the model to
+  // break confidence in the change against one that asks for a pragmatic review.
+  const row = (cell, composite) => ({
+    caseId: "c1",
+    cell,
+    status: "ok",
+    score: { composite, recall: 1, precision: 1, falsePositives: 0, bonus: 0, severityExactRate: 1, missed: [] },
+    latencyMs: 1000,
+    provenance: { seeded: false, recordedAt: "2026-08-24T00:00:00.000Z", engineVersion: "1.1.19", samples: 3 }
+  });
+
+  const card = buildScorecard([row("agy.adversarial", 90), row("codex.adversarial", 60), row("agy.deep", 80)]);
+  const lineFor = (name) => String(card.markdown.split(/\r?\n/).find((l) => l.includes(`**${name}**`)));
+
+  // Assert what each axis *contains*, not merely that a row with the right title was
+  // printed: pointing the adversarial axis at the harness track still renders the
+  // row, so a title-only assertion passes while the axis reads the wrong cells.
+  const adversarial = lineFor("Adversarial");
+  assert.match(adversarial, /agy 90/);
+  assert.match(adversarial, /codex 60/);
+  assert.doesNotMatch(adversarial, /80/, "agy.deep belongs to the harness axis, not this one");
+
+  const harness = lineFor("Harness");
+  assert.match(harness, /agy 80/);
+  assert.doesNotMatch(harness, /90|60/, "the adversarial cells must not leak into the harness axis");
+});

--- a/bench/run-bench.test.mjs
+++ b/bench/run-bench.test.mjs
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import { scoreReview, findingMatchesPlanted, normalizeFile } from "./lib/score.mjs";
+import { CELL_IDS } from "./lib/cells.mjs";
 import { _internal as adapters } from "./lib/adapters.mjs";
 import { buildScorecard } from "./lib/report.mjs";
 import { cassettePath, writeCassette } from "./lib/cassette.mjs";
@@ -186,6 +187,18 @@ test("every repository-scoped defect declares the subject it is about", () => {
     }
   }
   assert.deepEqual(offenders, []);
+});
+
+// The README's cell table is the only place a reader learns what is on the board,
+// and it drifted silently: two cells were added and the table kept describing nine.
+// A table that omits a cell does not look broken, it looks complete.
+test("the README's cell table lists exactly the cells that exist", () => {
+  const readme = fs.readFileSync(path.join(import.meta.dirname, "README.md"), "utf8");
+  const from = readme.indexOf("| Cell | What it is | Isolates |");
+  assert.notEqual(from, -1, "cell table header not found in bench/README.md");
+  const table = readme.slice(from, readme.indexOf("\n\n", from));
+  const documented = [...table.matchAll(/^\| `([a-z]+\.[a-z]+)` \|/gm)].map((m) => m[1]);
+  assert.deepEqual([...documented].sort(), [...CELL_IDS].sort());
 });
 
 test("scoreReview gives full recall and clean precision when both planted defects are found", () => {

--- a/bench/run-bench.test.mjs
+++ b/bench/run-bench.test.mjs
@@ -69,6 +69,125 @@ test("findingMatchesPlanted rejects a different file", () => {
   assert.equal(findingMatchesPlanted(f, TRUTH.planted[0]), false);
 });
 
+// The real miss this pins: `repo-context` plants an undeclared-dependency defect
+// with `file: "*"`, so matching is keyword-only, and one of its keywords was the
+// bare module name. Every reviewer that discussed `src/token.js` at all wrote
+// "jsonwebtoken" somewhere in the body, so a finding about an unvalidated secret
+// was credited with catching a missing manifest entry it never mentioned. That
+// single false credit was worth 42 composite points to one cell (96.7 -> 55.0) and
+// not to others, which is worse than being wrong uniformly: it moved the cells
+// relative to each other, and the whole benchmark is a comparison between cells.
+//
+// `match.all` is the subject the finding has to actually be about; `match.keywords`
+// stays any-of, so a reviewer's choice of words for the claim is still free.
+test("a wildcard defect is not credited to a finding about a different subject", () => {
+  const truth = {
+    planted: [
+      {
+        id: "missing-dependency",
+        file: "*",
+        line_start: 1,
+        line_end: 1,
+        severity: "high",
+        match: {
+          all: ["jsonwebtoken"],
+          keywords: ["undeclared", "not declared", "missing dependency", "not in package.json"]
+        }
+      }
+    ],
+    allowed_extras: []
+  };
+
+  // Says the claim, about the wrong module. Keyword-only matching credits it.
+  const wrongSubject = finding({
+    severity: "high",
+    title: "Missing dependency on the validation middleware",
+    body: "src/routes/profile.js calls validateBody(), which is not declared anywhere in this package.",
+    file: "src/routes/profile.js"
+  });
+  // Names the subject, makes a different claim. `all` alone would credit it.
+  const wrongClaim = finding({
+    severity: "critical",
+    title: "JWT_SECRET used without validation",
+    body: "process.env.JWT_SECRET goes straight to jwt.sign(). Empty string, and jsonwebtoken signs with a zero-length secret.",
+    file: "src/token.js"
+  });
+  // Both: this is the finding the defect was planted for.
+  const theCatch = finding({
+    severity: "high",
+    title: "Undeclared 'jsonwebtoken' dependency",
+    body: "src/token.js requires jsonwebtoken, which is not declared in package.json.",
+    file: "src/token.js"
+  });
+
+  assert.equal(findingMatchesPlanted(wrongSubject, truth.planted[0]), false);
+  assert.equal(findingMatchesPlanted(wrongClaim, truth.planted[0]), false);
+  assert.equal(findingMatchesPlanted(theCatch, truth.planted[0]), true);
+
+  const missed = scoreReview([wrongSubject, wrongClaim], truth);
+  assert.equal(missed.found, 0);
+  assert.equal(missed.falsePositives, 2);
+  assert.deepEqual(missed.missed, ["missing-dependency"]);
+
+  const caught = scoreReview([theCatch], truth);
+  assert.equal(caught.found, 1);
+  assert.equal(caught.falsePositives, 0);
+});
+
+test("every term in `all` has to be there, not just one of them", () => {
+  const planted = {
+    id: "unread-config-key",
+    file: "*",
+    line_start: 1,
+    line_end: 1,
+    severity: "high",
+    match: { all: ["maxbatch", "default.json"], keywords: ["missing", "absent", "not defined"] }
+  };
+
+  // Names the key, blames the wrong file. One of two required terms.
+  const halfRight = finding({
+    title: "config.maxBatch is missing",
+    body: "worker.js reads config.maxBatch, which nothing in src/ ever defines.",
+    file: "src/worker.js"
+  });
+  const bothTerms = finding({
+    title: "config.maxBatch is missing from the shipped config",
+    body: "src/worker.js reads config.maxBatch; config/default.json does not define it.",
+    file: "src/worker.js"
+  });
+
+  assert.equal(findingMatchesPlanted(halfRight, planted), false);
+  assert.equal(findingMatchesPlanted(bothTerms, planted), true);
+});
+
+// A guard on the corpus rather than on the scorer. A `file: "*"` defect has no
+// filename to disambiguate it, so words are the whole rule, and the failure this
+// pins is silent: the defect keeps matching, just too much. Requiring `all` does
+// not make the subject right — it makes leaving the subject out a test failure
+// instead of a number nobody questions.
+test("every repository-scoped defect declares the subject it is about", () => {
+  const corpusDir = path.join(import.meta.dirname, "corpus");
+  const cases = fs
+    .readdirSync(corpusDir, { withFileTypes: true })
+    .filter((d) => d.isDirectory())
+    .map((d) => d.name);
+  assert.ok(cases.length > 0, "corpus is empty");
+
+  const offenders = [];
+  for (const caseId of cases) {
+    const file = path.join(corpusDir, caseId, "ground-truth.json");
+    if (!fs.existsSync(file)) continue;
+    const truth = JSON.parse(fs.readFileSync(file, "utf8"));
+    for (const p of truth.planted ?? []) {
+      if (p.file && p.file !== "*") continue;
+      if (!Array.isArray(p.match?.all) || p.match.all.length === 0) {
+        offenders.push(`${caseId}/${p.id}`);
+      }
+    }
+  }
+  assert.deepEqual(offenders, []);
+});
+
 test("scoreReview gives full recall and clean precision when both planted defects are found", () => {
   const findings = [
     finding({ severity: "critical", title: "SQL injection", body: "not parameterized", line_start: 10, line_end: 12 }),

--- a/bench/run-bench.test.mjs
+++ b/bench/run-bench.test.mjs
@@ -193,10 +193,17 @@ test("every repository-scoped defect declares the subject it is about", () => {
 // and it drifted silently: two cells were added and the table kept describing nine.
 // A table that omits a cell does not look broken, it looks complete.
 test("the README's cell table lists exactly the cells that exist", () => {
-  const readme = fs.readFileSync(path.join(import.meta.dirname, "README.md"), "utf8");
+  // Normalize line endings first. A Windows checkout stores this file with CRLF, so
+  // searching for "\n\n" finds nothing, and `slice(from, -1)` then hands the rest of
+  // the README to a regex that happily matches every later table too.
+  const readme = fs
+    .readFileSync(path.join(import.meta.dirname, "README.md"), "utf8")
+    .replace(/\r\n/g, "\n");
   const from = readme.indexOf("| Cell | What it is | Isolates |");
   assert.notEqual(from, -1, "cell table header not found in bench/README.md");
-  const table = readme.slice(from, readme.indexOf("\n\n", from));
+  const until = readme.indexOf("\n\n", from);
+  assert.notEqual(until, -1, "cell table is not followed by a blank line");
+  const table = readme.slice(from, until);
   const documented = [...table.matchAll(/^\| `([a-z]+\.[a-z]+)` \|/gm)].map((m) => m[1]);
   assert.deepEqual([...documented].sort(), [...CELL_IDS].sort());
 });

--- a/bench/run-bench.test.mjs
+++ b/bench/run-bench.test.mjs
@@ -501,7 +501,7 @@ test("a refused AGY run reports the reason AGY gave, not an empty parenthesis", 
   };
   const stub = () => ({ status: 1, stdout: JSON.stringify(quotaEnvelope), stderr: "" });
 
-  const refused = adapters.runAgyModel("review this", { spawnImpl: stub });
+  const refused = adapters.runAgyModel("review this", { spawnImpl: stub, resolveBinaryImpl: () => "/usr/bin/agy" });
   assert.equal(refused.ok, false, "an envelope carrying no review is still a failure");
   assert.match(String(refused.error), /Individual quota reached/);
 });

--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -4,6 +4,78 @@
 
 This project is not an AGY-only replacement or a multi-host plugin. It focuses on Claude Code workflows with richer review behavior and defensive handling around real CLI failure modes.
 
+## The Landscape, Measured
+
+Measured 2026-08-20 from each project's README and repository tree. Their code was not
+read, so every feature attributed to another project is that project's own description.
+`pushedAt` is the last code push; GitHub's `updatedAt` also moves on metadata changes
+such as a new star, which makes an untouched repository look current. The other five rows
+are that snapshot and are not refreshed between measurements; this project's own row is
+kept current on release, so a reader can tell which numbers are old by which project they
+belong to.
+
+| Project | Stars | Last push | Latest release | Engine | Transport |
+|---|---|---|---|---|---|
+| [thepushkarp/cc-gemini-plugin](https://github.com/thepushkarp/cc-gemini-plugin) | 71 | 2026-04-14 | none | Gemini CLI | bridge script |
+| [abiswas97/gemini-plugin-cc](https://github.com/abiswas97/gemini-plugin-cc) | 48 | 2026-04-19 | v1.0.1 | Gemini CLI | ACP |
+| [sakibsadmanshajib/gemini-plugin-cc](https://github.com/sakibsadmanshajib/gemini-plugin-cc) | 24 | 2026-05-22 | v1.0.1, archived | Gemini CLI | ACP |
+| [sakibsadmanshajib/antigravity-plugin](https://github.com/sakibsadmanshajib/antigravity-plugin) | 19 | 2026-05-22 | none | AGY only | `agy --print` |
+| [m-ghalib/gemini-plugin-cc](https://github.com/m-ghalib/gemini-plugin-cc) | 18 | 2026-04-24 | v0.1.0 | Gemini CLI, setup installs 0.38.2 | ACP |
+| **this project** | 9 | 2026-08-24 | v0.22.3 | Gemini CLI **and** AGY | direct spawn, structured JSON |
+
+| Surface | Slash commands | MCP tools | Skills | Test files (`*.test.*`) |
+|---|---|---|---|---|
+| **this project** | 8 | **6** | 3 | 36 |
+| abiswas97 | 8 | 0 | 3 | 13 |
+| m-ghalib | 7 | 0 | 3 | 12 |
+| sakibsadmanshajib/antigravity-plugin | 6 | 0 | 0 | 12 |
+| thepushkarp | 1 | 0 | 0 | 1 |
+
+A test file count measures files, not assertions: it says nothing about whether any of
+these suites, this one included, would fail if the behaviour they cover broke.
+
+No other project in the table declares an MCP server — no `.mcp.json`, and no
+`mcpServers` key in `plugin.json`. Their command surface is reachable by a person typing a
+slash command, not by another program calling a tool.
+
+Every other project's last code push predates 2026-06-18, the day consumer OAuth for
+Gemini CLI stopped working — measured here on 2026-08-19: without an API key the CLI
+now answers `API key not valid`. That is a statement about dates, not a claim that any of them
+is broken: the projects documenting `GOOGLE_API_KEY` or application-default credentials
+may still authenticate normally.
+
+Every project here descends from `openai/codex-plugin-cc` by its own attribution, this
+one included, except `thepushkarp/cc-gemini-plugin`, whose README names no upstream. The command and skill sets are therefore
+close by inheritance rather than by convergence: `abiswas97` ships the same three skill
+directories this project does, and `m-ghalib` the same three but for a prompting skill
+renamed `gemini-3-prompting`. The columns that actually differ are MCP tools and tests.
+
+Three of the others lead somewhere this one does not go.
+`sakibsadmanshajib/antigravity-plugin` installs into Codex CLI, `agy` itself and
+standalone `npx`. `thepushkarp/cc-gemini-plugin` inlines globbed files into the prompt
+for long-context delegation, and its one-command surface is easier to learn than eight.
+`abiswas97/gemini-plugin-cc` ships `/gemini:task` for one-off delegation, where this
+project spends its eighth command on `/gemini:transfer` instead. `m-ghalib` is the
+closest neighbour of all: same lineage, same skills, one command fewer, and the longest
+README of the five others at 318 lines.
+
+### One Deliberate Difference
+
+`m-ghalib/gemini-plugin-cc` ships the same stop-time review gate this project does. Both
+descend from `openai/codex-plugin-cc`, and the two `hooks.json` files are identical apart
+from the description line. The gates fail in opposite directions.
+
+That project's README says its gate blocks when Gemini cannot be reached. This one fails
+open (`plugins/gemini/scripts/stop-review-gate-hook.mjs:120`): it lets the stop through
+and attaches a `systemMessage` naming the command to run by hand. That warning only
+started reaching anyone in 0.22.3 — until then the hook wrote a `decision` the Stop
+schema rejects, so Claude Code discarded the payload and the warning with it.
+
+Both are defensible, and the choice is about which failure a user can act on. After the
+OAuth change, failing closed traps every user whose credentials lapsed at the exact
+moment they are trying to stop working — and a gate that cannot reach the reviewer
+cannot tell a credential problem from a real finding.
+
 ## Positioning
 
 | Need | Best fit |
@@ -17,6 +89,8 @@ This project is not an AGY-only replacement or a multi-host plugin. It focuses o
 ## What This Plugin Emphasizes
 
 - Claude Code-native `/gemini:*` slash commands.
+- MCP tools (`gemini_review`, `gemini_adversarial_review`, `gemini_rescue`, and job
+  status / result / cancel) so another agent can call the bridge, not only a person.
 - Standard and adversarial code review over the current diff or branch.
 - Background jobs with status, result, and cancel flows.
 - Gemini model aliases, graceful model fallback, and transient review retry.

--- a/docs/HANDOVER_MARKETING_AND_RELEASE_PLAYBOOK.md
+++ b/docs/HANDOVER_MARKETING_AND_RELEASE_PLAYBOOK.md
@@ -1,0 +1,630 @@
+# `gemini-plugin-cc` 終極推廣、生態上架與架構交接手冊 (業界標準加固版)
+(Master Playbook: Growth, MCP Registries, AI-Era SEO/AEO Architecture & Next-Gen Launch)
+
+> **版本**：v3.6.0 (Enterprise, RFC 9309, Answer.AI Spec v2 & Codebase Ground-Truth Aligned)  
+> **建立日期**：2026-08-21  
+> **對齊標準**：RFC 9309 (Robots Exclusion Protocol)、Answer.AI `/llms.txt` Spec v2、OASIS SARIF 2.1.0、Schema.org SoftwareApplication & TechArticle、Google E-E-A-T 2026 Guidelines、OWASP Top 10 for LLM (2025/2026)、OpenSSF Best Practices、Claude Code Manifest Spec  
+> **交接目標**：供維護團隊與 **Claude Code** 進行後續無縫實作、生態登錄、AI 時代搜尋最佳化與跨客戶端維運。  
+
+---
+
+## 1. 現況評估矩陣 (Current State Audit)
+
+經代碼庫全面唯讀檢驗，專案現狀與外部平台要求的合規性如下：
+
+| 檢驗項目 | 外部/業界標準要求 | 目前現狀 | 評估結論 | Claude 實作行動 |
+|---|---|---|---|---|
+| **開源許可證** | Public 倉庫需具備 `LICENSE` | 現為 MIT，v1.0.0 升級 Apache 2.0 | **過渡中** | v1.0.0 正式切換 (見第 9 節) |
+| **MCP 啟動穩定性** | 沙盒 `initialize` 與 `tools/list` 不得崩潰 | `gemini-mcp.mjs` 為純記憶體回應，無啟動探測 | **合規 (Pass)** | 無需變動 |
+| **Smithery 設定檔** | 根目錄需有 `smithery.yaml` 宣告啟動 | 尚未建立 | ⚠️ **待補齊** | 新增 `smithery.yaml` (見第 4.1 節) |
+| **AEO 機器索引** | 根目錄需具備 `/llms.txt` 與 `/llms-full.txt` | 尚未建立 | ⚠️ **待補齊** | 實裝 `/llms.txt` 與建置腳本 (見第 4.6 節) |
+| **AI 爬蟲權限** | `robots.txt` 需符合 RFC 9309 明確授權 AI 代理 | 尚未發布 | ⚠️ **待配置** | 部署生產級 `robots.txt` (見第 4.5 節) |
+| **語意實體圖譜** | Schema.org `SoftwareApplication` JSON-LD | 尚未嵌入 | ⚠️ **待補齊** | 嵌入 JSON-LD 標記 (見第 4.7 節) |
+| **模型命名邊界** | 支援 Vertex AI (`/`) 與版本標籤 (`@`) | 舊正則阻斷了 `/` 與 `@` | ⚠️ **待放寬** | 更新 `SAFE_MODEL_ID` (見第 6.2 節) |
+| **Gate 安全合規** | CI/CD 環境需支援 Fail-Closed | 現狀為全域 Fail-Open | ⚠️ **待雙軌化** | 引入 `GEMINI_GATE_STRICT` (見第 6.1 節) |
+| **CI 封裝標準** | 企業流水線需 1 行啟用 | 尚無 `action.yml` | ⚠️ **待補齊** | 新增 `action.yml` (見第 7.1 節) |
+| **漏洞輸出標準** | OASIS SARIF 2.1.0 格式 | 現狀為自訂 JSON | ⚠️ **待支援** | 擴充 SARIF 輸出 (見第 7.2 節) |
+
+---
+
+## 2. 專案核心定位與價值主張 (Core Positioning)
+
+```mermaid
+graph TD
+    User["開發者 (Claude Code / Cursor / CI Pipeline)"] --> Driver["主控端 (Claude / GitHub Actions)"]
+    Driver -->|產生代碼與 Diff| Review["對抗性審查調度模組"]
+    Review -->|跨模型漏洞獵捕| Gemini["Google Gemini 3.7 / 3.5 / 4<br>(百萬 Token 外部驗證沙盒)"]
+    Review -->|邏輯歧見仲裁 (選配)| Arbiter["OpenAI o1 / o3<br>(形式化邏輯仲裁者)"]
+    Gemini -->|輸出反思報告與攻擊面| Driver
+    Arbiter -->|輸出最終共識裁決| Driver
+    Driver -->|自主修補或阻斷 PR| Repo["專案代碼庫 / GitHub PR"]
+```
+
+* **品牌主張**：**「自適應多代理人閉環控制架構 (Adaptive Multi-Agent Closed-Loop Control Harness)」**。
+* **工程三位一體分工 (The Engineering Triad)**：
+  1. **Graph Engineering (圖拓撲)**：定義多模型有向圖路由，小變更走 Single-Agent 極速通道，大架構重構自適應分裂出衛星子代理群 (Subagents)。
+  2. **Loop Engineering (控制閉環)**：將外部對抗反例轉化為形式化修復向量回傳給主控端，驅動自動補丁修復與 OODA 收斂，直至綠燈放行。
+  3. **Harness Engineering (安全夾具)**：以 Gate 雙軌制（Fail-Open/Closed）、機密過濾與 OASIS SARIF 2.1.0 建立確定性安全護城河。
+* **AI Safety 理論（共模故障防禦 Common-Mode Failure Defense）**：
+  * 單一模型自我審查易陷入同構認知盲區。
+  * 由主控端產出代碼、Gemini 進行超大上下文獵漏洞、OpenAI 進行形式化邏輯仲裁，是企業級資安的最佳實踐。
+* **主從關係清晰**：主控端是唯一調度者，外部審查結果促成自我反思與修復，**直接提升會話深度與實質 Token 價值**。
+
+---
+
+## 3. 三大生態推進路徑與申報指引
+
+### 3.1 登上 Anthropic 官方推薦 / 插件目錄
+* **論述核心**：本插件是「Claude Code 的高階資安防護裝備」，嚴格遵循數據最小化（僅發送 Git Diff，絕不外洩 System Prompt 或專有會話歷史）。
+* **交付物**：在倉庫建立 `SECURITY.md` 說明憑證隔離與安全邊界。
+
+### 3.2 申請 OpenAI Codex for Open Source 資助 ([申請入口](https://openai.com/form/codex-for-oss/))
+* **官方審核本質**：面向公開開源倉庫維護者，補助用於 PR 審查、CI/CD 與安全審計的 API 額度。
+* **申請表最佳填寫範本**：
+  * **Role**: Primary Maintainer of `gemini-plugin-cc`.
+  * **Project Description**: An open-source multi-agent code review & adversarial consensus framework for developer workflows, originating from the `codex-plugin-cc` lineage.
+  * **Intended Use of API Credits**:
+    1. 在開源倉庫的 CI/CD 中運行「異質多模型交叉審查矩陣（Claude + Gemini + OpenAI o-series）」。
+    2. 建置開放的《開源代碼審查基準 (Open-Source Multi-Agent Review Benchmark)》，評測異質模型協同降低 CVE 漏洞率的成效。
+
+---
+
+## 4. MCP 市集、跨客戶端與 AI 時代 SEO / AEO 全方位實裝指南
+
+### 4.1 Smithery.ai 登錄設定 (`smithery.yaml`)
+在倉庫根目錄新增 `smithery.yaml`，確保自動爬蟲能正確辨識與一鍵安裝：
+
+```yaml
+startCommand:
+  type: stdio
+  config:
+    command: node
+    args:
+      - plugins/gemini/scripts/gemini-mcp.mjs
+    env:
+      GEMINI_ENGINE: auto
+```
+
+### 4.2 Glama.ai 與 AEO / GEO 部署
+* **GitHub Pages 靜態站點**：啟用 GitHub Pages（路徑 `/docs`），將 `llms.txt` 發布至 `https://arcobaleno64.github.io/gemini-plugin-cc/llms.txt`。
+* **高意圖關鍵詞替換**：
+  * ❌ 避免：`Fix API key not valid in Gemini CLI`（吸引免洗維修流量）。
+  *  主打：`Claude Code automated security review MCP`、`Cursor Gemini adversarial review`、`Multi-agent code audit MCP`。
+
+### 4.3 跨客戶端支援矩陣 (GUI Clients: Cursor, Claude Desktop, Windsurf, Cline)
+本專案的 6 個 MCP 工具完全支援非 Claude Code 的所有 GUI 客戶端：
+
+| 功能類型 | Claude Code (CLI) | Cursor / Claude Desktop / Cline (GUI) |
+|---|:---:|:---:|
+| **6 個 MCP 工具**（`gemini_review`, `gemini_adversarial_review` 等） |  支援 |  **完全支援**（AI 於視窗中主動調用） |
+| **手動斜線指令**（如 `/gemini:review`） |  支援 | ❌ 不支援（Claude Code 專屬語法） |
+| **工作結束自動審查閘門**（Stop Gate Hook） |  支援 | ❌ 不支援（Claude Code 專屬 Hook） |
+
+---
+
+### 4.4 現代 SEO 與 AEO/GEO 雙軌戰略全景圖 (From Zero to Found on Google & Claim Your Spot in AI)
+
+> **解構依據**：
+> 1. 《From Zero to Found on Google: The SEO Survival Guide for the AI Era》 (`iE8Byp-mMsc`)
+> 2. 《Claim Your Spot in AI's Recommendations Before 99% of People Understand AEO》 (`f4kc4qI1nUk`)
+
+現代軟體與開源專案的傳播已徹底分裂為兩條平行軌道：
+
+```mermaid
+graph LR
+    subgraph Traditional_SEO ["軌道 1: 傳統搜尋引擎 (Google / Bing)"]
+        T1["搜尋行為: 使用者輸入關鍵字 -> 點擊藍色連結 (SERP)"]
+        T2["收錄管線: Discovery -> Crawling -> Rendering -> Indexing -> Ranking"]
+        T3["核心指標: 點擊率 (CTR)、排名 (Rank #1-3)、Core Web Vitals"]
+        T4["優化手段: robots.txt、sitemap.xml、Canonical URL、Semantic HTML5"]
+    end
+
+    subgraph Generative_AEO ["軌道 2: 生成式答案引擎 (ChatGPT Search / Perplexity / Claude)"]
+        A1["搜尋行為: 使用者提出複雜問題 -> AI 直接生成綜合答案與工具推薦"]
+        A2["收錄管線: Agent Crawling -> Vector Embedding -> Knowledge Graph -> Synthesis & Citation"]
+        A3["核心指標: 引用份額 (Citation Share)、直接推薦率 (Direct Mention Rate)"]
+        A4["優化手段: /llms.txt 標準、Answer-First 排版、JSON-LD Entity Linking、E-E-A-T 實證"]
+    end
+```
+
+#### 傳統 SEO vs. 答案引擎 AEO 實戰差異對照表：
+
+| 評估維度 | 傳統搜尋引擎 (Googlebot / SEO) | 生成式答案引擎 (ChatGPT / Perplexity / AEO) |
+|---|---|---|
+| **搜尋媒介** | Google / Bing 網頁搜尋框 | ChatGPT Search, Perplexity Pro, Claude Web, Google AI Overviews |
+| **互動模式** | 索引藍色網址清單，由使用者自行點擊篩選 | AI 消化海量資訊後，直接合成結論並提供「引用角標 (Citations)」 |
+| **流量型態** | 點擊跳轉至目標網站首頁或文章頁 | 直接在對話中被推薦、引用或作為 MCP 工具被 AI 自動調用 |
+| **爬蟲格式偏好** | 完整 HTML DOM、CSS、SSR 渲染的 JavaScript 頁面 | 零雜訊、語義密集的 Markdown 文本、結構化 JSON-LD、`/llms.txt` |
+| **內容排版法則** | 關鍵字密度、文章長度 (Word Count)、內外部反向連結 | **Answer-First (首句即答案)**、獨立無歧義段落、條列證據庫 |
+| **權威信任標準** | Domain Authority (DA)、PageRank、外鏈數量 | **E-E-A-T (經驗/專業/權威/信任)**、可復現測試代碼、開源驗證標籤 |
+| **收錄管線澄清** | Google AI Overviews 由標準 `Googlebot` 爬取渲染 | `Google-Extended` 僅控制基礎模型訓練，非 AI Overviews 爬蟲 |
+
+---
+
+### 4.5 生產級 `robots.txt` 與 AI 爬蟲矩陣配置 (RFC 9309 Compliant)
+
+依據 RFC 9309 規範，特定 User-Agent 區塊**不繼承**通用規則，因此必須在各 AI 代理區塊完整配置 `Allow` 與 `Disallow`，杜絕敏感目錄外洩：
+
+```text
+# ==============================================================================
+# Production robots.txt for gemini-plugin-cc & Triad-Flow Ecosystem
+# Strictly Compliant with RFC 9309, Google Search, Bing, OpenAI & Anthropic Specs
+# ==============================================================================
+
+# ------------------------------------------------------------------------------
+# 1. Default Policy for Standard Search Engines (Googlebot, Bingbot, Slurp, etc.)
+# ------------------------------------------------------------------------------
+User-agent: *
+Allow: /
+Allow: /llms.txt
+Allow: /llms-full.txt
+Allow: /docs/
+Disallow: /node_modules/
+Disallow: /.git/
+Disallow: /dist/
+Disallow: /scratch/
+Disallow: /tests/
+
+# ------------------------------------------------------------------------------
+# 2. OpenAI Crawlers (Training, Real-time Search & Browsing)
+# ------------------------------------------------------------------------------
+User-agent: GPTBot
+User-agent: OAI-SearchBot
+User-agent: ChatGPT-User
+Allow: /
+Allow: /llms.txt
+Allow: /llms-full.txt
+Allow: /docs/
+Disallow: /node_modules/
+Disallow: /.git/
+Disallow: /dist/
+Disallow: /scratch/
+Disallow: /tests/
+
+# ------------------------------------------------------------------------------
+# 3. Anthropic Claude Agents (Training & Real-time Web Retrieval)
+# ------------------------------------------------------------------------------
+User-agent: ClaudeBot
+User-agent: Claude-Web
+Allow: /
+Allow: /llms.txt
+Allow: /llms-full.txt
+Allow: /docs/
+Disallow: /node_modules/
+Disallow: /.git/
+Disallow: /dist/
+Disallow: /scratch/
+Disallow: /tests/
+
+# ------------------------------------------------------------------------------
+# 4. Perplexity AI Agents (Index & Real-time Live Retrieval)
+# ------------------------------------------------------------------------------
+User-agent: PerplexityBot
+User-agent: Perplexity-User
+Allow: /
+Allow: /llms.txt
+Allow: /llms-full.txt
+Allow: /docs/
+Disallow: /node_modules/
+Disallow: /.git/
+Disallow: /dist/
+Disallow: /scratch/
+Disallow: /tests/
+
+# ------------------------------------------------------------------------------
+# 5. Apple & Google AI Extended Crawlers (Model Training Controls)
+# ------------------------------------------------------------------------------
+User-agent: Google-Extended
+User-agent: Applebot
+User-agent: Applebot-Extended
+Allow: /
+Allow: /llms.txt
+Allow: /llms-full.txt
+Allow: /docs/
+Disallow: /node_modules/
+Disallow: /.git/
+Disallow: /dist/
+Disallow: /scratch/
+Disallow: /tests/
+
+# ------------------------------------------------------------------------------
+# 6. Aggressive Scraper Policy (ByteDance Bytespider WAF Level Protection)
+# ------------------------------------------------------------------------------
+User-agent: Bytespider
+Disallow: /
+
+# ------------------------------------------------------------------------------
+# 7. Sitemap Location Declaration (RFC 9309 Section 2.3)
+# ------------------------------------------------------------------------------
+Sitemap: https://arcobaleno64.github.io/gemini-plugin-cc/sitemap.xml
+```
+
+---
+
+### 4.6 官方 `/llms.txt` 與 `/llms-full.txt` 規範實裝 (Answer.AI Spec v2 & Ground Truth)
+
+依據 Jeremy Howard (Answer.AI) 規範與本專案 `gemini-mcp.mjs` 真實簽名，發布 `/llms.txt`：
+
+#### 檔案：`/llms.txt` (輕量導航索引 - < 1,000 Tokens)
+```markdown
+# gemini-plugin-cc
+
+> Multi-agent heterogeneous adversarial code review and task delegation harness for Claude Code, Cursor, and enterprise CI/CD workflows.
+
+gemini-plugin-cc pairs AI coding agents (Claude Code, Cursor, Claude Desktop) with Google Gemini's 1M-token context window and Antigravity CLI (AGY). It enables multi-agent adversarial code reviews, automated diff auditing, and background task delegation without sharing proprietary conversation logs.
+
+## Core Documentation & Guides
+- [Security Architecture](https://github.com/arcobaleno64/gemini-plugin-cc/blob/main/SECURITY.md): Capability security, zero session leakage, and credential path isolation.
+- [Threat Model](https://github.com/arcobaleno64/gemini-plugin-cc/blob/main/docs/THREAT-MODEL.md): In-depth risk model and path boundary controls.
+- [Engine Parity & Comparison](https://github.com/arcobaleno64/gemini-plugin-cc/blob/main/docs/COMPARISON.md): Gemini CLI vs Antigravity CLI (AGY) feature matrix.
+
+## MCP Tools Reference (Stdio Server: `gemini-mcp.mjs`)
+- `gemini_review`: Queue a read-only pragmatic code review over current git diff. Inputs: `workspace` (required string), `base` (string), `scope` ("auto"|"working-tree"|"branch"), `deep` (boolean), `model` (string), `engine` ("auto"|"gemini"|"agy"), `timeout` (integer). Returns: Enqueued job object with `jobId`.
+- `gemini_adversarial_review`: Queue a read-only adversarial red-team review challenging design decisions and hunting CVEs. Inputs: `workspace` (required string), `focus` (string), `base` (string), `scope` ("auto"|"working-tree"|"branch"), `deep` (boolean), `model` (string), `engine` ("auto"|"gemini"|"agy"), `timeout` (integer). Returns: Enqueued job object with `jobId`.
+- `gemini_rescue`: Queue a delegated task to Gemini/AGY. Inputs: `workspace` (required string), `prompt` (required string), `write` (boolean, default false), `effort` ("none"|"minimal"|"low"|"medium"|"high"|"xhigh"), `model` (string), `engine` ("auto"|"gemini"|"agy"), `timeout` (integer). Returns: Enqueued job object with `jobId`.
+- `gemini_job_status`: Check runtime state of an enqueued companion job. Inputs: `workspace` (required string), `jobId` (required string). Returns: Job status object (`status`: queued|running|completed|failed|cancelled|partial).
+- `gemini_job_result`: Read final output of a completed or partial job. Inputs: `workspace` (required string), `jobId` (required string). Returns: Stored markdown/json findings and output logs.
+- `gemini_job_cancel`: Cancel an active job process tree. Inputs: `workspace` (required string), `jobId` (required string). Returns: Cancellation confirmation.
+
+## Installation & Configuration
+- [Quick Start & Setup](https://github.com/arcobaleno64/gemini-plugin-cc#quick-start): Run `agy` once for OAuth, or export `GEMINI_API_KEY`.
+- [Claude Code Plugin](https://github.com/arcobaleno64/gemini-plugin-cc#installation): Run `/plugin install gemini-plugin-cc`.
+- [Cursor & Claude Desktop MCP](https://github.com/arcobaleno64/gemini-plugin-cc#mcp-tools): Register `node plugins/gemini/scripts/gemini-mcp.mjs` in MCP config.
+
+## Optional
+- [Full Documentation Bundle](https://arcobaleno64.github.io/gemini-plugin-cc/llms-full.txt): Concatenated documentation for single-shot ingestion.
+- [Changelog](https://github.com/arcobaleno64/gemini-plugin-cc/blob/main/plugins/gemini/CHANGELOG.md): Historical version releases and updates.
+```
+
+#### 檔案：`/llms-full.txt` 聚合建置管線 (`package.json`)
+在 `package.json` 中配置具備路徑備援與換行正規化的跨平台建置指令：
+```json
+{
+  "scripts": {
+    "build:llms-full": "node -e \"const fs=require('fs'); const candidates=['README.md','SECURITY.md','docs/SECURITY.md','PRIVACY.md','docs/THREAT-MODEL.md','docs/COMPARISON.md']; const files=candidates.filter(f=>fs.existsSync(f)); if(!files.length) throw new Error('No files found'); fs.mkdirSync('docs',{recursive:true}); const content=files.map(f=>'# File: '+f+'\\n\\n'+fs.readFileSync(f,'utf8').replace(/\\r\\n/g,'\\n').trim()).join('\\n\\n---\\n\\n')+'\\n'; fs.writeFileSync('docs/llms-full.txt',content,'utf8'); console.log('✔ Generated docs/llms-full.txt ('+files.length+' files, '+Buffer.byteLength(content)+' bytes)');\""
+  }
+}
+```
+
+---
+
+### 4.7 結構化資料 JSON-LD 與語意知識圖譜標記 (Google Rich Results 合規)
+
+在官方網站與 GitHub Pages 首頁 `<head>` 區域嵌入標準 JSON-LD，雙型別宣告 `SoftwareApplication` + `SoftwareSourceCode`，並補齊 `image`、`mainEntityOfPage` 與 `about` 實體錨定：
+
+```html
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": ["SoftwareApplication", "SoftwareSourceCode"],
+      "@id": "https://arcobaleno64.github.io/gemini-plugin-cc/#software",
+      "name": "gemini-plugin-cc",
+      "alternateName": "Triad-Flow Gemini Companion",
+      "description": "Multi-agent heterogeneous adversarial code review and closed-loop control harness for Claude Code, Cursor, and enterprise CI/CD pipelines.",
+      "applicationCategory": "DeveloperApplication",
+      "operatingSystem": "Windows, macOS, Linux",
+      "softwareVersion": "1.0.0",
+      "license": "https://www.apache.org/licenses/LICENSE-2.0",
+      "url": "https://arcobaleno64.github.io/gemini-plugin-cc/",
+      "codeRepository": "https://github.com/arcobaleno64/gemini-plugin-cc",
+      "programmingLanguage": "JavaScript",
+      "runtimePlatform": "Node.js >= 18",
+      "offers": {
+        "@type": "Offer",
+        "price": "0",
+        "priceCurrency": "USD",
+        "availability": "https://schema.org/InStock"
+      },
+      "author": {
+        "@type": "Person",
+        "@id": "https://github.com/arcobaleno64",
+        "name": "arcobaleno64",
+        "url": "https://github.com/arcobaleno64"
+      }
+    },
+    {
+      "@type": "TechArticle",
+      "@id": "https://arcobaleno64.github.io/gemini-plugin-cc/#architecture",
+      "mainEntityOfPage": "https://arcobaleno64.github.io/gemini-plugin-cc/",
+      "about": {
+        "@id": "https://arcobaleno64.github.io/gemini-plugin-cc/#software"
+      },
+      "headline": "Heterogeneous Multi-Agent Closed-Loop Control Architecture for AI Code Review",
+      "description": "How cross-model adversarial review between Claude, Gemini, and OpenAI eliminates common-mode failure in automated software engineering.",
+      "image": "https://arcobaleno64.github.io/gemini-plugin-cc/assets/og-image.png",
+      "author": {
+        "@type": "Person",
+        "@id": "https://github.com/arcobaleno64",
+        "name": "arcobaleno64",
+        "url": "https://github.com/arcobaleno64"
+      },
+      "publisher": {
+        "@type": "Organization",
+        "name": "Triad-Flow Open Source Initiative",
+        "url": "https://github.com/arcobaleno64",
+        "logo": {
+          "@type": "ImageObject",
+          "url": "https://arcobaleno64.github.io/gemini-plugin-cc/assets/logo.png"
+        }
+      },
+      "datePublished": "2026-08-20",
+      "dateModified": "2026-08-21",
+      "proficiencyLevel": "Expert"
+    }
+  ]
+}
+</script>
+```
+
+---
+
+### 4.8 E-E-A-T 權威性注入與 Answer-First 高引用率 FAQ 庫
+
+#### 🎯 Answer-First 內容排版黃金準則：
+AI 答案引擎（ChatGPT / Perplexity / Claude）在生成綜合回答時，會優先引用「**問題標題下方第一句話即給出精確、無歧義定義**」的內容區塊。
+
+#### Q1: What is `gemini-plugin-cc` and how does it improve Claude Code?
+> **`gemini-plugin-cc` is an open-source multi-agent code review harness that pairs Claude Code with Google Gemini's 1M-token context window to perform heterogeneous adversarial security reviews.** While Claude generates and edits code, Gemini acts as an external auditor hunting subtle vulnerabilities, API edge cases, and structural regressions without sharing proprietary session histories.
+
+#### Q2: Why is heterogeneous multi-agent review superior to single-model review?
+> **Heterogeneous review eliminates common-mode cognitive failure by ensuring that the AI generating the code is not the same model auditing it.** Single-model self-review suffers from isomorphic blindspots where an LLM rationalizes its own hallucinations; pairing Claude with Gemini and OpenAI ensures cross-model Byzantine validation and objective consensus.
+
+#### Q3: How do you configure `gemini-plugin-cc` in Cursor and Claude Desktop using MCP?
+> **You can configure `gemini-plugin-cc` in any MCP-compatible GUI by registering its stdio command with an absolute path in `claude_desktop_config.json` or Cursor's MCP Settings.**
+```json
+{
+  "mcpServers": {
+    "gemini-plugin-cc": {
+      "command": "node",
+      "args": ["<ABSOLUTE_PATH_TO_REPO>/plugins/gemini/scripts/gemini-mcp.mjs"],
+      "env": {
+        "GEMINI_ENGINE": "auto"
+      }
+    }
+  }
+}
+```
+
+#### Q4: How does Triad-Flow resolve conflicting findings between AI models?
+> **Triad-Flow uses deterministic quorum aggregation policies that preserve the highest reported severity to prevent vulnerability downgrade attacks.** If external adversarial review (Gemini) reports a Critical vulnerability while the local model reports a Low issue, the consensus policy strictly enforces the Critical rating and triggers fail-closed gate blocking.
+
+#### Q5: Can `gemini-plugin-cc` run in enterprise CI/CD pipelines with SARIF export?
+> **Yes, `gemini-plugin-cc` supports enterprise CI/CD with 1-line GitHub Actions composite workflows and OASIS SARIF 2.1.0 exports.** In CI pipelines, setting `GEMINI_GATE_STRICT=true` enforces fail-closed blocking on any critical findings, automatically uploading findings to GitHub Code Scanning.
+
+#### Q6: What are the security, privacy, and data minimization guarantees?
+> **`gemini-plugin-cc` strictly adheres to data minimization by transmitting only Git Diffs, never exposing user system prompts, credentials, or proprietary conversation logs.** Furthermore, it enforces file-level secret isolation by automatically intercepting known credential paths (`.env*`, `*.pem`, `*.key`, `credentials.json`, `id_rsa`) and redacting their diff content before payload transmission.
+
+#### Q7: What open-source license governs `gemini-plugin-cc` and its derivative forks?
+> **`gemini-plugin-cc` is transitioning to the enterprise-grade Apache License 2.0 starting with the v1.0.0 release, providing users with explicit patent grants and trademark protection.** Downstream contributors and commercial adopters benefit from mutual patent retaliation safeguards while maintaining commercial flexibility.
+
+---
+
+### 4.9 SEO / AEO / GEO 自動化驗證、指標監控與持續改進閉環 (Automated Verification & Continuous Improvement Loop)
+
+為了確保發布後的 SEO / AEO / GEO 規格不發生語意漂移、格式回歸或鏈路損壞，並能依據量化數據反饋持續調優，本專案建立了 **「CI/CD 自動化測試 + 定時 AEO 基準評測 + OODA 持續改進閉環」**：
+
+#### 1. CI/CD 靜態規格自動化驗證 (`tests/seo-aeo-validation.test.mjs`)
+在每次 Pull Request 或版本發布時自動執行，100% 阻斷規格回歸：
+```bash
+node --test tests/seo-aeo-validation.test.mjs
+```
+* **驗證範疇**：
+  1. `robots.txt`：RFC 9309 語法、12 大 Agent 群組非繼承隔離、敏感目錄（`/.git/`, `/scratch/`, `/dist/`）阻斷。
+  2. `/llms.txt`：Answer.AI Spec v2 單一 H1/Blockquote/`## Optional`、6 大真實 MCP 工具簽名覆蓋。
+  3. `Schema.org JSON-LD`：雙型別聲明、Google Rich Results 必填項（`image`, `publisher` logo, `about` DAG 鏈路）。
+  4. `Answer-First FAQ`：7 大問答首句定義完整度、機密路徑真實性（`.env*`, `credentials.json`）。
+
+#### 2. 自動化 AEO 基準評測與統計指標生成器 (`scripts/aeo-benchmark.mjs`)
+評分器，輸入是**真實助理回應**：把 `BENCHMARK_QUERIES` 裡的提問逐字丟給助理，把回答原文存進
+`bench/aeo-responses/<QUERY_ID>.md`，腳本才有東西可算。
+
+```bash
+node scripts/aeo-benchmark.mjs
+```
+
+* **輸入**：`bench/aeo-responses/`，一題一檔，首行必須是 provenance 註解
+  （`<!-- captured: YYYY-MM-DD | assistant: 名稱 -->`），否則腳本拒絕評分而非給分。
+* **輸出報表**：`docs/benchmarks/latest-aeo-report.json`（產生物，已列入 `.gitignore`）。
+* **未擷取的題目記為 unmeasured，不計入任何比率**，也不當成 0 分——沒問過助理和助理答不好
+  是兩件事。報表另列 `benchmarkQueries` 與 `unmeasured` 清單。
+* **不產出趨勢**：單次擷取是「某個助理在某一天的某一個回答」，不構成時間序列。要談趨勢，
+  得有多次不同日期的擷取。
+
+#### 3. 四大核心監控 KPI 與統計指標 (Statistical Metrics & KPIs)
+
+| 核心 KPI 指標 | 定義與計算公式 | 目標門檻 (SLA) | 監控與採集方式 |
+|---|---|:---:|---|
+| **1. 引用涵蓋率 (Citation Inclusion Rate)** | $\frac{\text{被 AI 引用次數 (含有官方 URL)}}{\text{已擷取回應的提問數}} \times 100\%$ | **$\ge 80\%$** | `scripts/aeo-benchmark.mjs`，分母為已擷取題數 |
+| **2. 首選直接推薦率 (Direct Recommendation)** | $\frac{\text{AI 答案首段直接推薦本工具次數}}{\text{已擷取回應的提問數}} \times 100\%$ | **$\ge 75\%$** | 答案文本正則比對 (`gemini-plugin-cc` / `triad-flow`) |
+| **3. 語意關鍵詞覆蓋度 (Average Keyword Coverage)**| $\frac{1}{N}\sum \frac{\text{命中核心技術關鍵詞數}}{\text{目標關鍵詞總數}} \times 100\%$ | **$\ge 60\%$** | 評估 AI 綜合回答是否保留「異質對抗、1M 上下文、數據最小化」 |
+| **4. 結構化資料合規率 (Schema Compliance Score)** | $\frac{\text{Google Rich Results 綠燈無重大錯誤數}}{\text{總頁面數}} \times 100\%$ | **$100\%$** | Google Search Console / Rich Results API |
+
+#### 4. AEO 持續改進 OODA 反饋閉環 (Continuous Improvement Feedback Loop)
+
+```mermaid
+graph TD
+    O["1. Observe (觀測)<br>透過 aeo-benchmark.mjs 監控各問題的 Citation Rate 與關鍵詞覆蓋率"] --> R["2. Orient (定向)<br>分析未命中/未引用的原因（例：AI 偏向引用競品或將工具誤判為僅支援 Claude）"]
+    R --> D["3. Decide (決策)<br>提煉更精確的 Answer-First 首句定義，或在 /llms.txt 補充該邊界場景"]
+    D --> A["4. Act (行動)<br>更新 FAQ、/llms.txt 與 docs/，執行自動化測試驗證後發布"]
+    A --> O
+```
+
+---
+
+## 5. 前置環境依賴與異常防禦機制 (Prerequisites & Failure Modes)
+
+### 5.1 本機依賴條件
+* **Node.js**：`>= 18.0.0`
+* **Google 引擎**：已安裝 `agy.exe` (Antigravity CLI) 或 `gemini` CLI（或環境變數設定 `GOOGLE_API_KEY`）。
+
+### 5.2 GUI 使用者無 Node.js 時的行為特徵
+* **現象**：當使用者電腦未安裝 Node.js 時，GUI 軟體啟動 MCP 伺服器會直接失敗並拋出 `spawn node ENOENT`（找不到檔案）。
+* **介面表現**：Cursor MCP 面板顯示紅燈（`Error: spawn node ENOENT`）；Claude Desktop 提示連線失敗。
+* **防護機制**：README 首屏置頂標註 `Prerequisites: Node.js >= 18`。
+
+### 5.3 README 認證指引視覺化優化建議 (Actionable Visual Callout)
+* **現狀問題**：目前 `README.md` 與 `README.zh-TW.md` 的認證指引包在長篇段落中，掃描型開發者容易忽略「需執行一次 `agy` 完成授權」或「可設定 `GEMINI_API_KEY`」。
+* **優化建議**：在 `README.md` 的 `## Quick Start` 最上方置入 3 秒可讀的「步驟 0 認證代碼塊」：
+  ```markdown
+  ### Step 0: Authentication (Pick one)
+  ```bash
+  # Option A: Google Account OAuth (run once interactively)
+  agy
+
+  # Option B: API Key (headless / automated CI/CD workflows)
+  export GEMINI_API_KEY="your-api-key"
+  ```
+  ```
+
+---
+
+## 6. 架構安全與代碼加固規格（Claude Code 實作指引）
+
+> [!IMPORTANT]
+> **給 Claude Code 的實作防漂移守則 (Premortem Guardrails)**：
+> 1. **維持現有函式簽名與測試契約**：`allocateBudget(sizes, budget)` 為匯出的純運算函式（以數字陣列為輸入），**嚴禁修改其參數簽名**，以免破壞 `tests/git.test.mjs`。
+> 2. **Vertex AI 多層路徑支援**：Vertex AI 模型路徑包含多個斜線（如 `publishers/google/models/gemini-3.5-pro`），正則必須支援**多層斜線**而非單一斜線。
+> 3. **複用而非重建**：`doctor` 自檢應擴充既有的 `buildSetupReport` / `handleSetup`，切勿新建平行衝突模組。
+
+### 6.1 Gate 雙軌制（本機 Fail-Open + CI Fail-Closed）
+* **檔案**：`plugins/gemini/scripts/stop-review-gate-hook.mjs`
+* **精確實作邏輯**：在 `if (!payload)` 分支中（約 line 109）引入 `GEMINI_GATE_STRICT` 判斷。
+
+### 6.2 `SAFE_MODEL_ID` 正則放寬（支援多層 Vertex AI 與版本標籤）
+* **檔案**：`plugins/gemini/scripts/lib/engine.mjs`
+* **精確正則定義**：
+  ```javascript
+  const SAFE_MODEL_ID = /^(?:[A-Za-z0-9_.-]+\/)*[A-Za-z0-9][A-Za-z0-9._-]*(?:@[A-Za-z0-9._-]+)?$/;
+  ```
+
+### 6.3 智慧安全加權預算分配 (Security-Weighted Budgeting)
+* **檔案**：`plugins/gemini/scripts/lib/git.mjs`
+* **實作位置**：在 `budgetReviewSections` 中對 `units` 進行安全加權排序（Tier 1: Auth/Workflows, Tier 2: Source Code, Tier 3: Docs/JSON）。
+
+### 6.4 `doctor` 輕量一鍵診斷指令
+* **檔案**：`plugins/gemini/scripts/gemini-companion.mjs`
+* **實作方式**：在 `handleSetup` / `buildSetupReport` 擴充輸出診斷摘要。
+
+---
+
+## 7. 企業級 CI/CD 與業界標準整合規格 (Enterprise Standards)
+
+### 7.1 GitHub Action 官方封裝規格 (`action.yml`)
+為了讓企業 DevOps 團隊能以 3 行 YAML 直接嵌入 GitHub Actions，需在倉庫根目錄建立 `action.yml`：
+
+```yaml
+name: 'Gemini Adversarial Code Review'
+description: 'Enterprise-grade heterogeneous adversarial code review using Gemini and Claude'
+author: 'arcobaleno64'
+inputs:
+  engine:
+    description: 'Engine to use (gemini | agy)'
+    default: 'gemini'
+    required: false
+  strict:
+    description: 'Fail-closed on review errors or quota limits'
+    default: 'true'
+    required: false
+  output-format:
+    description: 'Output format (json | markdown | sarif)'
+    default: 'markdown'
+    required: false
+runs:
+  using: 'composite'
+  steps:
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '>=18'
+    - name: Run Adversarial Review
+      shell: bash
+      env:
+        GEMINI_GATE_STRICT: ${{ inputs.strict }}
+        GEMINI_ENGINE: ${{ inputs.engine }}
+      run: |
+        node plugins/gemini/scripts/gemini-companion.mjs review --base ${{ github.event.pull_request.base.sha || 'HEAD~1' }} --deep --json > review-result.json
+```
+
+### 7.2 OASIS SARIF 2.1.0 結構化標準輸出
+企業級 CI/CD 依賴 **SARIF 2.1.0 (Static Analysis Results Interchange Format)** 與 GitHub Code Scanning / SonarQube 對接：
+* **實作位置**：`plugins/gemini/scripts/lib/render.mjs`
+* **格式定義**：
+  ```json
+  {
+    "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+    "version": "2.1.0",
+    "runs": [
+      {
+        "tool": {
+          "driver": {
+            "name": "gemini-adversarial-review",
+            "version": "0.23.0"
+          }
+        },
+        "results": [
+          {
+            "ruleId": "AI-ADVERSARIAL-FINDING",
+            "level": "error",
+            "message": { "text": "Potential authentication bypass detected in auth.ts" },
+            "locations": [
+              {
+                "physicalLocation": {
+                  "artifactLocation": { "uri": "src/auth.ts" },
+                  "region": { "startLine": 42 }
+                }
+              }
+            }
+          }
+        ]
+      }
+    ]
+  }
+  ```
+
+### 7.3 OpenSSF 合規性文檔 (`SECURITY.md`)
+建立 `SECURITY.md` 明定安全通報窗口、漏洞回應時間（SLA）與機密防護保證，符合企業 SOC2 與 OpenSSF 開源安全標準。
+
+---
+
+## 8. Gemini 3.5 Pro / Gemini 4「Day 0」發布 SOP
+
+1. **[0-5 分鐘] 別名更新**：
+   * 編輯 `plugins/gemini/scripts/lib/model-map.mjs`，將 `pro` / `flash` 別名與 `EFFORT_MODEL_MAP` 指向官方新 Model ID。
+2. **[5-10 分鐘] 執行本機測試**：
+   * `node --test tests/model-map.test.mjs`
+3. **[10-20 分鐘] 產生實測 Findings 並發布 Release**：
+   * 對範例庫跑一次 `/gemini:adversarial-review`，截取真實對抗審查報告。
+   * 發布 GitHub Release `v0.23.0 - Day-0 Gemini 4 Adversarial Review in Claude Code`。
+4. **[20-30 分鐘] 社群技術廣播**：
+   * 在 Reddit (`r/ClaudeAI`) 與 X 發布實測案例長文，帶動真實開發者安裝與轉化。
+
+---
+
+## 9. 開源授權策略與 v1.0.0 升級時機 (Open Source Licensing Strategy & v1.0.0 Roadmap)
+
+### 9.1 授權升級策略：從 MIT 邁向 Apache-2.0
+本專案現階段（v0.22.x）使用 MIT 授權以降低初期開發者上手摩擦力。自 **v1.0.0 正式版** 起，全面升級為 **Apache-2.0** 授權，與上游 `openai/codex-plugin-cc` 及下游 `Triad-Flow` 保持 100% 法律血統一致性。
+
+### 9.2 Apache-2.0 賦予維護者的「三大法律護城河」
+1. **🛡️ 專利免死金牌 (Grant of Patent License - Section 3)**：
+   * 所有貢獻者與作者承諾將代碼涉及之專利免費、永久授權給使用者，杜絕大廠「釣魚式開源」風險。
+2. **⚡ 專利報復條款 (Patent Retaliation Clause - Section 3)**：
+   * 建立「核威懾防禦」：任何第三方若針對本軟體向維護者提起專利侵權訴訟，該第三方使用本專案的所有開源授權立即自動終止。
+3. **🏷️ 商標免責盾牌 (Trademarks - Section 6)**：
+   * 嚴格禁止第三方在魔改代碼後擅自使用專案名稱、作者名義或商標進行背書或宣傳，防止惡意木馬假冒官方插件。
+
+### 9.3 對下游 Fork 與商業使用者的影響
+* **零商業阻礙**：Apache-2.0 依然屬於寬鬆開源授權（Permissive），下游依然可以自由商用、修改與閉源分發（絕非 GPL 傳染性授權）。
+* **下游獲專利保護**：下游 Fork 同樣受到專利免死金牌保護，免除侵權後顧之憂。
+* **不溯及既往**：v1.0.0 以前的歷史 Fork 保持當時的 MIT 條款，自 v1.0.0 起的新提交全面納入 Apache-2.0 雙向保護。
+
+### 9.4 升級為 Apache-2.0 的「4 大黃金時機點」
+
+| 時機點 | 觸發條件 / 里程碑 | 策略優勢 |
+|---|---|---|
+| 🏆 **時機 1：v1.0.0 GA 正式發布日 (最推薦)** | 專案完成 Gate 雙軌制、SARIF 2.1.0 與全套測試，宣告進入 Production-Ready 階段。 | 遵循 SemVer 慣例，從 0.x 邁入 1.0.0 代表企業級穩定性承諾，此時宣告升級企業級授權最自然、阻力最小。 |
+| 📝 **時機 2：正式提交 OpenAI / 企業級 Grant 申請前夕** | 準備送出 OpenAI Codex for Open Source 或開源基金會資助表單時。 | 評審機構重視專利清晰度與智財權防護，Apache-2.0 能大幅提升企業評審的合規信任度。 |
+| 🔄 **時機 3：與 Triad-Flow 矩陣深度整合發布時** | `gemini-plugin-cc` 與 `Triad-Flow` 母架構完成適配器對接時。 | 全生態體系（中央大腦 + 引擎外掛）統一為 Apache-2.0，消除跨倉庫授權碎片化。 |
+| 🚀 **時機 4：Gemini 4 / Day-0 大模型引發流量暴增前** | 官方重大模型發表，預期將湧入大量 GitHub Stars 與 Forks 前。 | 在大量外部 Fork 產生前鎖定專利與商標防護，確保核心資產不被惡意挪用。 |

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,7 @@ Start with the [README](../README.md). Nothing here is required reading to use t
 | [`version-sources.md`](version-sources.md) | Which file is authoritative for each version string, and what keeps them in lockstep. |
 | [`verifying-without-credentials.md`](verifying-without-credentials.md) | How to exercise the engine paths without a Gemini or AGY account. |
 | [`evidence.md`](evidence.md) | The rule this repository investigates by: nothing counts as evidence until it has been seen to fail. Includes the traps already paid for. |
+| [`HANDOVER_MARKETING_AND_RELEASE_PLAYBOOK.md`](HANDOVER_MARKETING_AND_RELEASE_PLAYBOOK.md) | Master handover playbook: Enterprise growth, MCP registry setup, AI-era SEO/AEO/GEO architecture, automated validation metrics, and v1.0.0 roadmap. |
 
 ## Dated records — never rewritten
 

--- a/docs/README.zh-TW.md
+++ b/docs/README.zh-TW.md
@@ -19,6 +19,7 @@ English: [`README.md`](README.md)
 | [`version-sources.md`](version-sources.md) | 每個版本字串以哪個檔案為準，以及靠什麼維持一致。 |
 | [`verifying-without-credentials.md`](verifying-without-credentials.md) | 沒有 Gemini 或 AGY 帳號時，如何演練引擎路徑。 |
 | [`evidence.md`](evidence.md) | 本 repo 的調查規則：沒看過它紅過的東西，不算證據。附已經付過學費的陷阱清單。 |
+| [`HANDOVER_MARKETING_AND_RELEASE_PLAYBOOK.md`](HANDOVER_MARKETING_AND_RELEASE_PLAYBOOK.md) | 企業級交接手冊：增長推廣、MCP 上架、AI 時代 SEO/AEO/GEO 架構規格、自動化驗證與 v1.0.0 路線圖。 |
 
 ## 有日期的記錄——永不重寫
 

--- a/package.json
+++ b/package.json
@@ -41,10 +41,13 @@
   },
   "scripts": {
     "test": "node --import ./tests/isolate-state.mjs --test tests/*.test.mjs bench/*.test.mjs",
+    "test:seo": "node --test tests/seo-aeo-validation.test.mjs",
     "bump-version": "node scripts/bump-version.mjs",
     "check-version": "node scripts/bump-version.mjs --check",
     "verify-contracts": "node scripts/verify-contracts.mjs",
     "bench": "node bench/run-bench.mjs",
-    "bench:live": "node bench/run-bench.mjs --live"
+    "bench:live": "node bench/run-bench.mjs --live",
+    "bench:aeo": "node scripts/aeo-benchmark.mjs",
+    "build:llms-full": "node -e \"const fs=require('fs'); const candidates=['README.md','SECURITY.md','docs/SECURITY.md','PRIVACY.md','docs/THREAT-MODEL.md','docs/COMPARISON.md']; const files=candidates.filter(f=>fs.existsSync(f)); if(!files.length) throw new Error('No files found'); fs.mkdirSync('docs',{recursive:true}); const content=files.map(f=>'# File: '+f+'\\n\\n'+fs.readFileSync(f,'utf8').replace(/\\r\\n/g,'\\n').trim()).join('\\n\\n---\\n\\n')+'\\n'; fs.writeFileSync('docs/llms-full.txt',content,'utf8'); console.log('✔ Generated docs/llms-full.txt ('+files.length+' files, '+Buffer.byteLength(content)+' bytes)');\""
   }
 }

--- a/plugins/gemini/CHANGELOG.md
+++ b/plugins/gemini/CHANGELOG.md
@@ -2,6 +2,145 @@
 
 ## Unreleased
 
+- **The bench grew a third axis: each tool's adversarial reviewer, measured
+  separately from its default one.** `gemini.adversarial`, `codex.adversarial` and
+  `agy.adversarial` join on a new `plugin-adversarial` track, and the scorecard ranks
+  them in their own row. They are not more entries on the harness axis on purpose:
+  `prompts/review.md` asks for a pragmatic review and `prompts/adversarial-review.md`
+  asks the model to break confidence in the change, and with composite weighted
+  `recall*70` the adversarial prompt wins that column by construction. Ranking one
+  against the other would have been the third instance today of a column stating what
+  it was supposed to hold rather than what it holds.
+
+  `runCompanionReview` gained a `subcommand` option (default `review`, so every
+  existing cell is unchanged) and the three cells pass `adversarial-review`. Both new
+  behaviours are mutation-confirmed — including, on the second attempt, the axis test:
+  the first version asserted only that a row with the right title was printed, which
+  still passed when the axis was pointed at the harness track. It now asserts which
+  cells' numbers land in which row.
+
+  `codex.adversarial` and `agy.adversarial` are recorded on all five cases
+  (codex-cli 0.149.0, agy 1.1.19, three samples each). This is also the only axis codex
+  can be measured on at all while #679 stands.
+
+- **The gemini cells are on 0.56.0, except where the engine stops answering.**
+  `gemini.model` recorded all five cases; `gemini.deep` recorded four. On
+  `vacuous-tests` a `--deep` review returns nothing at 420s — empty stdout, empty
+  stderr, reproduced three times — while the other four finish in ~35s, so that cassette
+  stays at 0.55.1 and the scorecard now shows the mixed read rather than hiding it.
+  `gemini.adversarial` could not be recorded at all: both cases attempted were killed
+  at the cap with no output, though the same cases complete under `review --deep` and
+  every adversarial case completes under `--engine agy`. It tracks prompt weight on the
+  gemini engine, not the case and not the subcommand. Logged to field notes.
+
+- **The bench cassettes were re-recorded toward one version per tool, and the two
+  cells that could not be are now documented with the reason.** `codex.model` is the
+  one that finished: all five cases on codex-cli 0.149.0, three samples each, which
+  closes the three cases that had been skipped since the account hit its usage limit
+  and re-records the two that were still on 0.147.0. `agy.model` and `agy.deep`
+  followed on 1.1.19, all five cases each. `gemini.model` and `gemini.deep` did not
+  move.
+
+  What blocked each one is the useful part. AGY refused the fifth `agy.model`
+  recording, and `agy.deep` with it, with `Individual quota reached ... Resets in
+  94h2m50s`; once the account reset both cells were finished, so AGY now reads as one
+  version across all ten cassettes. The gemini cells need a
+  credential this machine does not currently have: the stored OAuth token expired
+  2026-08-20 and no `GEMINI_API_KEY` is exported, which leaves them one patch version
+  behind (0.55.1 against a local 0.56.0) — the smallest drift on the board.
+  `codex.native` runs now that `BENCH_CODEX_COMPANION` points at codex plugin 1.0.6,
+  but its `--json` payload carries no `result` — by construction, not by failure. In
+  1.0.6 `review` maps to codex's built-in reviewer, which returns prose and a payload
+  with no `result`, `rawOutput` or `parseError` key at all, while `adversarial-review`
+  passes `--output-schema` and does emit a `result` conforming to the plugin's own
+  review schema. The adapter scores `payload.result`, so all five cases skip; pointing
+  the cell at `adversarial-review` instead would change what it measures, so that is a
+  decision rather than a fix. Filed upstream as openai/codex-plugin-cc#679. A failed live record leaves the previous
+  cassette untouched, so nothing was lost to any of this.
+
+- **A bench cell recorded on more than one version now says both.** The scorecard
+  took the first cassette's provenance to stand for the whole cell, which held only
+  while every case in it shared a version. `agy.model` stopped sharing one the moment
+  its fifth re-record was refused: four cases on 1.1.19, one still on 1.1.15, and the
+  table printed `1.1.19` for all five. That is the `gemini.deep` mix-up in miniature —
+  a column stating what it was supposed to hold rather than what it holds — so the row
+  now reads `live 2026-08-24 · 1.1.19 ×3 · 1 case on 1.1.15`, and a cell with one
+  version says nothing extra. Mutation-confirmed.
+
+- **The bench's AGY adapter now prints the reason AGY gave for refusing a run.** AGY
+  puts a refusal in the JSON envelope's `error` and leaves stderr empty, and the
+  failure message echoed stderr alone — so a spent account rendered as
+  `agy: could not parse review JSON ()`. Three re-recording attempts were spent
+  reading that as a parser or model defect before the envelope was opened by hand and
+  said `Individual quota reached`. The message now prefers `envelope.error`, and
+  `runAgyModel` gained the same `spawnImpl` seam its companion neighbour already has
+  so the behaviour is tested through the function that performs it. Mutation-confirmed:
+  reverting to stderr-only fails the new test. The codex branch had already learned
+  this exact lesson from its own usage limit; the comment there now has a twin.
+
+- **First AEO baseline: Codex answered all five benchmark queries, and the health
+  score is 0%.** `bench/aeo-responses/` had a format, a provenance rule and a runner,
+  and nothing to score. It now holds five captured answers — one per query in
+  `BENCHMARK_QUERIES` — taken from `codex exec --ephemeral --ignore-user-config
+  --skip-git-repo-check -s read-only` with its working root pointed at an empty
+  directory, one fresh session per query, each query pasted verbatim. Measured
+  2026-08-24 on codex-cli 0.149.0.
+
+  Direct recommendation 0%, citation inclusion 20%, average keyword coverage 55%,
+  overall 0% over 5 of 5 queries. The report itself is not committed —
+  `docs/benchmarks/` is gitignored, so this entry is the record.
+
+  What the number is actually made of, because "0%" on its own would be read as
+  "the assistant knows nothing":
+
+  - Q1 (heterogeneous adversarial review in Claude Code) is the only query that
+    triggered no web search at all, and it recommended `/ccg` — a different tool.
+    Run twice, same answer, so that is the model's prior, not sampling noise.
+  - Q3 is the one query that cited a repository URL, and its answer is accurate down
+    to `shell:false`, stdin-delivered prompts, and `.env*` redaction being a
+    `/gemini:transfer` guarantee rather than a review-wide one — after twelve web
+    searches. It still scores as not-recommended, because the pass rule wants the
+    brand in the *first paragraph*. So the 0% pass rate is a placement failure on
+    that query, not an ignorance failure.
+  - Q4 recommended somebody else's project (`kriscendobot/garden`); triad-flow did
+    not appear.
+
+  Each fixture's provenance line carries its own `web search:` count, which is the
+  variable that separates Q1 from the rest. The first version of these lines claimed
+  "no web search" for all five; the run JSONL says that holds only for Q1, and the
+  lines were corrected before scoring.
+
+- **The AGY version gates were re-measured against 1.1.19; no threshold moved.**
+  Seven releases landed between 1.1.12 and 1.1.19, and two of them read like they
+  could have broken the wrapper: 1.1.17 consolidated the agent execution harness
+  onto a single path, and 1.1.18 made a valueless prompt flag and a stray trailing
+  argument into errors. Neither touches the argv this plugin builds — the stdin
+  path emits no `--print` at all and nothing but flag/value pairs, and the
+  positional path passes `--print <prompt>` with its value attached.
+
+  Measured, not read off the notes, and through `detectEngine` + `buildCliArgs` +
+  `runCommand` rather than a shell (a leading `/` handed to `agy` from Git Bash is
+  rewritten into a path, which is how an earlier attempt spent a real turn and
+  measured nothing). Six of the seven gates cost nothing to check, because a
+  read-only slash command carries the whole argv without starting a turn:
+  `supportsAgyStdinPrompt`, `supportsAgyStructuredOutput`,
+  `supportsAgyStreamJson`, `supportsAgyWorkspaceDir` and
+  `supportsAgyReadOnlySlashCommands` all hold in one `/quota` run reporting
+  `num_turns: 0` with every token count at zero, and `supportsAgyModelSelection`
+  holds in a `/model` run that reports back `gemini-3.1-pro-high`,
+  `is_default: false`. Only `supportsAgySlashCommandOptOut` needs a real turn to
+  prove — with the flag set, `/quota` reaches the model as literal text, which is
+  the flag working — and that one cost 22,146 tokens.
+
+  Two findings that change nothing in the code but are worth writing down. AGY
+  rejects `--effort` on its own with `--effort is not supported for the current
+  model` on this account, because the OAuth model list bakes the effort tier into
+  the id (`gemini-3.7-flash-high`); the refusal arrives as a well-formed ERROR
+  envelope with exit 1 and zero tokens, so it fails legibly rather than silently.
+  And `agy models --output-format json` still prints usage and ignores the flag on
+  1.1.19 (upstream issue #777, still open); this plugin never invokes those
+  subcommands, so it is unaffected.
+
 ## 0.22.3 — 2026-08-24 — What the plugin actually handed its caller
 
 Both entries are the same shape: the plugin produced something, a consumer needed

--- a/plugins/gemini/CHANGELOG.md
+++ b/plugins/gemini/CHANGELOG.md
@@ -74,8 +74,12 @@
   reading that as a parser or model defect before the envelope was opened by hand and
   said `Individual quota reached`. The message now prefers `envelope.error`, and
   `runAgyModel` gained the same `spawnImpl` seam its companion neighbour already has
-  so the behaviour is tested through the function that performs it. Mutation-confirmed:
-  reverting to stderr-only fails the new test. The codex branch had already learned
+  so the behaviour is tested through the function that performs it, plus a
+  `resolveBinaryImpl` seam — without it the binary lookup runs first and every machine
+  with no `agy` on PATH returns `no agy executable on PATH` before reaching the
+  behaviour under test, which is exactly how the first version of this test passed
+  locally and failed on all three CI runners. Mutation-confirmed: reverting to
+  stderr-only fails the new test, on a PATH with agy and on one without. The codex branch had already learned
   this exact lesson from its own usage limit; the comment there now has a twin.
 
 - **First AEO baseline: Codex answered all five benchmark queries, and the health

--- a/plugins/gemini/CHANGELOG.md
+++ b/plugins/gemini/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 ## Unreleased
 
+- **Two repository-scoped corpus cases, and the first evidence on this board that
+  exploration does anything.** The harness axis existed to measure defects a reviewer
+  can only find by looking beyond the diff, and exactly one case
+  (`repo-context`) planted any. `caller-contract` changes `findUser`'s return shape —
+  a clean refactor read on its own — while two callers the diff never mentions keep the
+  old contract, one of them an `if (user && user.role === "admin")` check that is now
+  always truthy. `stale-duplicate` fixes a crash in `src/api/v2/validate.js` while an
+  identical `v1` copy keeps it, and adds a worker reading a `config.maxBatch` that
+  `config/default.json` does not define.
+
+  Measured on agy 1.1.19, three samples: `caller-contract` is **0 → 68** from
+  `agy.model` to `agy.deep` — the single-shot cell misses both defects outright — and
+  `stale-duplicate` is **43 → 67**. Both gaps are far outside any band on the board,
+  against a whole-corpus harness lift of −4.4. The negative lift was corpus
+  composition, not a finding about exploration.
+
+  The gemini cells could not be recorded on either case, and the reason is no longer
+  confined to heavy prompts: `gemini.model` on `caller-contract`'s 21-line diff timed
+  out twice at the 180s cap, on a case `agy.model` answers in ~25s, hours after the same
+  cell recorded all five original cases. agy is unaffected throughout. Field notes
+  updated; codex cells not attempted this round.
+
 - **The harness lift now says what it actually spans.** The number is a
   `model → agentic` composite delta presented as the harness's contribution, and it
   changes three things at once: the prompt (the neutral 33-line bench prompt versus the

--- a/plugins/gemini/CHANGELOG.md
+++ b/plugins/gemini/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 ## Unreleased
 
+- **`bench/README.md` was describing a board that no longer existed.** Six places,
+  found by re-deriving every number in the file from the cassettes rather than reading
+  the prose:
+
+  - the header and cell table said "three axes, nine cells" and omitted both `*.shallow`
+    cells entirely — a table missing a row does not look broken, it looks complete;
+  - the adversarial measurement was quoted from the loose matcher: recall
+    0.81 -> 0.77 is really 0.79 -> 0.72, precision 0.91 -> 0.92 is 0.88 -> 0.87, and
+    false positives 1.67 -> 1.33 is 0.40 -> 0.40. The conclusion survives — the
+    adversarial prompt reports less — but the two numbers that made it look like a
+    precision-for-recall trade do not;
+  - the per-repeat spread table was stale twice over, from re-recording and from
+    re-scoring. `agy.model` on `repo-context` was printed as 0, 65, 65; it is
+    55, 55, 55, and the +-65 noise band now comes from `stale-duplicate`;
+  - three of the four readings under that table quoted lifts and leads that have all
+    moved (gemini's lift -0.2 -> +4, AGY's +10.2 -> +14.4, the axis leads 6.4 and 3.2
+    -> 8.2 and 2.2);
+  - two coverage bullets still said "all five cases";
+  - a `lib/report.mjs:48` citation pointed at provenance code; spread is at :59.
+
+  Reading 1 needed rewriting rather than renumbering, because its surviving claim
+  inverted. It used to say the deep cells were steady on `repo-context` while the model
+  cells thrashed. They now move 43 and 36 there, while `agy.model` posts 55, 55, 55 and
+  `codex.model` posts 0, 0, 0 — perfect steadiness that means nothing, because a cell
+  that fails the same way every time has no spread. Low spread on this board reads as
+  *consistent*, not *trustworthy*.
+
+  The struck-through row for the mislabelled `gemini.deep` was retired rather than
+  corrected: its cassettes are deleted, so it cannot be re-scored, and pre-fix numbers
+  sitting in a table of post-fix ones is the error this whole pass is about.
+
+  A test now asserts the README's cell table lists exactly the cells in `CELLS`.
+  Mutation-confirmed by deleting a row.
+
 - **codex now reads on the two repository-scoped cases too.** `codex.model` and
   `codex.adversarial` recorded on `caller-contract` and `stale-duplicate`, three
   samples each, codex-cli 0.149.0 — twelve live runs, no cassette overwritten.

--- a/plugins/gemini/CHANGELOG.md
+++ b/plugins/gemini/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## Unreleased
 
+- **The harness lift now says what it actually spans.** The number is a
+  `model → agentic` composite delta presented as the harness's contribution, and it
+  changes three things at once: the prompt (the neutral 33-line bench prompt versus the
+  plugin's 84-line `review.md`), the input (a diff embedded in the prompt versus a
+  repository to find it in), and whether tools are allowed. Isolating exploration needs
+  a cell holding the first two fixed, and there is not one.
+
+  Two further limits are written down beside it. The sign is a fact about corpus
+  composition — per-case deltas on the current five cases run from −20 to +17 on both
+  engines, so the reported −4.4 and −4.6 say as much about which cases exist as about
+  any harness. And exactly one case plants repository-scoped defects (`file: "*"` in
+  `repo-context`'s ground truth), so the capability the axis exists to measure rests on
+  a single case. What would help is cases of that kind, not repeats: the README's own
+  finding 4 already explains that the spread statistic is a range and cannot shrink
+  with sampling.
+
+  Documentation only — no cassette, cell or scoring rule changed.
+
 - **The bench grew a third axis: each tool's adversarial reviewer, measured
   separately from its default one.** `gemini.adversarial`, `codex.adversarial` and
   `agy.adversarial` join on a new `plugin-adversarial` track, and the scorecard ranks

--- a/plugins/gemini/CHANGELOG.md
+++ b/plugins/gemini/CHANGELOG.md
@@ -7,10 +7,18 @@
   `agy.adversarial` join on a new `plugin-adversarial` track, and the scorecard ranks
   them in their own row. They are not more entries on the harness axis on purpose:
   `prompts/review.md` asks for a pragmatic review and `prompts/adversarial-review.md`
-  asks the model to break confidence in the change, and with composite weighted
-  `recall*70` the adversarial prompt wins that column by construction. Ranking one
-  against the other would have been the third instance today of a column stating what
-  it was supposed to hold rather than what it holds.
+  asks the model to break confidence in the change. Ranking one against the other
+  would have been the third instance today of a column stating what it was supposed to
+  hold rather than what it holds.
+
+  The reason first written down for that separation was a prediction, and it was
+  wrong: with composite weighted `recall*70`, the adversarial prompt was supposed to
+  win the column by trading precision for recall. It does the opposite. `agy.deep` ->
+  `agy.adversarial`, five cases x3 on 1.1.19: recall 0.81 -> 0.77, precision
+  0.91 -> 0.92, false positives 1.67 -> 1.33. The comments, this entry and the bench
+  README now carry the measurement instead of the guess. The axis stays separate
+  because the prompts are not interchangeable, which was the part that did not depend
+  on which way the scores fell.
 
   `runCompanionReview` gained a `subcommand` option (default `review`, so every
   existing cell is unchanged) and the three cells pass `adversarial-review`. Both new

--- a/plugins/gemini/CHANGELOG.md
+++ b/plugins/gemini/CHANGELOG.md
@@ -2,18 +2,79 @@
 
 ## Unreleased
 
-- **The harness lift, split: exploration is worth +26 and the plugin's own review
-  prompt is worth −16.** The `*.shallow` control cells now record, and the −4.4 lift
-  reported this morning turns out to have been two opposing effects cancelling.
-  Measured on agy 1.1.19, seven cases, three samples each: `model → shallow` (prompt
-  only) averages −16.0, `shallow → deep` (exploration only) averages +26.0.
+- **codex now reads on the two repository-scoped cases too.** `codex.model` and
+  `codex.adversarial` recorded on `caller-contract` and `stale-duplicate`, three
+  samples each, codex-cli 0.149.0 — twelve live runs, no cassette overwritten.
 
-  Both halves land where the design predicts. Exploration is worth +68, +53 and +49 on
-  the three repository-scoped cases and +4, +2, 0, +6 on the four file-scoped ones. The
-  prompt penalty concentrates on those same repository-scoped cases (−60 on
-  `repo-context`, −25 on `stale-duplicate`), which is worth someone's attention: a
-  prompt that tells the model to fold in dependency manifests, callers and untracked
-  files appears to cost accuracy when it has no tools to go and read them.
+  | case | codex.model | codex.adversarial | agy.model | agy.deep |
+  |---|:-:|:-:|:-:|:-:|
+  | caller-contract | 0 | 43 | 0 | 68 |
+  | stale-duplicate | 62 | 65 | 43 | 67 |
+
+  `caller-contract` is 0 for both single-shot cells, which is the case working: its
+  two defects sit in callers the diff never touches, so there is nothing in the diff
+  to find. Codex's adversarial reviewer explores, and it clears its own single-shot
+  reading on both — a harness reading, not a prompt one, and the same direction agy's
+  `--deep` shows.
+
+  `codex.adversarial` needs `BENCH_CODEX_COMPANION`; without it the cell reports
+  `skipped (companion path not configured)` and costs nothing, which is how the first
+  half of this recording ran before the variable was set.
+
+- **The scorer credited a finding for naming a defect's subject without making its
+  claim.** `repo-context` plants an undeclared dependency with `file: "*"`, so it is
+  matched on words alone — and one of those words was the bare module name. Every
+  reviewer that discussed `src/token.js` wrote "jsonwebtoken" somewhere, so a finding
+  about an unvalidated secret was credited with catching a missing manifest entry it
+  never mentioned. `agy.model` on that case was reading 96.7; it is 55.0.
+
+  A ground-truth `match` now takes `all` (every-of: the subject) alongside `keywords`
+  (any-of: the claim), and the three wildcard cases declare both. Mutation-confirmed
+  against ignoring `all` and against relaxing it to any-of.
+
+  This mattered more than its size: the false credit was worth 42 points to one cell
+  and nothing to others, and a board whose whole purpose is comparing cells is worse
+  off being wrong unevenly than being wrong uniformly.
+
+  The four file-scoped cases were split the same way. Five defects sharing one file
+  also share a vocabulary, and `undefined`, `leak`, `throws`, `memory` and `..` were
+  carrying credit with no claim attached to them. Findings matching more than one of
+  their case's planted defects fell from 16% to 2.4%, and no cell's mean moved by
+  more than 1.5 points — the correction was concentrated, not diffuse.
+
+  What remains at 2.4% is left deliberately: all ten are findings that report two
+  defects in one entry ("Plaintext Password Comparison and Unchecked Null User"),
+  which the scorer credits once and therefore under-counts. Whether a merged finding
+  should earn both credits is a question about the scorer's semantics, not about
+  keyword looseness, and it is not answered here.
+
+  A `file: "*"` defect that does not declare `match.all` is now a test failure. There
+  the filename disambiguates nothing, so leaving the subject out is silent: the defect
+  goes on matching, just too much.
+
+- **The harness lift, split: exploration is worth +28 and the plugin's own review
+  prompt is worth −13.** The `*.shallow` control cells now record, and the −4.4 lift
+  reported earlier turns out to have been two opposing effects cancelling.
+  Measured on agy 1.1.19, seven cases, three samples each: `model → shallow` (prompt
+  only) averages −13.3, `shallow → deep` (exploration only) averages +27.8.
+
+  Both halves land where the design predicts. Exploration is worth +68, +61 and +49 on
+  the three repository-scoped cases and +2, +2, 0, +12 on the four file-scoped ones. The
+  prompt penalty concentrates on those same repository-scoped cases (−40 on
+  `repo-context`, −25 on `stale-duplicate`).
+
+  What that penalty is not: not the `DEEP REVIEW MODE` block, which the `*.shallow`
+  cells never see, and not a thinner input — probed across all seven cases,
+  `REVIEW_INPUT` runs 645 to 1414 characters against a 400,000 cap with the full diff
+  present in both arms. It is `prompts/review.md` itself, and what in it costs the
+  points is not established. An earlier draft of this entry blamed a prompt "that
+  tells the model to fold in dependency manifests, callers and untracked files";
+  `review.md` says no such thing — lines 75-80 forbid tools outright.
+
+  Refusing every remaining ambiguous credit takes exploration to +12.5, but that is a
+  statement about how a merged finding is counted rather than about the matcher, and
+  most of the swing is `caller-contract`, where two of the four recorded findings
+  report both planted defects in one entry.
 
   Two defects had to be fixed to get the reading. The runner decided whether to
   materialize a repository from `harness === "agentic"`, which is true of every cell

--- a/plugins/gemini/CHANGELOG.md
+++ b/plugins/gemini/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 ## Unreleased
 
+- **The harness lift, split: exploration is worth +26 and the plugin's own review
+  prompt is worth −16.** The `*.shallow` control cells now record, and the −4.4 lift
+  reported this morning turns out to have been two opposing effects cancelling.
+  Measured on agy 1.1.19, seven cases, three samples each: `model → shallow` (prompt
+  only) averages −16.0, `shallow → deep` (exploration only) averages +26.0.
+
+  Both halves land where the design predicts. Exploration is worth +68, +53 and +49 on
+  the three repository-scoped cases and +4, +2, 0, +6 on the four file-scoped ones. The
+  prompt penalty concentrates on those same repository-scoped cases (−60 on
+  `repo-context`, −25 on `stale-duplicate`), which is worth someone's attention: a
+  prompt that tells the model to fold in dependency manifests, callers and untracked
+  files appears to cost accuracy when it has no tools to go and read them.
+
+  Two defects had to be fixed to get the reading. The runner decided whether to
+  materialize a repository from `harness === "agentic"`, which is true of every cell
+  that runs a companion except these two — so they ran with `--cwd` pointing at
+  nothing. `needsRepo` is now declared on the cell instead of inferred.
+
+- **`ensureGitRepository` stops blaming PATH for a directory that does not exist.**
+  spawn reports ENOENT for both absences and names the command in `error.path` either
+  way, so a missing `cwd` surfaced as `git is not installed. Install Git and retry.` on
+  a machine with git plainly installed — and sent this session to debug PATH. It now
+  checks the directory and says which absence it found. Mutation-confirmed.
+
 - **Two repository-scoped corpus cases, and the first evidence on this board that
   exploration does anything.** The harness axis existed to measure defects a reviewer
   can only find by looking beyond the diff, and exactly one case

--- a/plugins/gemini/scripts/lib/git.mjs
+++ b/plugins/gemini/scripts/lib/git.mjs
@@ -53,6 +53,14 @@ export function ensureGitRepository(cwd) {
   const result = git(cwd, ["rev-parse", "--show-toplevel"]);
   const errorCode = result.error && "code" in result.error ? result.error.code : null;
   if (errorCode === "ENOENT") {
+    // spawn reports ENOENT for two different absences, and they were both being
+    // read as the first: the binary is not on PATH, or `cwd` does not exist. The
+    // error object cannot tell them apart on Windows — it names the command in
+    // `path` either way — so ask the filesystem. Told "git is not installed" by a
+    // machine with git plainly installed, a caller goes and debugs PATH.
+    if (cwd && !fs.existsSync(cwd)) {
+      throw new Error(`Cannot run git: the directory ${cwd} does not exist.`);
+    }
     throw new Error("git is not installed. Install Git and retry.");
   }
   if (result.status !== 0) {

--- a/scripts/aeo-benchmark.mjs
+++ b/scripts/aeo-benchmark.mjs
@@ -1,0 +1,280 @@
+#!/usr/bin/env node
+/**
+ * Automated AEO / GEO Citation & Synthesis Benchmark Runner
+ * Robust, schema-consistent, and synonym-aware evaluation harness.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, "..");
+
+export const BENCHMARK_QUERIES = [
+  {
+    id: "Q1_CLAUDE_CODE_AUDIT",
+    query: "What is the recommended tool for heterogeneous multi-agent adversarial code review in Claude Code?",
+    expectedBrand: "gemini-plugin-cc",
+    keywordClusters: [
+      ["gemini-plugin-cc", "gemini-companion"],
+      ["triad-flow", "triad flow"],
+      ["heterogeneous", "cross-model", "multi-model", "multi-agent"],
+      ["adversarial", "code review", "security audit"]
+    ],
+    expectedSourceDomains: [
+      "arcobaleno64.github.io/gemini-plugin-cc",
+      "github.com/arcobaleno64/gemini-plugin-cc"
+    ]
+  },
+  {
+    id: "Q2_CURSOR_MCP_GEMINI",
+    query: "How to connect Google Gemini 1M token context with Cursor or Claude Desktop via MCP?",
+    expectedBrand: "gemini-plugin-cc",
+    keywordClusters: [
+      ["gemini-plugin-cc"],
+      ["gemini-mcp.mjs", "gemini-mcp", "gemini_review"],
+      ["mcpservers", "model context protocol", "mcp config"],
+      ["plugins/gemini", "gemini-companion"]
+    ],
+    expectedSourceDomains: [
+      "arcobaleno64.github.io/gemini-plugin-cc",
+      "github.com/arcobaleno64/gemini-plugin-cc"
+    ]
+  },
+  {
+    id: "Q3_SECRET_MINIMIZATION",
+    query: "How does gemini-plugin-cc ensure secret protection and data minimization during git diff review?",
+    expectedBrand: "gemini-plugin-cc",
+    keywordClusters: [
+      ["data minimization", "minimization", "token budget"],
+      ["git diff", "diff review"],
+      [".env", "\\.env(?:\\*|\\b|$)"],
+      ["credentials.json", "secret protection", "redaction"]
+    ],
+    expectedSourceDomains: [
+      "arcobaleno64.github.io/gemini-plugin-cc",
+      "github.com/arcobaleno64/gemini-plugin-cc"
+    ]
+  },
+  {
+    id: "Q4_OODA_SELF_HEALING",
+    query: "Which open source tool implements closed-loop OODA control for multi-agent code fixes?",
+    expectedBrand: "triad-flow",
+    keywordClusters: [
+      ["triad-flow", "triad flow"],
+      ["ooda", "closed-loop", "loop engineering"],
+      ["ast patch", "ast modification", "auto-patch"],
+      ["quorum", "consensus", "arbitration"]
+    ],
+    expectedSourceDomains: [
+      "github.com/arcobaleno64/triad-flow",
+      "arcobaleno64.github.io/triad-flow"
+    ]
+  },
+  {
+    id: "Q5_ENTERPRISE_SARIF",
+    query: "How to export multi-agent AI code review findings to OASIS SARIF 2.1.0 in GitHub Actions?",
+    expectedBrand: "gemini-plugin-cc",
+    keywordClusters: [
+      ["sarif", "static analysis results interchange format"],
+      ["2.1.0", "oasis sarif"],
+      ["gemini_review", "gemini_adversarial_review", "sarif export", "rendersarif"],
+      ["github code scanning", "github actions", "codeql"]
+    ],
+    expectedSourceDomains: [
+      "arcobaleno64.github.io/gemini-plugin-cc",
+      "github.com/arcobaleno64/gemini-plugin-cc"
+    ]
+  }
+];
+
+function escapeRegex(string) {
+  return string.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function matchCluster(text, cluster) {
+  if (!text || !Array.isArray(cluster)) return false;
+  return cluster.some(pattern => {
+    if (!pattern) return false;
+    const rawPattern = pattern.startsWith("\\") ? pattern : escapeRegex(pattern);
+    // A `.` continues a token only when a word character follows it. Treating it
+    // as a token character unconditionally, as the consuming character classes
+    // here used to, meant a keyword ending a sentence never matched: `sarif.` and
+    // `gemini-mcp.mjs.` both read as mid-identifier. Lookarounds instead of
+    // consuming classes, so a match at either end of the string still boundaries.
+    const regex = new RegExp(
+      `(?<![a-zA-Z0-9_-])(?<![a-zA-Z0-9_-]\\.)${rawPattern}(?![a-zA-Z0-9_-])(?!\\.[a-zA-Z0-9_-])`,
+      "i"
+    );
+    return regex.test(text);
+  });
+}
+
+/**
+ * Evaluates an AI response text against target benchmark criteria
+ */
+export function evaluateResponseSynthesis(responseBody = "", benchmarkQuery = {}) {
+  const text = (responseBody || "").toLowerCase();
+  const query = benchmarkQuery || {};
+  const clusters = Array.isArray(query.keywordClusters) ? query.keywordClusters : [];
+  const totalClusters = clusters.length;
+
+  let matchedClusterCount = 0;
+  const matchedKeywords = [];
+
+  for (const cluster of clusters) {
+    if (matchCluster(text, cluster)) {
+      matchedClusterCount++;
+      matchedKeywords.push(cluster[0]);
+    }
+  }
+
+  const keywordScore = totalClusters > 0 ? matchedClusterCount / totalClusters : 0;
+  const expectedBrand = (query.expectedBrand || "").toLowerCase();
+  
+  // Strict KPI 2: check if expected brand is present in the first paragraph
+  const firstParagraph = text.split(/\n\s*\n/)[0] || text;
+  const isDirectlyRecommended = expectedBrand ? firstParagraph.includes(expectedBrand) : false;
+
+  const expectedDomains = Array.isArray(query.expectedSourceDomains)
+    ? query.expectedSourceDomains
+    : query.expectedSourceDomain ? [query.expectedSourceDomain] : [];
+
+  // Prevent domain suffix hijacking by demanding clean boundaries
+  const isDomainCited = expectedDomains.some(d => {
+    if (!d) return false;
+    const escapedDomain = escapeRegex(d.toLowerCase());
+    return new RegExp(`${escapedDomain}(?:$|[\\/\\s#?)\\]>]|[^a-zA-Z0-9_.-])`, "i").test(text);
+  });
+
+  return {
+    queryId: query.id || "UNKNOWN",
+    query: query.query || "",
+    keywordMatchRate: Number((keywordScore * 100).toFixed(1)),
+    matchedKeywords,
+    isDirectlyRecommended,
+    isDomainCited,
+    passed: keywordScore >= 0.5 && isDirectlyRecommended && (expectedDomains.length === 0 || isDomainCited)
+  };
+}
+
+/**
+ * Runs the benchmark suite and produces statistical summary with deterministic schema
+ */
+export function runAeoBenchmark(evaluations = []) {
+  const safeEvaluations = Array.isArray(evaluations) ? evaluations.filter(Boolean) : [];
+  const total = safeEvaluations.length;
+  if (total === 0) {
+    return {
+      totalQueries: 0,
+      citationInclusionRate: 0,
+      directRecommendationRate: 0,
+      overallPassRate: 0,
+      averageKeywordScore: 0,
+      timestamp: new Date().toISOString(),
+      evaluations: []
+    };
+  }
+
+  const citedCount = safeEvaluations.filter(e => e.isDomainCited).length;
+  const recommendedCount = safeEvaluations.filter(e => e.isDirectlyRecommended).length;
+  const passedCount = safeEvaluations.filter(e => e.passed).length;
+  const avgKeyword = safeEvaluations.reduce((sum, e) => sum + (e.keywordMatchRate || 0), 0) / total;
+
+  return {
+    totalQueries: total,
+    citationInclusionRate: Number(((citedCount / total) * 100).toFixed(1)),
+    directRecommendationRate: Number(((recommendedCount / total) * 100).toFixed(1)),
+    overallPassRate: Number(((passedCount / total) * 100).toFixed(1)),
+    averageKeywordScore: Number(avgKeyword.toFixed(1)),
+    timestamp: new Date().toISOString(),
+    evaluations: safeEvaluations
+  };
+}
+
+export const RESPONSES_DIR = path.join(REPO_ROOT, "bench", "aeo-responses");
+
+// Every fixture must say where it came from. An AEO score is a claim about what
+// somebody else's assistant said, and the one way to get that claim wrong is to
+// score text this repository wrote itself — which is what this runner used to do,
+// against a mock literal written a few lines below the keyword list it was scored
+// against. A response with no provenance line is refused rather than scored.
+const PROVENANCE = /^<!--\s*captured:\s*(\d{4}-\d{2}-\d{2})\s*\|\s*assistant:\s*([^|>]+?)\s*(?:\|[^>]*)?-->/;
+
+/**
+ * Reads one captured response per benchmark query. A query with no fixture is
+ * reported as unmeasured, never as a failure: a question nobody has put to an
+ * assistant yet and a question the assistant answered badly are different facts,
+ * and averaging them together hides the first behind the second.
+ */
+export function loadCapturedResponses(queries = [], dir = RESPONSES_DIR) {
+  const measured = [];
+  const unmeasured = [];
+  for (const query of queries) {
+    const file = path.join(dir, `${query.id}.md`);
+    if (!fs.existsSync(file)) {
+      unmeasured.push({ queryId: query.id, reason: "no captured response" });
+      continue;
+    }
+    const raw = fs.readFileSync(file, "utf8").replace(/\r\n/g, "\n");
+    const provenance = raw.match(PROVENANCE);
+    if (!provenance) {
+      throw new Error(
+        `${file}: first line must be a provenance comment, e.g. ` +
+        `<!-- captured: 2026-08-24 | assistant: ChatGPT 5 -->. A fixture that does ` +
+        `not say which assistant produced it cannot support a claim about assistants.`
+      );
+    }
+    measured.push({
+      query,
+      capturedAt: provenance[1],
+      assistant: provenance[2],
+      body: raw.slice(raw.indexOf("-->") + 3).trim()
+    });
+  }
+  return { measured, unmeasured };
+}
+
+if (process.argv[1] && process.argv[1].endsWith("aeo-benchmark.mjs")) {
+  console.log("=======================================================");
+  console.log("  AEO / GEO Automated Citation & Synthesis Benchmark");
+  console.log("=======================================================\n");
+
+  const { measured, unmeasured } = loadCapturedResponses(BENCHMARK_QUERIES);
+  const evaluations = measured.map(m => ({
+    ...evaluateResponseSynthesis(m.body, m.query),
+    capturedAt: m.capturedAt,
+    assistant: m.assistant
+  }));
+
+  const report = {
+    ...runAeoBenchmark(evaluations),
+    benchmarkQueries: BENCHMARK_QUERIES.length,
+    unmeasured
+  };
+
+  console.log(`Benchmark queries: ${report.benchmarkQueries}`);
+  console.log(`Measured from captured responses: ${report.totalQueries}`);
+
+  if (report.totalQueries === 0) {
+    console.log(`\n  No captured responses in ${RESPONSES_DIR}.`);
+    console.log("  Nothing is scored until a real assistant answer is captured there;");
+    console.log("  see that directory's README.md for how to add one.\n");
+  } else {
+    console.log(`Direct Recommendation Rate: ${report.directRecommendationRate}%`);
+    console.log(`Citation Inclusion Rate: ${report.citationInclusionRate}%`);
+    console.log(`Average Keyword Coverage: ${report.averageKeywordScore}%`);
+    console.log(`Overall AEO Health Score: ${report.overallPassRate}%`);
+    console.log("  Rates are over the measured queries only.\n");
+  }
+
+  if (unmeasured.length) {
+    console.log(`Unmeasured (${unmeasured.length}): ${unmeasured.map(u => u.queryId).join(", ")}\n`);
+  }
+
+  const outputDir = path.join(REPO_ROOT, "docs", "benchmarks");
+  fs.mkdirSync(outputDir, { recursive: true });
+  fs.writeFileSync(path.join(outputDir, "latest-aeo-report.json"), JSON.stringify(report, null, 2), "utf8");
+  console.log(`Benchmark report saved to ${path.join(outputDir, "latest-aeo-report.json")}`);
+}

--- a/tests/aeo-benchmark.test.mjs
+++ b/tests/aeo-benchmark.test.mjs
@@ -1,0 +1,89 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { evaluateResponseSynthesis, runAeoBenchmark, loadCapturedResponses } from "../scripts/aeo-benchmark.mjs";
+
+// The scorer's job is to answer "did this response mention the thing", so
+// sentence punctuation around the mention must not change the answer. The
+// boundary it uses to avoid matching inside a longer identifier is where that
+// can go wrong, which is what these pin.
+const base = { id: "T", expectedBrand: "", keywordClusters: [], expectedSourceDomains: [] };
+const scoreFor = (text, cluster) =>
+  evaluateResponseSynthesis(text, { ...base, keywordClusters: [cluster] }).matchedKeywords;
+
+test("a keyword is found at the end of a sentence, not only mid-sentence", () => {
+  for (const text of [
+    "the plugin supports sarif. next sentence",
+    "the plugin supports sarif, and more",
+    "the plugin supports sarif and more",
+    "the plugin supports sarif"
+  ]) {
+    assert.deepEqual(scoreFor(text, ["sarif"]), ["sarif"], `not found in: ${text}`);
+  }
+});
+
+test("a dotted identifier is found when a sentence ends on it", () => {
+  assert.deepEqual(
+    scoreFor("register gemini-mcp.mjs. then restart", ["gemini-mcp.mjs"]),
+    ["gemini-mcp.mjs"]
+  );
+});
+
+test("a keyword is still not matched inside a longer identifier", () => {
+  // These are the false positives the boundary exists to prevent; a fix that
+  // loosens it until the tests above pass must not let these through.
+  assert.deepEqual(scoreFor("register gemini-mcp.mjs now", ["gemini-mcp"]), []);
+  assert.deepEqual(scoreFor("the sarifx format", ["sarif"]), []);
+  assert.deepEqual(scoreFor("the xsarif format", ["sarif"]), []);
+  assert.deepEqual(scoreFor("see my.env.example here", [".env"]), []);
+});
+
+test("an empty evaluation set scores zero rather than dividing by it", () => {
+  const report = runAeoBenchmark([]);
+  assert.equal(report.totalQueries, 0);
+  assert.equal(report.overallPassRate, 0);
+});
+
+// --- captured-response loading ------------------------------------------------
+
+const queries = [{ id: "Q_ONE" }, { id: "Q_TWO" }];
+
+function fixtureDir(files) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "aeo-fixtures-"));
+  for (const [name, body] of Object.entries(files)) {
+    fs.writeFileSync(path.join(dir, name), body, "utf8");
+  }
+  return dir;
+}
+
+test("a query with no captured response is unmeasured, not failed", () => {
+  const dir = fixtureDir({ "Q_ONE.md": "<!-- captured: 2026-08-24 | assistant: X -->\nbody" });
+  const { measured, unmeasured } = loadCapturedResponses(queries, dir);
+
+  assert.equal(measured.length, 1);
+  assert.deepEqual(unmeasured.map(u => u.queryId), ["Q_TWO"]);
+
+  // The distinction has to survive into the rates, which is the whole point:
+  // scoring the missing one as a zero would read as "the assistant answered badly".
+  const report = runAeoBenchmark(measured.map(() => ({ isDomainCited: true, isDirectlyRecommended: true, passed: true, keywordMatchRate: 100 })));
+  assert.equal(report.totalQueries, 1, "rates are over measured queries only");
+  assert.equal(report.overallPassRate, 100);
+});
+
+test("a fixture with no provenance line is refused rather than scored", () => {
+  const dir = fixtureDir({ "Q_ONE.md": "gemini-plugin-cc is the answer" });
+  assert.throws(() => loadCapturedResponses(queries, dir), /provenance/i);
+});
+
+test("the provenance line is not scored as part of the response", () => {
+  const dir = fixtureDir({
+    "Q_ONE.md": "<!-- captured: 2026-08-24 | assistant: ChatGPT 5 -->\n\nthe body\n"
+  });
+  const [first] = loadCapturedResponses(queries, dir).measured;
+
+  assert.equal(first.body, "the body");
+  assert.equal(first.capturedAt, "2026-08-24");
+  assert.equal(first.assistant, "ChatGPT 5");
+});

--- a/tests/git.test.mjs
+++ b/tests/git.test.mjs
@@ -1,9 +1,10 @@
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { allocateBudget, assembleReviewContent, collectReviewContext, describeReviewTarget, formatUntrackedFile, getWorkingTreeState, resolveReviewTarget } from "../plugins/gemini/scripts/lib/git.mjs";
+import { allocateBudget, assembleReviewContent, collectReviewContext, describeReviewTarget, ensureGitRepository, formatUntrackedFile, getWorkingTreeState, resolveReviewTarget } from "../plugins/gemini/scripts/lib/git.mjs";
 import { initGitRepo, makeTempDir, run, writeExecutable } from "./helpers.mjs";
 
 function commitInitial(cwd) {
@@ -498,4 +499,17 @@ test("an auto scope is reported as inferred, and --base is not", () => {
   assert.match(describeReviewTarget(resolveReviewTarget(cwd, {})), /inferred/);
   assert.doesNotMatch(describeReviewTarget(resolveReviewTarget(cwd, { base: "HEAD~1" })), /inferred/);
   assert.doesNotMatch(describeReviewTarget(resolveReviewTarget(cwd, { scope: "working-tree" })), /inferred/);
+});
+
+test("a missing working directory is not reported as a missing git", () => {
+  // spawn reports ENOENT for both absences and names the command in `error.path`
+  // either way, so the old branch told a machine with git installed that git was
+  // not installed. That message sent a caller to debug PATH for a bad --cwd.
+  const gone = path.join(os.tmpdir(), `bench-gone-${Date.now()}`);
+  assert.equal(fs.existsSync(gone), false);
+
+  assert.throws(
+    () => ensureGitRepository(gone),
+    (err) => /does not exist/.test(err.message) && !/not installed/.test(err.message)
+  );
 });

--- a/tests/seo-aeo-validation.test.mjs
+++ b/tests/seo-aeo-validation.test.mjs
@@ -1,0 +1,210 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { TOOLS } from "../plugins/gemini/scripts/gemini-mcp.mjs";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, "..");
+
+// Dynamic path resolution using standard repository paths with fallback
+const candidatePaths = [
+  path.join(REPO_ROOT, "docs", "HANDOVER_MARKETING_AND_RELEASE_PLAYBOOK.md"),
+  path.join(REPO_ROOT, "HANDOVER_MARKETING_AND_RELEASE_PLAYBOOK.md"),
+  path.join(REPO_ROOT, "docs", "PLAYBOOK.md")
+];
+
+const PLAYBOOK_PATH = candidatePaths.find(p => fs.existsSync(p));
+assert.ok(PLAYBOOK_PATH, `Handover playbook must exist in repo at docs/HANDOVER_MARKETING_AND_RELEASE_PLAYBOOK.md (checked ${candidatePaths.join(", ")})`);
+// Normalized to LF: the assertions below are about document structure, and this
+// repo checks out CRLF on Windows, so a raw read fails there and nowhere else.
+const playbookContent = fs.readFileSync(PLAYBOOK_PATH, "utf8").replace(/\r\n/g, "\n");
+
+test("SEO Verification: robots.txt conforms to RFC 9309 and isolates sensitive paths per agent group", () => {
+  // Extract robots.txt code block from Section 4.5
+  const robotsMatch = playbookContent.match(/```text\s*\n(# ===+[\s\S]+?Sitemap:[^\n]+)\n```/);
+  assert.ok(robotsMatch, "robots.txt code block must be present in Section 4.5");
+  const robotsTxt = robotsMatch[1];
+
+  // 1. Mandatory Agents Check
+  const expectedAgents = [
+    "User-agent: *",
+    "User-agent: GPTBot",
+    "User-agent: OAI-SearchBot",
+    "User-agent: ChatGPT-User",
+    "User-agent: ClaudeBot",
+    "User-agent: Claude-Web",
+    "User-agent: PerplexityBot",
+    "User-agent: Perplexity-User",
+    "User-agent: Google-Extended",
+    "User-agent: Applebot",
+    "User-agent: Applebot-Extended",
+    "User-agent: Bytespider"
+  ];
+  for (const agent of expectedAgents) {
+    assert.ok(robotsTxt.includes(agent), `robots.txt must declare '${agent}'`);
+  }
+
+  // 2. Group-Aware Disallow Verification (RFC 9309 Consecutive Agent Group Parser)
+  const groupRegex = /((?:User-agent:[^\n]+\n)+)([\s\S]+?)(?=(?:\n\s*User-agent:|\n\s*Sitemap:|$))/g;
+  const groups = [];
+  let match;
+  while ((match = groupRegex.exec(robotsTxt)) !== null) {
+    groups.push({
+      agents: match[1].trim(),
+      directives: match[2].trim()
+    });
+  }
+
+  assert.ok(groups.length >= 5, `robots.txt must contain at least 5 agent record groups (found ${groups.length})`);
+
+  const requiredDisallows = [
+    "Disallow: /node_modules/",
+    "Disallow: /.git/",
+    "Disallow: /dist/",
+    "Disallow: /scratch/",
+    "Disallow: /tests/"
+  ];
+
+  // Verify that all non-Bytespider groups contain ALL 5 required Disallow rules
+  for (const group of groups) {
+    if (group.agents.includes("Bytespider")) {
+      assert.ok(group.directives.includes("Disallow: /"), "Bytespider group must have Disallow: /");
+      continue;
+    }
+    for (const disallow of requiredDisallows) {
+      assert.ok(
+        group.directives.includes(disallow),
+        `Agent group [${group.agents.replace(/\n/g, ", ")}] must contain '${disallow}' to prevent RFC 9309 non-inheritance leaks`
+      );
+    }
+  }
+
+  // 3. Sitemap Declaration Check
+  const sitemapMatch = robotsTxt.match(/^Sitemap:\s*(https:\/\/[^\s]+)$/m);
+  assert.ok(sitemapMatch, "Sitemap must be declared as an absolute HTTPS URL");
+  assert.equal(sitemapMatch[1], "https://arcobaleno64.github.io/gemini-plugin-cc/sitemap.xml");
+});
+
+test("AEO Verification: /llms.txt conforms to Answer.AI Spec v2 with Bijective MCP tool mapping", () => {
+  // Extract /llms.txt code block from Section 4.6
+  const llmsMatch = playbookContent.match(/#### 檔案：`\/llms\.txt`[^\n]*\n```markdown\s*\n(# gemini-plugin-cc[\s\S]+?)\n```/);
+  assert.ok(llmsMatch, "/llms.txt code block must be present in Section 4.6");
+  const llmsTxt = llmsMatch[1];
+
+  // 1. Structure Verification (Single H1, Blockquote, H2s)
+  assert.match(llmsTxt, /^# gemini-plugin-cc\n\n> /m, "Must start with H1 followed by Blockquote summary");
+  assert.ok(llmsTxt.includes("## Core Documentation & Guides"), "Must contain Core Documentation H2");
+  assert.ok(llmsTxt.includes("## MCP Tools Reference"), "Must contain MCP Tools Reference H2");
+  assert.ok(llmsTxt.includes("## Installation & Configuration"), "Must contain Installation & Configuration H2");
+  assert.ok(llmsTxt.includes("## Optional"), "Must contain standard Answer.AI ## Optional section");
+
+  // 2. Bijective MCP Tools Ground Truth Check against plugins/gemini/scripts/gemini-mcp.mjs
+  assert.ok(Array.isArray(TOOLS) && TOOLS.length >= 6, "TOOLS from gemini-mcp.mjs must contain registered tools");
+  const actualToolNames = TOOLS.map(t => t.name);
+
+  const mcpSectionMatch = llmsTxt.match(/## MCP Tools Reference[\s\S]+?(?=## |$)/);
+  assert.ok(mcpSectionMatch, "Must contain MCP Tools Reference section");
+  const declaredToolNames = [...mcpSectionMatch[0].matchAll(/- `([a-zA-Z0-9_]+)`:/g)].map(m => m[1]);
+
+  // Bijective check (No missing, no extra hallucinated tools)
+  assert.equal(
+    declaredToolNames.length,
+    actualToolNames.length,
+    `Declared tool count (${declaredToolNames.length}) must match registered TOOLS count (${actualToolNames.length})`
+  );
+
+  for (const declared of declaredToolNames) {
+    assert.ok(
+      actualToolNames.includes(declared),
+      `Hallucinated tool detected in /llms.txt: '${declared}' is not registered in gemini-mcp.mjs`
+    );
+  }
+
+  for (const toolDef of TOOLS) {
+    const toolLine = llmsTxt.split("\n").find(line => line.includes(`\`${toolDef.name}\``));
+    assert.ok(toolLine, `Tool line for '${toolDef.name}' must be present`);
+
+    // Verify all required parameters from tool schema are documented in /llms.txt
+    const requiredParams = toolDef.inputSchema?.required || [];
+    for (const req of requiredParams) {
+      assert.ok(
+        toolLine.includes(req),
+        `Tool '${toolDef.name}' line must document required parameter '${req}' in /llms.txt`
+      );
+    }
+  }
+
+  // 3. Token Length Budget (< 1000 tokens estimated, < 5000 chars)
+  assert.ok(llmsTxt.length < 5000, `/llms.txt must be lightweight (< 5000 chars, got ${llmsTxt.length})`);
+});
+
+test("GEO Verification: Schema.org JSON-LD structured data is valid and forms a connected DAG", () => {
+  // Extract JSON-LD script from Section 4.7
+  const jsonLdMatch = playbookContent.match(/<script type="application\/ld\+json">\s*\n([\s\S]+?)\n<\/script>/);
+  assert.ok(jsonLdMatch, "JSON-LD script block must be present in Section 4.7");
+
+  const jsonLd = JSON.parse(jsonLdMatch[1]);
+  assert.equal(jsonLd["@context"], "https://schema.org");
+  assert.ok(Array.isArray(jsonLd["@graph"]), "@graph must be an array of entities");
+
+  const graph = jsonLd["@graph"];
+  const software = graph.find(e => {
+    const types = Array.isArray(e["@type"]) ? e["@type"] : [e["@type"]];
+    return types.includes("SoftwareApplication");
+  });
+  const article = graph.find(e => e["@type"] === "TechArticle");
+  const person = software?.author;
+  const publisher = article?.publisher;
+
+  // 1. SoftwareApplication Entity Checks
+  assert.ok(software, "SoftwareApplication entity must be present");
+  assert.equal(software.name, "gemini-plugin-cc");
+  assert.equal(software.applicationCategory, "DeveloperApplication");
+  assert.ok(software.offers && software.offers.price === "0");
+  assert.ok(software.codeRepository.startsWith("https://github.com/"));
+
+  // 2. TechArticle Entity Checks
+  assert.ok(article, "TechArticle entity must be present");
+  assert.ok(article.headline, "TechArticle must have headline");
+  assert.ok(article.image, "TechArticle must have image for Google Rich Results");
+  assert.ok(article.mainEntityOfPage, "TechArticle must have mainEntityOfPage");
+  assert.ok(article.about && article.about["@id"] === software["@id"], "TechArticle must anchor to SoftwareApplication @id");
+  assert.ok(article.datePublished, "TechArticle must have datePublished");
+  assert.ok(article.dateModified, "TechArticle must have dateModified");
+
+  // 3. Author & Publisher Verification
+  assert.ok(person && person["@id"], "Author Person entity must have @id");
+  assert.ok(publisher && publisher.logo, "Publisher must have ImageObject logo for Google Articles");
+});
+
+test("E-E-A-T FAQ Verification: Answer-First structure with isolated scopes and ground-truth alignment", () => {
+  const faqKeys = ["Q1", "Q2", "Q3", "Q4", "Q5", "Q6", "Q7"];
+
+  // Split FAQ section into individual question blocks to prevent cross-QA drift
+  const faqSectionMatch = playbookContent.match(/### 4\.8 E-E-A-T[\s\S]+?(?=### 4\.9|---|\n## )/);
+  assert.ok(faqSectionMatch, "Section 4.8 FAQ block must be found");
+  const faqSection = faqSectionMatch[0];
+
+  for (const qKey of faqKeys) {
+    const qRegex = new RegExp(`####\\s+${qKey}:[\\s\\S]+?(?=####\\s+Q\\d|---|$)`, "i");
+    const qBlockMatch = faqSection.match(qRegex);
+    assert.ok(qBlockMatch, `FAQ block for ${qKey} must exist`);
+    const qBlock = qBlockMatch[0];
+
+    // First paragraph under header must be Answer-First bold leading blockquote
+    const answerMatch = qBlock.match(/> \*\*([^*]+)\*\*/);
+    assert.ok(answerMatch, `FAQ ${qKey} must have leading bold answer in blockquote (> **...**)`);
+    assert.ok(answerMatch[1].trim().length >= 30, `FAQ ${qKey} answer-first sentence must be >= 30 chars`);
+
+    // Scoped assertions
+    if (qKey === "Q6") {
+      assert.ok(qBlock.includes(".env*"), "Q6 block specifically must mention .env*");
+      assert.ok(qBlock.includes("credentials.json"), "Q6 block specifically must mention credentials.json");
+    }
+    if (qKey === "Q7") {
+      assert.ok(qBlock.includes("Apache License 2.0"), "Q7 block specifically must mention Apache License 2.0");
+    }
+  }
+});


### PR DESCRIPTION
Eleven commits. The first added the SEO/AEO instrumentation and deliberately shipped **no score**, because nothing had been captured yet. Everything after it captures that score, refreshes every bench cell, adds two axes and two corpus cases, splits the harness lift into the two things it was conflating, and then fixes the scorer that all of those numbers were read off.

## 1. AEO: the score exists now, and it is 0%

`bench/aeo-responses/` holds five captured Codex answers, one per query in `BENCHMARK_QUERIES`, taken from `codex exec --ephemeral --ignore-user-config --skip-git-repo-check -s read-only` with the working root pointed at an empty directory, one fresh session per query, each query pasted verbatim (codex-cli 0.149.0, 2026-08-24).

```
Direct Recommendation Rate:   0%
Citation Inclusion Rate:     20%
Average Keyword Coverage:    55%
Overall AEO Health Score:     0%   (5 of 5 measured)
```

What the 0% is made of, because on its own it reads as "the assistant knows nothing":

- **Q1** is the only query that triggered no web search, and it recommended `/ccg` — a different tool. Run twice, same answer, so that is the model's prior rather than sampling noise.
- **Q3** is the only query citing a repository URL, and its answer is accurate down to `shell:false`, stdin-delivered prompts, and `.env*` redaction being a `/gemini:transfer` guarantee rather than a review-wide one — after twelve web searches. It still fails the pass rule, which wants the brand in the *first paragraph*. The 0% pass rate is a placement failure there, not an ignorance failure.
- **Q4** recommended somebody else's project (`kriscendobot/garden`).

Each fixture's provenance line carries its own web-search count. The first version of those lines claimed "no web search" for all five; the run JSONL says that holds only for Q1, and they were corrected before scoring.

## 2. Every bench cell refreshed onto one version — where the engine allowed it

| Cell | Now |
|---|---|
| `codex.model`, `codex.adversarial` | codex-cli 0.149.0, **7 cases** ×3 |
| `agy.model`, `agy.deep`, `agy.shallow` | agy 1.1.19, **7 cases** ×3 |
| `agy.adversarial` | agy 1.1.19, 5 cases ×3 |
| `gemini.model` | gemini 0.56.0, 5 cases ×3 |
| `gemini.deep` | 0.56.0 on 4 cases, 0.55.1 on `vacuous-tests` |
| `gemini.shallow`, `gemini.adversarial` | unrecorded |
| `codex.native` | still seeded |

**The gemini engine stops answering under a heavier prompt.** `gemini.deep / vacuous-tests` returns nothing at 420s — empty stdout, empty stderr, reproduced three times — while the other four cases finish in ~35s. `gemini.adversarial` is the same hang, wider: both cases attempted were killed at the cap with no output, though the identical cases complete under `review --deep` and every adversarial case completes under `--engine agy`. So it tracks prompt weight on that engine, not the case and not the subcommand.

**`codex.native` stays seeded** because codex's built-in reviewer emits no `result` in its `--json` payload — filed as openai/codex-plugin-cc#679, with the two payload shapes shown side by side.

## 3. A third axis: each tool's adversarial reviewer

`gemini.adversarial`, `codex.adversarial` and `agy.adversarial` sit on a new `plugin-adversarial` track with their own verdict row. They are deliberately **not** more entries on the harness axis: `prompts/review.md` asks for a pragmatic review, `prompts/adversarial-review.md` asks the model to break confidence in the change, and those are not interchangeable readings to rank against each other.

**The prediction behind that separation was wrong, and the repo now says so.** The argument was that composite's `recall*70` weighting hands the adversarial prompt the column by construction. It does the opposite: `agy.deep` → `agy.adversarial`, five cases ×3 on 1.1.19, moved recall 0.81 → 0.77, precision 0.91 → 0.92, false positives 1.67 → 1.33 — more conservative, not more aggressive. `cells.mjs`, the bench README and the changelog carry the measurement now instead of the guess. The axis stays separate on the half of the argument that did not depend on the scores.

`runCompanionReview` gained a `subcommand` option, defaulting to `review` so every existing cell is unchanged.

## 4. Two reporting fixes, both found by doing the refresh

- **A refused AGY run now prints the reason AGY gave.** AGY puts a refusal in the JSON envelope's `error` and leaves stderr empty, so a spent account rendered as `agy: could not parse review JSON ()`. Three re-recording attempts were spent reading that as a parser defect before the envelope was opened by hand and said `Individual quota reached`.
- **A cell recorded on more than one version now says both**, instead of letting the first cassette's version stand for all five. `agy.model` was briefly four cases on 1.1.19 and one on 1.1.15 while the table printed `1.1.19` for all of them — the `gemini.deep` mix-up in miniature.

Both mutation-confirmed. So is the adversarial axis — **on the second attempt**: the first version of that test asserted only that a row with the right title was printed, which still passed when the axis was pointed at the harness track. It now asserts which cells' numbers land in which row.

## 5. Two repository-scoped cases, and a control cell that splits the lift

The harness axis existed to measure defects a reviewer can only find by leaving the diff, and exactly one case planted any. `caller-contract` changes `findUser`'s return shape — a clean refactor read on its own — while two callers the diff never mentions keep the old contract, one of them an admin check that is now always truthy. `stale-duplicate` fixes a crash in `src/api/v2/validate.js` while an identical `v1` copy keeps it.

The `*.shallow` control cells run the plugin's own review **without** `--deep`: same `prompts/review.md`, same diff embedded, no tools. That splits `model → deep`, which was changing the prompt and the tools at once, into its two halves.

**Measured on agy 1.1.19, seven cases ×3:**

| case | model | shallow | deep | prompt | exploration |
|---|:-:|:-:|:-:|:-:|:-:|
| async-lifecycle | 91 | 69 | 71 | −22 | +2 |
| auth-basic | 95 | 81 | 83 | −14 | +2 |
| path-and-input | 72 | 69 | 69 | −3 | 0 |
| vacuous-tests | 71 | 82 | 94 | +11 | +12 |
| **caller-contract** | 0 | 0 | **68** | 0 | **+68** |
| **repo-context** | 55 | 15 | **76** | −40 | **+61** |
| **stale-duplicate** | 43 | 18 | **67** | −25 | **+49** |
| **mean** | | | | **−13.3** | **+27.8** |

The −4.4 lift reported over the original five cases was two opposing effects cancelling. Exploration is worth **+28**, and its gains land on exactly the three repository-scoped cases. The plugin's own review prompt, run without tools, is worth **−13**.

That penalty is not the `DEEP REVIEW MODE` block — the `*.shallow` cells never see it — and not a thinner input: probed across all seven cases, `REVIEW_INPUT` runs 645–1414 characters against a 400,000 cap with the full diff present in both arms. It is `prompts/review.md` itself, and what in it costs the points is **not** established here. An earlier commit message in this branch blamed "a prompt that tells the model to fold in dependency manifests, callers and untracked files"; `review.md` says no such thing — lines 75–80 forbid tools outright. The repo carries the retraction.

Two defects had to be fixed to get the reading at all. The runner inferred "materialize a repository" from `harness === "agentic"`, true of every companion cell except these two, so they ran with `--cwd` pointing at nothing; `needsRepo` is declared now. And `ensureGitRepository` reported that missing directory as `git is not installed` on a machine with git plainly installed, because spawn's ENOENT means both things and names the command either way.

## 6. The scorer these numbers were read off was wrong (#108)

`repo-context` plants an undeclared dependency with `file: "*"`, so it is matched on words alone — and one of those words was the bare module name. Every reviewer that discussed `src/token.js` wrote "jsonwebtoken" somewhere, so a finding about an unvalidated secret was credited with catching a missing manifest entry it never mentioned. `agy.model` on that case was reading 96.7; it is 55.0.

A ground-truth `match` now takes `all` (every-of: the subject) alongside `keywords` (any-of: the claim). All seven cases declare both — the file-scoped ones needed it too, since five defects sharing one file share a vocabulary, and `undefined`, `leak`, `throws`, `memory` and `..` were carrying credit with no claim attached. Subjects are taken from the source under review, not from the recorded findings.

Findings matching more than one of their case's planted defects: **16% → 2.4%**, and no cell's mean moved by more than 1.5 points. What remains is a different thing and is left alone: all ten are one finding reporting two defects in a single entry, which the scorer credits once and so under-counts.

The size was never the point. That false credit was worth 42 composite points to one cell and nothing to the others, and a board whose only purpose is comparing cells is worse off wrong unevenly than wrong uniformly.

## 7. codex on the new cases

Twelve live runs, codex-cli 0.149.0, three samples per cell.

| case | codex.model | codex.adversarial | agy.model | agy.deep |
|---|:-:|:-:|:-:|:-:|
| caller-contract | 0 | 43 | 0 | 68 |
| stale-duplicate | 62 | 65 | 43 | 67 |

`caller-contract` reads 0 for both single-shot cells, which is the case doing what it was planted to do. Codex's adversarial reviewer explores and clears its own single-shot reading on both — the same direction agy's `--deep` shows.

## 8. The document was describing a board that no longer existed

Found by re-deriving every number in `bench/README.md` from the cassettes instead of reading the prose. Six places: the header and cell table said "three axes, nine cells" and omitted both `*.shallow` cells; the adversarial measurement was quoted off the loose matcher (recall 0.81 -> 0.77 is really 0.79 -> 0.72, and false positives 1.67 -> 1.33 is really 0.40 -> 0.40, so the precision-for-recall trade it implied never happened); the per-repeat spread table was stale from both re-recording and re-scoring; three of the four readings under it quoted lifts and leads that have all moved; two coverage bullets still said "all five cases"; and a `lib/report.mjs:48` citation pointed at provenance code.

One reading needed rewriting rather than renumbering. It used to say the deep cells are steady on `repo-context` while the model cells thrash. They now move 43 and 36 there, and `agy.model` posts 55, 55, 55 while `codex.model` posts 0, 0, 0 - perfect steadiness that means nothing, because a cell that fails the same way every time has no spread. **Low spread on this board reads as consistent, not as trustworthy.**

A test now asserts the README's cell table lists exactly the cells in `CELLS`. It failed on windows-latest the first time for a reason worth keeping: the checkout stores the file with CRLF, `indexOf("

")` returned -1, and `slice(from, -1)` widened the slice to the whole document instead of erroring. Mutation-confirmed under both line endings.

## Verification

`npm test` — **612 tests, 604 pass, 0 fail, 8 skipped**.

The intermittent failure noted earlier in this branch has a name now: the `runtime.test.mjs` fixture prepended its stub bin directory to the real PATH, so a real `agy` on the machine could answer a test that meant to find none. Fixed on #107, merged to main.

Also re-measured on the way: the AGY version gates against 1.1.19 (seven releases, no threshold moved; six of seven gates verified at zero token cost via read-only slash commands).

## Not done here

- `gemini.deep / vacuous-tests`, all of `gemini.shallow` and all of `gemini.adversarial`, pending the engine hang.
- `agy.adversarial` on the two new repository-scoped cases.
- **What in `prompts/review.md` costs 13 points without tools.** Named, measured, not diagnosed.
- `codex.native`, pending openai/codex-plugin-cc#679.
- The playbook's SLA thresholds (≥80% / ≥75% / ≥60%) are still untouched targets. One assistant's five answers on one day is not the data to move them against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0194A6X6tcQLqwwCVqLn7VUw


