### PR TITLE
File the playbook as a plan, and say which parts of it survived contact

### DIFF
--- a/docs/HANDOVER_MARKETING_AND_RELEASE_PLAYBOOK.md
+++ b/docs/HANDOVER_MARKETING_AND_RELEASE_PLAYBOOK.md
@@ -1,78 +1,133 @@
 # `gemini-plugin-cc` 終極推廣、生態上架與架構交接手冊 (業界標準加固版)
 (Master Playbook: Growth, MCP Registries, AI-Era SEO/AEO Architecture & Next-Gen Launch)
 
-> **版本**：v3.6.0 (Enterprise, RFC 9309, Answer.AI Spec v2 & Codebase Ground-Truth Aligned)  
+> **版本**：v3.8.1 (3rd Adversarial-Review Pass; Handoff-Blocking Resolved)  
 > **建立日期**：2026-08-21  
-> **對齊標準**：RFC 9309 (Robots Exclusion Protocol)、Answer.AI `/llms.txt` Spec v2、OASIS SARIF 2.1.0、Schema.org SoftwareApplication & TechArticle、Google E-E-A-T 2026 Guidelines、OWASP Top 10 for LLM (2025/2026)、OpenSSF Best Practices、Claude Code Manifest Spec  
+> **對齊標準**：RFC 9309 (Robots Exclusion Protocol)、Answer.AI `/llms.txt` v2 community specification、OASIS SARIF 2.1.0、Schema.org SoftwareApplication & TechArticle、Google Search Central people-first content / E-E-A-T guidance、OWASP Top 10 for LLM (2025/2026)、OpenSSF Best Practices、Claude Code Manifest Spec  
 > **交接目標**：供維護團隊與 **Claude Code** 進行後續無縫實作、生態登錄、AI 時代搜尋最佳化與跨客戶端維運。  
 
+> [!IMPORTANT]
+> **Repository Baseline (Snapshot)**
+> ```
+> repo:     arcobaleno64/gemini-plugin-cc
+> commit:   22b93a7a6acfa6f7b18b7ae2b3e7774219dbbf38
+> branch:   main
+> verified: 2026-08-21
+> plugin:   v0.22.2 (MIT)
+> ```
+> 本文件所有 `[CURRENT]` 宣稱以上述 commit 為準。`main` 更新後可能漂移，實作前應 `git show <SHA>:<path>` 驗證。
+
+> [!IMPORTANT]
+> **狀態標籤系統 (Status Label Convention)**
+> 每個 implementation-state claim **必須顯式標籤**。**未標注者視為 `UNCLASSIFIED`，不得推定 implementation state，不得據此實作。**
+>
+> | 標籤 | 意義 | Claude Code 行為準則 |
+> |---|---|---|
+> | `[CURRENT]` | 上述 baseline commit 已驗證存在 | 可引用，但實作前仍應驗證 `main` HEAD |
+> | `[PLANNED]` | 已決策但尚未實作 | **須先實作再引用**；不得假設已存在 |
+> | `[EXPERIMENTAL]` | 假設、研究方向或 benchmark proposal | **不得作為實作依據**；僅供規劃參考 |
+> | `[EXTERNAL-CURRENT@date]` | 引用外部平台/規格在指定日期的狀態 | 實作前須重新查證該平台現行規格 |
+> | `[TEMPLATE]` | 通用 SOP 範本，佔位符須填入實際值 | 不可直接執行 |
+> | *(未標注)* | **UNCLASSIFIED** | **禁止推定為 CURRENT 或據此實作** |
+
 ---
+
+> [!WARNING]
+> **這份文件是計畫，不是現況。** 它的 baseline 是 `22b93a7` / v0.22.2 / 2026-08-21，
+> 而 repository 已經走遠了。第 1 節的評估矩陣、各節的 `[CURRENT]` 標記，都必須
+> 在動工當天對 HEAD 重新查證，不得直接採信。
+>
+> **先讀 [`ROADMAP.md`](ROADMAP.md)**：那裡逐項記錄了哪些前提經查證仍成立、哪些
+> 已經做掉、哪些前置條件不存在、哪些照做會出事。這份 playbook 保留下來是為了
+> 它的規格與範本（robots.txt、JSON-LD、`action.yml`、SARIF），不是為了它的狀態欄。
+
+---
+
 
 ## 1. 現況評估矩陣 (Current State Audit)
 
 經代碼庫全面唯讀檢驗，專案現狀與外部平台要求的合規性如下：
 
-| 檢驗項目 | 外部/業界標準要求 | 目前現狀 | 評估結論 | Claude 實作行動 |
+| 檢驗項目 | Project Target / Ecosystem Objective | 目前現狀 | 評估結論 | Claude 實作行動 |
 |---|---|---|---|---|
-| **開源許可證** | Public 倉庫需具備 `LICENSE` | 現為 MIT，v1.0.0 升級 Apache 2.0 | **過渡中** | v1.0.0 正式切換 (見第 9 節) |
-| **MCP 啟動穩定性** | 沙盒 `initialize` 與 `tools/list` 不得崩潰 | `gemini-mcp.mjs` 為純記憶體回應，無啟動探測 | **合規 (Pass)** | 無需變動 |
-| **Smithery 設定檔** | 根目錄需有 `smithery.yaml` 宣告啟動 | 尚未建立 | ⚠️ **待補齊** | 新增 `smithery.yaml` (見第 4.1 節) |
-| **AEO 機器索引** | 根目錄需具備 `/llms.txt` 與 `/llms-full.txt` | 尚未建立 | ⚠️ **待補齊** | 實裝 `/llms.txt` 與建置腳本 (見第 4.6 節) |
-| **AI 爬蟲權限** | `robots.txt` 需符合 RFC 9309 明確授權 AI 代理 | 尚未發布 | ⚠️ **待配置** | 部署生產級 `robots.txt` (見第 4.5 節) |
-| **語意實體圖譜** | Schema.org `SoftwareApplication` JSON-LD | 尚未嵌入 | ⚠️ **待補齊** | 嵌入 JSON-LD 標記 (見第 4.7 節) |
-| **模型命名邊界** | 支援 Vertex AI (`/`) 與版本標籤 (`@`) | 舊正則阻斷了 `/` 與 `@` | ⚠️ **待放寬** | 更新 `SAFE_MODEL_ID` (見第 6.2 節) |
-| **Gate 安全合規** | CI/CD 環境需支援 Fail-Closed | 現狀為全域 Fail-Open | ⚠️ **待雙軌化** | 引入 `GEMINI_GATE_STRICT` (見第 6.1 節) |
-| **CI 封裝標準** | 企業流水線需 1 行啟用 | 尚無 `action.yml` | ⚠️ **待補齊** | 新增 `action.yml` (見第 7.1 節) |
-| **漏洞輸出標準** | OASIS SARIF 2.1.0 格式 | 現狀為自訂 JSON | ⚠️ **待支援** | 擴充 SARIF 輸出 (見第 7.2 節) |
+| **開源許可證** | **Required**: Public 倉庫需具備 `LICENSE` | 現為 MIT，v1.0.0 升級 Apache 2.0 | **過渡中** | `[PLANNED]` v1.0.0 正式切換 (見第 9 節) |
+| **MCP 啟動穩定性** | **Required**: `initialize` 與 `tools/list` 不得崩潰 | `gemini-mcp.mjs` 為純記憶體回應，無啟動探測 | **部分合規** | `[CURRENT]` 無啟動時 upstream 呼叫（降低一項失敗模式），但不等於完整 MCP compliance 驗證 |
+| **Smithery 設定檔** | **Optional**: Smithery 市集可見性 | 尚未建立 | ⚠️ **待補齊** | `[PLANNED]` 新增 `smithery.yaml` (見第 4.1 節) |
+| **AEO 機器索引** | **Experimental**: community spec，非平台要求 | 尚未建立 | ⚠️ **待補齊** | `[PLANNED]` 實裝 `/llms.txt` 與建置腳本 (見第 4.6 節) |
+| **AI 爬蟲權限** | **Optional**: RFC 9309 crawling preference 表達 | 尚未發布 | ⚠️ **待配置** | `[PLANNED]` 部署 `robots.txt` (見第 4.5 節) |
+| **語意實體圖譜** | **Optional**: Schema.org vocabulary aid | 尚未嵌入 | ⚠️ **待補齊** | `[PLANNED]` 嵌入 JSON-LD 標記 (見第 4.7 節) |
+| **模型命名邊界** | **Required**: 支援 Vertex AI (`/`) 與版本標籤 (`@`) | 舊正則阻斷了 `/` 與 `@` | ⚠️ **待放寬** | `[PLANNED]` 更新 `SAFE_MODEL_ID` (見第 6.2 節) |
+| **Gate 安全合規** | **Required** (CI): CI/CD 環境需支援 Fail-Closed | 現狀為全域 Fail-Open | ⚠️ **待雙軌化** | `[PLANNED]` 引入 `GEMINI_GATE_STRICT` (見第 6.1 節) |
+| **CI 封裝標準** | **Optional**: 企業流水線 1-line 啟用 | 尚無 `action.yml` | ⚠️ **待補齊** | `[PLANNED]` 新增 `action.yml` (見第 7.1 節) |
+| **漏洞輸出標準** | **Optional**: OASIS SARIF 2.1.0 格式 | 現狀為自訂 JSON | ⚠️ **待支援** | `[PLANNED]` 擴充 SARIF 輸出 (見第 7.2 節) |
 
 ---
 
-## 2. 專案核心定位與價值主張 (Core Positioning)
+## 2. 專案核心定位與邊界 (Core Positioning & Boundary)
+
+> **本節只定義 `gemini-plugin-cc` 本身。**
+> `gemini-plugin-cc` 是可被 Claude Code、Cursor、CI 或其他 orchestrator 呼叫的 **Gemini / AGY capability provider**；
+> 它不擁有上層 multi-agent orchestration、finding adjudication 或 release authority。
+> Triad-Flow 的角色分工、Evidence Contract、Codex verification lens 與 deterministic release policy 已移至獨立架構文件，不在本文件重複定義。
 
 ```mermaid
 graph TD
-    User["開發者 (Claude Code / Cursor / CI Pipeline)"] --> Driver["主控端 (Claude / GitHub Actions)"]
-    Driver -->|產生代碼與 Diff| Review["對抗性審查調度模組"]
-    Review -->|跨模型漏洞獵捕| Gemini["Google Gemini 3.7 / 3.5 / 4<br>(百萬 Token 外部驗證沙盒)"]
-    Review -->|邏輯歧見仲裁 (選配)| Arbiter["OpenAI o1 / o3<br>(形式化邏輯仲裁者)"]
-    Gemini -->|輸出反思報告與攻擊面| Driver
-    Arbiter -->|輸出最終共識裁決| Driver
-    Driver -->|自主修補或阻斷 PR| Repo["專案代碼庫 / GitHub PR"]
+    Caller["Caller<br/>Claude Code / Cursor / CI / External Orchestrator"] --> Plugin["gemini-plugin-cc<br/>Review Capability Provider"]
+    Plugin --> Adapter["Engine Adapter"]
+    Adapter --> Gemini["Gemini CLI / AGY"]
+    Gemini --> Findings["Structured Review Findings / Evidence"]
+    Findings --> Caller
+    Plugin --> Guard["Local Safety / Context-Minimization Guards"]
 ```
 
-* **品牌主張**：**「自適應多代理人閉環控制架構 (Adaptive Multi-Agent Closed-Loop Control Harness)」**。
-* **工程三位一體分工 (The Engineering Triad)**：
-  1. **Graph Engineering (圖拓撲)**：定義多模型有向圖路由，小變更走 Single-Agent 極速通道，大架構重構自適應分裂出衛星子代理群 (Subagents)。
-  2. **Loop Engineering (控制閉環)**：將外部對抗反例轉化為形式化修復向量回傳給主控端，驅動自動補丁修復與 OODA 收斂，直至綠燈放行。
-  3. **Harness Engineering (安全夾具)**：以 Gate 雙軌制（Fail-Open/Closed）、機密過濾與 OASIS SARIF 2.1.0 建立確定性安全護城河。
-* **AI Safety 理論（共模故障防禦 Common-Mode Failure Defense）**：
-  * 單一模型自我審查易陷入同構認知盲區。
-  * 由主控端產出代碼、Gemini 進行超大上下文獵漏洞、OpenAI 進行形式化邏輯仲裁，是企業級資安的最佳實踐。
-* **主從關係清晰**：主控端是唯一調度者，外部審查結果促成自我反思與修復，**直接提升會話深度與實質 Token 價值**。
+* **核心責任**：
+  1. **Engine abstraction**：封裝 Gemini CLI / AGY 的版本、模型、認證與 capability 差異。
+  2. **Review harness**：提供 pragmatic review、adversarial review、rescue/job lifecycle 等穩定入口。
+  3. **Structured evidence**：將 review 結果輸出為可供上層系統消費的 JSON / SARIF 等格式，而不是自行決定最終 release verdict。
+  4. **Safety boundary**：最小化 plugin 主動組裝的 context、避免已知敏感檔案路徑被納入 payload，並清楚揭露底層 agentic CLI 並非 filesystem sandbox。
+  5. **Integration surfaces**：支援 Claude Code plugin、MCP、CLI 與 CI/CD 等呼叫介面。
+
+* **明確 Non-Goals**：
+  - 不在本插件內實作通用 multi-agent workflow engine。
+  - 不以模型投票或 `max severity` 自動建立 finding authority。
+  - 不把 Gemini/AGY 宣稱為強制 filesystem sandbox。
+  - 不讓本插件成為上層系統不可替換的 orchestration hard dependency。
+  - 不在本文件定義 Triad-Flow 的 Claude / Codex / Gemini 全域角色與 release policy。
+
+* **與 Triad-Flow 的關係**：
+  - `gemini-plugin-cc` 可作為 Triad-Flow 的 Gemini-side adapter / capability provider。
+  - 兩者只透過薄的 request/result/evidence contract 對接。
+  - Triad-Flow 可獨立演進；本插件亦可獨立發版。
 
 ---
 
 ## 3. 三大生態推進路徑與申報指引
 
 ### 3.1 登上 Anthropic 官方推薦 / 插件目錄
-* **論述核心**：本插件是「Claude Code 的高階資安防護裝備」，嚴格遵循數據最小化（僅發送 Git Diff，絕不外洩 System Prompt 或專有會話歷史）。
-* **交付物**：在倉庫建立 `SECURITY.md` 說明憑證隔離與安全邊界。
+* **論述核心**：本插件旨在降低送往外部模型的上下文範圍，並對已知機密檔案路徑實施 filename-based redaction。Review payloads 可能包含 git status、diffs 與符合條件的 untracked file 內容。底層 Gemini/AGY CLI 為 agentic 且非 path-sandboxed，可能獨立讀取工作區中的其他檔案。詳見 `PRIVACY.md`。
+* **交付物**：`SECURITY.md` `[CURRENT]` 已建立（含 private advisory、email、48 hr initial response SLA、7 business days status update）。
 
-### 3.2 申請 OpenAI Codex for Open Source 資助 ([申請入口](https://openai.com/form/codex-for-oss/))
-* **官方審核本質**：面向公開開源倉庫維護者，補助用於 PR 審查、CI/CD 與安全審計的 API 額度。
+### 3.2 申請 OpenAI Codex for Open Source 資助 ([申請入口](https://openai.com/form/codex-for-oss/)) `[EXTERNAL-CURRENT@2026-08]`
+* **官方審核本質**：面向公開開源倉庫維護者。入選 signals 包括 active maintenance、meaningful usage、broad adoption、ecosystem importance。入選資源包括 ChatGPT Pro（6 個月）、API credits、conditional Codex Security access。
 * **申請表最佳填寫範本**：
   * **Role**: Primary Maintainer of `gemini-plugin-cc`.
   * **Project Description**: An open-source multi-agent code review & adversarial consensus framework for developer workflows, originating from the `codex-plugin-cc` lineage.
   * **Intended Use of API Credits**:
-    1. 在開源倉庫的 CI/CD 中運行「異質多模型交叉審查矩陣（Claude + Gemini + OpenAI o-series）」。
+    1. 在開源倉庫的 CI/CD 中運行 `gemini-plugin-cc` 異質外部審查，並以結構化 evidence 供上層 orchestrator 或人工 reviewer 驗證。
     2. 建置開放的《開源代碼審查基準 (Open-Source Multi-Agent Review Benchmark)》，評測異質模型協同降低 CVE 漏洞率的成效。
+  * **Adoption Evidence**（建議補充）：提供 GitHub stars/forks/clones 增長趨勢、issue/PR 活動量、下游整合實例等**實際使用者採用證據**，而非僅描述架構。評審關注專案對 OSS 生態的實際價值。
 
 ---
 
 ## 4. MCP 市集、跨客戶端與 AI 時代 SEO / AEO 全方位實裝指南
 
-### 4.1 Smithery.ai 登錄設定 (`smithery.yaml`)
-在倉庫根目錄新增 `smithery.yaml`，確保自動爬蟲能正確辨識與一鍵安裝：
+### 4.1 Smithery.ai 登錄設定 (`smithery.yaml`) `[PLANNED]`
+
+> [!WARNING]
+> **Schema 需重新驗證** `[EXTERNAL-CURRENT@2026-08]`
+> 以下範例基於早期 Smithery stdio config 格式。Smithery 目前可能已轉向 `configSchema` / `commandFunction` 模式以及 **MCPB bundle** 發布路徑。實作前須以 Smithery 當前 CLI / schema 文件實測一次，不得直接複製。
+
+在倉庫根目錄新增 `smithery.yaml`（範本，待驗證）：
 
 ```yaml
 startCommand:
@@ -85,30 +140,38 @@ startCommand:
       GEMINI_ENGINE: auto
 ```
 
-### 4.2 Glama.ai 與 AEO / GEO 部署
+### 4.2 Glama.ai 與 AEO / GEO 部署 `[PLANNED]`
 * **GitHub Pages 靜態站點**：啟用 GitHub Pages（路徑 `/docs`），將 `llms.txt` 發布至 `https://arcobaleno64.github.io/gemini-plugin-cc/llms.txt`。
 * **高意圖關鍵詞替換**：
   * ❌ 避免：`Fix API key not valid in Gemini CLI`（吸引免洗維修流量）。
   *  主打：`Claude Code automated security review MCP`、`Cursor Gemini adversarial review`、`Multi-agent code audit MCP`。
 
 ### 4.3 跨客戶端支援矩陣 (GUI Clients: Cursor, Claude Desktop, Windsurf, Cline)
-本專案的 6 個 MCP 工具完全支援非 Claude Code 的所有 GUI 客戶端：
+
+> [!NOTE]
+> **MCP Protocol Version** `[CURRENT]`：Server 目前硬編碼 `MCP_PROTOCOL_VERSION = "2025-03-26"`。MCP 後續已發布 `2025-06-18` 及 `2025-11-25` revisions。正式 lifecycle 要求 initialize 時進行 version negotiation。
+> **Compatibility Claim**：以下「完全支援」基於 MCP stdio interface 存在的事實，但**未經 Client × Version × OS 完整 compatibility matrix 測試**。宣稱「Cursor / Claude Desktop / Windsurf / Cline 完全支援」需要實際 `initialize → tools/list → tools/call` 端對端驗證後才能確認。
+
+本專案的 6 個 MCP 工具 `[CURRENT]` 透過 stdio interface 提供，理論上可被任何 MCP-compatible GUI 客戶端調用：
 
 | 功能類型 | Claude Code (CLI) | Cursor / Claude Desktop / Cline (GUI) |
 |---|:---:|:---:|
-| **6 個 MCP 工具**（`gemini_review`, `gemini_adversarial_review` 等） |  支援 |  **完全支援**（AI 於視窗中主動調用） |
+| **6 個 MCP 工具**（`gemini_review`, `gemini_adversarial_review` 等） |  支援 |  **stdio interface 可用**（待完整 client matrix 驗證） |
 | **手動斜線指令**（如 `/gemini:review`） |  支援 | ❌ 不支援（Claude Code 專屬語法） |
 | **工作結束自動審查閘門**（Stop Gate Hook） |  支援 | ❌ 不支援（Claude Code 專屬 Hook） |
 
 ---
 
-### 4.4 現代 SEO 與 AEO/GEO 雙軌戰略全景圖 (From Zero to Found on Google & Claim Your Spot in AI)
+### 4.4 現代 SEO 與 AEO/GEO 雙軌戰略全景圖 `[EXPERIMENTAL / CONCEPTUAL MODEL]`
+
+> [!WARNING]
+> 本節為**概念模型**，非各 AI 平台的已確認技術架構。Google 官方 AI Features 指南明確指出：traditional SEO best practices 繼續適用、**不需要建立特殊 AI text files**、**不需要 special schema.org markup**。以下框架用於規劃思路，不代表各平台的實際 retrieval/ranking 實作。
 
 > **解構依據**：
 > 1. 《From Zero to Found on Google: The SEO Survival Guide for the AI Era》 (`iE8Byp-mMsc`)
 > 2. 《Claim Your Spot in AI's Recommendations Before 99% of People Understand AEO》 (`f4kc4qI1nUk`)
 
-現代軟體與開源專案的傳播已徹底分裂為兩條平行軌道：
+現代軟體與開源專案的傳播已分裂為兩條平行軌道：
 
 ```mermaid
 graph LR
@@ -116,38 +179,44 @@ graph LR
         T1["搜尋行為: 使用者輸入關鍵字 -> 點擊藍色連結 (SERP)"]
         T2["收錄管線: Discovery -> Crawling -> Rendering -> Indexing -> Ranking"]
         T3["核心指標: 點擊率 (CTR)、排名 (Rank #1-3)、Core Web Vitals"]
-        T4["優化手段: robots.txt、sitemap.xml、Canonical URL、Semantic HTML5"]
+        T4["優化基礎: crawlability、indexability、internal linking、useful/original content、page experience、descriptive titles/metadata"]
     end
 
-    subgraph Generative_AEO ["軌道 2: 生成式答案引擎 (ChatGPT Search / Perplexity / Claude)"]
+    subgraph Generative_AEO ["軌道 2: 生成式答案引擎 (ChatGPT Search / Perplexity / Claude) [EXPERIMENTAL]"]
         A1["搜尋行為: 使用者提出複雜問題 -> AI 直接生成綜合答案與工具推薦"]
-        A2["收錄管線: Agent Crawling -> Vector Embedding -> Knowledge Graph -> Synthesis & Citation"]
-        A3["核心指標: 引用份額 (Citation Share)、直接推薦率 (Direct Mention Rate)"]
-        A4["優化手段: /llms.txt 標準、Answer-First 排版、JSON-LD Entity Linking、E-E-A-T 實證"]
+        A2["收錄管線: 各平台自有 retrieval 實作（具體架構未公開）"]
+        A3["核心指標: 引用份額 (Citation Share)、直接推薦率 (Direct Mention Rate) [EXPERIMENTAL]"]
+        A4["可嘗試手段: /llms.txt (community spec)、Answer-First 排版 (hypothesis)、JSON-LD (vocabulary aid)"]
     end
 ```
 
 #### 傳統 SEO vs. 答案引擎 AEO 實戰差異對照表：
 
-| 評估維度 | 傳統搜尋引擎 (Googlebot / SEO) | 生成式答案引擎 (ChatGPT / Perplexity / AEO) |
+| 評估維度 | 傳統搜尋引擎 (Googlebot / SEO) | 生成式答案引擎 (ChatGPT / Perplexity / AEO) `[EXPERIMENTAL]` |
 |---|---|---|
 | **搜尋媒介** | Google / Bing 網頁搜尋框 | ChatGPT Search, Perplexity Pro, Claude Web, Google AI Overviews |
 | **互動模式** | 索引藍色網址清單，由使用者自行點擊篩選 | AI 消化海量資訊後，直接合成結論並提供「引用角標 (Citations)」 |
 | **流量型態** | 點擊跳轉至目標網站首頁或文章頁 | 直接在對話中被推薦、引用或作為 MCP 工具被 AI 自動調用 |
-| **爬蟲格式偏好** | 完整 HTML DOM、CSS、SSR 渲染的 JavaScript 頁面 | 零雜訊、語義密集的 Markdown 文本、結構化 JSON-LD、`/llms.txt` |
-| **內容排版法則** | 關鍵字密度、文章長度 (Word Count)、內外部反向連結 | **Answer-First (首句即答案)**、獨立無歧義段落、條列證據庫 |
-| **權威信任標準** | Domain Authority (DA)、PageRank、外鏈數量 | **E-E-A-T (經驗/專業/權威/信任)**、可復現測試代碼、開源驗證標籤 |
-| **收錄管線澄清** | Google AI Overviews 由標準 `Googlebot` 爬取渲染 | `Google-Extended` 僅控制基礎模型訓練，非 AI Overviews 爬蟲 |
+| **爬蟲格式偏好** | 完整 HTML DOM、CSS、SSR 渲染的 JavaScript 頁面 | **假設**：語義密集的文本、結構化 JSON-LD、`/llms.txt`（尚無平台官方確認偏好） |
+| **內容排版** | crawlability、useful/original content、descriptive metadata、internal/external linking | **假設**：Answer-First 排版、獨立無歧義段落（尚無平台確認因果） |
+| **權威信任標準** | E-E-A-T conceptual framework（非 specific ranking factor）、外部引用 | E-E-A-T 同理適用、可復現測試代碼、開源驗證標籤 |
+| **收錄管線澄清** | Google AI Overviews 由標準 `Googlebot` 爬取渲染 | `Google-Extended` 控制 Gemini training 與 Gemini Apps/Vertex AI 的 Google Search grounding 用途；它不是獨立 crawler HTTP UA，僅為 robots product token；不控制 Google Search indexing/ranking |
 
 ---
 
-### 4.5 生產級 `robots.txt` 與 AI 爬蟲矩陣配置 (RFC 9309 Compliant)
+### 4.5 生產級 `robots.txt` 與 AI 爬蟲矩陣配置 (RFC 9309 Compliant) `[PLANNED]`
 
-依據 RFC 9309 規範，特定 User-Agent 區塊**不繼承**通用規則，因此必須在各 AI 代理區塊完整配置 `Allow` 與 `Disallow`，杜絕敏感目錄外洩：
+> [!CAUTION]
+> **`robots.txt` 不是安全控制機制。**
+> RFC 9309 明確警告：Robots Exclusion Protocol 不是 content security mechanism，而且把路徑放進 `robots.txt` 本身會公開那些路徑。
+> `Disallow` 只能表達「請合規 crawler 不要抓」，**不能保證內容不外洩**。惡意 scraper 不受 robots.txt 約束。
+> **真正的安全不變量**：敏感內容根本不得被 GitHub Pages / production web root 發布。robots.txt 僅控制 compliant crawler 的 crawling preference。
+
+依據 RFC 9309 規範，特定 User-Agent 區塊**不繼承**通用規則（此技術判斷正確），因此在各 AI 代理區塊完整配置 `Allow` 與 `Disallow` 以表達 crawling preference：
 
 ```text
 # ==============================================================================
-# Production robots.txt for gemini-plugin-cc & Triad-Flow Ecosystem
+# Production robots.txt for gemini-plugin-cc
 # Strictly Compliant with RFC 9309, Google Search, Bing, OpenAI & Anthropic Specs
 # ==============================================================================
 
@@ -182,10 +251,33 @@ Disallow: /scratch/
 Disallow: /tests/
 
 # ------------------------------------------------------------------------------
-# 3. Anthropic Claude Agents (Training & Real-time Web Retrieval)
+# 3. Anthropic Claude Agents
+#    - ClaudeBot: model-development crawling (training data)
+#    - Claude-User: user-directed retrieval (real-time)
+#    - Claude-SearchBot: search indexing / search result quality
+#    Policy decision: Allow search/retrieval, restrict training crawling.
+#    Adjust ClaudeBot policy if you want training inclusion.
 # ------------------------------------------------------------------------------
 User-agent: ClaudeBot
-User-agent: Claude-Web
+Allow: /llms.txt
+Allow: /llms-full.txt
+Allow: /docs/
+Disallow: /
+# NOTE: ClaudeBot set to Disallow by default to restrict training use.
+# Change to Allow: / if you explicitly want training-data inclusion.
+
+User-agent: Claude-User
+Allow: /
+Allow: /llms.txt
+Allow: /llms-full.txt
+Allow: /docs/
+Disallow: /node_modules/
+Disallow: /.git/
+Disallow: /dist/
+Disallow: /scratch/
+Disallow: /tests/
+
+User-agent: Claude-SearchBot
 Allow: /
 Allow: /llms.txt
 Allow: /llms-full.txt
@@ -212,10 +304,42 @@ Disallow: /scratch/
 Disallow: /tests/
 
 # ------------------------------------------------------------------------------
-# 5. Apple & Google AI Extended Crawlers (Model Training Controls)
+# 5. Google-Extended (Gemini Training & Grounding Control Token)
+#    NOT an independent crawler HTTP UA — it is a robots product token.
+#    Controls: (1) future Gemini model training, (2) Gemini Apps / Vertex AI
+#    Google Search grounding uses of Google-crawled content.
+#    Does NOT control Google Search indexing or ranking.
 # ------------------------------------------------------------------------------
 User-agent: Google-Extended
+Allow: /
+Allow: /llms.txt
+Allow: /llms-full.txt
+Allow: /docs/
+Disallow: /node_modules/
+Disallow: /.git/
+Disallow: /dist/
+Disallow: /scratch/
+Disallow: /tests/
+
+# ------------------------------------------------------------------------------
+# 6. Applebot (Apple Search / Siri / Safari — actual web crawler)
+# ------------------------------------------------------------------------------
 User-agent: Applebot
+Allow: /
+Allow: /llms.txt
+Allow: /llms-full.txt
+Allow: /docs/
+Disallow: /node_modules/
+Disallow: /.git/
+Disallow: /dist/
+Disallow: /scratch/
+Disallow: /tests/
+
+# ------------------------------------------------------------------------------
+# 7. Applebot-Extended (Apple Foundation Model Training Control Token)
+#    NOT a crawler — controls whether Applebot's already-crawled data
+#    may be used for Apple foundation model training.
+# ------------------------------------------------------------------------------
 User-agent: Applebot-Extended
 Allow: /
 Allow: /llms.txt
@@ -228,22 +352,29 @@ Disallow: /scratch/
 Disallow: /tests/
 
 # ------------------------------------------------------------------------------
-# 6. Aggressive Scraper Policy (ByteDance Bytespider WAF Level Protection)
+# 8. Aggressive Scraper Policy (ByteDance Bytespider)
+#    NOTE: Disallow: / is a polite request, not a WAF.
+#    Non-compliant scrapers will ignore this entirely.
 # ------------------------------------------------------------------------------
 User-agent: Bytespider
 Disallow: /
 
 # ------------------------------------------------------------------------------
-# 7. Sitemap Location Declaration (RFC 9309 Section 2.3)
+# 7. Sitemap Location Declaration
+#    NOTE: `Sitemap` is a widely supported robots.txt extension;
+#    it is NOT one of RFC 9309's core Allow/Disallow directives.
 # ------------------------------------------------------------------------------
 Sitemap: https://arcobaleno64.github.io/gemini-plugin-cc/sitemap.xml
 ```
 
 ---
 
-### 4.6 官方 `/llms.txt` 與 `/llms-full.txt` 規範實裝 (Answer.AI Spec v2 & Ground Truth)
+### 4.6 `/llms.txt` 與 `/llms-full.txt` 實裝 (Answer.AI llms.txt v2 Community Specification) `[PLANNED]`
 
-依據 Jeremy Howard (Answer.AI) 規範與本專案 `gemini-mcp.mjs` 真實簽名，發布 `/llms.txt`：
+> [!NOTE]
+> `/llms.txt` 是 Jeremy Howard (Answer.AI) 提出的 **community proposal/specification**，旨在為 AI agent 提供機器友善的站點導航索引。它**並非** IETF RFC、W3C Recommendation 或任何平台的強制索引協議。採用它是一種 ecosystem best practice，不保證搜尋引擎或答案引擎的收錄或排名。
+
+依據 Answer.AI llms.txt v2 specification 與本專案 `gemini-mcp.mjs` 真實簽名，發布 `/llms.txt`：
 
 #### 檔案：`/llms.txt` (輕量導航索引 - < 1,000 Tokens)
 ```markdown
@@ -288,9 +419,23 @@ gemini-plugin-cc pairs AI coding agents (Claude Code, Cursor, Claude Desktop) wi
 
 ---
 
-### 4.7 結構化資料 JSON-LD 與語意知識圖譜標記 (Google Rich Results 合規)
+### 4.7 結構化資料 JSON-LD 與語意知識圖譜標記 `[PLANNED]`
+
+> [!WARNING]
+> **Schema.org vocabulary validity ≠ Google Rich Result eligibility**
+> 以下 JSON-LD 使用的是合法的 Schema.org vocabulary，但要觸發 **Google Rich Results** 需滿足額外條件：
+> - **`SoftwareApplication`**：Google 要求 `name` + `offers.price` + **`aggregateRating` 或 `review` 至少其一**。下方範例缺少 rating/review，因此**目前不符合 Google SoftwareApplication Rich Result eligibility**。
+> - **`Article` / `TechArticle`**：Google 明確表示 **no required properties**；`image`、`author`、`headline`、`datePublished` 等均為 recommended，非 required。
+> - Google Search behavior 應以 [Search Central 文件](https://developers.google.com/search/docs/appearance/structured-data/intro-structured-data)為準，不是看到 schema.org 有 property 就代表 Google rich result 會使用。
+>
+> 實作時應建立兩層驗證：**(1) Schema vocabulary validity** 與 **(2) Google Search feature eligibility**。
+>
+> **⚠️ 不得為滿足 eligibility 而偽造 rating/review。** Google 對 rating/review 有內容真實性規則，結構化資料必須反映頁面真正可見的內容。若無 genuine qualifying rating/review，應保持不符合 SoftwareApplication rich result eligibility，而非 synthesize 假資料。
 
 在官方網站與 GitHub Pages 首頁 `<head>` 區域嵌入標準 JSON-LD，雙型別宣告 `SoftwareApplication` + `SoftwareSourceCode`，並補齊 `image`、`mainEntityOfPage` 與 `about` 實體錨定：
+
+> [!NOTE]
+> 以下 `softwareVersion` 與 `license` 為**範本佔位符**。實作時必須從 `plugin.json` / `package.json` / `LICENSE` 動態生成，不得硬編碼未來狀態。目前 repo 實際為 `v0.22.2` + `MIT`。
 
 ```html
 <script type="application/ld+json">
@@ -301,12 +446,12 @@ gemini-plugin-cc pairs AI coding agents (Claude Code, Cursor, Claude Desktop) wi
       "@type": ["SoftwareApplication", "SoftwareSourceCode"],
       "@id": "https://arcobaleno64.github.io/gemini-plugin-cc/#software",
       "name": "gemini-plugin-cc",
-      "alternateName": "Triad-Flow Gemini Companion",
-      "description": "Multi-agent heterogeneous adversarial code review and closed-loop control harness for Claude Code, Cursor, and enterprise CI/CD pipelines.",
+      "alternateName": "Gemini Adversarial Review Companion",
+      "description": "Heterogeneous Gemini/AGY adversarial code review capability provider for Claude Code, Cursor, and enterprise CI/CD pipelines.",
       "applicationCategory": "DeveloperApplication",
       "operatingSystem": "Windows, macOS, Linux",
-      "softwareVersion": "1.0.0",
-      "license": "https://www.apache.org/licenses/LICENSE-2.0",
+      "softwareVersion": "{{DYNAMIC: read from plugin.json}}",
+      "license": "{{DYNAMIC: read from LICENSE — currently MIT, Apache-2.0 after v1.0.0}}",
       "url": "https://arcobaleno64.github.io/gemini-plugin-cc/",
       "codeRepository": "https://github.com/arcobaleno64/gemini-plugin-cc",
       "programmingLanguage": "JavaScript",
@@ -332,7 +477,7 @@ gemini-plugin-cc pairs AI coding agents (Claude Code, Cursor, Claude Desktop) wi
         "@id": "https://arcobaleno64.github.io/gemini-plugin-cc/#software"
       },
       "headline": "Heterogeneous Multi-Agent Closed-Loop Control Architecture for AI Code Review",
-      "description": "How cross-model adversarial review between Claude, Gemini, and OpenAI eliminates common-mode failure in automated software engineering.",
+      "description": "How cross-model adversarial review between Claude, Gemini, and OpenAI can reduce correlated blind spots in automated software engineering.",
       "image": "https://arcobaleno64.github.io/gemini-plugin-cc/assets/og-image.png",
       "author": {
         "@type": "Person",
@@ -342,7 +487,7 @@ gemini-plugin-cc pairs AI coding agents (Claude Code, Cursor, Claude Desktop) wi
       },
       "publisher": {
         "@type": "Organization",
-        "name": "Triad-Flow Open Source Initiative",
+        "name": "gemini-plugin-cc",
         "url": "https://github.com/arcobaleno64",
         "logo": {
           "@type": "ImageObject",
@@ -360,16 +505,29 @@ gemini-plugin-cc pairs AI coding agents (Claude Code, Cursor, Claude Desktop) wi
 
 ---
 
-### 4.8 E-E-A-T 權威性注入與 Answer-First 高引用率 FAQ 庫
+### 4.8 E-E-A-T 內容指引與 Answer-First FAQ 庫 `[EXPERIMENTAL]`
 
-#### 🎯 Answer-First 內容排版黃金準則：
-AI 答案引擎（ChatGPT / Perplexity / Claude）在生成綜合回答時，會優先引用「**問題標題下方第一句話即給出精確、無歧義定義**」的內容區塊。
+> [!NOTE]
+> **證據分層聲明 (Evidence Tier Disclosure)**
+> 本節涉及的 AEO/GEO 宣稱有不同證據等級。下表列出目前可查證的邊界：
+>
+> | 宣稱 | 證據層級 | 依據 |
+> |---|---|---|
+> | `OAI-SearchBot` 影響 ChatGPT Search 能否 crawl 你的內容 | **官方證實** | [OpenAI Help Center](https://help.openai.com/en/articles/9237897) |
+> | `/llms.txt` 可提供 agent-friendly discovery 索引 | **Community spec / ecosystem practice** | [llmstxt.org](https://llmstxt.org/) |
+> | Answer-First 排版能提高被 AI 答案引擎引用的機率 | **待 benchmark 驗證的 hypothesis** | 尚無官方公開 ranking signal 文件支持因果關係 |
+> | JSON-LD 能提升 AI recommendation | **待驗證的 hypothesis** | Google 明確表示 [E-E-A-T 不是 specific ranking factor](https://developers.google.com/search/docs/fundamentals/creating-helpful-content) |
+>
+> Google 在 2026 年 5 月的 generative-AI Search guidance 中強調傳統 SEO 基礎仍是核心，並 myth-bust 了若干 AEO/GEO misconceptions。OpenAI 官方也明確表示**沒有辦法保證 ChatGPT Search 排名靠前**。
+
+#### 🎯 Answer-First 內容排版指引 `[EXPERIMENTAL]`：
+以下為**內容工程 heuristic（未經平台官方確認的因果關係）**：AI 答案引擎在生成綜合回答時，**可能**傾向引用在問題標題下方首句即給出精確、無歧義定義的內容區塊。此效果的強度與穩定性取決於各 AI 平台的 retrieval/ranking 實作，目前尚無平台公開確認此為 ranking signal。
 
 #### Q1: What is `gemini-plugin-cc` and how does it improve Claude Code?
 > **`gemini-plugin-cc` is an open-source multi-agent code review harness that pairs Claude Code with Google Gemini's 1M-token context window to perform heterogeneous adversarial security reviews.** While Claude generates and edits code, Gemini acts as an external auditor hunting subtle vulnerabilities, API edge cases, and structural regressions without sharing proprietary session histories.
 
 #### Q2: Why is heterogeneous multi-agent review superior to single-model review?
-> **Heterogeneous review eliminates common-mode cognitive failure by ensuring that the AI generating the code is not the same model auditing it.** Single-model self-review suffers from isomorphic blindspots where an LLM rationalizes its own hallucinations; pairing Claude with Gemini and OpenAI ensures cross-model Byzantine validation and objective consensus.
+> **Heterogeneous review can reduce correlated blind spots by ensuring that the AI generating the code is not the same model family auditing it.** Single-model self-review is susceptible to isomorphic reasoning patterns where an LLM may rationalize its own errors; pairing Claude with Gemini introduces a partially independent model family with different training data, internal representations, and reasoning paths, which can surface issues the generating model missed. Note: this does not guarantee independence — LLMs may still share training corpora, benchmark incentives, and common code patterns.
 
 #### Q3: How do you configure `gemini-plugin-cc` in Cursor and Claude Desktop using MCP?
 > **You can configure `gemini-plugin-cc` in any MCP-compatible GUI by registering its stdio command with an absolute path in `claude_desktop_config.json` or Cursor's MCP Settings.**
@@ -387,59 +545,72 @@ AI 答案引擎（ChatGPT / Perplexity / Claude）在生成綜合回答時，會
 }
 ```
 
-#### Q4: How does Triad-Flow resolve conflicting findings between AI models?
-> **Triad-Flow uses deterministic quorum aggregation policies that preserve the highest reported severity to prevent vulnerability downgrade attacks.** If external adversarial review (Gemini) reports a Critical vulnerability while the local model reports a Low issue, the consensus policy strictly enforces the Critical rating and triggers fail-closed gate blocking.
+#### Q4: How should callers treat conflicting or high-severity findings?
+> **`gemini-plugin-cc` findings are review evidence, not final release authority.** A high-severity result should be surfaced for validation, reproduction, or human/upstream adjudication; the plugin must not convert `max severity` into automatic truth. Callers should keep severity separate from validation status and make final disposition from evidence quality, reproducibility, confidence, and independent verification.
 
 #### Q5: Can `gemini-plugin-cc` run in enterprise CI/CD pipelines with SARIF export?
-> **Yes, `gemini-plugin-cc` supports enterprise CI/CD with 1-line GitHub Actions composite workflows and OASIS SARIF 2.1.0 exports.** In CI pipelines, setting `GEMINI_GATE_STRICT=true` enforces fail-closed blocking on any critical findings, automatically uploading findings to GitHub Code Scanning.
+> **`gemini-plugin-cc` can be invoked in CI/CD pipelines today via its MCP tools or direct CLI invocation.** `[PLANNED]` Roadmap items include: (1) a 1-line GitHub Actions composite workflow (`action.yml`), (2) OASIS SARIF 2.1.0 structured output for GitHub Code Scanning integration, and (3) `GEMINI_GATE_STRICT=true` for fail-closed blocking on critical findings. These features are **not yet implemented** — the current stop-review gate explicitly fails open on review errors.
 
 #### Q6: What are the security, privacy, and data minimization guarantees?
-> **`gemini-plugin-cc` strictly adheres to data minimization by transmitting only Git Diffs, never exposing user system prompts, credentials, or proprietary conversation logs.** Furthermore, it enforces file-level secret isolation by automatically intercepting known credential paths (`.env*`, `*.pem`, `*.key`, `credentials.json`, `id_rsa`) and redacting their diff content before payload transmission.
+> **The plugin minimizes the repository context it explicitly assembles for review and applies filename-based secret-file redaction (intercepting known paths like `.env*`, `*.pem`, `*.key`, `credentials.json`, `id_rsa`).** Review payloads may include git status, diffs, and eligible untracked-file contents — not only git diffs. Hard-coded credentials in ordinary source files (`.cs`, `.js`, config, test fixtures) are **not** caught by filename-based redaction. The underlying Gemini/AGY CLI is agentic and is not path-sandboxed, so it may independently read additional workspace files beyond what the plugin explicitly assembles. System prompts and proprietary conversation logs are not included in plugin-assembled payloads, but this is a plugin-level design, not an enforced sandbox boundary. See `PRIVACY.md` for the full data-flow specification.
 
 #### Q7: What open-source license governs `gemini-plugin-cc` and its derivative forks?
-> **`gemini-plugin-cc` is transitioning to the enterprise-grade Apache License 2.0 starting with the v1.0.0 release, providing users with explicit patent grants and trademark protection.** Downstream contributors and commercial adopters benefit from mutual patent retaliation safeguards while maintaining commercial flexibility.
+> **`gemini-plugin-cc` is transitioning to the Apache License 2.0 starting with the v1.0.0 release, providing an explicit contributor patent license and patent-litigation termination clause.** `[PLANNED]` Apache-2.0 does not grant trademark rights (§6) — trademark protection, if needed, must be established independently. Downstream contributors and commercial adopters benefit from the patent grant while maintaining commercial flexibility. See §9 for relicensing prerequisites.
 
 ---
 
-### 4.9 SEO / AEO / GEO 自動化驗證、指標監控與持續改進閉環 (Automated Verification & Continuous Improvement Loop)
+### 4.9 SEO / AEO / GEO 自動化驗證、指標監控與持續改進閉環 `[PLANNED]`
 
 為了確保發布後的 SEO / AEO / GEO 規格不發生語意漂移、格式回歸或鏈路損壞，並能依據量化數據反饋持續調優，本專案建立了 **「CI/CD 自動化測試 + 定時 AEO 基準評測 + OODA 持續改進閉環」**：
 
-#### 1. CI/CD 靜態規格自動化驗證 (`tests/seo-aeo-validation.test.mjs`)
+#### 1. CI/CD 靜態規格自動化驗證 (`tests/seo-aeo-validation.test.mjs`) `[PLANNED]`
 在每次 Pull Request 或版本發布時自動執行，100% 阻斷規格回歸：
 ```bash
 node --test tests/seo-aeo-validation.test.mjs
 ```
 * **驗證範疇**：
-  1. `robots.txt`：RFC 9309 語法、12 大 Agent 群組非繼承隔離、敏感目錄（`/.git/`, `/scratch/`, `/dist/`）阻斷。
-  2. `/llms.txt`：Answer.AI Spec v2 單一 H1/Blockquote/`## Optional`、6 大真實 MCP 工具簽名覆蓋。
-  3. `Schema.org JSON-LD`：雙型別聲明、Google Rich Results 必填項（`image`, `publisher` logo, `about` DAG 鏈路）。
+  1. `robots.txt`：RFC 9309 語法、各 Agent 群組非繼承隔離、crawling preference 表達（注意：這是 crawling preference，不是安全控制）。
+  2. `/llms.txt`（注意區分 **spec requirement** vs. **project policy**）：
+     - **Spec requirement**（llms.txt v2）：H1 是唯一 required section。Blockquote、H2 sections、`## Optional` 均可省略。
+     - **Project policy**：本專案額外要求 Blockquote summary + H2 sections + 6 大真實 MCP 工具簽名覆蓋。
+     - CI 失敗訊息應寫 `project llms.txt profile violation`，**不得**寫 `llms.txt spec non-compliant`（除非真的違反 H1 requirement）。
+  3. `Schema.org JSON-LD`（兩層驗證）：
+     - **(a) Schema vocabulary validity**：雙型別聲明語法正確性。
+     - **(b) Google Rich Result eligibility**：`SoftwareApplication` 需有 `aggregateRating` 或 `review`；`Article` 無 required properties（`image`、`author` 等為 recommended）。不得為滿足 eligibility 而偽造 rating。
   4. `Answer-First FAQ`：7 大問答首句定義完整度、機密路徑真實性（`.env*`, `credentials.json`）。
 
-#### 2. 自動化 AEO 基準評測與統計指標生成器 (`scripts/aeo-benchmark.mjs`)
-評分器，輸入是**真實助理回應**：把 `BENCHMARK_QUERIES` 裡的提問逐字丟給助理，把回答原文存進
-`bench/aeo-responses/<QUERY_ID>.md`，腳本才有東西可算。
-
+#### 2. 自動化 AEO 基準評測與統計指標生成器 (`scripts/aeo-benchmark.mjs`) `[EXPERIMENTAL]`
+提供開箱即用的基準評測腳本，模擬高意圖開發者提問，計算量化指標：
 ```bash
 node scripts/aeo-benchmark.mjs
 ```
+* **輸出報表**：自動於 `docs/benchmarks/latest-aeo-report.json` 產出 JSON 與統計趨勢日報。
 
-* **輸入**：`bench/aeo-responses/`，一題一檔，首行必須是 provenance 註解
-  （`<!-- captured: YYYY-MM-DD | assistant: 名稱 -->`），否則腳本拒絕評分而非給分。
-* **輸出報表**：`docs/benchmarks/latest-aeo-report.json`（產生物，已列入 `.gitignore`）。
-* **未擷取的題目記為 unmeasured，不計入任何比率**，也不當成 0 分——沒問過助理和助理答不好
-  是兩件事。報表另列 `benchmarkQueries` 與 `unmeasured` 清單。
-* **不產出趨勢**：單次擷取是「某個助理在某一天的某一個回答」，不構成時間序列。要談趨勢，
-  得有多次不同日期的擷取。
+> [!WARNING]
+> **Benchmark 反 Goodhart 設計要求**：
+> 若 benchmark prompt 直接包含品牌名稱（`gemini-plugin-cc`），然後檢測輸出是否出現同一品牌名稱，你會得到漂亮但無意義的數字。對抗性 benchmark 至少應：
+> 1. 使用 **blind queries**（不直接洩漏品牌名稱）與 **competitor-inclusive queries**
+> 2. 每個 query **多次 sampling**，報 confidence interval 而非單次百分比
+> 3. 固定 model/version/search mode/region/date
+> 4. 記錄 **citation URL**（不只 regex 品牌名）
+> 5. 區分 branded / non-branded discovery
+> 6. 將 benchmark prompt set 與優化內容隔離，避免直接 overfit
+> 7. 維護 **hidden/rotating holdout** query set，不對優化團隊公開，防止 teaching to the test
+> 8. 加入 **negative controls**（已知不相關或競品優先的 query），確保 KPI 提升不是來自單一指標最適化
+>
+> `80% / 75%` 可保留為 internal aspiration，但不能用來證明 `/llms.txt` 或 Answer-First 產生因果提升。
 
-#### 3. 四大核心監控 KPI 與統計指標 (Statistical Metrics & KPIs)
+#### 3. 四大核心監控 KPI 與內部基準目標 (Internal Benchmark Targets)
 
-| 核心 KPI 指標 | 定義與計算公式 | 目標門檻 (SLA) | 監控與採集方式 |
+> [!NOTE]
+> 以下為**內部基準目標 (internal benchmark targets)**，不是 SLA。你無法對 ChatGPT、Perplexity、Claude 的 recommendation behavior 提供 service-level guarantee，因為你不控制它們的模型、搜尋索引、個人化機制或 ranking system。
+
+| 核心 KPI 指標 | 定義與計算公式 | 目標門檻 (Internal Target) | 監控與採集方式 |
 |---|---|:---:|---|
-| **1. 引用涵蓋率 (Citation Inclusion Rate)** | $\frac{\text{被 AI 引用次數 (含有官方 URL)}}{\text{已擷取回應的提問數}} \times 100\%$ | **$\ge 80\%$** | `scripts/aeo-benchmark.mjs`，分母為已擷取題數 |
-| **2. 首選直接推薦率 (Direct Recommendation)** | $\frac{\text{AI 答案首段直接推薦本工具次數}}{\text{已擷取回應的提問數}} \times 100\%$ | **$\ge 75\%$** | 答案文本正則比對 (`gemini-plugin-cc` / `triad-flow`) |
+| **1. 引用涵蓋率 (Citation Inclusion Rate)** | $\frac{\text{被 AI 引用次數 (含有官方 URL)}}{\text{基準測試總提問數}} \times 100\%$ | **$\ge 80\%$** | `scripts/aeo-benchmark.mjs` 定時排程統計 |
+| **2. 首選直接推薦率 (Direct Recommendation)** | $\frac{\text{AI 答案首段直接推薦本工具次數}}{\text{基準測試總提問數}} \times 100\%$ | **$\ge 75\%$** | 答案文本正則比對 (`gemini-plugin-cc`) |
 | **3. 語意關鍵詞覆蓋度 (Average Keyword Coverage)**| $\frac{1}{N}\sum \frac{\text{命中核心技術關鍵詞數}}{\text{目標關鍵詞總數}} \times 100\%$ | **$\ge 60\%$** | 評估 AI 綜合回答是否保留「異質對抗、1M 上下文、數據最小化」 |
-| **4. 結構化資料合規率 (Schema Compliance Score)** | $\frac{\text{Google Rich Results 綠燈無重大錯誤數}}{\text{總頁面數}} \times 100\%$ | **$100\%$** | Google Search Console / Rich Results API |
+| **4. 結構化資料合規率 (Schema Compliance Score)** | $\frac{\text{Schema vocabulary validity 無重大錯誤數}}{\text{總頁面數}} \times 100\%$ | **$100\%$** | Rich Results Test (manual)、Schema.org Validator、Google Search Console |
 
 #### 4. AEO 持續改進 OODA 反饋閉環 (Continuous Improvement Feedback Loop)
 
@@ -453,11 +624,34 @@ graph TD
 
 ---
 
+### 4.10 Google Preferred Sources `[EXTERNAL-CURRENT@2026-08-20]`
+
+Google 已推出 **Preferred Sources** 功能，允許使用者在 Google Search Settings 中指定偏好的網站來源。此功能已延伸至 **AI Mode / AI Overviews**，影響 AI 生成回答中的來源優先順序。
+
+> [!NOTE]
+> **分類**：Explicit User Preference / Personalization mechanism
+>
+> **Guardrails — Preferred Sources 不是以下任何一項**：
+> - ❌ **不是** global ranking factor（僅影響明確選擇的使用者）
+> - ❌ **不是** universal SEO boost（不改變未設定此偏好的使用者之搜尋結果）
+> - ❌ **不是** evidence that `/llms.txt`、JSON-LD 或 Answer-First 能改善 AI ranking
+> - 受益主要限於**明確選擇該來源的使用者**
+>
+> **與本專案的關係**：若維護者希望被使用者加入 Preferred Sources，最實際的做法是產出 **genuinely useful content**（與 Google 的 people-first guidance 一致），而非追加技術 metadata。此功能比本文件多數 `[EXPERIMENTAL]` AEO heuristic 更有官方佐證。
+
+---
+
 ## 5. 前置環境依賴與異常防禦機制 (Prerequisites & Failure Modes)
 
 ### 5.1 本機依賴條件
 * **Node.js**：`>= 18.0.0`
-* **Google 引擎**：已安裝 `agy.exe` (Antigravity CLI) 或 `gemini` CLI（或環境變數設定 `GOOGLE_API_KEY`）。
+* **Google 引擎認證**（擇一）：
+  | 方法 | 環境變數 / 指令 | 適用場景 |
+  |---|---|---|
+  | AGY OAuth | 執行 `agy` 一次完成互動式授權 | 本機開發 |
+  | Gemini Developer API Key | `GEMINI_API_KEY` | AI Studio key、headless CI |
+  | Vertex AI Express | `GOOGLE_API_KEY` | Vertex Express mode |
+  | Vertex AI ADC | `GOOGLE_CLOUD_PROJECT` + `GOOGLE_CLOUD_LOCATION` 等 | 企業 Vertex AI |
 
 ### 5.2 GUI 使用者無 Node.js 時的行為特徵
 * **現象**：當使用者電腦未安裝 Node.js 時，GUI 軟體啟動 MCP 伺服器會直接失敗並拋出 `spawn node ENOENT`（找不到檔案）。
@@ -488,22 +682,34 @@ graph TD
 > 2. **Vertex AI 多層路徑支援**：Vertex AI 模型路徑包含多個斜線（如 `publishers/google/models/gemini-3.5-pro`），正則必須支援**多層斜線**而非單一斜線。
 > 3. **複用而非重建**：`doctor` 自檢應擴充既有的 `buildSetupReport` / `handleSetup`，切勿新建平行衝突模組。
 
-### 6.1 Gate 雙軌制（本機 Fail-Open + CI Fail-Closed）
+### 6.1 Gate 雙軌制（本機 Fail-Open + CI Fail-Closed） `[PLANNED]`
 * **檔案**：`plugins/gemini/scripts/stop-review-gate-hook.mjs`
+* **現狀**：目前 stop gate **明確 fail-open**（source comment 與行為均確認）。
 * **精確實作邏輯**：在 `if (!payload)` 分支中（約 line 109）引入 `GEMINI_GATE_STRICT` 判斷。
 
-### 6.2 `SAFE_MODEL_ID` 正則放寬（支援多層 Vertex AI 與版本標籤）
+### 6.2 `SAFE_MODEL_ID` 正則放寬（支援多層 Vertex AI 與版本標籤） `[PLANNED]`
 * **檔案**：`plugins/gemini/scripts/lib/engine.mjs`
-* **精確正則定義**：
+* **現有安全不變量**：現行 regex 要求整個 model ID 首字元為 alphanumeric，以避免 `--yolo` 類字串被 CLI argument parser 視為 flag（option confusion / argument interpretation ambiguity）。
+
+> [!CAUTION]
+> **不得使用文件先前版本提議的 `(?:[A-Za-z0-9_.-]+\/)*` 開頭模式。**
+> 該模式接受 `--yolo/foo`、`-x/foo`、`../foo`、`./foo`，會破壞「首字元不得為 `-`」的原始安全約束。
+> 下方修正版本要求**每個 path segment 的首字元均為 alphanumeric**。
+
+* **修正後正則定義**：
   ```javascript
-  const SAFE_MODEL_ID = /^(?:[A-Za-z0-9_.-]+\/)*[A-Za-z0-9][A-Za-z0-9._-]*(?:@[A-Za-z0-9._-]+)?$/;
+  const SAFE_MODEL_ID = /^[A-Za-z0-9][A-Za-z0-9._-]*(?:\/[A-Za-z0-9][A-Za-z0-9._-]*)*(?:@[A-Za-z0-9][A-Za-z0-9._-]*)?$/;
   ```
+* **接受**：`publishers/google/models/gemini-3.5-pro`、`gemini-3.5-pro@001`
+* **拒絕**：`../foo`、`--foo/bar`、`-x/foo`、`./foo`
+* **實作前額外驗證**：確認 downstream CLI 是否真正接受 `/`；Gemini CLI 與 AGY 的 exact model ID namespace 是否同規則；`/` 與 `@` 是否可能改變 CLI semantic parsing。單純 character allowlist 不等同於安全——應考慮是否需要 known-prefix allowlist。
 
-### 6.3 智慧安全加權預算分配 (Security-Weighted Budgeting)
+### 6.3 智慧安全加權預算分配 (Security-Weighted Budgeting) `[PLANNED]`
 * **檔案**：`plugins/gemini/scripts/lib/git.mjs`
-* **實作位置**：在 `budgetReviewSections` 中對 `units` 進行安全加權排序（Tier 1: Auth/Workflows, Tier 2: Source Code, Tier 3: Docs/JSON）。
+* **現狀**：`budgetReviewSections()` 目前為 flat fair-share allocation，**尚未實作** Tier 1/2/3 security weighting。
+* **計畫實作位置**：在 `budgetReviewSections` 中對 `units` 進行安全加權排序（Tier 1: Auth/Workflows, Tier 2: Source Code, Tier 3: Docs/JSON）。
 
-### 6.4 `doctor` 輕量一鍵診斷指令
+### 6.4 `doctor` 輕量一鍵診斷指令 `[PLANNED]`
 * **檔案**：`plugins/gemini/scripts/gemini-companion.mjs`
 * **實作方式**：在 `handleSetup` / `buildSetupReport` 擴充輸出診斷摘要。
 
@@ -511,8 +717,21 @@ graph TD
 
 ## 7. 企業級 CI/CD 與業界標準整合規格 (Enterprise Standards)
 
-### 7.1 GitHub Action 官方封裝規格 (`action.yml`)
-為了讓企業 DevOps 團隊能以 3 行 YAML 直接嵌入 GitHub Actions，需在倉庫根目錄建立 `action.yml`：
+### 7.1 GitHub Action 官方封裝規格 (`action.yml`) `[PLANNED]`
+
+> [!CAUTION]
+> **下方 YAML 為初版概念草稿，包含 4 個已知結構性缺陷，禁止照原樣發布。**
+>
+> | # | 缺陷 | 說明 |
+> |---|---|---|
+> | 1 | **路徑解析錯誤** | `node plugins/gemini/...` 預設在呼叫者的 `$GITHUB_WORKSPACE` 執行，第三方 repo 使用 `uses: arcobaleno64/gemini-plugin-cc@...` 時該路徑不存在。應使用 `${{ github.action_path }}` 定位 action 自身目錄。 |
+> | 2 | **`output-format` input 未接線** | 無論填 `markdown`、`sarif` 或 `json`，實際命令硬編碼 `--json`。此 API contract 為裝飾品。 |
+> | 3 | **`GEMINI_GATE_STRICT` 無後端** | 目前 stop gate 仍為 fail-open，且此 Action 執行的是 `gemini-companion.mjs review`，不是 stop gate。設定 env var 不會讓另一條 execution path 自動學會 fail-closed。 |
+> | 4 | **無 verdict 解析與 exit code** | 未 parse review JSON verdict、未對 critical/high severity 返回 non-zero exit、未處理 engine/quota/timeout failure、無 SARIF upload、未宣告 `security-events: write` permission。 |
+>
+> **正式實作前必須解決上述全部缺陷，並補齊**：caller checkout/fetch-depth contract、`$GITHUB_ACTION_PATH` 路徑定位、output-format 實際接線、verdict → exit code 映射、SARIF upload step（如適用）。
+
+以下為**概念草稿**（僅供架構參考，不可直接使用）：
 
 ```yaml
 name: 'Gemini Adversarial Code Review'
@@ -544,11 +763,15 @@ runs:
         GEMINI_GATE_STRICT: ${{ inputs.strict }}
         GEMINI_ENGINE: ${{ inputs.engine }}
       run: |
+        # TODO: Fix path to use ${{ github.action_path }}
+        # TODO: Wire output-format input to actual CLI flag
+        # TODO: Parse verdict JSON and exit non-zero on critical/high
+        # TODO: Handle engine/quota/timeout failures per strict mode
         node plugins/gemini/scripts/gemini-companion.mjs review --base ${{ github.event.pull_request.base.sha || 'HEAD~1' }} --deep --json > review-result.json
 ```
 
-### 7.2 OASIS SARIF 2.1.0 結構化標準輸出
-企業級 CI/CD 依賴 **SARIF 2.1.0 (Static Analysis Results Interchange Format)** 與 GitHub Code Scanning / SonarQube 對接：
+### 7.2 OASIS SARIF 2.1.0 結構化標準輸出 `[PLANNED]`
+企業級 CI/CD 依賴 **SARIF 2.1.0 (Static Analysis Results Interchange Format)** 與 GitHub Code Scanning / SonarQube 對接（**目前輸出為自訂 JSON，SARIF 尚未實作**）：
 * **實作位置**：`plugins/gemini/scripts/lib/render.mjs`
 * **格式定義**：
   ```json
@@ -560,7 +783,7 @@ runs:
         "tool": {
           "driver": {
             "name": "gemini-adversarial-review",
-            "version": "0.23.0"
+            "version": "{{DYNAMIC: read from plugin.json}}"
           }
         },
         "results": [
@@ -575,7 +798,7 @@ runs:
                   "region": { "startLine": 42 }
                 }
               }
-            }
+            ]
           }
         ]
       }
@@ -583,12 +806,18 @@ runs:
   }
   ```
 
-### 7.3 OpenSSF 合規性文檔 (`SECURITY.md`)
-建立 `SECURITY.md` 明定安全通報窗口、漏洞回應時間（SLA）與機密防護保證，符合企業 SOC2 與 OpenSSF 開源安全標準。
+### 7.3 安全通報文檔 (`SECURITY.md`) `[CURRENT]`
+`SECURITY.md` 已建立，包含安全通報窗口、漏洞回應時間（48 hr initial response、7 business days status update）與機密防護保證。
+
+> [!NOTE]
+> `SECURITY.md` 支持 vulnerability-management documentation practices，可作為 OpenSSF OSPS Baseline 或 SOC 2-aligned controls 的**部分證據**；但它本身**不等於合規**。OpenSSF OSPS Baseline 是一整套 maturity-level security controls（含 CI/CD isolation、input validation、threat modelling 等）；SOC 2 是針對組織控制環境的 assurance audit，不是 repo-level Markdown badge。
 
 ---
 
-## 8. Gemini 3.5 Pro / Gemini 4「Day 0」發布 SOP
+## 8. Next Gemini Major Model「Day 0」發布 SOP `[TEMPLATE]`
+
+> [!NOTE]
+> 以下為**任意未來 Gemini 重大 model release** 的通用 SOP 範本。截至 2026-08-21，Google 官方 Gemini API model catalogue 尚無 「Gemini 3.5 Pro」或「Gemini 4」。不要把尚未存在的產品名稱寫成 release roadmap。
 
 1. **[0-5 分鐘] 別名更新**：
    * 編輯 `plugins/gemini/scripts/lib/model-map.mjs`，將 `pro` / `flash` 別名與 `EFFORT_MODEL_MAP` 指向官方新 Model ID。
@@ -596,7 +825,7 @@ runs:
    * `node --test tests/model-map.test.mjs`
 3. **[10-20 分鐘] 產生實測 Findings 並發布 Release**：
    * 對範例庫跑一次 `/gemini:adversarial-review`，截取真實對抗審查報告。
-   * 發布 GitHub Release `v0.23.0 - Day-0 Gemini 4 Adversarial Review in Claude Code`。
+   * 發布 GitHub Release `vX.Y.Z - Day-0 <NEW_MODEL_NAME> Adversarial Review in Claude Code`。
 4. **[20-30 分鐘] 社群技術廣播**：
    * 在 Reddit (`r/ClaudeAI`) 與 X 發布實測案例長文，帶動真實開發者安裝與轉化。
 
@@ -604,21 +833,29 @@ runs:
 
 ## 9. 開源授權策略與 v1.0.0 升級時機 (Open Source Licensing Strategy & v1.0.0 Roadmap)
 
-### 9.1 授權升級策略：從 MIT 邁向 Apache-2.0
-本專案現階段（v0.22.x）使用 MIT 授權以降低初期開發者上手摩擦力。自 **v1.0.0 正式版** 起，全面升級為 **Apache-2.0** 授權，與上游 `openai/codex-plugin-cc` 及下游 `Triad-Flow` 保持 100% 法律血統一致性。
+### 9.1 授權升級策略：從 MIT 邁向 Apache-2.0 `[PLANNED]`
+本專案現階段（v0.22.x）使用 MIT 授權以降低初期開發者上手摩擦力。自 **v1.0.0 正式版** 起，全面升級為 **Apache-2.0** 授權，採 Apache-2.0 作為預定的 v1.0.0 licensing target；正式切換仍以 §9.5 provenance audit 結果為前提。
 
-### 9.2 Apache-2.0 賦予維護者的「三大法律護城河」
-1. **🛡️ 專利免死金牌 (Grant of Patent License - Section 3)**：
-   * 所有貢獻者與作者承諾將代碼涉及之專利免費、永久授權給使用者，杜絕大廠「釣魚式開源」風險。
-2. **⚡ 專利報復條款 (Patent Retaliation Clause - Section 3)**：
-   * 建立「核威懾防禦」：任何第三方若針對本軟體向維護者提起專利侵權訴訟，該第三方使用本專案的所有開源授權立即自動終止。
-3. **🏷️ 商標免責盾牌 (Trademarks - Section 6)**：
-   * 嚴格禁止第三方在魔改代碼後擅自使用專案名稱、作者名義或商標進行背書或宣傳，防止惡意木馬假冒官方插件。
+### 9.2 Apache-2.0 的法律特性（精確依據 License 原文）
+
+> [!WARNING]
+> 以下為 Apache-2.0 License 原文的摘要說明，**不構成法律建議**。具體法律效果取決於司法管轄區。
+
+1. **專利授權 (Grant of Patent License — §3)**：
+   * 每位 Contributor 授予使用者永久、全球、非獨佔、免費的專利授權，涵蓋該 Contributor 的 Contribution 所涉及的專利 claims。
+   * **專利終止觸發**：若任何實體對 Work 發動指定 patent litigation，則 **under this License 授予該實體的 patent licenses 終止**。注意：終止的是 patent license，不是所有 copyright permission 一起蒸發。
+
+2. **商標不授權 (Trademarks — §6)**：
+   * License **不授予商標使用權限**，但允許合理描述 Work 的來源 (origin)，以及 NOTICE 檔案所需用途。
+   * 這**不等同於**完整的反冒牌商標防護機制。若 `gemini-plugin-cc` 名稱本身沒有另外建立 trademark policy 或可執行的商標權，Apache-2.0 不會自動產生商標護城河。如需商標保護，須獨立建立 Trademark Policy。
+
+3. **寬鬆授權特性**：
+   * Apache-2.0 仍屬寬鬆開源授權 (Permissive)，下游可自由商用、修改與閉源分發（非 GPL copyleft 傳染性授權）。
 
 ### 9.3 對下游 Fork 與商業使用者的影響
-* **零商業阻礙**：Apache-2.0 依然屬於寬鬆開源授權（Permissive），下游依然可以自由商用、修改與閉源分發（絕非 GPL 傳染性授權）。
-* **下游獲專利保護**：下游 Fork 同樣受到專利免死金牌保護，免除侵權後顧之憂。
-* **不溯及既往**：v1.0.0 以前的歷史 Fork 保持當時的 MIT 條款，自 v1.0.0 起的新提交全面納入 Apache-2.0 雙向保護。
+* **低摩擦商用授權 (low-friction permissive commercial use)**：Apache-2.0 屬寬鬆開源授權，下游可商用、修改與閉源分發（非 GPL copyleft 傳染性授權）。但仍有 redistribution obligations：license copy、modification notice、copyright/patent/trademark/attribution notice retention、NOTICE file obligations。
+* **下游獲專利保護**：下游 Fork 同樣受到 §3 專利授權保護。
+* **不溯及既往**：v1.0.0 以前的歷史 Fork 保持當時的 MIT 條款，自 v1.0.0 起的新提交全面納入 Apache-2.0 保護。
 
 ### 9.4 升級為 Apache-2.0 的「4 大黃金時機點」
 
@@ -626,5 +863,22 @@ runs:
 |---|---|---|
 | 🏆 **時機 1：v1.0.0 GA 正式發布日 (最推薦)** | 專案完成 Gate 雙軌制、SARIF 2.1.0 與全套測試，宣告進入 Production-Ready 階段。 | 遵循 SemVer 慣例，從 0.x 邁入 1.0.0 代表企業級穩定性承諾，此時宣告升級企業級授權最自然、阻力最小。 |
 | 📝 **時機 2：正式提交 OpenAI / 企業級 Grant 申請前夕** | 準備送出 OpenAI Codex for Open Source 或開源基金會資助表單時。 | 評審機構重視專利清晰度與智財權防護，Apache-2.0 能大幅提升企業評審的合規信任度。 |
-| 🔄 **時機 3：與 Triad-Flow 矩陣深度整合發布時** | `gemini-plugin-cc` 與 `Triad-Flow` 母架構完成適配器對接時。 | 全生態體系（中央大腦 + 引擎外掛）統一為 Apache-2.0，消除跨倉庫授權碎片化。 |
-| 🚀 **時機 4：Gemini 4 / Day-0 大模型引發流量暴增前** | 官方重大模型發表，預期將湧入大量 GitHub Stars 與 Forks 前。 | 在大量外部 Fork 產生前鎖定專利與商標防護，確保核心資產不被惡意挪用。 |
+| 🔄 **時機 3：穩定 Adapter Contract 發布時** | `gemini-plugin-cc` 對外 review/evidence contract 進入穩定版。 | 讓下游 orchestrator 可依穩定公共介面整合，同時維持獨立發版與低耦合。 |
+| 🚀 **時機 4：重大 Gemini model release 引發流量暴增前** | 官方重大模型發表，預期將湧入大量 GitHub Stars 與 Forks 前。 | 在大量外部 Fork 產生前鎖定專利保護，確保核心資產不被惡意挪用。 |
+
+### 9.5 授權轉換先決條件：Relicensing Provenance Gate `[PLANNED]`
+
+> [!CAUTION]
+> **MIT → Apache-2.0 全庫重授權的法律前提**
+> 若 repository 有外部 contributors，每位 contributor 對自己的 contribution 保有 copyright（Apache 官方 guidance 明確指出：original authors retain copyright in their parts）。因此「MIT → Apache-2.0」能否直接把既有整份 codebase 改成 Apache-only，不能只看 repository owner 想不想。
+>
+> **重要區分**：對 derivative work / aggregate distribution 採額外 Apache terms（同時完整保留原始 MIT code 的 MIT notice/permission）與「把別人的原始 contribution retroactively 改成 Apache-only」不是同一件事。Apache 允許 derivative works 採 additional/different terms，但必須遵守原始 work 的條件。正式 relicensing 前應做 provenance review，此文件不提供法律建議。
+
+v1.0.0 切換授權前必須完成以下檢查：
+
+| 檢查項目 | 方法 | 狀態 |
+|---|---|---|
+| **1. Contribution 來源清查** | `git log --format='%aN <%aE>' \| sort -u` 列出所有 authors | `[PLANNED]` |
+| **2. Copyright provenance audit** | 確認 maintainer 是所有 in-scope original code 的 sole copyright holder，且完成 third-party provenance audit（vendored code、copied snippets、employment-related IP assignment）。Git log 只是 discovery input，不等於 copyright ownership proof。 | 待確認 |
+| **3. 外部 contributor 授權同意** | 若有外部 contributor，需取得書面同意或 CLA (Contributor License Agreement) | 待確認 |
+| **4. 備選方案** | 若無法取得全部同意，可採：(a) 舊代碼保持 MIT + 新代碼 Apache-2.0 dual-license；(b) provenance analysis 逐檔標注 | 規劃中 |

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,7 +19,7 @@ Start with the [README](../README.md). Nothing here is required reading to use t
 | [`version-sources.md`](version-sources.md) | Which file is authoritative for each version string, and what keeps them in lockstep. |
 | [`verifying-without-credentials.md`](verifying-without-credentials.md) | How to exercise the engine paths without a Gemini or AGY account. |
 | [`evidence.md`](evidence.md) | The rule this repository investigates by: nothing counts as evidence until it has been seen to fail. Includes the traps already paid for. |
-| [`HANDOVER_MARKETING_AND_RELEASE_PLAYBOOK.md`](HANDOVER_MARKETING_AND_RELEASE_PLAYBOOK.md) | Master handover playbook: Enterprise growth, MCP registry setup, AI-era SEO/AEO/GEO architecture, automated validation metrics, and v1.0.0 roadmap. |
+| [`ROADMAP.md`](ROADMAP.md) | Every item in the handover playbook, triaged against HEAD: already done, premise verified and worth doing, blocked on something that does not exist, wrong as written, or a non-goal. Read this before acting on the playbook. Traditional Chinese. |
 
 ## Dated records — never rewritten
 
@@ -29,5 +29,6 @@ Start with the [README](../README.md). Nothing here is required reading to use t
 | [`PARITY_AUDIT_v0.6.1.md`](PARITY_AUDIT_v0.6.1.md) | plugin v0.6.1 re-score | `PARITY_AUDIT_v0.11.1.md` |
 | [`PARITY_AUDIT_v0.11.1.md`](PARITY_AUDIT_v0.11.1.md) | plugin v0.11.1 vs upstream v1.0.6, 2026-08-04 | current state: [`parity.md`](parity.md) |
 | [`AGY_1.1.2_MACOS_LINUX_VALIDATION.md`](AGY_1.1.2_MACOS_LINUX_VALIDATION.md) | plugin v0.7.1 against AGY **1.1.2**, macOS/Linux | nothing re-ran it; see the banner in the file |
+| [`HANDOVER_MARKETING_AND_RELEASE_PLAYBOOK.md`](HANDOVER_MARKETING_AND_RELEASE_PLAYBOOK.md) | plugin v0.22.2 / `22b93a7`, 2026-08-21 | Its status columns: [`ROADMAP.md`](ROADMAP.md). Its specs and templates are not superseded. |
 
 Behaviour measured after the newest of these lives in the [CHANGELOG](../plugins/gemini/CHANGELOG.md) and in `THREAT-MODEL.md` §7.2, both of which carry their own measurement dates.

--- a/docs/README.zh-TW.md
+++ b/docs/README.zh-TW.md
@@ -19,7 +19,7 @@ English: [`README.md`](README.md)
 | [`version-sources.md`](version-sources.md) | 每個版本字串以哪個檔案為準，以及靠什麼維持一致。 |
 | [`verifying-without-credentials.md`](verifying-without-credentials.md) | 沒有 Gemini 或 AGY 帳號時，如何演練引擎路徑。 |
 | [`evidence.md`](evidence.md) | 本 repo 的調查規則：沒看過它紅過的東西，不算證據。附已經付過學費的陷阱清單。 |
-| [`HANDOVER_MARKETING_AND_RELEASE_PLAYBOOK.md`](HANDOVER_MARKETING_AND_RELEASE_PLAYBOOK.md) | 企業級交接手冊：增長推廣、MCP 上架、AI 時代 SEO/AEO/GEO 架構規格、自動化驗證與 v1.0.0 路線圖。 |
+| [`ROADMAP.md`](ROADMAP.md) | 交接手冊裡的每一項，對 HEAD 逐項分類：已經做掉、前提成立該做、前置條件不存在、內容有錯、不做。動手之前先讀這份。 |
 
 ## 有日期的記錄——永不重寫
 
@@ -29,5 +29,6 @@ English: [`README.md`](README.md)
 | [`PARITY_AUDIT_v0.6.1.md`](PARITY_AUDIT_v0.6.1.md) | 外掛 v0.6.1 重評 | `PARITY_AUDIT_v0.11.1.md` |
 | [`PARITY_AUDIT_v0.11.1.md`](PARITY_AUDIT_v0.11.1.md) | 外掛 v0.11.1 對上游 v1.0.6，2026-08-04 | 當前狀態見 [`parity.zh-TW.md`](parity.zh-TW.md) |
 | [`AGY_1.1.2_MACOS_LINUX_VALIDATION.md`](AGY_1.1.2_MACOS_LINUX_VALIDATION.md) | 外掛 v0.7.1 對 AGY **1.1.2**，macOS/Linux | 無人重跑；見該檔開頭的說明 |
+| [`HANDOVER_MARKETING_AND_RELEASE_PLAYBOOK.md`](HANDOVER_MARKETING_AND_RELEASE_PLAYBOOK.md) | 外掛 v0.22.2 / `22b93a7`，2026-08-21 | 狀態欄見 [`ROADMAP.md`](ROADMAP.md)；其規格與範本未被取代。 |
 
 比上述最新一份更晚量到的行為，記在 [CHANGELOG](../plugins/gemini/CHANGELOG.md) 與 `THREAT-MODEL.md` §7.2，兩者各自帶有量測日期。

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,144 @@
+# Roadmap — playbook 逐項分類
+
+繁體中文。這份文件的對象是維護者，不是使用者。
+
+[`HANDOVER_MARKETING_AND_RELEASE_PLAYBOOK.md`](HANDOVER_MARKETING_AND_RELEASE_PLAYBOOK.md)（v3.8.1）列了大約三十個待辦。它寫得很細，但它是**計畫**，而 `docs/README.md` 開宗明義說過：把計畫當成現況讀，是這個目錄最容易犯的錯。
+
+這份文件做三件事：**查證前提**、**分類**、**擋住不該做的**。
+
+> **查證基準**：commit `41b719b`，2026-08-26，plugin v0.23.0。
+> playbook 自己的 baseline 是 `22b93a7` / v0.22.2 / 2026-08-21，已漂移三個 release。
+> 本文件同樣會過期。**動工當天重新查證那一項的前提，不要採信這裡的欄位。**
+> 每一列都註明查證方式，就是為了讓重驗只花幾秒。
+
+分類共五類，優先級由上而下遞減：
+
+| | 類別 | 意義 |
+|---|---|---|
+| **A** | 已經做掉 | playbook 仍列為待辦，實際已存在 |
+| **B** | 前提成立、該做 | 已對 HEAD 查證，有真實使用者情境 |
+| **C** | 前置條件不存在 | 前置物做出來之前，做了也沒有消費者 |
+| **D** | 內容有錯或矛盾 | 照抄會出事，需先修正 |
+| **E** | 不做 | Non-goal，或順序根本反了 |
+
+---
+
+## A — 已經做掉，playbook 還列為待辦
+
+| 項目 | playbook 說 | 實際 | 查證 |
+|---|---|---|---|
+| §4.9 AEO benchmark | 「⚠️ 待補齊」 | **已實作**：`scripts/aeo-benchmark.mjs` + `tests/aeo-benchmark.test.mjs` | `ls scripts/` |
+| §5.3 認證指引視覺化 | 「包在長篇段落中，掃描型開發者容易忽略」 | **對送審面已不成立**：`plugins/gemini/README.md` 的 Install 區是一張三行需求表。根 `README.md` 的認證段落確實仍長，但那不是審查員第一眼看的檔案 | `plugins/gemini/README.md` §Install |
+| §7.3 `SECURITY.md` | `[CURRENT]` | 正確，仍存在 | `SECURITY.md` |
+| §1「MCP 啟動穩定性」 | v3.8.1 已從「合規」降為「部分合規」 | 這個降級是對的。無啟動探測 ≠ 通過 MCP 合規驗證 | — |
+
+**§4.9 有一個缺陷要記下來。** `scripts/aeo-benchmark.mjs:76-82` 的 `Q5_ENTERPRISE_SARIF` 期待 AI 回答裡出現 `sarif export`、`rendersarif` 這些關鍵字——**而這個功能不存在**（§7.2 仍是 `[PLANNED]`，全 repo 無 SARIF 實作）。這條 query 若哪天「通過」，通過的原因是模型幻覺出一個功能，不是這個 repo 做對了什麼。
+
+這正是 benchmark 最典型的失效方式：**它量的是關鍵字出現率，代理的是「這個工具被正確描述」，而兩者可以反向脫鉤。** 要嘛先實作 SARIF，要嘛把 Q5 降級成 `[PLANNED]` 專用、不計入 pass rate。現在兩者都沒做。
+
+---
+
+## B — 前提經查證成立，該做，但都在上架之後
+
+按建議順序排列。**每一項的前提都對 HEAD 查過，成立。**
+
+### B1. §6.2 `SAFE_MODEL_ID` 放寬 — 唯一有真實使用者情境的
+
+- **前提查證**：`plugins/gemini/scripts/lib/engine.mjs:36` 目前是 `/^[A-Za-z0-9][A-Za-z0-9._-]*$/`，單一 segment，**確實擋掉 `/` 與 `@`**。
+- **真實情境**：Vertex AI 模型路徑（`publishers/google/models/…`）與版本標籤（`…@001`）現在會被拒絕。這是使用者現在就會撞到的，不是假想的。
+- **playbook 的 `[CAUTION]` 是對的，照它做**：舊提案的 `(?:[A-Za-z0-9_.-]+\/)*` 開頭會接受 `--yolo/foo`、`-x/foo`、`../foo`，破壞「首字元不得為 `-`」這個原始安全不變量。修正版要求**每個 path segment 首字元均為 alphanumeric**。
+- **動工前必做**（playbook 自己列的，別跳過）：確認下游 CLI 真的接受 `/`；確認 Gemini CLI 與 AGY 的 model-id namespace 同規則；確認 `/` `@` 不會改變 CLI 的 argument parsing 語意。**單純放寬 character allowlist 不等於安全**——若下游只吃固定幾種前綴，known-prefix allowlist 比 regex 正確。
+
+### B2. §7.1 `action.yml`
+
+- **前提查證**：不存在。
+- 它是 B3 與 C1 的前置物。playbook §7.1 已列出已知缺陷（action path、output-format wiring、verdict/exit 語意、engine/quota/timeout、SARIF upload permissions），**那些要先解掉再發布 action**，不要先發布再補。
+
+### B3. §7.2 SARIF 2.1.0 輸出
+
+- **前提查證**：全 repo 無 SARIF 實作。
+- 純序列化／匯出層，風險低。**但要守住 playbook 自己的界線**：SARIF 只是輸出格式，不得反過來讓 SARIF schema 決定 core finding model；plugin 的 finding 不是 release authority。
+- 做完這項，A 類記的那個 Q5 缺陷才會自然消失。
+
+### B4. §6.4 `doctor`
+
+- **前提查證**：`plugins/gemini/commands/` 下無 `doctor`，只有 `setup`。
+- 價值不高（`setup` 已涵蓋大部分），但成本也低。**照 playbook 的守則做**：擴充既有的 `buildSetupReport` / `handleSetup`，不要新建平行模組。
+
+---
+
+## C — 前置條件不存在，現在做等於為空氣蓋橋
+
+### C1. §6.1 `GEMINI_GATE_STRICT`（CI fail-closed）
+
+- **前提查證**：`plugins/gemini/scripts/stop-review-gate-hook.mjs:110-118` 確實 fail-open，且已附可見警告（`systemMessage` + stderr）。playbook 對現狀的描述正確。
+- **但它存在的唯一目的是服務 §7.1 的 `action.yml`，而 `action.yml` 不存在。**
+- 這違反 playbook **自己的** Complexity Guardrail 第 1 條：「現在是否已有兩個真實 use case？」——目前零個。
+- **解除條件**：B2 完成，且 CI 端出現真實的 fail-closed 需求。在那之前，一個沒有消費者的環境變數只是多一條要維護的分支。
+
+### C2. §4 全部（robots.txt / llms.txt / JSON-LD / Preferred Sources / Glama / Smithery）
+
+- **前提查證**：`smithery.yaml`、`robots.txt`、`llms.txt`、`llms-full.txt` 皆不存在；**GitHub Pages 未啟用**（`gh api repos/…/pages` 回 404）。
+- `robots.txt` 與 JSON-LD 需要一個 host 得起來的網站。**沒有網站的 robots.txt 不會被任何爬蟲讀到。**
+- **解除條件**：先有 Pages 站台，再談上面那些檔案。
+
+### C3. §9.1 MIT → Apache-2.0
+
+- **解除條件**：playbook §9.5 自己列的 Relicensing Provenance Gate。
+- **額外複雜度，playbook 沒寫**：本 repo 已是 Apache-2.0 上游（`openai/codex-plugin-cc`）的衍生作品，且目前是 MIT + Apache-2.0 雙授權（見 `NOTICE`、`LICENSE-APACHE-2.0`）。換授權要同時處理外部貢獻者 provenance **和**既有雙授權結構，不是單純換一個 `LICENSE` 檔。
+
+---
+
+## D — 內容有錯或自我矛盾，照抄會出事
+
+### D1. §3.2 OpenAI Codex for OSS 申請範本與 §2 牴觸
+
+playbook §3.2 建議的 Project Description 是：
+
+> An open-source multi-agent code review & adversarial consensus framework
+
+**同一份文件的 §2 明確否定這個定位**：「不擁有上層 multi-agent orchestration」「不在本插件內實作通用 multi-agent workflow engine」「不以模型投票或 max severity 自動建立 finding authority」。
+
+照這個範本送出，等於提交一份與自己架構文件矛盾的描述。**要送就照 §2 的定位寫**：一個 Gemini / AGY capability provider。
+
+**另外**：§3.2 自己註明評審看 broad adoption。查證當日 **10 stars / 4 forks**，repo 三個月大。**上架取得實際採用數據之後再申請**，否則最強的那一格是空的。
+
+### D2. §1 評估矩陣至少兩格已隨 v0.23.0 過期
+
+v0.23.0 改動了 `gemini_review` / `gemini_adversarial_review` 的 `readOnlyHint`，以及 `--resume` + `--write` 的語意（見 CHANGELOG 0.23.0）。矩陣未反映。**這不是 playbook 的錯**（它標了 baseline），但它示範了為什麼矩陣欄位不能直接採信。
+
+### D3. §6.3 security-weighted budgeting 是古德哈特陷阱
+
+- **前提查證屬實**：`plugins/gemini/scripts/lib/git.mjs:224` 的 `allocateBudget` 是最小優先的 fair-share，無安全加權。
+- **但這一項不該照做。** 把 Tier 1/2/3 權重塞進預算分配，直接抬高的是「安全相關檔案有被送進 review」這個**數字**，而它代理的是「安全問題有被發現」。兩者可以在不改善任何東西的情況下脫鉤：權重讓一個檔案進了 payload，不表示模型在那個檔案上找到了東西。
+- **正確順序**：`bench/` 已經是量發現率的工具。**先用它量出「flat 配額漏掉了安全檔案裡的真實缺陷」，再改配額邏輯。** 沒有那個量測，這項改動無法被證明有效，也無法被證明無效。
+- playbook 的 start prompt 自己寫了「security-weighted review budget **if evidence supports it**」。目前沒有 evidence。
+- **守住這個**：`allocateBudget(sizes, budget)` 是匯出的純函式、以數字陣列為輸入，`tests/git.test.mjs` 依賴其簽名。**嚴禁改參數簽名**（已查證此守則屬實）。
+
+---
+
+## E — 不做
+
+來自 playbook §2 的 Non-Goals 與其 start prompt 的 Scope Boundary。**這一節存在的目的就是防止失焦**：以下每一項在某次對話裡聽起來都會很合理。
+
+1. **通用 multi-agent workflow / orchestration engine** — 本 plugin 是 capability provider，不是 orchestrator。
+2. **consensus / voting engine、Claude adjudicator、Triad release policy、generic multi-agent DAG** — 不在本 repo 實作。
+3. **以模型投票或 `max severity` 自動建立 finding authority** — plugin 的 finding 不是 release verdict。
+4. **宣稱 Gemini / AGY 是 filesystem sandbox** — 它不是，而且 `docs/THREAT-MODEL.md` §7.2 有實測說明它不是。
+5. **為提高 review recall 而擴大 payload surface** — 隱私邊界優先於召回率。
+
+另外兩條是順序問題，不是 non-goal，但同樣會失焦：
+
+- **上架前做 SEO / AEO** — directory 上架本身就是散佈通路。**在還沒被列上去之前優化漏斗，是在優化一個沒有入口的漏斗。**
+- **上架前打 1.0.0** — 見 `README.md` 的 Versioning 一節，1.0.0 的條件已寫成可檢驗的形式。
+
+---
+
+## 怎麼用這份文件
+
+1. **要動 playbook 的某一節之前，先在這裡找到它。** 若它落在 C、D、E，先讀完那一段再決定。
+2. **B 類動工前，重跑該項的「前提查證」那一欄。** 每一列都寫了怎麼查，通常一個 `grep` 或 `ls`。
+3. **查證結果與這裡不符時，改這份文件，不要改 playbook。** playbook 是 dated 的計畫；這份是 current 的分類。
+4. **完成一項就把它移到 A 類**，並註明實作它的 commit。
+
+相關：[`evidence.md`](evidence.md)（本 repo 的查證規則）、[`THREAT-MODEL.md`](THREAT-MODEL.md)（§7.2 是任何「read-only」宣稱的前置閱讀）。

--- a/plugins/gemini/CHANGELOG.md
+++ b/plugins/gemini/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 ## 0.23.0 - 2026-08-26 - What a repository could make this plugin run, and what it never asked for
 
+- **The handover playbook is now triaged, and filed as a dated record.** It sat
+  under "Reference -- kept current" while carrying a baseline three releases old,
+  which is precisely the mistake `docs/README.md` exists to prevent. It moves to
+  "Dated records", and `docs/ROADMAP.md` takes its place: every item in it sorted
+  into already-done, premise-verified-and-worth-doing, blocked-on-something-that-
+  does-not-exist, wrong-as-written, or non-goal -- each with the command that
+  re-checks it, because this classification will go stale too.
+
+  What the triage found, verified against HEAD rather than against the playbook:
+  `SAFE_MODEL_ID` really does still reject Vertex AI paths, the stop gate really
+  is fail-open, and `allocateBudget` really is unweighted -- three premises that
+  survived. Against that, the AEO benchmark it lists as missing already exists and
+  ships tests; the CI fail-closed switch exists only to serve an `action.yml` that
+  does not; `robots.txt` and JSON-LD need a site, and GitHub Pages is not enabled;
+  and its funding-application template describes the project as a multi-agent
+  consensus framework, which its own 2 explicitly says the project is not.
+
+  Also recorded: `scripts/aeo-benchmark.mjs` asks whether an answer mentions SARIF
+  export, and there is no SARIF export. That query can only pass on a hallucination.
+
+  Upgrading the playbook to v3.8.1 broke two assertions in
+  `tests/seo-aeo-validation.test.mjs`, and both were the test being wrong rather
+  than the document. It required `User-agent: Claude-Web`, which is retired --
+  Anthropic documents ClaudeBot, Claude-User and Claude-SearchBot, and they take
+  different policies, which a single retired name cannot express. It also demanded
+  five literal `Disallow:` lines from every group, failing a group that disallows
+  the entire site more strongly; and it extracted 4.8 by stopping at the first
+  `---`, which a markdown table's `|---|` satisfies, so the whole FAQ section came
+  back empty and every assertion under it silently went unreached. The
+  answer-first check then read `[^*]+` across an answer naming `.env*` and
+  `*.pem`. Each fix was mutation-tested: dropping an agent, unbolding an answer,
+  removing a group's blanket disallow, and stripping one `Disallow:` line all
+  still fail the suite.
+
 - **Documented what the hooks decline, and what 0.x promises.** Two additions,
   no behavior change. `PRIVACY.md` 3 now names the hook payload: Claude Code
   hands each hook a JSON object whose documented fields include a

--- a/tests/seo-aeo-validation.test.mjs
+++ b/tests/seo-aeo-validation.test.mjs
@@ -34,7 +34,12 @@ test("SEO Verification: robots.txt conforms to RFC 9309 and isolates sensitive p
     "User-agent: OAI-SearchBot",
     "User-agent: ChatGPT-User",
     "User-agent: ClaudeBot",
-    "User-agent: Claude-Web",
+    // Claude-Web is retired. Anthropic documents three agents, and the policy
+    // decision differs per agent: ClaudeBot is training crawl, Claude-User is
+    // user-directed retrieval, Claude-SearchBot is search indexing. A template
+    // that names only the retired one cannot express that split.
+    "User-agent: Claude-User",
+    "User-agent: Claude-SearchBot",
     "User-agent: PerplexityBot",
     "User-agent: Perplexity-User",
     "User-agent: Google-Extended",
@@ -67,12 +72,19 @@ test("SEO Verification: robots.txt conforms to RFC 9309 and isolates sensitive p
     "Disallow: /tests/"
   ];
 
-  // Verify that all non-Bytespider groups contain ALL 5 required Disallow rules
+  // Verify that every group states its own sensitive-path policy. RFC 9309
+  // groups do not inherit from `*`, so each one has to say it itself -- but a
+  // group that disallows the whole site has already said it, more strongly than
+  // the five lines would. `Disallow: /` is therefore accepted in their place,
+  // which is what lets a training-crawl group be blanket-denied.
+  const deniesEverything = (directives) => /^Disallow:\s*\/\s*$/m.test(directives);
+
   for (const group of groups) {
     if (group.agents.includes("Bytespider")) {
-      assert.ok(group.directives.includes("Disallow: /"), "Bytespider group must have Disallow: /");
+      assert.ok(deniesEverything(group.directives), "Bytespider group must have Disallow: /");
       continue;
     }
+    if (deniesEverything(group.directives)) continue;
     for (const disallow of requiredDisallows) {
       assert.ok(
         group.directives.includes(disallow),
@@ -183,7 +195,10 @@ test("E-E-A-T FAQ Verification: Answer-First structure with isolated scopes and 
   const faqKeys = ["Q1", "Q2", "Q3", "Q4", "Q5", "Q6", "Q7"];
 
   // Split FAQ section into individual question blocks to prevent cross-QA drift
-  const faqSectionMatch = playbookContent.match(/### 4\.8 E-E-A-T[\s\S]+?(?=### 4\.9|---|\n## )/);
+  // Stop on a real section boundary only. A bare `---` also matches the `|---|`
+  // of a markdown table, so any table added inside 4.8 used to truncate the
+  // section before Q1 and every block assertion below went unreached.
+  const faqSectionMatch = playbookContent.match(/### 4\.8 E-E-A-T[\s\S]+?(?=\n### 4\.9|\n---\n|\n## )/);
   assert.ok(faqSectionMatch, "Section 4.8 FAQ block must be found");
   const faqSection = faqSectionMatch[0];
 
@@ -193,8 +208,12 @@ test("E-E-A-T FAQ Verification: Answer-First structure with isolated scopes and 
     assert.ok(qBlockMatch, `FAQ block for ${qKey} must exist`);
     const qBlock = qBlockMatch[0];
 
-    // First paragraph under header must be Answer-First bold leading blockquote
-    const answerMatch = qBlock.match(/> \*\*([^*]+)\*\*/);
+    // First paragraph under header must be Answer-First bold leading blockquote.
+    // Inline code is blanked first: a glob like `.env*` or `*.pem` inside the
+    // answer carries real asterisks, and the character class below cannot span
+    // them, so an answer that named one used to read as having no bold at all.
+    const prose = qBlock.replace(/`[^`]*`/g, "CODE");
+    const answerMatch = prose.match(/> \*\*([^*]+)\*\*/);
     assert.ok(answerMatch, `FAQ ${qKey} must have leading bold answer in blockquote (> **...**)`);
     assert.ok(answerMatch[1].trim().length >= 30, `FAQ ${qKey} answer-first sentence must be >= 30 chars`);
 


### PR DESCRIPTION
Documentation and tests only. No plugin behavior change. 649 tests, 641 pass, 8 skipped.

## The index was making the mistake it warns about

`docs/README.md` opens by saying that reading a **dated record** as if it were current **reference** is the mistake that page exists to prevent. The handover playbook was indexed under *Reference — kept current* while carrying a baseline of `22b93a7` / v0.22.2 / 2026-08-21 — three releases behind.

It moves to *Dated records*, upgraded to v3.8.1, with a banner saying it is a plan.

## `docs/ROADMAP.md` takes its slot

Every item in the playbook, sorted into five classes, each row carrying **the command that re-checks it** — because this classification will go stale the same way:

| | Class | Contents |
|---|---|---|
| **A** | Already done | AEO benchmark (exists with tests), auth callout (already compact in the submission README) |
| **B** | Premise verified, worth doing | `SAFE_MODEL_ID`, `action.yml`, SARIF, `doctor` |
| **C** | Blocked on something that does not exist | `GEMINI_GATE_STRICT`, all of §4, the Apache-2.0 relicense |
| **D** | Wrong as written | funding template, stale audit matrix, security-weighted budgeting |
| **E** | Non-goal | orchestration engine, voting, `max severity` as authority, sandbox claims |

**Verified against HEAD, not against the playbook.** Three premises survived: `SAFE_MODEL_ID` really does still reject Vertex AI paths (`engine.mjs:36`), the stop gate really is fail-open (`stop-review-gate-hook.mjs:110`), `allocateBudget` really is unweighted (`git.mjs:224`).

Against that: the AEO benchmark it lists as missing **already exists and ships tests**; `GEMINI_GATE_STRICT` exists only to serve an `action.yml` that does not, failing the playbook's own *"two real use cases"* guardrail; `robots.txt` and JSON-LD need a site and **Pages is not enabled** (`gh api …/pages` → 404); and its funding-application template calls the project *"a multi-agent code review & adversarial consensus framework"*, which its own §2 explicitly says the project is not.

Also recorded: `scripts/aeo-benchmark.mjs:76-82` asks whether an answer mentions `sarif export` / `rendersarif`, and **no SARIF export exists**. That query can only pass on a hallucination.

## Four test fixes, and one of them was hiding a green

Upgrading the playbook broke two assertions in `tests/seo-aeo-validation.test.mjs`. Both were **the test being wrong**, so the test is fixed rather than the document bent to fit.

1. **`User-agent: Claude-Web` is retired.** Anthropic documents `ClaudeBot` (training crawl), `Claude-User` (user-directed retrieval) and `Claude-SearchBot` (search indexing) — and the right policy differs per agent. One retired name cannot express that split.
2. **Five literal `Disallow:` lines were demanded from every group**, which failed a group that disallows the *entire site* — strictly stronger. A blanket `Disallow: /` now satisfies the rule. This is what lets a training-crawl group be blanket-denied.
3. **§4.8 was extracted by stopping at the first `---`** — which a markdown table's `|---|` satisfies. Adding an evidence-tier table to that section truncated it before Q1, so **every assertion under it went unreached rather than failing**. Worth finding on its own: a test can report green over an empty section.
4. **The answer-first check read `[^*]+`** across an answer naming `` `.env*` `` and `` `*.pem` ``. Inline code is blanked before the match now.

**Mutation-tested, four for four killed:**

| Mutation | Result |
|---|---|
| Drop `User-agent: Claude-User` | KILLED |
| Unbold Q1's answer | KILLED |
| ClaudeBot no longer blanket-denies | KILLED |
| GPTBot loses `Disallow: /node_modules/` | KILLED |

The relaxations in 2 and 3 did not gut the assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MMdin2G2pLeyg8Jy6okQH7
