### PR TITLE
docs: add evidence-based FAQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 agy-plugin-cc is a Claude Code companion for running Gemini CLI or Antigravity CLI (agy) as a cross-model task delegate and code reviewer, with pragmatic and adversarial review, MCP tools, and background jobs.
 
-[繁體中文說明 →](README.zh-TW.md)
+[繁體中文說明 →](README.zh-TW.md) · FAQ: [English](docs/FAQ.md) / [繁體中文](docs/FAQ.zh-TW.md)
 
 Ported from [openai/codex-plugin-cc](https://github.com/openai/codex-plugin-cc) (Apache-2.0), retaining a familiar slash-command and background-job workflow while adapting behavior to Gemini/AGY capabilities and documenting intentional divergences.
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -2,6 +2,8 @@
 
 `agy-plugin-cc` 是 Claude Code 協作外掛，可透過 Gemini CLI 或 Antigravity CLI（`agy`）進行跨模型任務委派與程式碼審查，並提供務實與對抗性審查、MCP 工具及背景工作。
 
+[English →](README.md) · 常見問題：[繁體中文](docs/FAQ.zh-TW.md) / [English](docs/FAQ.md)
+
 本外掛移植自 [openai/codex-plugin-cc](https://github.com/openai/codex-plugin-cc)（Apache-2.0），在保留熟悉的斜線命令與背景工作模型之同時，將行為調適至 Gemini/AGY 能力並記錄刻意之差異。
 
 > **獨立專案。** `agy-plugin-cc` 由社群維護，**與 Google LLC 及 Anthropic 均無隸屬、背書或贊助關係**。「Gemini」與「Antigravity」為 Google LLC 的商標，「Claude」為 Anthropic 的商標，此處僅用於指稱本外掛所驅動的工具。這些工具需由你自行安裝與認證，送交其處理的內容適用各該工具自身的條款。

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -6,7 +6,7 @@ This FAQ is a short route to the repository's current evidence. The linked sourc
 
 ## What is agy-plugin-cc?
 
-It is an independent Claude Code companion that runs Gemini CLI or Antigravity CLI (`agy`) as a cross-model task delegate and code reviewer. It is not affiliated with Google or Anthropic, and it is not a general-purpose multi-agent framework.
+It is an independent Claude Code companion that runs Gemini CLI or Antigravity CLI (`agy`) as a cross-model task delegate and code reviewer. It is not affiliated with, endorsed by, or sponsored by Google or Anthropic, and it is not a general-purpose multi-agent framework.
 
 Evidence: [`README.md`](../README.md) · [`COMPARISON.md`](COMPARISON.md)
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,0 +1,65 @@
+# Frequently asked questions
+
+繁體中文版：[`FAQ.zh-TW.md`](FAQ.zh-TW.md)
+
+This FAQ is a short route to the repository's current evidence. The linked source documents remain authoritative when behavior changes.
+
+## What is agy-plugin-cc?
+
+It is an independent Claude Code companion that runs Gemini CLI or Antigravity CLI (`agy`) as a cross-model task delegate and code reviewer. It is not affiliated with Google or Anthropic, and it is not a general-purpose multi-agent framework.
+
+Evidence: [`README.md`](../README.md) · [`COMPARISON.md`](COMPARISON.md)
+
+## Which engine should I choose?
+
+Install and authenticate one engine, not both. AGY is the practical default for personal accounts; choose Gemini CLI when you have supported access and want its engine-specific model and JSON behavior. `auto` checks an authenticated Gemini CLI first, then AGY, and an explicit `--engine` overrides that choice.
+
+Evidence: [`README.md`](../README.md) · [`engine.mjs`](../plugins/gemini/scripts/lib/engine.mjs)
+
+## How do pragmatic and adversarial review differ?
+
+`/gemini:review` looks for concrete defects and incomplete code paths. `/gemini:adversarial-review` challenges the approach and accepts optional focus text; `--deep` lets either review inspect relevant repository context beyond the diff.
+
+Evidence: [`README.md`](../README.md) · [`review.md`](../plugins/gemini/commands/review.md) · [`adversarial-review.md`](../plugins/gemini/commands/adversarial-review.md)
+
+## Can delegated work write files?
+
+`/gemini:rescue` is dispatched without write intent unless you explicitly pass `--write`. Review commands are dispatched with read-only intent, but the plugin cannot promise that every engine configuration will prevent writes; it checks the workspace afterward and reports detected changes.
+
+Evidence: [`PRIVACY.md`](../PRIVACY.md) · [`THREAT-MODEL.md`](THREAT-MODEL.md)
+
+## Is the delegated engine sandboxed or filesystem-confined?
+
+No such universal boundary is provided by this plugin. AGY permissions depend on the user's settings, while Gemini CLI has a container sandbox that this plugin does not enable or require; do not treat a review command or MCP annotation as an enforceable filesystem sandbox.
+
+Evidence: [`PRIVACY.md`](../PRIVACY.md) · [`THREAT-MODEL.md`](THREAT-MODEL.md)
+
+## What data can leave my machine?
+
+The plugin operates no hosted service. It starts the engine CLI you installed, which sends the assembled prompt to Google; reviews can include git status, diffs, and eligible untracked-file contents, and an agentic engine may read additional workspace data after dispatch. The optional Stop review gate is the only automated send and is disabled until enabled by the user.
+
+Evidence: [`PRIVACY.md`](../PRIVACY.md) · [`SECURITY.md`](../SECURITY.md)
+
+## What is available through MCP?
+
+The MCP server exposes background task delegation, pragmatic and adversarial review, and job status, result, and cancellation tools. It does not expose every slash command, and its safety annotations describe the conservative worst case rather than guaranteeing engine behavior or universal MCP-client compatibility.
+
+Evidence: [`README.md`](../README.md) · [`gemini-mcp.mjs`](../plugins/gemini/scripts/gemini-mcp.mjs)
+
+## How do I install the plugin?
+
+Add `arcobaleno64/agy-plugin-cc` as a Claude Code marketplace, install `gemini@agy-plugin-cc`, and run `/reload-plugins`. Install and authenticate the selected Gemini CLI or AGY engine separately.
+
+Evidence: [`README.md`](../README.md)
+
+## How do updates work?
+
+The release-channel marketplace follows `main`, but an existing installation updates only after the manifest version changes. Third-party marketplace auto-update is off by default; the README documents both the opt-in setting and the explicit update commands, followed by `/reload-plugins`.
+
+Evidence: [`README.md`](../README.md) · [`version-sources.md`](version-sources.md)
+
+## How do I pin a specific version?
+
+Add the marketplace as `arcobaleno64/agy-plugin-cc@<release-tag>`, then install the plugin and reload. A pinned marketplace stays on that git tag even when marketplace auto-update is enabled; moving versions requires re-adding the marketplace at the new tag.
+
+Evidence: [`README.md`](../README.md) · [`version-sources.md`](version-sources.md)

--- a/docs/FAQ.zh-TW.md
+++ b/docs/FAQ.zh-TW.md
@@ -1,0 +1,65 @@
+# 常見問題
+
+English: [`FAQ.md`](FAQ.md)
+
+這份 FAQ 只提供通往 repository 現行證據的短路徑；行為變更時，仍以連結的來源文件為準。
+
+## agy-plugin-cc 是什麼？
+
+它是獨立維護的 Claude Code companion，透過 Gemini CLI 或 Antigravity CLI（`agy`）執行跨模型任務委派與程式碼審查。它與 Google、Anthropic 均無隸屬、背書或贊助關係，也不是通用型 multi-agent framework。
+
+依據：[`README.md`](../README.md) · [`COMPARISON.md`](COMPARISON.md)
+
+## 我該選哪個引擎？
+
+安裝並認證其中一個引擎即可，不必兩者都裝。個人帳號實務上以 AGY 為預設選擇；若具備支援的存取資格，且需要 Gemini CLI 特有的模型與 JSON 行為，則可選 Gemini CLI。`auto` 會先檢查已認證的 Gemini CLI，再檢查 AGY；明確指定 `--engine` 會覆蓋此選擇。
+
+依據：[`README.md`](../README.md) · [`engine.mjs`](../plugins/gemini/scripts/lib/engine.mjs)
+
+## 實用型與對抗性審查有何不同？
+
+`/gemini:review` 尋找具體缺陷與未完成的程式路徑。`/gemini:adversarial-review` 會挑戰做法本身，並接受選用的聚焦文字；兩者加上 `--deep` 後，都可檢查 diff 以外的相關 repository 脈絡。
+
+依據：[`README.md`](../README.md) · [`review.md`](../plugins/gemini/commands/review.md) · [`adversarial-review.md`](../plugins/gemini/commands/adversarial-review.md)
+
+## 被委派的工作可以寫入檔案嗎？
+
+除非明確傳入 `--write`，否則 `/gemini:rescue` 不會以寫入意圖派送。審查命令雖以唯讀意圖派送，但本外掛無法保證每種引擎設定都會阻止寫入；它會在執行後比對 workspace，並回報偵測到的變更。
+
+依據：[`PRIVACY.md`](../PRIVACY.md) · [`THREAT-MODEL.md`](THREAT-MODEL.md)
+
+## 被委派的引擎有 sandbox 或檔案系統邊界嗎？
+
+本外掛不提供可一概而論的此類邊界。AGY 權限取決於使用者設定；Gemini CLI 雖有 container sandbox，但本外掛不會啟用或要求它。不要把審查命令或 MCP annotation 視為可強制執行的 filesystem sandbox。
+
+依據：[`PRIVACY.md`](../PRIVACY.md) · [`THREAT-MODEL.md`](THREAT-MODEL.md)
+
+## 哪些資料可能離開我的電腦？
+
+本外掛不營運任何 hosted service；它啟動你安裝的 engine CLI，由該 CLI 將組合後的 prompt 傳給 Google。審查內容可能包含 git status、diff 與符合條件的 untracked file 內容，而 agentic engine 在派送後仍可能自行讀取其他 workspace 資料。選用的 Stop review gate 是唯一的自動傳送路徑，且在使用者啟用前預設關閉。
+
+依據：[`PRIVACY.md`](../PRIVACY.md) · [`SECURITY.md`](../SECURITY.md)
+
+## MCP 提供哪些功能？
+
+MCP server 提供背景任務委派、實用型與對抗性審查，以及工作狀態、結果與取消工具。它不涵蓋所有 slash command；安全 annotation 描述的是保守的最壞情況，不是對引擎行為或所有 MCP client 相容性的保證。
+
+依據：[`README.md`](../README.md) · [`gemini-mcp.mjs`](../plugins/gemini/scripts/gemini-mcp.mjs)
+
+## 如何安裝外掛？
+
+將 `arcobaleno64/agy-plugin-cc` 加入 Claude Code marketplace、安裝 `gemini@agy-plugin-cc`，再執行 `/reload-plugins`。所選的 Gemini CLI 或 AGY 引擎必須另外安裝並完成認證。
+
+依據：[`README.md`](../README.md)
+
+## 如何更新？
+
+release-channel marketplace 會追蹤 `main`，但既有安裝只會在 manifest 版本變更後更新。第三方 marketplace 預設關閉自動更新；README 同時記載啟用方式與明確更新命令，完成後需執行 `/reload-plugins`。
+
+依據：[`README.md`](../README.md) · [`version-sources.md`](version-sources.md)
+
+## 如何釘選特定版本？
+
+以 `arcobaleno64/agy-plugin-cc@<release-tag>` 加入 marketplace，再安裝外掛並重新載入。即使 marketplace 已啟用自動更新，釘選後仍會停在該 git tag；如需移至其他版本，必須用新 tag 重新加入 marketplace。
+
+依據：[`README.md`](../README.md) · [`version-sources.md`](version-sources.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@ Start with the [README](../README.md). Nothing here is required reading to use t
 
 | File | Answers |
 |---|---|
+| [`FAQ.md`](FAQ.md) · [`FAQ.zh-TW.md`](FAQ.zh-TW.md) | Concise answers to identity, engine, review, trust-boundary, data-handling, MCP, installation, update, and version-pinning questions, each routed to current repository evidence. |
 | [`THREAT-MODEL.md`](THREAT-MODEL.md) | What an untrusted repository can make a delegated agent do, mapped to OWASP LLM Top 10. §7.2 is the one to read before trusting any "read-only" claim. |
 | [`parity.md`](parity.md) · [`parity.zh-TW.md`](parity.zh-TW.md) | How this plugin maps to `codex-plugin-cc`, command by command, and where the runtimes differ. |
 | [`known-diffs.md`](known-diffs.md) | Deliberate divergences from upstream, with the reason each one is kept. |

--- a/docs/README.zh-TW.md
+++ b/docs/README.zh-TW.md
@@ -10,6 +10,7 @@ English: [`README.md`](README.md)
 
 | 檔案 | 回答什麼 |
 |---|---|
+| [`FAQ.zh-TW.md`](FAQ.zh-TW.md) · [`FAQ.md`](FAQ.md) | 以精簡回答說明身分、引擎、審查、信任邊界、資料處理、MCP、安裝、更新與版本釘選，並逐題導向 repository 的現行證據。 |
 | [`THREAT-MODEL.md`](THREAT-MODEL.md) | 不可信的版本庫能讓被委派的 agent 做到什麼，對照 OWASP LLM Top 10。相信任何「唯讀」宣稱之前，先讀 §7.2。 |
 | [`parity.zh-TW.md`](parity.zh-TW.md) · [`parity.md`](parity.md) | 本外掛與 `codex-plugin-cc` 的逐命令對應，以及兩者執行時的差異。 |
 | [`known-diffs.md`](known-diffs.md) | 與上游的刻意差異，以及每一項保留的理由。 |

--- a/tests/privacy-doc.test.mjs
+++ b/tests/privacy-doc.test.mjs
@@ -221,6 +221,11 @@ test("FAQ trust-boundary answers reject universal read-only and sandbox claims",
   assert.match(traditionalChinese, /不提供可一概而論的此類邊界/);
 });
 
+test("FAQ identity answers preserve the independent-project disclaimer", () => {
+  assert.match(read("docs", "FAQ.md"), /not affiliated with, endorsed by, or sponsored by Google or Anthropic/);
+  assert.match(read("docs", "FAQ.zh-TW.md"), /與 Google、Anthropic 均無隸屬、背書或贊助關係/);
+});
+
 test("root READMEs and documentation indexes link both FAQ languages", () => {
   for (const file of ["README.md", "README.zh-TW.md", "docs/README.md", "docs/README.zh-TW.md"]) {
     const text = read(...file.split("/"));

--- a/tests/privacy-doc.test.mjs
+++ b/tests/privacy-doc.test.mjs
@@ -13,6 +13,31 @@ const ROOT = path.resolve(fileURLToPath(new URL("..", import.meta.url)));
 
 const read = (...segments) => fs.readFileSync(path.join(ROOT, ...segments), "utf8");
 
+const FAQ_TOPICS = [
+  ["What is agy-plugin-cc?", "agy-plugin-cc 是什麼？"],
+  ["Which engine should I choose?", "我該選哪個引擎？"],
+  ["How do pragmatic and adversarial review differ?", "實用型與對抗性審查有何不同？"],
+  ["Can delegated work write files?", "被委派的工作可以寫入檔案嗎？"],
+  ["Is the delegated engine sandboxed or filesystem-confined?", "被委派的引擎有 sandbox 或檔案系統邊界嗎？"],
+  ["What data can leave my machine?", "哪些資料可能離開我的電腦？"],
+  ["What is available through MCP?", "MCP 提供哪些功能？"],
+  ["How do I install the plugin?", "如何安裝外掛？"],
+  ["How do updates work?", "如何更新？"],
+  ["How do I pin a specific version?", "如何釘選特定版本？"]
+];
+
+function faqSections(text) {
+  const entries = [...text.matchAll(/^## (.+)$/gm)];
+  return entries.map((entry, index) => ({
+    heading: entry[1],
+    body: text.slice(entry.index + entry[0].length, entries[index + 1]?.index ?? text.length)
+  }));
+}
+
+function faqTargets(text) {
+  return [...text.matchAll(/\]\(([^)]+)\)/g)].map((match) => match[1]).sort();
+}
+
 test("PRIVACY.md exists and answers the four directory questions", () => {
   const privacy = read("PRIVACY.md");
 
@@ -151,5 +176,51 @@ test("the docs index lists every file in docs/", () => {
     for (const file of present) {
       assert.ok(text.includes(`(${file})`), `${index} does not list \`${file}\``);
     }
+  }
+});
+
+test("the English and Traditional Chinese FAQs cover the frozen topics in order", () => {
+  const english = faqSections(read("docs", "FAQ.md"));
+  const traditionalChinese = faqSections(read("docs", "FAQ.zh-TW.md"));
+
+  assert.deepEqual(english.map(({ heading }) => heading), FAQ_TOPICS.map(([heading]) => heading));
+  assert.deepEqual(traditionalChinese.map(({ heading }) => heading), FAQ_TOPICS.map(([, heading]) => heading));
+});
+
+test("every FAQ answer cites evidence and both languages use the same targets", () => {
+  const english = faqSections(read("docs", "FAQ.md"));
+  const traditionalChinese = faqSections(read("docs", "FAQ.zh-TW.md"));
+
+  assert.equal(english.length, FAQ_TOPICS.length);
+  assert.equal(traditionalChinese.length, FAQ_TOPICS.length);
+
+  for (let index = 0; index < FAQ_TOPICS.length; index += 1) {
+    assert.match(english[index].body, /Evidence:/, `${english[index].heading} has no evidence label`);
+    assert.match(traditionalChinese[index].body, /依據：/, `${traditionalChinese[index].heading} 沒有依據標示`);
+    assert.ok(faqTargets(english[index].body).length > 0, `${english[index].heading} has no evidence link`);
+    assert.deepEqual(
+      faqTargets(traditionalChinese[index].body),
+      faqTargets(english[index].body),
+      `FAQ evidence targets differ for topic ${index + 1}`
+    );
+  }
+});
+
+test("FAQ trust-boundary answers reject universal read-only and sandbox claims", () => {
+  const english = read("docs", "FAQ.md");
+  const traditionalChinese = read("docs", "FAQ.zh-TW.md");
+
+  assert.match(english, /cannot promise that every engine configuration will prevent writes/);
+  assert.match(english, /No such universal boundary is provided by this plugin/);
+  assert.match(traditionalChinese, /無法保證每種引擎設定都會阻止寫入/);
+  assert.match(traditionalChinese, /不提供可一概而論的此類邊界/);
+});
+
+test("root READMEs and documentation indexes link both FAQ languages", () => {
+  for (const file of ["README.md", "README.zh-TW.md", "docs/README.md", "docs/README.zh-TW.md"]) {
+    const text = read(...file.split("/"));
+    const prefix = file.startsWith("docs/") ? "" : "docs/";
+    assert.match(text, new RegExp(`\\(${prefix}FAQ\\.md\\)`), `${file} does not link FAQ.md`);
+    assert.match(text, new RegExp(`\\(${prefix}FAQ\\.zh-TW\\.md\\)`), `${file} does not link FAQ.zh-TW.md`);
   }
 });

--- a/tests/privacy-doc.test.mjs
+++ b/tests/privacy-doc.test.mjs
@@ -27,7 +27,7 @@ const FAQ_TOPICS = [
 ];
 
 function faqSections(text) {
-  const entries = [...text.matchAll(/^## (.+)$/gm)];
+  const entries = [...text.matchAll(/^## ([^\r\n]+)\r?$/gm)];
   return entries.map((entry, index) => ({
     heading: entry[1],
     body: text.slice(entry.index + entry[0].length, entries[index + 1]?.index ?? text.length)
@@ -180,11 +180,16 @@ test("the docs index lists every file in docs/", () => {
 });
 
 test("the English and Traditional Chinese FAQs cover the frozen topics in order", () => {
-  const english = faqSections(read("docs", "FAQ.md"));
-  const traditionalChinese = faqSections(read("docs", "FAQ.zh-TW.md"));
+  const englishSource = read("docs", "FAQ.md");
+  const traditionalChineseSource = read("docs", "FAQ.zh-TW.md");
 
-  assert.deepEqual(english.map(({ heading }) => heading), FAQ_TOPICS.map(([heading]) => heading));
-  assert.deepEqual(traditionalChinese.map(({ heading }) => heading), FAQ_TOPICS.map(([, heading]) => heading));
+  for (const lineEnding of ["\n", "\r\n"]) {
+    const english = faqSections(englishSource.replace(/\r?\n/g, lineEnding));
+    const traditionalChinese = faqSections(traditionalChineseSource.replace(/\r?\n/g, lineEnding));
+
+    assert.deepEqual(english.map(({ heading }) => heading), FAQ_TOPICS.map(([heading]) => heading));
+    assert.deepEqual(traditionalChinese.map(({ heading }) => heading), FAQ_TOPICS.map(([, heading]) => heading));
+  }
 });
 
 test("every FAQ answer cites evidence and both languages use the same targets", () => {


### PR DESCRIPTION
## Outcome

Adds concise English and Traditional Chinese FAQs for Issue #121 P1-B. Each material answer points to repository evidence instead of duplicating the security, privacy, runtime, or release contracts.

Progresses #121; does not close it.

## Scope

- Adds `docs/FAQ.md` and `docs/FAQ.zh-TW.md`.
- Covers the frozen ten topics: identity, engine choice, review modes, write behavior, sandbox boundaries, data handling, MCP scope, installation, updates, and version pinning.
- Adds compact navigation from both root READMEs and both documentation indexes.
- Extends the existing documentation contract test; no new test file is added, so the measured test-file count in `docs/COMPARISON.md` remains accurate.

No runtime, command, engine, MCP implementation, hook, dependency, version, release, security/privacy specification, comparison snapshot, or AEO benchmark file changes.

## Contract

- English and Traditional Chinese topics must remain in the same fixed order.
- Every answer must carry an evidence label and at least one repository link.
- Each language must cite the same evidence targets for the corresponding topic.
- Trust-boundary answers must continue to reject universal read-only and sandbox claims.
- Root READMEs and documentation indexes must link both FAQ languages.
- Existing repo-relative link resolution and docs-index completeness checks cover the new files.

## Verification

Fresh local results at commit content:

- `node --test tests/privacy-doc.test.mjs tests/contract.test.mjs`: 31 passed, 0 failed.
- `npm test`: 685 tests, 674 passed, 11 platform skips, 0 failed.
- `npm run verify-contracts`: passed.
- `npm run check-version`: passed.
- `npm run bench:aeo`: 6/6 measured, 3 manually adjudicated, 0 pending, 0 unmeasured.
- `git diff --check`: passed.
- Four mutation probes correctly failed for: missing evidence, Traditional Chinese topic drift, a false universal read-only claim, and a missing FAQ navigation link.
- Exact-head GitHub checks at `a0d098de6658236bf4d7d274e0deec773a368f0c`: 8/8 completed successfully (Node 18, Ubuntu, macOS, Windows, CodeQL, both CodeQL analyses, and Semgrep).

The Claude CLI is not installed in the local container, so both strict plugin validation commands are not reported as locally verified; exact-head Ubuntu, macOS, and Windows CI ran both commands successfully.

## Deliberately deferred

- P1-C GitHub Topics.
- P1-D final consistency audit.
- Any runtime, security-boundary, privacy, release, comparison, or benchmark change.
- Any causal claim that FAQ publication improves ranking or recommendation visibility.
