### PR TITLE
fix(mcp): start Gemini server on Codex Windows

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,13 +7,13 @@
   },
   "metadata": {
     "description": "Use Gemini CLI or Antigravity CLI (agy) inside Claude Code for task delegation, code review, and adversarial review.",
-    "version": "0.22.3"
+    "version": "0.22.4"
   },
   "plugins": [
     {
       "name": "gemini",
       "description": "Gemini CLI and Antigravity CLI bridge for Claude Code task delegation and adversarial review",
-      "version": "0.22.3",
+      "version": "0.22.4",
       "author": {
         "name": "arcobaleno64",
         "email": "arcobaleno830623@gmail.com"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@arcobaleno64/gemini-plugin-cc",
-  "version": "0.22.3",
+  "version": "0.22.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@arcobaleno64/gemini-plugin-cc",
-      "version": "0.22.3",
+      "version": "0.22.4",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arcobaleno64/gemini-plugin-cc",
-  "version": "0.22.3",
+  "version": "0.22.4",
   "private": true,
   "type": "module",
   "description": "Use Gemini CLI or Antigravity CLI (agy) inside Claude Code for task delegation, code review, and adversarial review.",

--- a/plugins/gemini/.claude-plugin/plugin.json
+++ b/plugins/gemini/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gemini",
-  "version": "0.22.3",
+  "version": "0.22.4",
   "description": "Use Gemini/AGY from Claude Code to review code or delegate tasks.",
   "author": {
     "name": "arcobaleno64",

--- a/plugins/gemini/.mcp.json
+++ b/plugins/gemini/.mcp.json
@@ -2,8 +2,7 @@
   "mcpServers": {
     "gemini": {
       "command": "node",
-      "args": ["${CLAUDE_PLUGIN_ROOT}/scripts/gemini-mcp.mjs"],
-      "cwd": "${CLAUDE_PLUGIN_ROOT}"
+      "args": ["${CLAUDE_PLUGIN_ROOT}/scripts/gemini-mcp.mjs"]
     }
   }
 }

--- a/plugins/gemini/CHANGELOG.md
+++ b/plugins/gemini/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+## 0.22.4 — 2026-08-25 — Start the MCP before it can do anything else
+
+- **The Gemini MCP now starts under Codex on Windows.** Its manifest supplied
+  `${CLAUDE_PLUGIN_ROOT}` as both the script location and the process working
+  directory. Codex expands the script argument but passed the working directory
+  through literally, so Windows rejected process creation with error 267 before
+  the server could answer `initialize`. The manifest now inherits the host working
+  directory while keeping the script path rooted at the plugin. The launch test
+  pins that split and waits for the server process to exit before removing its
+  temporary Windows directory.
+
 - **Half of the -13 prompt penalty is now diagnosed, and the other half is now known
   not to be what it looked like.** The board reported that `prompts/review.md`, run
   without tools, costs 13 composite points against the bench's neutral prompt, and

--- a/tests/mcp-launch.test.mjs
+++ b/tests/mcp-launch.test.mjs
@@ -4,16 +4,17 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { spawn } from "node:child_process";
+import { once } from "node:events";
 import { fileURLToPath } from "node:url";
 
 const PLUGIN_ROOT = path.resolve(fileURLToPath(new URL("../plugins/gemini", import.meta.url)));
 
-// Regression guard for the .mcp.json launch path: the declared command/args
-// MUST resolve relative to the plugin root (${CLAUDE_PLUGIN_ROOT}), NOT the
-// host's cwd. A relative "./scripts/..." + cwd "." would fail to launch
-// whenever the user's cwd differs from the plugin dir -- which is the normal
-// case. So we launch EXACTLY what .mcp.json declares, from a temp cwd that is
-// deliberately not the plugin dir, and require it to answer initialize.
+// Regression guard for the .mcp.json launch path: the script argument MUST
+// resolve relative to the plugin root (${CLAUDE_PLUGIN_ROOT}), while the server
+// MUST NOT declare cwd using that placeholder. Codex expands the script argument
+// but may pass cwd through literally on Windows, where process creation then
+// fails with ERROR_DIRECTORY (267). Launch from a temp cwd that is deliberately
+// not the plugin dir and require the server to answer initialize.
 test("the .mcp.json server command launches from a cwd that is not the plugin dir", async () => {
   const config = JSON.parse(fs.readFileSync(path.join(PLUGIN_ROOT, ".mcp.json"), "utf8"));
   const server = config.mcpServers.gemini;
@@ -21,7 +22,7 @@ test("the .mcp.json server command launches from a cwd that is not the plugin di
   const expand = (s) => s.replaceAll("${CLAUDE_PLUGIN_ROOT}", PLUGIN_ROOT);
   const command = expand(server.command);
   const args = server.args.map(expand);
-  const cwd = server.cwd ? expand(server.cwd) : undefined;
+  assert.equal(server.cwd, undefined, ".mcp.json must inherit the host cwd instead of declaring ${CLAUDE_PLUGIN_ROOT} as cwd");
 
   // Sanity: the resolved script path must be absolute and exist, so a
   // relative-path regression (./scripts/...) is caught before spawning.
@@ -29,7 +30,7 @@ test("the .mcp.json server command launches from a cwd that is not the plugin di
   assert.ok(scriptArg && path.isAbsolute(scriptArg) && fs.existsSync(scriptArg), `.mcp.json must resolve gemini-mcp.mjs to an existing absolute path, got: ${scriptArg}`);
 
   const tempCwd = fs.mkdtempSync(path.join(os.tmpdir(), "gemini-mcp-launch-"));
-  const child = spawn(command, args, { cwd: cwd ?? tempCwd, stdio: ["pipe", "pipe", "pipe"], shell: process.platform === "win32" && !path.isAbsolute(command) });
+  const child = spawn(command, args, { cwd: tempCwd, stdio: ["pipe", "pipe", "pipe"] });
 
   try {
     const firstLine = new Promise((resolve, reject) => {
@@ -52,7 +53,10 @@ test("the .mcp.json server command launches from a cwd that is not the plugin di
     assert.equal(reply.result.serverInfo.name, "gemini");
     assert.equal(typeof reply.result.protocolVersion, "string");
   } finally {
-    child.kill();
+    if (child.exitCode === null && child.signalCode === null) {
+      child.kill();
+      await once(child, "exit");
+    }
     fs.rmSync(tempCwd, { recursive: true, force: true });
   }
 });


### PR DESCRIPTION
## Summary

- remove the unexpanded plugin-root working directory from the Gemini MCP manifest
- pin the inherited-cwd launch contract and deterministic Windows cleanup in the MCP launch test
- release as v0.22.4 with synchronized metadata and changelog

## Verification

- npm test — 606 passed, 8 skipped, 0 failed
- npm run bench
- npm run check-version
- npm run verify-contracts
- claude plugin validate ./plugins/gemini --strict
- claude plugin validate . --strict