### PR TITLE
Resolve the plugin root at runtime instead of trusting the host

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,13 +7,13 @@
   },
   "metadata": {
     "description": "Use Gemini CLI or Antigravity CLI (agy) inside Claude Code for task delegation, code review, and adversarial review.",
-    "version": "0.22.4"
+    "version": "0.22.5"
   },
   "plugins": [
     {
       "name": "gemini",
       "description": "Gemini CLI and Antigravity CLI bridge for Claude Code task delegation and adversarial review",
-      "version": "0.22.4",
+      "version": "0.22.5",
       "author": {
         "name": "arcobaleno64",
         "email": "arcobaleno830623@gmail.com"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@arcobaleno64/gemini-plugin-cc",
-  "version": "0.22.4",
+  "version": "0.22.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@arcobaleno64/gemini-plugin-cc",
-      "version": "0.22.4",
+      "version": "0.22.5",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arcobaleno64/gemini-plugin-cc",
-  "version": "0.22.4",
+  "version": "0.22.5",
   "private": true,
   "type": "module",
   "description": "Use Gemini CLI or Antigravity CLI (agy) inside Claude Code for task delegation, code review, and adversarial review.",

--- a/plugins/gemini/.claude-plugin/plugin.json
+++ b/plugins/gemini/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gemini",
-  "version": "0.22.4",
+  "version": "0.22.5",
   "description": "Use Gemini/AGY from Claude Code to review code or delegate tasks.",
   "author": {
     "name": "arcobaleno64",

--- a/plugins/gemini/.mcp.json
+++ b/plugins/gemini/.mcp.json
@@ -2,7 +2,14 @@
   "mcpServers": {
     "gemini": {
       "command": "node",
-      "args": ["${CLAUDE_PLUGIN_ROOT}/scripts/gemini-mcp.mjs"]
+      "args": [
+        "-e",
+        "process.env.GEMINI_MCP_STDIO='1';const r=process.env.GEMINI_PLUGIN_ROOT||'';const root=(!r||/[{}]/.test(r))?process.cwd():r;const{pathToFileURL}=require('node:url');const{join}=require('node:path');import(pathToFileURL(join(root,'scripts','gemini-mcp.mjs')).href).catch((e)=>{console.error(e);process.exit(1)})"
+      ],
+      "cwd": ".",
+      "env": {
+        "GEMINI_PLUGIN_ROOT": "${CLAUDE_PLUGIN_ROOT}"
+      }
     }
   }
 }

--- a/plugins/gemini/.mcp.json
+++ b/plugins/gemini/.mcp.json
@@ -4,7 +4,7 @@
       "command": "node",
       "args": [
         "-e",
-        "process.env.GEMINI_MCP_STDIO='1';const r=process.env.GEMINI_PLUGIN_ROOT||'';const root=(!r||/[{}]/.test(r))?process.cwd():r;const{pathToFileURL}=require('node:url');const{join}=require('node:path');import(pathToFileURL(join(root,'scripts','gemini-mcp.mjs')).href).catch((e)=>{console.error(e);process.exit(1)})"
+        "process.env.GEMINI_MCP_STDIO='1';const p=require('node:path');const r=String(process.env.GEMINI_PLUGIN_ROOT);const root=p.isAbsolute(r)?r:process.cwd();import(require('node:url').pathToFileURL(p.join(root,'scripts','gemini-mcp.mjs')).href).catch(function(e){console.error(e);process.exit(1)})"
       ],
       "cwd": ".",
       "env": {

--- a/plugins/gemini/CHANGELOG.md
+++ b/plugins/gemini/CHANGELOG.md
@@ -13,6 +13,15 @@
   host that substitutes, through `cwd: "."` for the host that does not -- and a
   short `node -e` bootstrap uses whichever arrived intact. The launch test runs
   each host's reading, including Codex forwarding no env at all.
+- **The bootstrap's start signal no longer escapes into everything the server
+  spawns.** `GEMINI_MCP_STDIO` was set in the bootstrap's own environment, and
+  the server hands `process.env` to its detached worker, which hands it to the
+  CLI -- so any descendant that merely imported the server module took over
+  stdin and never exited, hanging a delegated turn that ran this repo's suite.
+  The guard now deletes the flag before starting, so it is consumed rather than
+  inherited. The bootstrap also drops `||` and `=>`: hosts spawn `node`
+  directly today, but one `shell: true` away those are cmd.exe operators, and
+  `>` there creates a file.
 
 ## 0.22.4 — 2026-08-25 — Start the MCP before it can do anything else
 

--- a/plugins/gemini/CHANGELOG.md
+++ b/plugins/gemini/CHANGELOG.md
@@ -1,6 +1,18 @@
 # Changelog
 
-## Unreleased
+## 0.22.5 — 2026-08-25 — Neither host reads the manifest the other one's way
+
+- **The Gemini MCP now actually starts under Codex.** 0.22.4 removed the literal
+  `cwd` placeholder that failed Windows process creation, on the assumption that
+  Codex expanded the script argument. It does not: `codex mcp get gemini --json`
+  shows `${CLAUDE_PLUGIN_ROOT}/scripts/gemini-mcp.mjs` reaching `node` verbatim,
+  so the server died before `initialize` for a second reason. Codex substitutes
+  nothing in `command`/`args`/`env` and resolves `cwd` against the plugin
+  directory; Claude Code substitutes in all three and has no `cwd` field at all.
+  The manifest now carries the plugin root both ways -- through `env` for the
+  host that substitutes, through `cwd: "."` for the host that does not -- and a
+  short `node -e` bootstrap uses whichever arrived intact. The launch test runs
+  each host's reading, including Codex forwarding no env at all.
 
 ## 0.22.4 — 2026-08-25 — Start the MCP before it can do anything else
 

--- a/plugins/gemini/scripts/gemini-mcp.mjs
+++ b/plugins/gemini/scripts/gemini-mcp.mjs
@@ -332,6 +332,12 @@ async function main() {
   }
 }
 
-if (process.argv[1] === SELF_PATH) {
+// Started as the process entry point (`node scripts/gemini-mcp.mjs`), or by the
+// `.mcp.json` bootstrap, which sets GEMINI_MCP_STDIO in its own process before
+// importing this module. The bootstrap exists because Codex passes MCP `args`
+// through literally -- it never expands ${CLAUDE_PLUGIN_ROOT} -- so the script
+// path has to be computed at runtime, and then argv[1] is `-e`, not this file.
+// Importing this module for a test still starts nothing.
+if (process.argv[1] === SELF_PATH || process.env.GEMINI_MCP_STDIO === "1") {
   main();
 }

--- a/plugins/gemini/scripts/gemini-mcp.mjs
+++ b/plugins/gemini/scripts/gemini-mcp.mjs
@@ -336,8 +336,15 @@ async function main() {
 // `.mcp.json` bootstrap, which sets GEMINI_MCP_STDIO in its own process before
 // importing this module. The bootstrap exists because Codex passes MCP `args`
 // through literally -- it never expands ${CLAUDE_PLUGIN_ROOT} -- so the script
-// path has to be computed at runtime, and then argv[1] is `-e`, not this file.
-// Importing this module for a test still starts nothing.
+// path has to be computed at runtime, and under `node -e` there is no argv[1]
+// to match against at all.
 if (process.argv[1] === SELF_PATH || process.env.GEMINI_MCP_STDIO === "1") {
+  // Consume the signal instead of propagating it. This process hands
+  // `process.env` to the detached worker it spawns, which hands it to the CLI,
+  // so an inherited flag would make every descendant that merely *imports* this
+  // module take over stdin and never exit -- a delegated turn running this
+  // repo's own suite hangs on the files that import it. Deleting it here is what
+  // keeps "importing this module starts nothing" true below the server too.
+  delete process.env.GEMINI_MCP_STDIO;
   main();
 }

--- a/tests/mcp-launch.test.mjs
+++ b/tests/mcp-launch.test.mjs
@@ -28,13 +28,21 @@ const SERVER = JSON.parse(fs.readFileSync(path.join(PLUGIN_ROOT, ".mcp.json"), "
 // one host's reading; all three must answer initialize.
 async function initialize(t, { cwd, expand, dropEnv }) {
   const ex = (s) => (expand ? s.replaceAll("${CLAUDE_PLUGIN_ROOT}", PLUGIN_ROOT) : s);
-  const env = dropEnv
-    ? {}
-    : Object.fromEntries(Object.entries(SERVER.env ?? {}).map(([k, v]) => [k, ex(v)]));
+
+  // Each case must pin exactly one host's reading, so the manifest's own entry is
+  // the only source of GEMINI_PLUGIN_ROOT. Inheriting it would let "Codex
+  // forwards no env at all" quietly take the env path and pass for the wrong
+  // reason -- and it is genuinely set in the environment whenever this suite is
+  // run from a turn delegated through this plugin.
+  const env = { ...process.env };
+  delete env.GEMINI_PLUGIN_ROOT;
+  if (!dropEnv) {
+    for (const [key, value] of Object.entries(SERVER.env ?? {})) env[key] = ex(value);
+  }
 
   const child = spawn(ex(SERVER.command), SERVER.args.map(ex), {
     cwd,
-    env: { ...process.env, ...env },
+    env,
     stdio: ["pipe", "pipe", "pipe"]
   });
 
@@ -105,4 +113,48 @@ test("Codex's reading still launches the server when it forwards no env at all",
 test("importing the server module starts no stdio loop", async () => {
   const module = await import(new URL("../plugins/gemini/scripts/gemini-mcp.mjs", import.meta.url));
   assert.ok(module, "module must import without taking over stdin");
+});
+
+test("the bootstrap arg carries no character cmd.exe would read as an operator", () => {
+  // Hosts spawn `node` directly today, so this string reaches argv verbatim. It
+  // is one `shell: true` away from being parsed instead -- a common Windows
+  // workaround for resolving .cmd shims -- and there `>` is a redirect that
+  // creates a file and `|` splits the command. The bootstrap is expressible
+  // without any of them at no behavioral cost, so it is.
+  const bootstrap = SERVER.args.find((a) => a.includes("gemini-mcp.mjs"));
+  for (const ch of [">", "<", "|", "&", "^"]) {
+    assert.ok(!bootstrap.includes(ch), `bootstrap must not contain ${ch}, which cmd.exe would treat as an operator`);
+  }
+});
+
+test("starting the server consumes GEMINI_MCP_STDIO instead of passing it to children", async () => {
+  // The server spawns its detached worker with `env: process.env`, and the
+  // worker spawns the CLI the same way. An inherited flag turns every descendant
+  // that imports this module into a server that grabs stdin and never exits --
+  // including a delegated turn running this repo's own suite.
+  const probe = [
+    "await import(process.argv[1]);",
+    "console.log(JSON.stringify({ flag: process.env.GEMINI_MCP_STDIO ?? null }));",
+    "process.exit(0);"
+  ].join("");
+
+  const child = spawn(
+    process.execPath,
+    // A file:// href, not a path: on Windows the ESM loader rejects `c:\...`.
+    ["--input-type=module", "-e", probe, new URL("../plugins/gemini/scripts/gemini-mcp.mjs", import.meta.url).href],
+    { env: { ...process.env, GEMINI_MCP_STDIO: "1" }, stdio: ["pipe", "pipe", "pipe"] }
+  );
+
+  let out = "";
+  let err = "";
+  child.stdout.setEncoding("utf8");
+  child.stderr.setEncoding("utf8");
+  child.stdout.on("data", (chunk) => { out += chunk; });
+  child.stderr.on("data", (chunk) => { err += chunk; });
+
+  const [code] = await once(child, "exit");
+  assert.equal(code, 0, `probe exited ${code}: ${err.trim()}`);
+  const line = out.trim().split(/\r?\n/).find((l) => l.includes("flag"));
+  assert.ok(line, `probe printed no result: ${out.trim() || err.trim()}`);
+  assert.equal(JSON.parse(line).flag, null, "the flag must not survive into anything the server spawns");
 });

--- a/tests/mcp-launch.test.mjs
+++ b/tests/mcp-launch.test.mjs
@@ -8,31 +8,41 @@ import { once } from "node:events";
 import { fileURLToPath } from "node:url";
 
 const PLUGIN_ROOT = path.resolve(fileURLToPath(new URL("../plugins/gemini", import.meta.url)));
+const SERVER = JSON.parse(fs.readFileSync(path.join(PLUGIN_ROOT, ".mcp.json"), "utf8")).mcpServers.gemini;
 
-// Regression guard for the .mcp.json launch path: the script argument MUST
-// resolve relative to the plugin root (${CLAUDE_PLUGIN_ROOT}), while the server
-// MUST NOT declare cwd using that placeholder. Codex expands the script argument
-// but may pass cwd through literally on Windows, where process creation then
-// fails with ERROR_DIRECTORY (267). Launch from a temp cwd that is deliberately
-// not the plugin dir and require the server to answer initialize.
-test("the .mcp.json server command launches from a cwd that is not the plugin dir", async () => {
-  const config = JSON.parse(fs.readFileSync(path.join(PLUGIN_ROOT, ".mcp.json"), "utf8"));
-  const server = config.mcpServers.gemini;
+// The two hosts that read this manifest disagree about it, and neither reading
+// is negotiable:
+//
+//   Claude Code substitutes ${CLAUDE_PLUGIN_ROOT} in command/args/env, and has
+//   no cwd field at all -- the server inherits the host's working directory.
+//
+//   Codex passes command/args/env through literally (verified with
+//   `codex mcp get gemini --json`) and resolves cwd against the plugin
+//   directory. A ${CLAUDE_PLUGIN_ROOT} in args reaches node as those 21
+//   characters; a ${CLAUDE_PLUGIN_ROOT} in cwd fails process creation on
+//   Windows with ERROR_DIRECTORY (267).
+//
+// So the manifest carries the plugin root twice -- expanded through env for the
+// host that substitutes, and implied by cwd for the host that does not -- and
+// the bootstrap in args picks whichever one arrived intact. Each case below is
+// one host's reading; all three must answer initialize.
+async function initialize(t, { cwd, expand, dropEnv }) {
+  const ex = (s) => (expand ? s.replaceAll("${CLAUDE_PLUGIN_ROOT}", PLUGIN_ROOT) : s);
+  const env = dropEnv
+    ? {}
+    : Object.fromEntries(Object.entries(SERVER.env ?? {}).map(([k, v]) => [k, ex(v)]));
 
-  const expand = (s) => s.replaceAll("${CLAUDE_PLUGIN_ROOT}", PLUGIN_ROOT);
-  const command = expand(server.command);
-  const args = server.args.map(expand);
-  assert.equal(server.cwd, undefined, ".mcp.json must inherit the host cwd instead of declaring ${CLAUDE_PLUGIN_ROOT} as cwd");
-
-  // Sanity: the resolved script path must be absolute and exist, so a
-  // relative-path regression (./scripts/...) is caught before spawning.
-  const scriptArg = args.find((a) => a.endsWith("gemini-mcp.mjs"));
-  assert.ok(scriptArg && path.isAbsolute(scriptArg) && fs.existsSync(scriptArg), `.mcp.json must resolve gemini-mcp.mjs to an existing absolute path, got: ${scriptArg}`);
-
-  const tempCwd = fs.mkdtempSync(path.join(os.tmpdir(), "gemini-mcp-launch-"));
-  const child = spawn(command, args, { cwd: tempCwd, stdio: ["pipe", "pipe", "pipe"] });
+  const child = spawn(ex(SERVER.command), SERVER.args.map(ex), {
+    cwd,
+    env: { ...process.env, ...env },
+    stdio: ["pipe", "pipe", "pipe"]
+  });
 
   try {
+    let stderr = "";
+    child.stderr.setEncoding("utf8");
+    child.stderr.on("data", (chunk) => { stderr += chunk; });
+
     const firstLine = new Promise((resolve, reject) => {
       let buf = "";
       const timer = setTimeout(() => reject(new Error("MCP server did not respond to initialize within 15s")), 15000);
@@ -43,20 +53,56 @@ test("the .mcp.json server command launches from a cwd that is not the plugin di
         if (nl !== -1) { clearTimeout(timer); resolve(buf.slice(0, nl)); }
       });
       child.once("error", (e) => { clearTimeout(timer); reject(e); });
-      child.once("exit", (code) => { clearTimeout(timer); reject(new Error(`MCP server exited early (code ${code}) -- it likely could not find its script from this cwd`)); });
+      // Exit code 0 with no reply is the failure this test exists to catch: the
+      // bootstrap loaded a module that then started no stdio loop.
+      child.once("exit", (code) => {
+        clearTimeout(timer);
+        reject(new Error(`MCP server exited before answering initialize (code ${code}): ${stderr.trim() || "no stderr"}`));
+      });
     });
 
     child.stdin.write(`${JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} })}\n`);
-
-    const reply = JSON.parse(await firstLine);
-    assert.equal(reply.id, 1);
-    assert.equal(reply.result.serverInfo.name, "gemini");
-    assert.equal(typeof reply.result.protocolVersion, "string");
+    return JSON.parse(await firstLine);
   } finally {
     if (child.exitCode === null && child.signalCode === null) {
       child.kill();
       await once(child, "exit");
     }
+  }
+}
+
+test("the manifest never puts a placeholder anywhere Codex reads literally", () => {
+  assert.equal(SERVER.cwd, ".", "cwd must be the plugin dir by relative path, never ${CLAUDE_PLUGIN_ROOT}");
+  assert.ok(!SERVER.command.includes("${"), "command must not carry a placeholder");
+  for (const arg of SERVER.args) {
+    assert.ok(!arg.includes("${CLAUDE_PLUGIN_ROOT}"), `args must not carry a placeholder Codex would pass through: ${arg}`);
+  }
+  assert.equal(SERVER.env?.GEMINI_PLUGIN_ROOT, "${CLAUDE_PLUGIN_ROOT}", "env is where the substituting host hands over the plugin root");
+});
+
+test("Claude Code's reading launches the server: placeholders expanded, cwd inherited", async (t) => {
+  const tempCwd = fs.mkdtempSync(path.join(os.tmpdir(), "gemini-mcp-launch-"));
+  try {
+    const reply = await initialize(t, { cwd: tempCwd, expand: true });
+    assert.equal(reply.id, 1);
+    assert.equal(reply.result.serverInfo.name, "gemini");
+    assert.equal(typeof reply.result.protocolVersion, "string");
+  } finally {
     fs.rmSync(tempCwd, { recursive: true, force: true });
   }
+});
+
+test("Codex's reading launches the server: args literal, cwd is the plugin dir", async (t) => {
+  const reply = await initialize(t, { cwd: PLUGIN_ROOT, expand: false });
+  assert.equal(reply.result.serverInfo.name, "gemini");
+});
+
+test("Codex's reading still launches the server when it forwards no env at all", async (t) => {
+  const reply = await initialize(t, { cwd: PLUGIN_ROOT, expand: false, dropEnv: true });
+  assert.equal(reply.result.serverInfo.name, "gemini");
+});
+
+test("importing the server module starts no stdio loop", async () => {
+  const module = await import(new URL("../plugins/gemini/scripts/gemini-mcp.mjs", import.meta.url));
+  assert.ok(module, "module must import without taking over stdin");
 });


### PR DESCRIPTION
## What was broken

`gemini` never started under Codex. The reported symptom:

```
⚠ MCP client for `gemini` failed to start: MCP startup failed:
  handshaking with MCP server failed: connection closed: initialize response
```

0.22.4 (#110) fixed one half of this — it removed the `${CLAUDE_PLUGIN_ROOT}`
that Codex passed through as a literal `cwd`, failing Windows process creation
with ERROR_DIRECTORY (267) — but it assumed Codex expanded the same placeholder
in the script argument. It does not:

```
$ codex mcp get gemini --json
"args": ["${CLAUDE_PLUGIN_ROOT}/scripts/gemini-mcp.mjs"],   # reaches node verbatim
"cwd": null
```

`node` then exits with "Cannot find module", which is exactly the observed
"connection closed: initialize response".

## The two readings

| | `command` / `args` / `env` | `cwd` |
|---|---|---|
| Claude Code | substituted | no such field; inherits the host cwd |
| Codex | literal | resolved against the plugin directory |

Neither reading is negotiable, and no single field satisfies both. So the
manifest hands over the plugin root **twice** — expanded through `env` for the
host that substitutes, implied by `cwd: "."` for the host that does not — and a
short `node -e` bootstrap uses whichever arrived intact (a value still carrying
braces is the unsubstituted one, so it falls back to `process.cwd()`).

The entry guard in `gemini-mcp.mjs` also accepts the bootstrap's in-process
`GEMINI_MCP_STDIO`, because under `node -e` `argv[1]` is `-e`, not the script.
Its original purpose — importing the module in a test must not take over stdin —
is unchanged and still pinned by a test.

## Verification

- `npm test`: 618 tests, 608 pass. **The 2 failures are pre-existing and
  unrelated** (`tests/runtime.test.mjs`, "setup is not ready when gemini is
  installed but unauthenticated" / "…token is expired"). Confirmed by stashing
  this branch's changes and re-running: they fail identically on `main`. They
  are local-environment leakage — the machine has an authenticated Gemini CLI,
  so the unauthenticated fixtures do not hold.
- `tests/mcp-launch.test.mjs` now runs each host's reading of the manifest:
  Claude Code (expanded, foreign cwd), Codex (literal, plugin cwd), and Codex
  forwarding no env at all. All three answer `initialize`.
- Mutation check: reverting the entry-guard condition alone fails all three
  launch tests (and passes the two that do not spawn), so they are not scoring
  execution coverage.
- End to end: the fix was installed into the local Codex plugin cache and the
  server spawned with Codex's own resolved config (cwd = plugin dir, env value
  the literal `${CLAUDE_PLUGIN_ROOT}`) — it answers `initialize`. Restarting
  Codex now reports only `MCP startup incomplete (failed: github)`; `gemini` is
  gone from the failure list.

## Not in this change

The `clamping SessionEnd hook timeout to 3s` warning stays. Codex clamps the
5s budget to 3s and warns; the upstream `openai-codex` plugin emits the same
line for the same reason. Lowering the manifest to 3 would not change Codex's
behavior at all, and would shorten the budget Claude Code actually honors for
a hook that terminates background process trees on Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
