### PR TITLE
Keep an inherited API key out of the stand-in fixtures

### DIFF
--- a/tests/fake-gemini-fixture.mjs
+++ b/tests/fake-gemini-fixture.mjs
@@ -221,9 +221,23 @@ export function pathWithoutRealEngines(binDir, inherited = process.env.PATH) {
   return [binDir, ...kept].join(PATH_SEP);
 }
 
+// GEMINI_API_KEY / GOOGLE_API_KEY outrank every stored credential -- that is the
+// CLI's real precedence, and `hasGeminiCredentials` reproduces it deliberately.
+// So a fixture that inherits one has already answered the question it was built
+// to ask: an "unauthenticated" stand-in reports ready, and the setup fixtures
+// fail on any machine that exports a key while staying green on CI, which has
+// none. This is the same leak already closed for PATH, the keychain and
+// GEMINI_ENGINE; the key was the one left open.
+function inheritedEnvWithoutCredentials() {
+  const env = { ...process.env };
+  delete env.GEMINI_API_KEY;
+  delete env.GOOGLE_API_KEY;
+  return env;
+}
+
 export function buildEnv(binDir) {
   return {
-    ...process.env,
+    ...inheritedEnvWithoutCredentials(),
     PATH: pathWithoutRealEngines(binDir),
     GEMINI_ENGINE: "gemini",
     GEMINI_HOME: path.join(binDir, "gemini-home"),
@@ -238,7 +252,7 @@ export function buildEnv(binDir) {
 // Like buildEnv but does not force an engine and points GEMINI_HOME at an empty
 // directory; pair with installUnavailableEngines for "not ready" assertions.
 export function buildEnvUnavailable(binDir) {
-  const env = { ...process.env };
+  const env = inheritedEnvWithoutCredentials();
   // Must resolve to "auto" regardless of the calling shell's own engine
   // preference (e.g. a developer's GEMINI_ENGINE=agy), so delete it rather
   // than inherit it.

--- a/tests/fake-gemini-fixture.mjs
+++ b/tests/fake-gemini-fixture.mjs
@@ -150,16 +150,21 @@ export function installFailingAgyExecutable(binDir) {
 }
 
 export function buildFailingAgyEnv(binDir) {
-  const sep = process.platform === "win32" ? ";" : ":";
   const home = path.join(binDir, "agy-home");
   fs.mkdirSync(path.join(home, ".gemini", "antigravity-cli", "brain"), { recursive: true });
   return {
-    ...process.env,
-    PATH: `${binDir}${sep}${process.env.PATH}`,
+    // This builder was the one the three isolation fixes above never reached. It
+    // prepended to PATH rather than closing it, which is the exact defect
+    // 4b39509 was written to fix -- and the `--engine agy` tests below it run a
+    // stand-in that a developer machine with a real agy installed can resolve
+    // past, spending a real turn on a test asserting a fixture's stderr.
+    ...inheritedEnvWithoutCredentials(),
+    PATH: pathWithoutRealEngines(binDir),
     HOME: home,
     USERPROFILE: home,
     GEMINI_ENGINE: "agy",
-    GEMINI_HOME: path.join(home, ".gemini")
+    GEMINI_HOME: path.join(home, ".gemini"),
+    GEMINI_COMPANION_DISABLE_KEYCHAIN: "1"
   };
 }
 

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -2132,9 +2132,18 @@ test("the fixture env drops an inherited API key, which would outrank the stand-
 
   try {
     const binDir = makeTempDir();
-    for (const [name, env] of [["buildEnv", buildEnv(binDir)], ["buildEnvUnavailable", buildEnvUnavailable(binDir)]]) {
+    const builders = [
+      ["buildEnv", buildEnv(binDir)],
+      ["buildEnvUnavailable", buildEnvUnavailable(binDir)],
+      ["buildFailingAgyEnv", buildFailingAgyEnv(binDir)]
+    ];
+    for (const [name, env] of builders) {
       assert.equal(env.GEMINI_API_KEY, undefined, `${name} must not hand the child an inherited GEMINI_API_KEY`);
       assert.equal(env.GOOGLE_API_KEY, undefined, `${name} must not hand the child an inherited GOOGLE_API_KEY`);
+      // Every builder must close PATH rather than merely go first on it: the
+      // `--engine agy` tests run a stand-in that a real installation further
+      // down the PATH can be resolved past, which spends a real turn.
+      assert.equal(env.PATH, pathWithoutRealEngines(binDir), `${name} must drop directories holding a real engine`);
     }
   } finally {
     for (const [key, value] of Object.entries(previous)) {

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -2117,3 +2117,29 @@ test("the fixture PATH drops directories holding a real gemini or agy", () => {
   assert.ok(!built.includes(realish), "a directory holding a real agy is dropped");
   assert.ok(built.includes(innocent), "everything else is kept, so node and git stay reachable");
 });
+
+test("the fixture env drops an inherited API key, which would outrank the stand-in credential", () => {
+  // Same class of leak as the PATH one above, one layer further in: the key wins
+  // over every stored credential, so a fixture that inherits one reports ready no
+  // matter what the stand-in was told to be. It stayed hidden because CI exports
+  // no key -- only a developer machine with one ever saw the red.
+  const previous = {
+    GEMINI_API_KEY: process.env.GEMINI_API_KEY,
+    GOOGLE_API_KEY: process.env.GOOGLE_API_KEY
+  };
+  process.env.GEMINI_API_KEY = "AIza-inherited-from-the-shell";
+  process.env.GOOGLE_API_KEY = "AIza-inherited-from-the-shell";
+
+  try {
+    const binDir = makeTempDir();
+    for (const [name, env] of [["buildEnv", buildEnv(binDir)], ["buildEnvUnavailable", buildEnvUnavailable(binDir)]]) {
+      assert.equal(env.GEMINI_API_KEY, undefined, `${name} must not hand the child an inherited GEMINI_API_KEY`);
+      assert.equal(env.GOOGLE_API_KEY, undefined, `${name} must not hand the child an inherited GOOGLE_API_KEY`);
+    }
+  } finally {
+    for (const [key, value] of Object.entries(previous)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  }
+});


### PR DESCRIPTION
## What was broken

Two assertions in `tests/runtime.test.mjs` fail on any machine that exports
`GEMINI_API_KEY`, and pass on CI, which exports none:

```
✖ setup is not ready when gemini is installed but unauthenticated
✖ setup is not ready when the gemini OAuth token is expired
   AssertionError: true !== false      # payload.ready
```

`GEMINI_API_KEY` / `GOOGLE_API_KEY` outrank every stored credential — that is
the CLI's real precedence, and `hasGeminiCredentials` reproduces it on purpose.
`buildEnv` and `buildEnvUnavailable` spread `process.env` wholesale, so the key
reached the child and the "unauthenticated" stand-in reported ready. The
fixtures were answering a question they were built to hold fixed.

Nothing in the production path changes here. The credential precedence is
correct; only the fixture's isolation was incomplete.

## Why it was hidden

The same file had already closed this leak three times — for PATH (a real `agy`
answering below the stand-in), for the OS keychain, and for a developer's
`GEMINI_ENGINE` — each with a comment recording the incident. The API key is the
fourth door in that same wall, and the only one that had stayed open. CI never
saw it because runners export no key.

## Verification

- `npm test` on this branch: 615 tests, **607 pass, 0 fail** — run on the machine
  that exports a key, which is where the red was.
- New test `the fixture env drops an inherited API key…` exports both key names
  and asserts neither builder forwards them, so the contract no longer depends on
  the developer's shell happening to be clean.
- Mutation check: removing just the two `delete` lines fails all three tests (the
  two setup assertions and the new one), and `node -c` confirms the mutant still
  parses — so the failure comes from the behavior change, not a broken file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
