### PR TITLE
docs: make README entry answer-first

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,32 @@ Ported from [openai/codex-plugin-cc](https://github.com/openai/codex-plugin-cc) 
 
 ---
 
+## Start here
+
+You need **Claude Code**, **Node.js ≥ 18**, and **one** supported engine: Gemini CLI ≥ 0.40 or AGY ≥ 1.0.3. Install and authenticate the engine you choose; you do not need both. Gemini CLI requires a Standard/Enterprise account or an API key, while AGY is the practical default for personal accounts. See [Prerequisites](#prerequisites) for the supported versions and authentication details.
+
+### Install from the release channel
+
+```
+/plugin marketplace add arcobaleno64/agy-plugin-cc
+/plugin install gemini@agy-plugin-cc
+/reload-plugins
+```
+
+Verify the selected engine with `/gemini:setup --engine agy` for AGY, or `/gemini:setup` for auto/Gemini. See [Installation](#installation) for explicit updates and pinned releases.
+
+### Three common workflows
+
+| Goal | Command |
+|---|---|
+| Pragmatic review of the current change | `/gemini:review --wait` |
+| Adversarial challenge of a design decision | `/gemini:adversarial-review --wait Focus on the retry logic` |
+| Background delegation of a longer task | `/gemini:rescue --background Investigate the failing tests` |
+
+Use `/gemini:status` and `/gemini:result <job-id>` to collect a background result. See [Commands](#commands) for the complete interface and engine-specific behavior.
+
+---
+
 ## Why this plugin?
 
 `agy-plugin-cc` is a Claude Code-native companion bridge for users who want both Gemini CLI and Antigravity CLI (`agy`) support during Google's Gemini CLI transition.

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -8,6 +8,32 @@
 
 ---
 
+## 從這裡開始
+
+你需要 **Claude Code**、**Node.js ≥ 18**，以及**一個**支援的引擎：Gemini CLI ≥ 0.40 或 AGY ≥ 1.0.3。只需安裝並認證你選擇的引擎，不必兩者都裝。Gemini CLI 需要 Standard／Enterprise 帳戶或 API 金鑰；個人帳戶實務上以 AGY 為預設選擇。支援版本與認證細節請見[系統需求](#系統需求)。
+
+### 從發布通道安裝
+
+```
+/plugin marketplace add arcobaleno64/agy-plugin-cc
+/plugin install gemini@agy-plugin-cc
+/reload-plugins
+```
+
+AGY 請用 `/gemini:setup --engine agy` 驗證所選引擎；auto／Gemini 請用 `/gemini:setup`。明確更新與釘選發布版的方式請見[安裝](#安裝)。
+
+### 三個常見工作流程
+
+| 目標 | 命令 |
+|---|---|
+| 對目前變更進行務實審查 | `/gemini:review --wait` |
+| 對設計決策進行對抗性挑戰 | `/gemini:adversarial-review --wait 重點檢查 retry 邏輯` |
+| 將較長任務交由背景執行 | `/gemini:rescue --background 調查失敗的測試` |
+
+背景工作完成後，用 `/gemini:status` 與 `/gemini:result <job-id>` 取得結果。完整介面與各引擎差異請見[命令說明](#命令說明)。
+
+---
+
 ## 為什麼選這個外掛？
 
 `agy-plugin-cc` 是 Claude Code-native 的 companion bridge，適合在 Google Gemini CLI transition 期間同時保留 Gemini CLI 與 Antigravity CLI (`agy`) 路徑的使用者。

--- a/tests/contract.test.mjs
+++ b/tests/contract.test.mjs
@@ -11,6 +11,11 @@ const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const BUMP = path.join(ROOT, "scripts", "bump-version.mjs");
 const VERIFY = path.join(ROOT, "scripts", "verify-contracts.mjs");
 const COMMANDS = ["setup", "review", "adversarial-review", "rescue", "status", "result", "cancel", "transfer"];
+const ENTRY_INSTALL_COMMANDS = [
+  "/plugin marketplace add arcobaleno64/agy-plugin-cc",
+  "/plugin install gemini@agy-plugin-cc",
+  "/reload-plugins"
+];
 const CANONICAL_DESCRIPTION = "agy-plugin-cc is a Claude Code companion for running Gemini CLI or Antigravity CLI (agy) as a cross-model task delegate and code reviewer, with pragmatic and adversarial review, MCP tools, and background jobs.";
 const CANONICAL_ZH_TW = "`agy-plugin-cc` 是 Claude Code 協作外掛，可透過 Gemini CLI 或 Antigravity CLI（`agy`）進行跨模型任務委派與程式碼審查，並提供務實與對抗性審查、MCP 工具及背景工作。";
 
@@ -81,12 +86,11 @@ test("root READMEs surface setup and representative workflows before detailed po
   const cases = [
     {
       file: "README.md",
+      detailsHeading: "## Installation",
       markers: [
         "## Start here",
         "You need **Claude Code**, **Node.js ≥ 18**, and **one** supported engine",
-        "/plugin marketplace add arcobaleno64/agy-plugin-cc",
-        "/plugin install gemini@agy-plugin-cc",
-        "/reload-plugins",
+        ...ENTRY_INSTALL_COMMANDS,
         "### Three common workflows",
         "/gemini:review --wait",
         "/gemini:adversarial-review --wait",
@@ -96,12 +100,11 @@ test("root READMEs surface setup and representative workflows before detailed po
     },
     {
       file: "README.zh-TW.md",
+      detailsHeading: "## 安裝",
       markers: [
         "## 從這裡開始",
         "你需要 **Claude Code**、**Node.js ≥ 18**，以及**一個**支援的引擎",
-        "/plugin marketplace add arcobaleno64/agy-plugin-cc",
-        "/plugin install gemini@agy-plugin-cc",
-        "/reload-plugins",
+        ...ENTRY_INSTALL_COMMANDS,
         "### 三個常見工作流程",
         "/gemini:review --wait",
         "/gemini:adversarial-review --wait",
@@ -111,13 +114,19 @@ test("root READMEs surface setup and representative workflows before detailed po
     }
   ];
 
-  for (const { file, markers } of cases) {
+  for (const { file, detailsHeading, markers } of cases) {
     const text = fs.readFileSync(path.join(ROOT, file), "utf8");
     let cursor = -1;
     for (const marker of markers) {
       const index = text.indexOf(marker, cursor + 1);
       assert.ok(index > cursor, `${file} does not surface ${JSON.stringify(marker)} in the expected order`);
       cursor = index;
+    }
+
+    const detailsIndex = text.indexOf(detailsHeading, cursor + 1);
+    assert.ok(detailsIndex > cursor, `${file} does not retain its detailed installation section`);
+    for (const command of ENTRY_INSTALL_COMMANDS) {
+      assert.ok(text.indexOf(`\n${command}\n`, detailsIndex) > detailsIndex, `${file} detailed installation drifted from the entry commands`);
     }
   }
 });

--- a/tests/contract.test.mjs
+++ b/tests/contract.test.mjs
@@ -77,6 +77,51 @@ test("the Traditional Chinese entry description stays semantically aligned", () 
   assert.equal(readLines(path.join(ROOT, "README.zh-TW.md"))[2], CANONICAL_ZH_TW);
 });
 
+test("root READMEs surface setup and representative workflows before detailed positioning", () => {
+  const cases = [
+    {
+      file: "README.md",
+      markers: [
+        "## Start here",
+        "You need **Claude Code**, **Node.js ≥ 18**, and **one** supported engine",
+        "/plugin marketplace add arcobaleno64/agy-plugin-cc",
+        "/plugin install gemini@agy-plugin-cc",
+        "/reload-plugins",
+        "### Three common workflows",
+        "/gemini:review --wait",
+        "/gemini:adversarial-review --wait",
+        "/gemini:rescue --background",
+        "## Why this plugin?"
+      ]
+    },
+    {
+      file: "README.zh-TW.md",
+      markers: [
+        "## 從這裡開始",
+        "你需要 **Claude Code**、**Node.js ≥ 18**，以及**一個**支援的引擎",
+        "/plugin marketplace add arcobaleno64/agy-plugin-cc",
+        "/plugin install gemini@agy-plugin-cc",
+        "/reload-plugins",
+        "### 三個常見工作流程",
+        "/gemini:review --wait",
+        "/gemini:adversarial-review --wait",
+        "/gemini:rescue --background",
+        "## 為什麼選這個外掛？"
+      ]
+    }
+  ];
+
+  for (const { file, markers } of cases) {
+    const text = fs.readFileSync(path.join(ROOT, file), "utf8");
+    let cursor = -1;
+    for (const marker of markers) {
+      const index = text.indexOf(marker, cursor + 1);
+      assert.ok(index > cursor, `${file} does not surface ${JSON.stringify(marker)} in the expected order`);
+      cursor = index;
+    }
+  }
+});
+
 test("verify-contracts passes on a well-formed fixture", () => {
   const result = run("node", [VERIFY, "--root", makeFixture()], { cwd: ROOT });
   assert.equal(result.status, 0, result.stderr);

--- a/tests/contract.test.mjs
+++ b/tests/contract.test.mjs
@@ -87,6 +87,9 @@ test("root READMEs surface setup and representative workflows before detailed po
     {
       file: "README.md",
       detailsHeading: "## Installation",
+      entryHeading: "## Start here",
+      entryEndHeading: "## Why this plugin?",
+      releaseHeading: "### Release channel (marketplace follows `main`)",
       markers: [
         "## Start here",
         "You need **Claude Code**, **Node.js ≥ 18**, and **one** supported engine",
@@ -101,6 +104,9 @@ test("root READMEs surface setup and representative workflows before detailed po
     {
       file: "README.zh-TW.md",
       detailsHeading: "## 安裝",
+      entryHeading: "## 從這裡開始",
+      entryEndHeading: "## 為什麼選這個外掛？",
+      releaseHeading: "### 發布通道（marketplace 來源追蹤 `main`）",
       markers: [
         "## 從這裡開始",
         "你需要 **Claude Code**、**Node.js ≥ 18**，以及**一個**支援的引擎",
@@ -114,20 +120,29 @@ test("root READMEs surface setup and representative workflows before detailed po
     }
   ];
 
-  for (const { file, detailsHeading, markers } of cases) {
-    const text = fs.readFileSync(path.join(ROOT, file), "utf8");
+  for (const { file, detailsHeading, entryHeading, entryEndHeading, releaseHeading, markers } of cases) {
+    const lines = readLines(path.join(ROOT, file));
+    const entryStart = lines.indexOf(entryHeading);
+    const entryEnd = lines.indexOf(entryEndHeading, entryStart + 1);
+    assert.ok(entryStart >= 0 && entryEnd > entryStart, `${file} does not retain its bounded entry section`);
+
+    const entryText = lines.slice(entryStart, entryEnd + 1).join("\n");
     let cursor = -1;
     for (const marker of markers) {
-      const index = text.indexOf(marker, cursor + 1);
+      const index = entryText.indexOf(marker, cursor + 1);
       assert.ok(index > cursor, `${file} does not surface ${JSON.stringify(marker)} in the expected order`);
       cursor = index;
     }
 
-    const detailsIndex = text.indexOf(detailsHeading, cursor + 1);
-    assert.ok(detailsIndex > cursor, `${file} does not retain its detailed installation section`);
-    for (const command of ENTRY_INSTALL_COMMANDS) {
-      assert.ok(text.indexOf(`\n${command}\n`, detailsIndex) > detailsIndex, `${file} detailed installation drifted from the entry commands`);
-    }
+    const detailsIndex = lines.indexOf(detailsHeading, entryEnd + 1);
+    const releaseIndex = lines.indexOf(releaseHeading, detailsIndex + 1);
+    const releaseFenceStart = lines.indexOf("```", releaseIndex + 1);
+    const releaseFenceEnd = lines.indexOf("```", releaseFenceStart + 1);
+    assert.ok(detailsIndex > entryEnd, `${file} does not retain its detailed installation section`);
+    assert.ok(releaseIndex > detailsIndex && releaseFenceStart > releaseIndex && releaseFenceEnd > releaseFenceStart, `${file} does not retain its bounded release-channel command block`);
+
+    const releaseCommands = lines.slice(releaseFenceStart + 1, releaseFenceEnd).filter((line) => line.startsWith("/"));
+    assert.deepEqual(releaseCommands, ENTRY_INSTALL_COMMANDS, `${file} detailed release-channel commands drifted from the entry commands`);
   }
 });
 


### PR DESCRIPTION
## Outcome

P1-A for Issue #121 makes the root English and Traditional Chinese README openings answer-first. It surfaces the minimum engine/authentication prerequisite, the three-step install path, and three representative workflows before the longer positioning and reference material.

Progresses #121; it intentionally does **not** close the issue.

## What changed

- added a compact `Start here` / `從這裡開始` entry block to both root READMEs
- stated that users need one supported engine, not both, and must authenticate it themselves
- surfaced the release-channel install commands
- surfaced pragmatic review, adversarial review, and background delegation examples
- linked the entry block to the existing detailed prerequisites, installation, and command sections
- added a cross-platform contract test that locks the entry order and required commands in both languages

## Verification

- focused contract tests: 16 passed, 0 failed
- `npm test`: 680 tests, 669 passed, 11 platform skips, 0 failed
- `npm run verify-contracts`: passed
- `npm run check-version`: passed
- `npm run bench:aeo`: 6/6 measured, 0 candidate violations, 3 manually adjudicated, 0 pending, 0 unmeasured
- `git diff --check`: passed

## Scope

Exactly three files change:

- `README.md`
- `README.zh-TW.md`
- `tests/contract.test.mjs`

No runtime, command, engine, MCP, hook, security-boundary, privacy, dependency, version, release, benchmark, packaged plugin README, FAQ, topic, comparison, or website change is included.

## Deliberately deferred

- P1-B evidence-based FAQ
- P1-C high-intent GitHub topics
- P1-D final cross-document consistency audit
- all P2 and P3 work