### PR TITLE
Stop crediting a finding for naming a defect's subject

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -57,19 +57,19 @@ one scorer grades all of them.
 >
 > | case | model | shallow | deep | prompt | exploration |
 > |---|:-:|:-:|:-:|:-:|:-:|
-> | async-lifecycle | 91 | 70 | 74 | −21 | +4 |
+> | async-lifecycle | 91 | 69 | 71 | −22 | +2 |
 > | auth-basic | 95 | 81 | 83 | −14 | +2 |
 > | path-and-input | 72 | 69 | 69 | −3 | 0 |
-> | vacuous-tests | 71 | 82 | 88 | +11 | +6 |
+> | vacuous-tests | 71 | 82 | 94 | +11 | +12 |
 > | **caller-contract** | 0 | 0 | **68** | 0 | **+68** |
 > | **repo-context** | 55 | 15 | **76** | −40 | **+61** |
 > | **stale-duplicate** | 43 | 18 | **67** | −25 | **+49** |
-> | **mean** | | | | **−13.1** | **+27.2** |
+> | **mean** | | | | **−13.3** | **+27.8** |
 >
 > The −4.4 harness lift reported over the original five cases was two opposing effects
-> cancelling. Exploration is worth **+27** on average and its gains land exactly where
+> cancelling. Exploration is worth **+28** on average and its gains land exactly where
 > the design says they should — +68, +61, +49 on the three repository-scoped cases,
-> against +4, +2, 0, +6 on the four file-scoped ones. The plugin's own review prompt,
+> against +2, +2, 0, +12 on the four file-scoped ones. The plugin's own review prompt,
 > run without tools, is worth **−13** against the bench's neutral prompt, and that
 > penalty is concentrated on the same repository-scoped cases (−40, −25).
 >
@@ -80,17 +80,21 @@ one scorer grades all of them.
 > what in it costs the points is not yet established. Until it is, this is a fact
 > about the two prompts, not a diagnosis of either.
 >
-> **How much of this survives the scorer is a separate question.** Two of these
-> numbers moved once the matcher stopped crediting a finding for naming a defect's
-> subject without making its claim (see "Matching" below): `repo-context`'s
-> `agy.model` fell 97 → 55, and with it the prompt penalty on that case, −60 → −40.
-> A second looseness is still in place: 16% of all recorded findings keyword-match
-> more than one planted defect in their case, concentrated in the four file-scoped
-> cases where five defects share one file and one vocabulary. Refusing every
-> ambiguous credit — a hard lower bound, not a proposal — leaves the prompt penalty
-> at −12.6 and takes exploration down to +12.4. So **−13 is robust and +27 is not**:
-> the exploration lift is somewhere in +12 to +27 until those four cases get the
-> same subject/claim split the wildcard ones now have.
+> **These numbers were read off a matcher that had to be fixed first.** It credited a
+> finding for naming a defect's subject without making its claim, and the credit was
+> not spread evenly: `repo-context`'s `agy.model` was reading 97 for catching an
+> undeclared dependency it never mentioned, which alone put 20 points of the prompt
+> penalty on that case. Tightening every planted defect into a subject (`match.all`)
+> and a claim (`match.keywords`) took the share of recorded findings that match more
+> than one planted defect from 16% to 2.4%, and moved no cell's mean by more than
+> 1.5 points — the correction was concentrated, not diffuse.
+>
+> The 2.4% that remains is a different thing and is left alone: all ten are findings
+> that genuinely report two defects in one entry ("Plaintext Password Comparison and
+> Unchecked Null User"). The scorer credits one of the two, so it under-counts them.
+> Dropping them outright takes exploration to +12.5, but that number is a statement
+> about how a merged finding is counted, not about the matcher, and most of the swing
+> is `caller-contract`, where two of the four recorded findings are merged reports.
 >
 > `caller-contract` and `stale-duplicate` were added for exactly that, joining
 > `repo-context` as the cases whose planted defects are repository-scoped (`file: "*"`).
@@ -373,9 +377,13 @@ Per cell, findings are matched against the case's `ground-truth.json`:
   That single false credit was worth 42 composite points to one cell and nothing to
   others — worse than being wrong uniformly, because the board is a comparison
   between cells. Put the subject in `all` and the claim in `keywords`, and a
-  finding has to carry both. The three wildcard cases now do; the four file-scoped
-  ones still lean on the filename to disambiguate, and 16% of recorded findings
-  keyword-match more than one of their planted defects.
+  finding has to carry both. Every case declares both now; a `file: "*"` defect that
+  does not is a test failure, because there the filename disambiguates nothing.
+  The four file-scoped cases were split the same way — five defects sharing one file
+  also share a vocabulary, and words like `undefined`, `leak`, `throws`, `memory` and
+  `..` were carrying credit on their own. Findings matching more than one planted
+  defect fell from 16% to 2.4%, and what is left is genuine: one entry reporting two
+  defects at once, which the scorer credits once.
 - Each finding is assigned to its **single best** unmatched planted defect, so two
   line-adjacent defects are never double-counted.
 - `recall` = planted found / planted total. `precision` = relevant / findings.

--- a/bench/README.md
+++ b/bench/README.md
@@ -62,18 +62,35 @@ one scorer grades all of them.
 > | path-and-input | 72 | 69 | 69 | −3 | 0 |
 > | vacuous-tests | 71 | 82 | 88 | +11 | +6 |
 > | **caller-contract** | 0 | 0 | **68** | 0 | **+68** |
-> | **repo-context** | 97 | 37 | **90** | −60 | **+53** |
+> | **repo-context** | 55 | 15 | **76** | −40 | **+61** |
 > | **stale-duplicate** | 43 | 18 | **67** | −25 | **+49** |
-> | **mean** | | | | **−16.0** | **+26.0** |
+> | **mean** | | | | **−13.1** | **+27.2** |
 >
 > The −4.4 harness lift reported over the original five cases was two opposing effects
-> cancelling. Exploration is worth **+26** on average and its gains land exactly where
-> the design says they should — +68, +53, +49 on the three repository-scoped cases,
+> cancelling. Exploration is worth **+27** on average and its gains land exactly where
+> the design says they should — +68, +61, +49 on the three repository-scoped cases,
 > against +4, +2, 0, +6 on the four file-scoped ones. The plugin's own review prompt,
-> run without tools, is worth **−16** against the bench's neutral prompt, and that
-> penalty is concentrated on the same repository-scoped cases (−60, −25). A prompt that
-> tells the model to fold in dependency manifests and callers appears to cost accuracy
-> when it cannot go and read them.
+> run without tools, is worth **−13** against the bench's neutral prompt, and that
+> penalty is concentrated on the same repository-scoped cases (−40, −25).
+>
+> What that penalty is *not*: it is not the `DEEP REVIEW MODE` block, which the
+> `*.shallow` cells never see, and it is not a thinner input — the probe over all
+> seven cases puts `REVIEW_INPUT` between 645 and 1414 characters against a 400,000
+> cap, with the full diff present in both. It is `prompts/review.md` itself, and
+> what in it costs the points is not yet established. Until it is, this is a fact
+> about the two prompts, not a diagnosis of either.
+>
+> **How much of this survives the scorer is a separate question.** Two of these
+> numbers moved once the matcher stopped crediting a finding for naming a defect's
+> subject without making its claim (see "Matching" below): `repo-context`'s
+> `agy.model` fell 97 → 55, and with it the prompt penalty on that case, −60 → −40.
+> A second looseness is still in place: 16% of all recorded findings keyword-match
+> more than one planted defect in their case, concentrated in the four file-scoped
+> cases where five defects share one file and one vocabulary. Refusing every
+> ambiguous credit — a hard lower bound, not a proposal — leaves the prompt penalty
+> at −12.6 and takes exploration down to +12.4. So **−13 is robust and +27 is not**:
+> the exploration lift is somewhere in +12 to +27 until those four cases get the
+> same subject/claim split the wildcard ones now have.
 >
 > `caller-contract` and `stale-duplicate` were added for exactly that, joining
 > `repo-context` as the cases whose planted defects are repository-scoped (`file: "*"`).
@@ -347,6 +364,18 @@ Per cell, findings are matched against the case's `ground-truth.json`:
   keyword is present (keyword is the robust signal; an exact line overlap is the
   fallback for keyword-less defects). `file: "*"` means keyword-only (for defects
   that span files, e.g. an undeclared dependency).
+- `match.keywords` is **any-of** — the reviewer's wording for the claim is free.
+  `match.all` is **every-of** — the subject the finding has to actually be about.
+  A wildcard defect is matched on words alone, and a subject word is a word every
+  finding about that area writes down: `repo-context` listed the bare module name
+  among its any-of keywords, so a finding about an unvalidated secret, which named
+  the module only in passing, was credited with catching a missing manifest entry.
+  That single false credit was worth 42 composite points to one cell and nothing to
+  others — worse than being wrong uniformly, because the board is a comparison
+  between cells. Put the subject in `all` and the claim in `keywords`, and a
+  finding has to carry both. The three wildcard cases now do; the four file-scoped
+  ones still lean on the filename to disambiguate, and 16% of recorded findings
+  keyword-match more than one of their planted defects.
 - Each finding is assigned to its **single best** unmatched planted defect, so two
   line-adjacent defects are never double-counted.
 - `recall` = planted found / planted total. `precision` = relevant / findings.
@@ -384,7 +413,11 @@ corpus/<case-id>/
   "planted": [
     { "id": "sqli", "category": "injection", "file": "src/auth.js",
       "line_start": 7, "line_end": 9, "severity": "critical",
-      "match": { "keywords": ["sql injection", "concatenat"] } }
+      "match": { "keywords": ["sql injection", "concatenat"] } },
+    { "id": "missing-dependency", "file": "*",
+      "line_start": 1, "line_end": 1, "severity": "high",
+      "match": { "all": ["jsonwebtoken"],
+                 "keywords": ["undeclared", "not in package.json"] } }
   ],
   "allowed_extras": [
     { "id": "jwt-expiry", "file": "src/auth.js", "match": { "keywords": ["expiresin"] } }

--- a/bench/README.md
+++ b/bench/README.md
@@ -165,10 +165,13 @@ A cassette recorded from a real run carries `recordedAt`, the `engineVersion` it
 recorded against, every repeat in `samples`, and no `source`; a seeded one carries a
 `source` field. The scorecard prints all of it per cell. Current committed state:
 
-- **`codex.model` — live-recorded on all five cases** (codex-cli 0.149.0, three
-  samples each, 2026-08-24). The three cases that were missing while the account sat
-  at its usage limit were recorded once it reset, and the two older ones were
-  re-recorded on the same version so the cell reads as one tool at one version.
+- **`codex.model` — live-recorded on all seven cases** (codex-cli 0.149.0, three
+  samples each, 2026-08-24 and 2026-08-25). The three cases that were missing while
+  the account sat at its usage limit were recorded once it reset, and the two older
+  ones were re-recorded on the same version so the cell reads as one tool at one
+  version. The two repository-scoped cases came last: `caller-contract` **0**,
+  `stale-duplicate` **62**. The zero is the case doing its job — both planted defects
+  live outside the diff, and `agy.model` scores 0 on it too.
 - **`agy.model`, `agy.deep` — live-recorded on all five cases** (agy 1.1.19, three
   samples each, 2026-08-24). Both cells sat mid-refresh for part of that day: AGY
   refused four recordings with `Individual quota reached ... Resets in 94h2m50s`, and
@@ -189,8 +192,12 @@ recorded against, every repeat in `samples`, and no `source`; a seeded one carri
   identical cases complete under `review --deep` and every adversarial case completes
   under `--engine agy`. It tracks prompt weight on the gemini engine, not the case and
   not the subcommand.
-- **`codex.adversarial`, `agy.adversarial` — live-recorded on all five cases**
-  (codex-cli 0.149.0 and agy 1.1.19, three samples each, 2026-08-24).
+- **`codex.adversarial` — live-recorded on all seven cases**, `agy.adversarial` on
+  five (codex-cli 0.149.0 and agy 1.1.19, three samples each, 2026-08-24 and
+  2026-08-25). On the two repository-scoped cases codex's adversarial reviewer scores
+  **43** and **65** against its own single-shot **0** and **62** — it explores, so the
+  gain is a harness reading and not a prompt one. `agy.adversarial` has not been run
+  on those two cases yet.
 - **`codex.native` — still seeded, and now for a known reason.** Pointing
   `BENCH_CODEX_COMPANION` at the installed codex plugin 1.0.6 makes the cell run: the
   companion completes, exits 0, and returns a payload carrying `review`, `target`,

--- a/bench/cassettes/caller-contract/codex.adversarial.json
+++ b/bench/cassettes/caller-contract/codex.adversarial.json
@@ -1,0 +1,76 @@
+{
+  "caseId": "caller-contract",
+  "cell": "codex.adversarial",
+  "recordedAt": "2026-08-24T23:26:54.527Z",
+  "verdict": "needs-attention",
+  "summary": "Do not ship: the return-type change breaks every existing caller.",
+  "findings": [
+    {
+      "severity": "high",
+      "title": "Result envelope is incompatible with both route callers",
+      "body": "`findUser` now always returns a truthy envelope and moves record fields under `user`, but callers still treat the result as a nullable user record. `profileRoute` therefore returns HTTP 200 with missing `id` and `name` for both found and absent IDs, while `requireAdmin` reads `role` from the envelope and rejects even valid administrators. This is directly evidenced by `src/routes/profile.js:4-8` and `src/routes/admin.js:4-8`.",
+      "file": "src/store.js",
+      "line_start": 7,
+      "line_end": 12,
+      "confidence": 1,
+      "recommendation": "Update all callers atomically to branch on `result.ok` and read `result.user`; add route tests covering an existing admin, existing member, and unknown ID."
+    }
+  ],
+  "latencyMs": 47356,
+  "engineVersion": "codex-cli 0.149.0",
+  "engineObserved": null,
+  "samples": [
+    {
+      "verdict": "needs-attention",
+      "summary": "Do not ship: the return-type change breaks every existing caller.",
+      "findings": [
+        {
+          "severity": "high",
+          "title": "Result envelope is incompatible with all existing callers",
+          "body": "`findUser` now always returns a truthy envelope and moves user fields under `user`, but callers still expect a nullable user record. Consequently, `profileRoute` returns HTTP 200 with missing `id` and `name` even for unknown IDs, while `requireAdmin` reads an absent top-level `role` and rejects every administrator. This is directly evidenced by `profile.js:4-8` and `admin.js:4-8`.",
+          "file": "src/store.js",
+          "line_start": 9,
+          "line_end": 12,
+          "confidence": 1,
+          "recommendation": "Update every caller atomically to branch on `result.ok` and read `result.user`, with tests covering found, missing, admin, and non-admin users; otherwise retain the original nullable-record contract."
+        }
+      ],
+      "latencyMs": 38782
+    },
+    {
+      "verdict": "needs-attention",
+      "summary": "Do not ship: this silently breaks the exported function’s established return contract.",
+      "findings": [
+        {
+          "severity": "high",
+          "title": "Return-type change breaks existing callers and absence checks",
+          "body": "`findUser` previously returned a user record or `null`; it now always returns a truthy envelope. Existing callers that read fields directly (for example, `findUser(id).name`) will receive `undefined`, while checks such as `if (findUser(id))` will incorrectly treat missing users as present. Because the function is exported and the diff contains no coordinated caller migration or compatibility layer, this is a plausible runtime regression.",
+          "file": "src/store.js",
+          "line_start": 6,
+          "line_end": 13,
+          "confidence": 0.98,
+          "recommendation": "Either preserve the record-or-null contract, introduce a separately named envelope-returning API, or update every caller atomically and add tests covering direct field access and truthiness-based not-found handling."
+        }
+      ],
+      "latencyMs": 21334
+    },
+    {
+      "verdict": "needs-attention",
+      "summary": "Do not ship: the return-type change breaks every existing caller.",
+      "findings": [
+        {
+          "severity": "high",
+          "title": "Result envelope is incompatible with both route callers",
+          "body": "`findUser` now always returns a truthy envelope and moves record fields under `user`, but callers still treat the result as a nullable user record. `profileRoute` therefore returns HTTP 200 with missing `id` and `name` for both found and absent IDs, while `requireAdmin` reads `role` from the envelope and rejects even valid administrators. This is directly evidenced by `src/routes/profile.js:4-8` and `src/routes/admin.js:4-8`.",
+          "file": "src/store.js",
+          "line_start": 7,
+          "line_end": 12,
+          "confidence": 1,
+          "recommendation": "Update all callers atomically to branch on `result.ok` and read `result.user`; add route tests covering an existing admin, existing member, and unknown ID."
+        }
+      ],
+      "latencyMs": 47356
+    }
+  ],
+  "raw": "{\n  \"review\": \"Adversarial Review\",\n  \"target\": {\n    \"mode\": \"working-tree\",\n    \"label\": \"working tree diff\",\n    \"explicit\": true\n  },\n  \"threadId\": \"01a03618-7fb2-79b1-a279-f707007e5912\",\n  \"context\": {\n    \"repoRoot\": \"C:/Users/arcobaleno/AppData/Local/Temp/bench-caller-contract-2mEqNH\",\n    \"branch\": \"main\",\n    \"summary\": \"Reviewing 0 staged, 1 unstaged, and 0 untracked file(s).\"\n  },\n  \"codex\": {\n    \"status\": 0,\n    \"stderr\": \"\",\n    \"stdout\": \"{\\\"verdict\\\":\\\"needs-attention\\\",\\\"summary\\\":\\\"Do not ship: the return-type change breaks every existing caller.\\\",\\\"findings\\\":[{\\\"severity\\\":\\\"high\\\",\\\"title\\\":\\\"Result envelope is incompatible with both route callers\\\",\\\"body\\\":\\\"`findUser` now always returns a truthy envelope and moves record fields under `user`, but callers still treat the result as a nullable user record. `profileRoute` therefore returns HTTP 200 with missing `id` and `name` for both found and absent IDs, while `requireAdmin` reads `role` from the envelope and rejects even valid administrators. This is directly evidenced by `src/routes/profile.js:4-8` and `src/routes/admin.js:4-8`.\\\",\\\"file\\\":\\\"src/store.js\\\",\\\"line_start\\\":7,\\\"line_end\\\":12,\\\"confidence\\\":1,\\\"recommendation\\\":\\\"Update all callers atomically to branch on `result.ok` and read `result.user`; add route tests covering an existing admin, existing member, and unknown ID.\\\"}],\\\"next_steps\\\":[\\\"Fix both callers and run route-level regression tests before shipping.\\\"]}\",\n    \"reasoning\": []\n  },\n  \"result\": {\n    \"verdict\": \"needs-attention\",\n    \"summary\": \"Do not ship: the return-type change breaks every existing caller.\",\n    \"findings\": [\n      {\n        \"severity\": \"high\",\n        \"title\": \"Result envelope is incompatible with both route callers\",\n        \"body\": \"`findUser` now always returns a truthy envelope and moves record fields under `user`, but callers still treat the result as a nullable user record. `profileRoute` therefore returns HTTP 200 with missing `id` and `name` for both found and absent IDs, while `requireAdmin` reads `role` from the envelope and rejects even valid administrators. This is directly evidenced by `src/routes/profile.js:4-8` and `src/routes/admin.js:4-8`.\",\n        \"file\": \"src/store.js\",\n        \"line_start\": 7,\n        \"line_end\": 12,\n        \"confidence\": 1,\n        \"recommendation\": \"Update all callers atomically to branch on `result.ok` and read `result.user`; add route tests covering an existing admin, existing member, and unknown ID.\"\n      }\n    ],\n    \"next_steps\": [\n      \"Fix both callers and run route-level regression tests before shipping.\"\n    ]\n  },\n  \"rawOutput\": \"{\\\"verdict\\\":\\\"needs-attention\\\",\\\"summary\\\":\\\"Do not ship: the return-type change breaks every existing caller.\\\",\\\"findings\\\":[{\\\"severity\\\":\\\"high\\\",\\\"title\\\":\\\"Result envelope is incompatible with both route callers\\\",\\\"body\\\":\\\"`findUser` now always returns a truthy envelope and moves record fields under `user`, but callers still treat the result as a nullable user record. `profileRoute` therefore returns HTTP 200 with missing `id` and `name` for both found and absent IDs, while `requireAdmin` reads `role` from the envelope and rejects even valid administrators. This is directly evidenced by `src/routes/profile.js:4-8` and `src/routes/admin.js:4-8`.\\\",\\\"file\\\":\\\"src/store.js\\\",\\\"line_start\\\":7,\\\"line_end\\\":12,\\\"confidence\\\":1,\\\"recommendation\\\":\\\"Update all callers atomically to branch on `result.ok` and read `result.user`; add route tests covering an existing admin, existing member, and unknown ID.\\\"}],\\\"next_steps\\\":[\\\"Fix both callers and run route-level regression tests before shipping.\\\"]}\",\n  \"parseError\": null,\n  \"reasoningSummary\": []\n}\n"
+}

--- a/bench/cassettes/caller-contract/codex.model.json
+++ b/bench/cassettes/caller-contract/codex.model.json
@@ -1,0 +1,32 @@
+{
+  "caseId": "caller-contract",
+  "cell": "codex.model",
+  "recordedAt": "2026-08-24T23:23:43.203Z",
+  "verdict": "approve",
+  "summary": "The result-envelope implementation correctly distinguishes found and absent users within the provided diff.",
+  "findings": [],
+  "latencyMs": 14382,
+  "engineVersion": "codex-cli 0.149.0",
+  "engineObserved": null,
+  "samples": [
+    {
+      "verdict": "approve",
+      "summary": "The result-envelope implementation is internally consistent and introduces no material defect visible in the provided diff.",
+      "findings": [],
+      "latencyMs": 17989
+    },
+    {
+      "verdict": "approve",
+      "summary": "The result-envelope change is internally consistent and introduces no material defect visible in the diff.",
+      "findings": [],
+      "latencyMs": 16628
+    },
+    {
+      "verdict": "approve",
+      "summary": "The result-envelope implementation correctly distinguishes found and absent users within the provided diff.",
+      "findings": [],
+      "latencyMs": 14382
+    }
+  ],
+  "raw": "{\"verdict\":\"approve\",\"summary\":\"The result-envelope implementation correctly distinguishes found and absent users within the provided diff.\",\"findings\":[],\"next_steps\":[]}\n"
+}

--- a/bench/cassettes/stale-duplicate/codex.adversarial.json
+++ b/bench/cassettes/stale-duplicate/codex.adversarial.json
@@ -1,0 +1,76 @@
+{
+  "caseId": "stale-duplicate",
+  "cell": "codex.adversarial",
+  "recordedAt": "2026-08-24T23:29:39.435Z",
+  "verdict": "needs-attention",
+  "summary": "Do not ship: the new worker silently drops every ID in non-empty batches.",
+  "findings": [
+    {
+      "severity": "high",
+      "title": "Missing maxBatch causes valid IDs to be discarded",
+      "body": "config/default.json does not define maxBatch. Therefore the first slice uses NaN as its end index and produces [], after which i becomes NaN and the loop exits. Reproduced with two valid IDs: drain([{id:'a'},{id:'b'}]) returned {\"queue\":\"ingest\",\"chunks\":[[]]}. Downstream processing would silently lose the entire batch.",
+      "file": "src/worker.js",
+      "line_start": 7,
+      "line_end": 8,
+      "confidence": 1,
+      "recommendation": "Define maxBatch as a positive integer, reject missing or invalid values at startup, and add a test proving a non-empty batch preserves every ID across chunks."
+    }
+  ],
+  "latencyMs": 74192,
+  "engineVersion": "codex-cli 0.149.0",
+  "engineObserved": null,
+  "samples": [
+    {
+      "verdict": "needs-attention",
+      "summary": "Do not ship: the new worker silently discards every non-empty batch because its chunk size is undefined.",
+      "findings": [
+        {
+          "severity": "high",
+          "title": "Missing maxBatch configuration produces an empty chunk and drops all IDs",
+          "body": "`config/default.json` defines `queueName` and `retryDelayMs` but no `maxBatch`. Therefore `i + config.maxBatch` becomes `NaN`, `ids.slice(0, NaN)` yields an empty array, and the loop terminates after one iteration. This was reproduced with two valid IDs: `drain([{id:1},{id:2}])` returned `{\"queue\":\"ingest\",\"chunks\":[[]]}`. Any caller treating this result as successfully drained can lose the entire batch without an exception.",
+          "file": "src/worker.js",
+          "line_start": 7,
+          "line_end": 8,
+          "confidence": 1,
+          "recommendation": "Define and validate a positive integer `maxBatch` before processing, and add tests asserting that non-empty input preserves every ID across chunks and that missing, zero, negative, or non-numeric chunk sizes fail explicitly."
+        }
+      ],
+      "latencyMs": 42047
+    },
+    {
+      "verdict": "needs-attention",
+      "summary": "Do not ship: the new worker silently discards every non-empty batch.",
+      "findings": [
+        {
+          "severity": "high",
+          "title": "Missing maxBatch produces an empty chunk and drops all IDs",
+          "body": "config/default.json does not define maxBatch. At runtime, slice(0, undefined) becomes slice(0, 0), so the first chunk is empty; then i += undefined makes i NaN and terminates the loop. Direct execution of drain([{id:1},{id:2}]) returned {\"queue\":\"ingest\",\"chunks\":[[]]}, losing both validated IDs without an error.",
+          "file": "src/worker.js",
+          "line_start": 7,
+          "line_end": 8,
+          "confidence": 1,
+          "recommendation": "Define maxBatch as a positive integer, validate it before entering the loop, fail fast on invalid configuration, and add a test asserting that a non-empty batch preserves every ID across chunks."
+        }
+      ],
+      "latencyMs": 47737
+    },
+    {
+      "verdict": "needs-attention",
+      "summary": "Do not ship: the new worker silently drops every ID in non-empty batches.",
+      "findings": [
+        {
+          "severity": "high",
+          "title": "Missing maxBatch causes valid IDs to be discarded",
+          "body": "config/default.json does not define maxBatch. Therefore the first slice uses NaN as its end index and produces [], after which i becomes NaN and the loop exits. Reproduced with two valid IDs: drain([{id:'a'},{id:'b'}]) returned {\"queue\":\"ingest\",\"chunks\":[[]]}. Downstream processing would silently lose the entire batch.",
+          "file": "src/worker.js",
+          "line_start": 7,
+          "line_end": 8,
+          "confidence": 1,
+          "recommendation": "Define maxBatch as a positive integer, reject missing or invalid values at startup, and add a test proving a non-empty batch preserves every ID across chunks."
+        }
+      ],
+      "latencyMs": 74192
+    }
+  ],
+  "raw": "{\n  \"review\": \"Adversarial Review\",\n  \"target\": {\n    \"mode\": \"working-tree\",\n    \"label\": \"working tree diff\",\n    \"explicit\": true\n  },\n  \"threadId\": \"01a0361a-9b74-7573-8817-39e39ec3e900\",\n  \"context\": {\n    \"repoRoot\": \"C:/Users/arcobaleno/AppData/Local/Temp/bench-stale-duplicate-AYQEBP\",\n    \"branch\": \"main\",\n    \"summary\": \"Reviewing 0 staged, 2 unstaged, and 0 untracked file(s).\"\n  },\n  \"codex\": {\n    \"status\": 0,\n    \"stderr\": \"\",\n    \"stdout\": \"{\\\"verdict\\\":\\\"needs-attention\\\",\\\"summary\\\":\\\"Do not ship: the new worker silently drops every ID in non-empty batches.\\\",\\\"findings\\\":[{\\\"severity\\\":\\\"high\\\",\\\"title\\\":\\\"Missing maxBatch causes valid IDs to be discarded\\\",\\\"body\\\":\\\"config/default.json does not define maxBatch. Therefore the first slice uses NaN as its end index and produces [], after which i becomes NaN and the loop exits. Reproduced with two valid IDs: drain([{id:'a'},{id:'b'}]) returned {\\\\\\\"queue\\\\\\\":\\\\\\\"ingest\\\\\\\",\\\\\\\"chunks\\\\\\\":[[]]}. Downstream processing would silently lose the entire batch.\\\",\\\"file\\\":\\\"src/worker.js\\\",\\\"line_start\\\":7,\\\"line_end\\\":8,\\\"confidence\\\":1,\\\"recommendation\\\":\\\"Define maxBatch as a positive integer, reject missing or invalid values at startup, and add a test proving a non-empty batch preserves every ID across chunks.\\\"}],\\\"next_steps\\\":[\\\"Fix and validate maxBatch, then rerun the working-tree review.\\\"]}\",\n    \"reasoning\": []\n  },\n  \"result\": {\n    \"verdict\": \"needs-attention\",\n    \"summary\": \"Do not ship: the new worker silently drops every ID in non-empty batches.\",\n    \"findings\": [\n      {\n        \"severity\": \"high\",\n        \"title\": \"Missing maxBatch causes valid IDs to be discarded\",\n        \"body\": \"config/default.json does not define maxBatch. Therefore the first slice uses NaN as its end index and produces [], after which i becomes NaN and the loop exits. Reproduced with two valid IDs: drain([{id:'a'},{id:'b'}]) returned {\\\"queue\\\":\\\"ingest\\\",\\\"chunks\\\":[[]]}. Downstream processing would silently lose the entire batch.\",\n        \"file\": \"src/worker.js\",\n        \"line_start\": 7,\n        \"line_end\": 8,\n        \"confidence\": 1,\n        \"recommendation\": \"Define maxBatch as a positive integer, reject missing or invalid values at startup, and add a test proving a non-empty batch preserves every ID across chunks.\"\n      }\n    ],\n    \"next_steps\": [\n      \"Fix and validate maxBatch, then rerun the working-tree review.\"\n    ]\n  },\n  \"rawOutput\": \"{\\\"verdict\\\":\\\"needs-attention\\\",\\\"summary\\\":\\\"Do not ship: the new worker silently drops every ID in non-empty batches.\\\",\\\"findings\\\":[{\\\"severity\\\":\\\"high\\\",\\\"title\\\":\\\"Missing maxBatch causes valid IDs to be discarded\\\",\\\"body\\\":\\\"config/default.json does not define maxBatch. Therefore the first slice uses NaN as its end index and produces [], after which i becomes NaN and the loop exits. Reproduced with two valid IDs: drain([{id:'a'},{id:'b'}]) returned {\\\\\\\"queue\\\\\\\":\\\\\\\"ingest\\\\\\\",\\\\\\\"chunks\\\\\\\":[[]]}. Downstream processing would silently lose the entire batch.\\\",\\\"file\\\":\\\"src/worker.js\\\",\\\"line_start\\\":7,\\\"line_end\\\":8,\\\"confidence\\\":1,\\\"recommendation\\\":\\\"Define maxBatch as a positive integer, reject missing or invalid values at startup, and add a test proving a non-empty batch preserves every ID across chunks.\\\"}],\\\"next_steps\\\":[\\\"Fix and validate maxBatch, then rerun the working-tree review.\\\"]}\",\n  \"parseError\": null,\n  \"reasoningSummary\": []\n}\n"
+}

--- a/bench/cassettes/stale-duplicate/codex.model.json
+++ b/bench/cassettes/stale-duplicate/codex.model.json
@@ -1,0 +1,76 @@
+{
+  "caseId": "stale-duplicate",
+  "cell": "codex.model",
+  "recordedAt": "2026-08-24T23:24:47.507Z",
+  "verdict": "needs-attention",
+  "summary": "Chunking can hang indefinitely when maxBatch is not a positive finite integer.",
+  "findings": [
+    {
+      "severity": "medium",
+      "title": "Invalid maxBatch causes a non-terminating drain loop",
+      "body": "The loop assumes config.maxBatch is a positive finite number. If it is 0, negative, NaN, or otherwise invalid, i may never advance toward ids.length, causing drain() to loop indefinitely and consume memory or CPU.",
+      "file": "src/worker.js",
+      "line_start": 7,
+      "line_end": 9,
+      "confidence": 0.98,
+      "recommendation": "Validate config.maxBatch before the loop as a positive finite integer and fail fast with a clear configuration error."
+    }
+  ],
+  "latencyMs": 23869,
+  "engineVersion": "codex-cli 0.149.0",
+  "engineObserved": null,
+  "samples": [
+    {
+      "verdict": "needs-attention",
+      "summary": "The worker can hang indefinitely when maxBatch is zero or negative.",
+      "findings": [
+        {
+          "severity": "high",
+          "title": "Unvalidated chunk size can cause an infinite loop",
+          "body": "The loop increments i by config.maxBatch without verifying that it is a positive integer. A zero value prevents i from advancing, while a negative value moves it away from the termination condition, causing drain() to loop indefinitely and consume memory whenever ids is nonempty.",
+          "file": "src/worker.js",
+          "line_start": 7,
+          "line_end": 9,
+          "confidence": 0.99,
+          "recommendation": "Validate config.maxBatch before the loop and throw a configuration error unless it is a positive integer."
+        }
+      ],
+      "latencyMs": 20635
+    },
+    {
+      "verdict": "needs-attention",
+      "summary": "Chunking trusts an unvalidated configuration value that can hang the worker or silently lose the batch.",
+      "findings": [
+        {
+          "severity": "high",
+          "title": "Invalid maxBatch can hang or discard work",
+          "body": "The loop uses config.maxBatch as both its increment and slice width without verifying that it is a positive integer. A value of 0 or a negative value makes the loop non-terminating for any non-empty batch; a missing, non-numeric, or fractional value can produce empty or inconsistent chunks and silently omit IDs.",
+          "file": "src/worker.js",
+          "line_start": 6,
+          "line_end": 8,
+          "confidence": 0.99,
+          "recommendation": "Validate maxBatch before the loop with Number.isInteger(config.maxBatch) && config.maxBatch > 0, and throw a clear configuration error when invalid."
+        }
+      ],
+      "latencyMs": 18304
+    },
+    {
+      "verdict": "needs-attention",
+      "summary": "Chunking can hang indefinitely when maxBatch is not a positive finite integer.",
+      "findings": [
+        {
+          "severity": "medium",
+          "title": "Invalid maxBatch causes a non-terminating drain loop",
+          "body": "The loop assumes config.maxBatch is a positive finite number. If it is 0, negative, NaN, or otherwise invalid, i may never advance toward ids.length, causing drain() to loop indefinitely and consume memory or CPU.",
+          "file": "src/worker.js",
+          "line_start": 7,
+          "line_end": 9,
+          "confidence": 0.98,
+          "recommendation": "Validate config.maxBatch before the loop as a positive finite integer and fail fast with a clear configuration error."
+        }
+      ],
+      "latencyMs": 23869
+    }
+  ],
+  "raw": "{\"verdict\":\"needs-attention\",\"summary\":\"Chunking can hang indefinitely when maxBatch is not a positive finite integer.\",\"findings\":[{\"severity\":\"medium\",\"title\":\"Invalid maxBatch causes a non-terminating drain loop\",\"body\":\"The loop assumes config.maxBatch is a positive finite number. If it is 0, negative, NaN, or otherwise invalid, i may never advance toward ids.length, causing drain() to loop indefinitely and consume memory or CPU.\",\"file\":\"src/worker.js\",\"line_start\":7,\"line_end\":9,\"confidence\":0.98,\"recommendation\":\"Validate config.maxBatch before the loop as a positive finite integer and fail fast with a clear configuration error.\"}],\"next_steps\":[\"Add maxBatch validation and tests covering zero, negative, non-numeric, and valid values.\"]}\n"
+}

--- a/bench/corpus/async-lifecycle/ground-truth.json
+++ b/bench/corpus/async-lifecycle/ground-truth.json
@@ -9,17 +9,7 @@
       "line_start": 26,
       "line_end": 28,
       "severity": "critical",
-      "match": {
-        "keywords": [
-          "swallow",
-          "ok: true",
-          "reports success",
-          "silently",
-          "catch block",
-          "hides the error",
-          "always returns"
-        ]
-      }
+      "match": { "all": ["runone"], "keywords": ["swallow", "ok: true", "reports success", "silently", "catch block", "hides the error", "always returns", "masks"] }
     },
     {
       "id": "handle-leak",
@@ -28,16 +18,7 @@
       "line_start": 6,
       "line_end": 10,
       "severity": "high",
-      "match": {
-        "keywords": [
-          "file handle",
-          "not closed",
-          "leak",
-          "finally",
-          "close()",
-          "descriptor"
-        ]
-      }
+      "match": { "all": ["openjob"], "keywords": ["file handle", "not closed", "leak", "finally", "close()", "descriptor"] }
     },
     {
       "id": "unbounded-interval",
@@ -46,15 +27,7 @@
       "line_start": 16,
       "line_end": 18,
       "severity": "medium",
-      "match": {
-        "keywords": [
-          "setinterval",
-          "never cleared",
-          "clearinterval",
-          "no handle",
-          "runs forever"
-        ]
-      }
+      "match": { "all": ["setinterval"], "keywords": ["never cleared", "clearinterval", "no handle", "runs forever", "cannot be stopped"] }
     },
     {
       "id": "floating-promise",
@@ -63,16 +36,7 @@
       "line_start": 17,
       "line_end": 17,
       "severity": "high",
-      "match": {
-        "keywords": [
-          "not awaited",
-          "floating promise",
-          "unhandled rejection",
-          "no await",
-          "no catch",
-          "promise is ignored"
-        ]
-      }
+      "match": { "all": ["appendfile"], "keywords": ["not awaited", "floating promise", "unhandled rejection", "no await", "no catch", "promise is ignored"] }
     },
     {
       "id": "unbounded-map",
@@ -81,16 +45,7 @@
       "line_start": 3,
       "line_end": 7,
       "severity": "medium",
-      "match": {
-        "keywords": [
-          "never removed",
-          "grows",
-          "unbounded",
-          "memory",
-          "delete",
-          "map is never"
-        ]
-      }
+      "match": { "all": ["handles"], "keywords": ["never removed", "grows", "unbounded", "delete", "never cleaned"] }
     }
   ],
   "allowed_extras": [

--- a/bench/corpus/auth-basic/ground-truth.json
+++ b/bench/corpus/auth-basic/ground-truth.json
@@ -9,7 +9,7 @@
       "line_start": 7,
       "line_end": 9,
       "severity": "critical",
-      "match": { "keywords": ["sql injection", "injection", "parameteriz", "concatenat"] }
+      "match": { "all": ["sql"], "keywords": ["injection", "parameteriz", "concatenat"] }
     },
     {
       "id": "hardcoded-secret",
@@ -18,7 +18,7 @@
       "line_start": 4,
       "line_end": 4,
       "severity": "high",
-      "match": { "keywords": ["hardcoded", "hard-coded", "hard coded", "secret in source", "jwt_secret"] }
+      "match": { "all": ["jwt_secret"], "keywords": ["hardcoded", "hard-coded", "hard coded", "secret in source", "in the source", "committed to source"] }
     },
     {
       "id": "null-check",
@@ -27,7 +27,7 @@
       "line_start": 14,
       "line_end": 15,
       "severity": "medium",
-      "match": { "keywords": ["null check", "null-check", "undefined", "may be null", "user could be", "missing check"] }
+      "match": { "all": ["finduser"], "keywords": ["null check", "null-check", "may be null", "could be null", "user could be", "missing check", "no row", "undefined"] }
     },
     {
       "id": "plaintext-compare",
@@ -36,7 +36,7 @@
       "line_start": 15,
       "line_end": 15,
       "severity": "high",
-      "match": { "keywords": ["plaintext", "plain text", "hash", "bcrypt", "constant-time", "timing attack"] }
+      "match": { "all": ["password"], "keywords": ["plaintext", "plain text", "hash", "bcrypt", "constant-time", "timing attack"] }
     },
     {
       "id": "json-parse",
@@ -45,7 +45,7 @@
       "line_start": 22,
       "line_end": 22,
       "severity": "high",
-      "match": { "keywords": ["json.parse", "unguarded", "try/catch", "throws", "malformed"] }
+      "match": { "all": ["json.parse"], "keywords": ["unguarded", "try/catch", "throws", "malformed", "invalid json"] }
     }
   ],
   "allowed_extras": [

--- a/bench/corpus/caller-contract/ground-truth.json
+++ b/bench/corpus/caller-contract/ground-truth.json
@@ -9,9 +9,7 @@
       "line_start": 1,
       "line_end": 1,
       "severity": "high",
-      "match": {
-        "keywords": ["profile", "profileroute", "caller", "callers", "call site", "call sites", "not updated", "still expects", "return shape", "envelope"]
-      }
+      "match": { "all": ["profile"], "keywords": ["caller", "callers", "call site", "call sites", "not updated", "still expects", "return shape", "envelope"] }
     },
     {
       "id": "admin-check-always-passes",
@@ -20,9 +18,7 @@
       "line_start": 1,
       "line_end": 1,
       "severity": "critical",
-      "match": {
-        "keywords": ["requireadmin", "admin", "role", "always truthy", "always true", "authorization", "auth bypass", "forbidden"]
-      }
+      "match": { "all": ["admin"], "keywords": ["role", "always truthy", "always true", "authorization", "auth bypass", "forbidden"] }
     }
   ],
   "allowed_extras": [

--- a/bench/corpus/path-and-input/ground-truth.json
+++ b/bench/corpus/path-and-input/ground-truth.json
@@ -9,18 +9,7 @@
       "line_start": 8,
       "line_end": 9,
       "severity": "critical",
-      "match": {
-        "keywords": [
-          "path traversal",
-          "traversal",
-          "..",
-          "escape",
-          "outside",
-          "resolve",
-          "containment",
-          "directory traversal"
-        ]
-      }
+      "match": { "keywords": ["path traversal", "traversal", "directory traversal", "outside the root", "containment", "escape the root"] }
     },
     {
       "id": "command-injection",
@@ -29,16 +18,7 @@
       "line_start": 13,
       "line_end": 13,
       "severity": "critical",
-      "match": {
-        "keywords": [
-          "command injection",
-          "execsync",
-          "shell",
-          "interpolat",
-          "untrusted",
-          "execfile"
-        ]
-      }
+      "match": { "all": ["execsync"], "keywords": ["command injection", "shell", "interpolat", "untrusted", "execfile"] }
     },
     {
       "id": "parseint-radix",
@@ -47,17 +27,7 @@
       "line_start": 17,
       "line_end": 18,
       "severity": "medium",
-      "match": {
-        "keywords": [
-          "radix",
-          "parseint",
-          "nan",
-          "not validated",
-          "negative",
-          "out of range",
-          "undefined"
-        ]
-      }
+      "match": { "all": ["parseint"], "keywords": ["radix", "nan", "not validated", "negative", "out of range"] }
     },
     {
       "id": "unbounded-read",
@@ -66,16 +36,7 @@
       "line_start": 9,
       "line_end": 9,
       "severity": "medium",
-      "match": {
-        "keywords": [
-          "size limit",
-          "entire file",
-          "memory",
-          "large file",
-          "no limit",
-          "streaming"
-        ]
-      }
+      "match": { "all": ["readfilesync"], "keywords": ["size limit", "entire file", "large file", "no limit", "streaming"] }
     },
     {
       "id": "unhandled-enoent",
@@ -84,16 +45,7 @@
       "line_start": 7,
       "line_end": 9,
       "severity": "medium",
-      "match": {
-        "keywords": [
-          "enoent",
-          "missing file",
-          "throws",
-          "try/catch",
-          "does not exist",
-          "unhandled"
-        ]
-      }
+      "match": { "keywords": ["enoent", "no such file", "file does not exist", "missing file"] }
     }
   ],
   "allowed_extras": [

--- a/bench/corpus/repo-context/ground-truth.json
+++ b/bench/corpus/repo-context/ground-truth.json
@@ -9,7 +9,7 @@
       "line_start": 1,
       "line_end": 1,
       "severity": "high",
-      "match": { "keywords": ["jsonwebtoken", "undeclared", "not declared", "missing dependency", "not listed", "not in package.json"] }
+      "match": { "all": ["jsonwebtoken"], "keywords": ["undeclared", "not declared", "missing dependency", "not listed", "not in package.json"] }
     },
     {
       "id": "committed-state",
@@ -18,7 +18,7 @@
       "line_start": 1,
       "line_end": 1,
       "severity": "medium",
-      "match": { "keywords": [".omc/state", "runtime state", "should not be committed", "gitignore", "should be ignored", "untracked state"] }
+      "match": { "all": [".omc"], "keywords": ["runtime state", "should not be committed", "gitignore", "should be ignored", "untracked state"] }
     }
   ],
   "allowed_extras": []

--- a/bench/corpus/stale-duplicate/ground-truth.json
+++ b/bench/corpus/stale-duplicate/ground-truth.json
@@ -9,9 +9,7 @@
       "line_start": 1,
       "line_end": 1,
       "severity": "high",
-      "match": {
-        "keywords": ["v1", "api/v1", "duplicate", "copy", "same bug", "not applied", "legacy", "both versions"]
-      }
+      "match": { "all": ["v1"], "keywords": ["duplicate", "copy", "same bug", "not applied", "legacy", "both versions"] }
     },
     {
       "id": "undefined-config-key",
@@ -20,9 +18,7 @@
       "line_start": 1,
       "line_end": 1,
       "severity": "high",
-      "match": {
-        "keywords": ["maxbatch", "config", "default.json", "undefined", "not defined", "missing key", "nan"]
-      }
+      "match": { "all": ["maxbatch"], "keywords": ["config", "default.json", "undefined", "not defined", "missing key", "nan"] }
     }
   ],
   "allowed_extras": [

--- a/bench/corpus/vacuous-tests/ground-truth.json
+++ b/bench/corpus/vacuous-tests/ground-truth.json
@@ -9,15 +9,7 @@
       "line_start": 6,
       "line_end": 7,
       "severity": "high",
-      "match": {
-        "keywords": [
-          "no assertion",
-          "asserts nothing",
-          "does not assert",
-          "always passes",
-          "no expectation"
-        ]
-      }
+      "match": { "all": ["parsesession"], "keywords": ["no assertion", "asserts nothing", "does not assert", "always passes", "no expectation"] }
     },
     {
       "id": "vacuous-ordering",
@@ -26,18 +18,7 @@
       "line_start": 11,
       "line_end": 12,
       "severity": "high",
-      "match": {
-        "keywords": [
-          "indexof",
-          "-1",
-          "not present",
-          "absent",
-          "empty",
-          "vacuous",
-          "passes when",
-          "missing element"
-        ]
-      }
+      "match": { "all": ["indexof"], "keywords": ["-1", "not present", "absent", "vacuous", "passes when", "missing element"] }
     },
     {
       "id": "permanent-skip",
@@ -46,15 +27,7 @@
       "line_start": 15,
       "line_end": 18,
       "severity": "medium",
-      "match": {
-        "keywords": [
-          "skip",
-          "never runs",
-          "disabled",
-          "not executed",
-          "unprotected"
-        ]
-      }
+      "match": { "all": ["test.skip"], "keywords": ["never runs", "disabled", "not executed", "skipped permanently", "unprotected"] }
     },
     {
       "id": "assertion-never-runs",
@@ -63,17 +36,7 @@
       "line_start": 22,
       "line_end": 24,
       "severity": "high",
-      "match": {
-        "keywords": [
-          "callback",
-          "nexttick",
-          "after the test",
-          "never runs",
-          "asynchronous",
-          "not awaited",
-          "test ends"
-        ]
-      }
+      "match": { "all": ["nexttick"], "keywords": ["callback", "after the test", "never runs", "asynchronous", "not awaited", "test ends"] }
     }
   ],
   "allowed_extras": [

--- a/bench/lib/score.mjs
+++ b/bench/lib/score.mjs
@@ -3,7 +3,7 @@
 // (see bench/review-output.schema.json), so one scorer grades both.
 //
 // finding:  { severity, title, body, file, line_start, line_end, confidence, recommendation }
-// planted:  { id, category, file, line_start, line_end, severity, match: { keywords: [...] } }
+// planted:  { id, category, file, line_start, line_end, severity, match: { keywords: [...], all?: [...] } }
 // extra:    { id, file?, match: { keywords: [...] } }   // a legitimate "unique catch", not a false positive
 // truth:    { planted: [planted...], allowed_extras: [extra...] }
 
@@ -22,9 +22,28 @@ function rangesOverlap(aStart, aEnd, bStart, bEnd, tol = 0) {
   return aStart - tol <= bEnd && bStart <= aEnd + tol;
 }
 
-function keywordsHit(finding, keywords) {
-  if (!Array.isArray(keywords) || keywords.length === 0) return false;
-  const hay = `${finding.title ?? ""} ${finding.body ?? ""}`.toLowerCase();
+function haystack(finding) {
+  return `${finding.title ?? ""} ${finding.body ?? ""}`.toLowerCase();
+}
+
+// `match.keywords` is any-of: the reviewer's wording for the claim is free.
+// `match.all` is every-of: the subject the finding has to actually be about.
+//
+// The split exists because a wildcard defect (`file: "*"`) is matched on words
+// alone, and a subject word is a word every finding about that area writes down.
+// `repo-context` listed the bare module name among its any-of keywords, so a
+// finding about an unvalidated secret — which mentioned the module only in
+// passing — was credited with catching a missing manifest entry. Put the subject
+// in `all` and the claim in `keywords`, and a finding has to carry both.
+function keywordsHit(finding, keywords, required) {
+  const hay = haystack(finding);
+  if (Array.isArray(required) && required.length > 0) {
+    if (!required.every((k) => hay.includes(String(k).toLowerCase()))) return false;
+    // `all` on its own is a complete rule; `keywords` narrows it when present.
+    if (!Array.isArray(keywords) || keywords.length === 0) return true;
+  } else if (!Array.isArray(keywords) || keywords.length === 0) {
+    return false;
+  }
   return keywords.some((k) => hay.includes(String(k).toLowerCase()));
 }
 
@@ -46,7 +65,7 @@ function fileMatches(findingFile, declaredFile) {
 
 function matchQuality(finding, planted, lineTolerance) {
   if (!fileMatches(finding.file, planted.file)) return 0;
-  if (keywordsHit(finding, planted.match?.keywords)) return 2;
+  if (keywordsHit(finding, planted.match?.keywords, planted.match?.all)) return 2;
   if (planted.file === "*" || !planted.file) return 0; // wildcard defects are keyword-only
   const lineOk = rangesOverlap(
     finding.line_start,
@@ -64,7 +83,7 @@ export function findingMatchesPlanted(finding, planted, { lineTolerance = 0 } = 
 
 function findingMatchesExtra(finding, extra) {
   if (extra.file && normalizeFile(finding.file) !== normalizeFile(extra.file)) return false;
-  return keywordsHit(finding, extra.match?.keywords);
+  return keywordsHit(finding, extra.match?.keywords, extra.match?.all);
 }
 
 function severityCalibration(plantedSeverity, findingSeverity) {

--- a/bench/run-bench.test.mjs
+++ b/bench/run-bench.test.mjs
@@ -69,6 +69,97 @@ test("findingMatchesPlanted rejects a different file", () => {
   assert.equal(findingMatchesPlanted(f, TRUTH.planted[0]), false);
 });
 
+// The real miss this pins: `repo-context` plants an undeclared-dependency defect
+// with `file: "*"`, so matching is keyword-only, and one of its keywords was the
+// bare module name. Every reviewer that discussed `src/token.js` at all wrote
+// "jsonwebtoken" somewhere in the body, so a finding about an unvalidated secret
+// was credited with catching a missing manifest entry it never mentioned. That
+// single false credit was worth 42 composite points to one cell (96.7 -> 55.0) and
+// not to others, which is worse than being wrong uniformly: it moved the cells
+// relative to each other, and the whole benchmark is a comparison between cells.
+//
+// `match.all` is the subject the finding has to actually be about; `match.keywords`
+// stays any-of, so a reviewer's choice of words for the claim is still free.
+test("a wildcard defect is not credited to a finding about a different subject", () => {
+  const truth = {
+    planted: [
+      {
+        id: "missing-dependency",
+        file: "*",
+        line_start: 1,
+        line_end: 1,
+        severity: "high",
+        match: {
+          all: ["jsonwebtoken"],
+          keywords: ["undeclared", "not declared", "missing dependency", "not in package.json"]
+        }
+      }
+    ],
+    allowed_extras: []
+  };
+
+  // Says the claim, about the wrong module. Keyword-only matching credits it.
+  const wrongSubject = finding({
+    severity: "high",
+    title: "Missing dependency on the validation middleware",
+    body: "src/routes/profile.js calls validateBody(), which is not declared anywhere in this package.",
+    file: "src/routes/profile.js"
+  });
+  // Names the subject, makes a different claim. `all` alone would credit it.
+  const wrongClaim = finding({
+    severity: "critical",
+    title: "JWT_SECRET used without validation",
+    body: "process.env.JWT_SECRET goes straight to jwt.sign(). Empty string, and jsonwebtoken signs with a zero-length secret.",
+    file: "src/token.js"
+  });
+  // Both: this is the finding the defect was planted for.
+  const theCatch = finding({
+    severity: "high",
+    title: "Undeclared 'jsonwebtoken' dependency",
+    body: "src/token.js requires jsonwebtoken, which is not declared in package.json.",
+    file: "src/token.js"
+  });
+
+  assert.equal(findingMatchesPlanted(wrongSubject, truth.planted[0]), false);
+  assert.equal(findingMatchesPlanted(wrongClaim, truth.planted[0]), false);
+  assert.equal(findingMatchesPlanted(theCatch, truth.planted[0]), true);
+
+  const missed = scoreReview([wrongSubject, wrongClaim], truth);
+  assert.equal(missed.found, 0);
+  assert.equal(missed.falsePositives, 2);
+  assert.deepEqual(missed.missed, ["missing-dependency"]);
+
+  const caught = scoreReview([theCatch], truth);
+  assert.equal(caught.found, 1);
+  assert.equal(caught.falsePositives, 0);
+});
+
+test("every term in `all` has to be there, not just one of them", () => {
+  const planted = {
+    id: "unread-config-key",
+    file: "*",
+    line_start: 1,
+    line_end: 1,
+    severity: "high",
+    match: { all: ["maxbatch", "default.json"], keywords: ["missing", "absent", "not defined"] }
+  };
+
+  // Names the key, blames the wrong file. One of two required terms.
+  const halfRight = finding({
+    title: "config.maxBatch is missing",
+    body: "worker.js reads config.maxBatch, which nothing in src/ ever defines.",
+    file: "src/worker.js"
+  });
+  const bothTerms = finding({
+    title: "config.maxBatch is missing from the shipped config",
+    body: "src/worker.js reads config.maxBatch; config/default.json does not define it.",
+    file: "src/worker.js"
+  });
+
+  assert.equal(findingMatchesPlanted(halfRight, planted), false);
+  assert.equal(findingMatchesPlanted(bothTerms, planted), true);
+});
+
 test("scoreReview gives full recall and clean precision when both planted defects are found", () => {
   const findings = [
     finding({ severity: "critical", title: "SQL injection", body: "not parameterized", line_start: 10, line_end: 12 }),

--- a/bench/run-bench.test.mjs
+++ b/bench/run-bench.test.mjs
@@ -160,6 +160,34 @@ test("every term in `all` has to be there, not just one of them", () => {
   assert.equal(findingMatchesPlanted(bothTerms, planted), true);
 });
 
+// A guard on the corpus rather than on the scorer. A `file: "*"` defect has no
+// filename to disambiguate it, so words are the whole rule, and the failure this
+// pins is silent: the defect keeps matching, just too much. Requiring `all` does
+// not make the subject right — it makes leaving the subject out a test failure
+// instead of a number nobody questions.
+test("every repository-scoped defect declares the subject it is about", () => {
+  const corpusDir = path.join(import.meta.dirname, "corpus");
+  const cases = fs
+    .readdirSync(corpusDir, { withFileTypes: true })
+    .filter((d) => d.isDirectory())
+    .map((d) => d.name);
+  assert.ok(cases.length > 0, "corpus is empty");
+
+  const offenders = [];
+  for (const caseId of cases) {
+    const file = path.join(corpusDir, caseId, "ground-truth.json");
+    if (!fs.existsSync(file)) continue;
+    const truth = JSON.parse(fs.readFileSync(file, "utf8"));
+    for (const p of truth.planted ?? []) {
+      if (p.file && p.file !== "*") continue;
+      if (!Array.isArray(p.match?.all) || p.match.all.length === 0) {
+        offenders.push(`${caseId}/${p.id}`);
+      }
+    }
+  }
+  assert.deepEqual(offenders, []);
+});
+
 test("scoreReview gives full recall and clean precision when both planted defects are found", () => {
   const findings = [
     finding({ severity: "critical", title: "SQL injection", body: "not parameterized", line_start: 10, line_end: 12 }),

--- a/plugins/gemini/CHANGELOG.md
+++ b/plugins/gemini/CHANGELOG.md
@@ -2,18 +2,47 @@
 
 ## Unreleased
 
-- **The harness lift, split: exploration is worth +26 and the plugin's own review
-  prompt is worth −16.** The `*.shallow` control cells now record, and the −4.4 lift
-  reported this morning turns out to have been two opposing effects cancelling.
-  Measured on agy 1.1.19, seven cases, three samples each: `model → shallow` (prompt
-  only) averages −16.0, `shallow → deep` (exploration only) averages +26.0.
+- **The scorer credited a finding for naming a defect's subject without making its
+  claim.** `repo-context` plants an undeclared dependency with `file: "*"`, so it is
+  matched on words alone — and one of those words was the bare module name. Every
+  reviewer that discussed `src/token.js` wrote "jsonwebtoken" somewhere, so a finding
+  about an unvalidated secret was credited with catching a missing manifest entry it
+  never mentioned. `agy.model` on that case was reading 96.7; it is 55.0.
 
-  Both halves land where the design predicts. Exploration is worth +68, +53 and +49 on
+  A ground-truth `match` now takes `all` (every-of: the subject) alongside `keywords`
+  (any-of: the claim), and the three wildcard cases declare both. Mutation-confirmed
+  against ignoring `all` and against relaxing it to any-of.
+
+  This mattered more than its size: the false credit was worth 42 points to one cell
+  and nothing to others, and a board whose whole purpose is comparing cells is worse
+  off being wrong unevenly than being wrong uniformly. A second looseness is still
+  standing and is now written down in `bench/README.md`: 16% of recorded findings
+  keyword-match more than one planted defect in their case, all of it in the four
+  file-scoped cases where five defects share one file and one vocabulary.
+
+- **The harness lift, split: exploration is worth +27 and the plugin's own review
+  prompt is worth −13.** The `*.shallow` control cells now record, and the −4.4 lift
+  reported earlier turns out to have been two opposing effects cancelling.
+  Measured on agy 1.1.19, seven cases, three samples each: `model → shallow` (prompt
+  only) averages −13.1, `shallow → deep` (exploration only) averages +27.2.
+
+  Both halves land where the design predicts. Exploration is worth +68, +61 and +49 on
   the three repository-scoped cases and +4, +2, 0, +6 on the four file-scoped ones. The
-  prompt penalty concentrates on those same repository-scoped cases (−60 on
-  `repo-context`, −25 on `stale-duplicate`), which is worth someone's attention: a
-  prompt that tells the model to fold in dependency manifests, callers and untracked
-  files appears to cost accuracy when it has no tools to go and read them.
+  prompt penalty concentrates on those same repository-scoped cases (−40 on
+  `repo-context`, −25 on `stale-duplicate`).
+
+  What that penalty is not: not the `DEEP REVIEW MODE` block, which the `*.shallow`
+  cells never see, and not a thinner input — probed across all seven cases,
+  `REVIEW_INPUT` runs 645 to 1414 characters against a 400,000 cap with the full diff
+  present in both arms. It is `prompts/review.md` itself, and what in it costs the
+  points is not established. An earlier draft of this entry blamed a prompt "that
+  tells the model to fold in dependency manifests, callers and untracked files";
+  `review.md` says no such thing — lines 75-80 forbid tools outright.
+
+  Only the −13 is robust. Refusing every ambiguous keyword credit as a hard lower
+  bound leaves the prompt penalty at −12.6 but takes exploration to +12.4, so the
+  exploration lift is +12 to +27 until the four file-scoped cases get the same
+  subject/claim split.
 
   Two defects had to be fixed to get the reading. The runner decided whether to
   materialize a repository from `harness === "agentic"`, which is true of every cell

--- a/plugins/gemini/CHANGELOG.md
+++ b/plugins/gemini/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 ## Unreleased
 
+- **codex now reads on the two repository-scoped cases too.** `codex.model` and
+  `codex.adversarial` recorded on `caller-contract` and `stale-duplicate`, three
+  samples each, codex-cli 0.149.0 — twelve live runs, no cassette overwritten.
+
+  | case | codex.model | codex.adversarial | agy.model | agy.deep |
+  |---|:-:|:-:|:-:|:-:|
+  | caller-contract | 0 | 43 | 0 | 68 |
+  | stale-duplicate | 62 | 65 | 43 | 67 |
+
+  `caller-contract` is 0 for both single-shot cells, which is the case working: its
+  two defects sit in callers the diff never touches, so there is nothing in the diff
+  to find. Codex's adversarial reviewer explores, and it clears its own single-shot
+  reading on both — a harness reading, not a prompt one, and the same direction agy's
+  `--deep` shows.
+
+  `codex.adversarial` needs `BENCH_CODEX_COMPANION`; without it the cell reports
+  `skipped (companion path not configured)` and costs nothing, which is how the first
+  half of this recording ran before the variable was set.
+
 - **The scorer credited a finding for naming a defect's subject without making its
   claim.** `repo-context` plants an undeclared dependency with `file: "*"`, so it is
   matched on words alone — and one of those words was the bare module name. Every

--- a/plugins/gemini/CHANGELOG.md
+++ b/plugins/gemini/CHANGELOG.md
@@ -15,19 +15,32 @@
 
   This mattered more than its size: the false credit was worth 42 points to one cell
   and nothing to others, and a board whose whole purpose is comparing cells is worse
-  off being wrong unevenly than being wrong uniformly. A second looseness is still
-  standing and is now written down in `bench/README.md`: 16% of recorded findings
-  keyword-match more than one planted defect in their case, all of it in the four
-  file-scoped cases where five defects share one file and one vocabulary.
+  off being wrong unevenly than being wrong uniformly.
 
-- **The harness lift, split: exploration is worth +27 and the plugin's own review
+  The four file-scoped cases were split the same way. Five defects sharing one file
+  also share a vocabulary, and `undefined`, `leak`, `throws`, `memory` and `..` were
+  carrying credit with no claim attached to them. Findings matching more than one of
+  their case's planted defects fell from 16% to 2.4%, and no cell's mean moved by
+  more than 1.5 points — the correction was concentrated, not diffuse.
+
+  What remains at 2.4% is left deliberately: all ten are findings that report two
+  defects in one entry ("Plaintext Password Comparison and Unchecked Null User"),
+  which the scorer credits once and therefore under-counts. Whether a merged finding
+  should earn both credits is a question about the scorer's semantics, not about
+  keyword looseness, and it is not answered here.
+
+  A `file: "*"` defect that does not declare `match.all` is now a test failure. There
+  the filename disambiguates nothing, so leaving the subject out is silent: the defect
+  goes on matching, just too much.
+
+- **The harness lift, split: exploration is worth +28 and the plugin's own review
   prompt is worth −13.** The `*.shallow` control cells now record, and the −4.4 lift
   reported earlier turns out to have been two opposing effects cancelling.
   Measured on agy 1.1.19, seven cases, three samples each: `model → shallow` (prompt
-  only) averages −13.1, `shallow → deep` (exploration only) averages +27.2.
+  only) averages −13.3, `shallow → deep` (exploration only) averages +27.8.
 
   Both halves land where the design predicts. Exploration is worth +68, +61 and +49 on
-  the three repository-scoped cases and +4, +2, 0, +6 on the four file-scoped ones. The
+  the three repository-scoped cases and +2, +2, 0, +12 on the four file-scoped ones. The
   prompt penalty concentrates on those same repository-scoped cases (−40 on
   `repo-context`, −25 on `stale-duplicate`).
 
@@ -39,10 +52,10 @@
   tells the model to fold in dependency manifests, callers and untracked files";
   `review.md` says no such thing — lines 75-80 forbid tools outright.
 
-  Only the −13 is robust. Refusing every ambiguous keyword credit as a hard lower
-  bound leaves the prompt penalty at −12.6 but takes exploration to +12.4, so the
-  exploration lift is +12 to +27 until the four file-scoped cases get the same
-  subject/claim split.
+  Refusing every remaining ambiguous credit takes exploration to +12.5, but that is a
+  statement about how a merged finding is counted rather than about the matcher, and
+  most of the swing is `caller-contract`, where two of the four recorded findings
+  report both planted defects in one entry.
 
   Two defects had to be fixed to get the reading. The runner decided whether to
   materialize a repository from `harness === "agentic"`, which is true of every cell


### PR DESCRIPTION
Stacked on #106.

## What was wrong

`repo-context` plants an undeclared dependency with `file: "*"`, so the scorer matches it on words alone — and one of those words was the bare module name `jsonwebtoken`. Every reviewer that discussed `src/token.js` at all wrote it somewhere in the body, so a finding about an unvalidated `JWT_SECRET` was credited with catching a missing manifest entry it never mentioned.

`agy.model` on that case was reading **96.7**. It is **55.0**.

The size is not the point. That false credit was worth 42 composite points to one cell and nothing to the others, and a board whose only purpose is comparing cells is worse off wrong unevenly than wrong uniformly.

## The fix

A ground-truth `match` now takes two lists:

- `keywords` — **any-of**, the claim. The reviewer's wording stays free.
- `all` — **every-of**, the subject the finding has to actually be about.

All seven cases declare both. The four file-scoped cases needed it as much as the wildcard ones: five defects sharing one file share a vocabulary too, and `undefined` (15 cross-matches), `leak` (15), `throws` (7), `memory` (5) and `..` (matched any ellipsis) were carrying credit with no claim attached. Every subject is taken from the source under review — `openJob`, `startHeartbeat`, `runOne`, `JSON.parse`, `execSync`, `nextTick` — not from the recorded findings, because fitting the rubric to the answers already on file is the failure this whole exercise is about.

Findings matching more than one of their case's planted defects: **16% → 2.4%**. No cell's mean moved by more than 1.5 points, and the moves are upward — with the generic words gone, findings stop being assigned to a neighbour and land on the defect they were about.

## What this moves

Re-derived from the recorded cassettes, no new quota spent:

| | before | after |
|---|:-:|:-:|
| prompt penalty (`model → shallow`) | −16.0 | **−13.3** |
| exploration (`shallow → deep`) | +26.0 | **+27.8** |
| `repo-context` `agy.model` | 96.7 | **55.0** |

## What this retracts

#106 blamed the prompt penalty on "a prompt that tells the model to fold in dependency manifests, callers and untracked files". `prompts/review.md` says no such thing — lines 75–80 forbid tools outright — and the `*.shallow` cells never see the `DEEP REVIEW MODE` block that does say it. Probing all seven cases also rules out a thinner input: `REVIEW_INPUT` runs 645–1414 characters against a 400,000 cap, with the full diff present in both arms. The penalty is `review.md` itself and nothing here explains it. `bench/README.md` and the CHANGELOG now say that instead.

## What is deliberately left

The 2.4% that remains is not the same phenomenon: all ten are one finding reporting two defects in a single entry ("Plaintext Password Comparison and Unchecked Null User"), which the scorer credits once and therefore under-counts. Whether a merged finding should earn both credits is a question about scorer semantics, not keyword looseness.

It also means the −12.5 lower bound quoted mid-way through this work was measuring the wrong thing: two of `caller-contract`'s four recorded findings are merged reports, and dropping them is what took exploration to +12.5.

## Tests

- The false credit is pinned by a test that fails on the old matcher. Mutation-confirmed twice: against ignoring `all`, and against relaxing it from every-of to any-of.
- A `file: "*"` defect that does not declare `match.all` is now a test failure — that failure mode is otherwise silent, since the defect keeps matching, just too much. Mutation-confirmed by dropping `all` from `repo-context`.
- `npm test`: 611 tests, 603 pass, 0 fail, 8 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0194A6X6tcQLqwwCVqLn7VUw