### PR TITLE
docs: align canonical project description

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,13 +6,13 @@
     "email": "arcobaleno830623@gmail.com"
   },
   "metadata": {
-    "description": "Use Gemini CLI or Antigravity CLI (agy) inside Claude Code for task delegation, code review, and adversarial review.",
+    "description": "agy-plugin-cc is a Claude Code companion for running Gemini CLI or Antigravity CLI (agy) as a cross-model task delegate and code reviewer, with pragmatic and adversarial review, MCP tools, and background jobs.",
     "version": "0.24.1"
   },
   "plugins": [
     {
       "name": "gemini",
-      "description": "Gemini CLI and Antigravity CLI bridge for Claude Code task delegation and adversarial review",
+      "description": "agy-plugin-cc is a Claude Code companion for running Gemini CLI or Antigravity CLI (agy) as a cross-model task delegate and code reviewer, with pragmatic and adversarial review, MCP tools, and background jobs.",
       "version": "0.24.1",
       "author": {
         "name": "arcobaleno64",

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # agy-plugin-cc — Gemini / Antigravity Companion for Claude Code
 
-`agy-plugin-cc` is a Claude Code plugin that delegates tasks and runs pragmatic or adversarial code reviews through Gemini CLI or Antigravity CLI (`agy`), with foreground/background job control and no plugin-operated service.
+agy-plugin-cc is a Claude Code companion for running Gemini CLI or Antigravity CLI (agy) as a cross-model task delegate and code reviewer, with pragmatic and adversarial review, MCP tools, and background jobs.
 
 [繁體中文說明 →](README.zh-TW.md)
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -1,6 +1,6 @@
 # agy-plugin-cc — Gemini / Antigravity Companion for Claude Code
 
-`agy-plugin-cc` 是 Claude Code 外掛，可透過 Gemini CLI 或 Antigravity CLI (`agy`) 委派任務並執行務實或對抗性程式碼審查，支援前景／背景工作控制，且不經營外掛自有服務。
+`agy-plugin-cc` 是 Claude Code 協作外掛，可透過 Gemini CLI 或 Antigravity CLI（`agy`）進行跨模型任務委派與程式碼審查，並提供務實與對抗性審查、MCP 工具及背景工作。
 
 本外掛移植自 [openai/codex-plugin-cc](https://github.com/openai/codex-plugin-cc)（Apache-2.0），在保留熟悉的斜線命令與背景工作模型之同時，將行為調適至 Gemini/AGY 能力並記錄刻意之差異。
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.24.1",
   "private": true,
   "type": "module",
-  "description": "Use Gemini CLI or Antigravity CLI (agy) inside Claude Code for task delegation, code review, and adversarial review.",
+  "description": "agy-plugin-cc is a Claude Code companion for running Gemini CLI or Antigravity CLI (agy) as a cross-model task delegate and code reviewer, with pragmatic and adversarial review, MCP tools, and background jobs.",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/arcobaleno64/agy-plugin-cc.git"

--- a/plugins/gemini/.claude-plugin/plugin.json
+++ b/plugins/gemini/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gemini",
   "version": "0.24.1",
-  "description": "Use Gemini/AGY from Claude Code to review code or delegate tasks.",
+  "description": "agy-plugin-cc is a Claude Code companion for running Gemini CLI or Antigravity CLI (agy) as a cross-model task delegate and code reviewer, with pragmatic and adversarial review, MCP tools, and background jobs.",
   "author": {
     "name": "arcobaleno64",
     "email": "arcobaleno830623@gmail.com",

--- a/plugins/gemini/README.md
+++ b/plugins/gemini/README.md
@@ -1,6 +1,6 @@
 # agy-plugin-cc — Gemini / Antigravity Companion for Claude Code
 
-`agy-plugin-cc` is a Claude Code plugin that delegates tasks and runs pragmatic or adversarial code reviews through Gemini CLI or Antigravity CLI (`agy`), with foreground/background job control and no plugin-operated service.
+agy-plugin-cc is a Claude Code companion for running Gemini CLI or Antigravity CLI (agy) as a cross-model task delegate and code reviewer, with pragmatic and adversarial review, MCP tools, and background jobs.
 
 > **Independent project.** Community-maintained, and **not affiliated with, endorsed by, or sponsored by Google LLC or Anthropic**. "Gemini" and "Antigravity" are trademarks of Google LLC and "Claude" is a trademark of Anthropic; all are used here only to name the tools this plugin works with.
 

--- a/tests/contract.test.mjs
+++ b/tests/contract.test.mjs
@@ -11,6 +11,8 @@ const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const BUMP = path.join(ROOT, "scripts", "bump-version.mjs");
 const VERIFY = path.join(ROOT, "scripts", "verify-contracts.mjs");
 const COMMANDS = ["setup", "review", "adversarial-review", "rescue", "status", "result", "cancel", "transfer"];
+const CANONICAL_DESCRIPTION = "agy-plugin-cc is a Claude Code companion for running Gemini CLI or Antigravity CLI (agy) as a cross-model task delegate and code reviewer, with pragmatic and adversarial review, MCP tools, and background jobs.";
+const CANONICAL_ZH_TW = "`agy-plugin-cc` 是 Claude Code 協作外掛，可透過 Gemini CLI 或 Antigravity CLI（`agy`）進行跨模型任務委派與程式碼審查，並提供務實與對抗性審查、MCP 工具及背景工作。";
 
 function writeJson(filePath, json) {
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
@@ -50,6 +52,25 @@ function makeFixture(version = "0.5.0") {
 test("verify-contracts passes on the real repository", () => {
   const result = run("node", [VERIFY], { cwd: ROOT });
   assert.equal(result.status, 0, result.stderr || result.stdout);
+});
+
+test("public English metadata uses one canonical short description", () => {
+  const packageManifest = readJson(path.join(ROOT, "package.json"));
+  const marketplace = readJson(path.join(ROOT, ".claude-plugin", "marketplace.json"));
+  const pluginManifest = readJson(path.join(ROOT, "plugins", "gemini", ".claude-plugin", "plugin.json"));
+
+  assert.equal(packageManifest.description, CANONICAL_DESCRIPTION);
+  assert.equal(marketplace.metadata.description, CANONICAL_DESCRIPTION);
+  assert.equal(marketplace.plugins.find(plugin => plugin.name === "gemini")?.description, CANONICAL_DESCRIPTION);
+  assert.equal(pluginManifest.description, CANONICAL_DESCRIPTION);
+
+  for (const file of ["README.md", path.join("plugins", "gemini", "README.md")]) {
+    assert.equal(fs.readFileSync(path.join(ROOT, file), "utf8").split("\n")[2], CANONICAL_DESCRIPTION, file);
+  }
+});
+
+test("the Traditional Chinese entry description stays semantically aligned", () => {
+  assert.equal(fs.readFileSync(path.join(ROOT, "README.zh-TW.md"), "utf8").split("\n")[2], CANONICAL_ZH_TW);
 });
 
 test("verify-contracts passes on a well-formed fixture", () => {

--- a/tests/contract.test.mjs
+++ b/tests/contract.test.mjs
@@ -23,6 +23,10 @@ function readJson(filePath) {
   return JSON.parse(fs.readFileSync(filePath, "utf8"));
 }
 
+function readLines(filePath) {
+  return fs.readFileSync(filePath, "utf8").split(/\r?\n/);
+}
+
 function makeFixture(version = "0.5.0") {
   const root = makeTempDir();
   writeJson(path.join(root, "package.json"), { name: "@arcobaleno64/agy-plugin-cc", version });
@@ -65,12 +69,12 @@ test("public English metadata uses one canonical short description", () => {
   assert.equal(pluginManifest.description, CANONICAL_DESCRIPTION);
 
   for (const file of ["README.md", path.join("plugins", "gemini", "README.md")]) {
-    assert.equal(fs.readFileSync(path.join(ROOT, file), "utf8").split("\n")[2], CANONICAL_DESCRIPTION, file);
+    assert.equal(readLines(path.join(ROOT, file))[2], CANONICAL_DESCRIPTION, file);
   }
 });
 
 test("the Traditional Chinese entry description stays semantically aligned", () => {
-  assert.equal(fs.readFileSync(path.join(ROOT, "README.zh-TW.md"), "utf8").split("\n")[2], CANONICAL_ZH_TW);
+  assert.equal(readLines(path.join(ROOT, "README.zh-TW.md"))[2], CANONICAL_ZH_TW);
 });
 
 test("verify-contracts passes on a well-formed fixture", () => {


### PR DESCRIPTION
## Outcome

PR2 for Issue #121 P0 defines one canonical short description and applies it consistently to repository entry points and distributable metadata. It changes no runtime behavior, command, engine routing, security boundary, privacy behavior, dependency, or version.

Progresses #121; it intentionally does **not** close the issue.

## Canonical short description

> agy-plugin-cc is a Claude Code companion for running Gemini CLI or Antigravity CLI (agy) as a cross-model task delegate and code reviewer, with pragmatic and adversarial review, MCP tools, and background jobs.

The Traditional Chinese README uses a fixed semantic translation rather than mixing a second English positioning.

## What changed

- aligned `package.json`
- aligned marketplace metadata and the marketplace plugin entry
- aligned the distributable plugin manifest
- aligned the root and packaged English README opening
- aligned the Traditional Chinese README opening
- added a contract test that fails when these public descriptions drift

## Verification

- focused contract tests: 15 passed, 0 failed
- `npm test`: 679 tests, 668 passed, 11 platform skips, 0 failed
- `npm run verify-contracts`: passed
- `npm run check-version`: passed
- `npm run bench:aeo`: 6/6 measured, 3 manually adjudicated, 0 pending, 0 unmeasured
- `git diff --check`: passed
- GitHub Actions run #189 on `f553fcca1e30eb90714fb3f788dde328be2ddb1e`: Node 18, Ubuntu, macOS, and Windows passed
- pinned Claude strict validation passed in the Ubuntu, macOS, and Windows CI jobs
- CodeQL and Semgrep passed; all 8 checks completed successfully
- independent exact-head review: APPROVE, 0 P0 findings, 0 P1 findings

## Scope

Only seven files change: six public description surfaces plus the existing contract test. The first Windows run exposed a CRLF-only assertion in the new test; the final test reads both LF and CRLF, and the exact-head Windows rerun passed. No test-file-count, runtime, plugin command, hook, agent, skill, MCP, privacy, security, comparison, topic, FAQ, website, release, or version change is included.

## Post-merge external alignment

GitHub About is intentionally not modified before review. After this PR is approved and merged, update the repository description to the exact canonical English sentence, verify the live value, and only then mark the remaining P0 item complete in Issue #121.

P1 README restructuring, topics, FAQ, installation prominence, website work, and post-improvement visibility capture remain separate work.