### PR TITLE
docs: close P1 consistency gaps

### DIFF
--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -106,4 +106,4 @@ cannot tell a credential problem from a real finding.
 
 ## Recommended GitHub Topics
 
-`claude-code`, `claude-code-plugin`, `gemini-cli`, `antigravity-cli`, `agy`, `google-gemini`, `google-antigravity`, `code-review`, `adversarial-review`, `ai-code-review`, `task-delegation`, `ai-coding-agent`, `agentic-coding`, `developer-tools`, `cli`, `nodejs`, `javascript`, `llm`, `plugins`
+`agy`, `adversarial-review`, `ai-code-review`, `antigravity-cli`, `claude-code`, `claude-code-plugin`, `code-review`, `cross-model-review`, `gemini-cli`, `mcp`, `model-context-protocol`, `task-delegation`

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -60,6 +60,6 @@ Evidence: [`README.md`](../README.md) · [`version-sources.md`](version-sources.
 
 ## How do I pin a specific version?
 
-Add the marketplace as `arcobaleno64/agy-plugin-cc@<release-tag>`, then install the plugin and reload. A pinned marketplace stays on that git tag even when marketplace auto-update is enabled; moving versions requires re-adding the marketplace at the new tag.
+Add the marketplace as `arcobaleno64/agy-plugin-cc@<release-tag>`, then install the plugin and reload. A pinned marketplace stays on that git tag even when marketplace auto-update is enabled. To move versions, remove the existing marketplace first (which also uninstalls the plugin), add it again at the new tag, reinstall the plugin, and run `/reload-plugins`.
 
 Evidence: [`README.md`](../README.md) · [`version-sources.md`](version-sources.md)

--- a/docs/FAQ.zh-TW.md
+++ b/docs/FAQ.zh-TW.md
@@ -60,6 +60,6 @@ release-channel marketplace 會追蹤 `main`，但既有安裝只會在 manifest
 
 ## 如何釘選特定版本？
 
-以 `arcobaleno64/agy-plugin-cc@<release-tag>` 加入 marketplace，再安裝外掛並重新載入。即使 marketplace 已啟用自動更新，釘選後仍會停在該 git tag；如需移至其他版本，必須用新 tag 重新加入 marketplace。
+以 `arcobaleno64/agy-plugin-cc@<release-tag>` 加入 marketplace，再安裝外掛並重新載入。即使 marketplace 已啟用自動更新，釘選後仍會停在該 git tag。如需移至其他版本，先移除現有 marketplace（這也會解除安裝該 marketplace 的外掛），再以新 tag 重新加入、重新安裝外掛，並執行 `/reload-plugins`。
 
 依據：[`README.md`](../README.md) · [`version-sources.md`](version-sources.md)

--- a/tests/privacy-doc.test.mjs
+++ b/tests/privacy-doc.test.mjs
@@ -26,6 +26,21 @@ const FAQ_TOPICS = [
   ["How do I pin a specific version?", "如何釘選特定版本？"]
 ];
 
+const RECOMMENDED_GITHUB_TOPICS = [
+  "agy",
+  "adversarial-review",
+  "ai-code-review",
+  "antigravity-cli",
+  "claude-code",
+  "claude-code-plugin",
+  "code-review",
+  "cross-model-review",
+  "gemini-cli",
+  "mcp",
+  "model-context-protocol",
+  "task-delegation"
+].sort();
+
 function faqSections(text) {
   const entries = [...text.matchAll(/^## ([^\r\n]+)\r?$/gm)];
   return entries.map((entry, index) => ({
@@ -154,6 +169,15 @@ test("current comparison and parity docs follow shipped behavior", () => {
   assert.match(parityZh, /agy --conversation/);
 });
 
+test("current comparison recommends the approved high-intent GitHub topic set", () => {
+  const comparison = read("docs", "COMPARISON.md");
+  const section = comparison.match(/## Recommended GitHub Topics\r?\n\r?\n([^\r\n]+)/);
+
+  assert.ok(section, "docs/COMPARISON.md has no Recommended GitHub Topics section");
+  const actual = [...section[1].matchAll(/`([^`]+)`/g)].map((match) => match[1]).sort();
+  assert.deepEqual(actual, RECOMMENDED_GITHUB_TOPICS);
+});
+
 test("dated playbook indexes require revalidation instead of promising currency", () => {
   for (const index of ["docs/README.md", "docs/README.zh-TW.md"]) {
     const text = read(...index.split("/"));
@@ -219,6 +243,13 @@ test("FAQ trust-boundary answers reject universal read-only and sandbox claims",
   assert.match(english, /No such universal boundary is provided by this plugin/);
   assert.match(traditionalChinese, /無法保證每種引擎設定都會阻止寫入/);
   assert.match(traditionalChinese, /不提供可一概而論的此類邊界/);
+
+  assert.doesNotMatch(english, /\b(?:all|every)\s+review commands?\s+are\s+read-only\b/i);
+  assert.doesNotMatch(english, /\bfully sandboxed\b/i);
+  assert.doesNotMatch(english, /\bcannot (?:touch|write to|modify) (?:your |the )?filesystem\b/i);
+  assert.doesNotMatch(traditionalChinese, /所有審查命令(?:都是|一律)(?:唯讀|只讀)/);
+  assert.doesNotMatch(traditionalChinese, /(?:完全沙箱化|完全受到沙箱保護|一律唯讀)/);
+  assert.doesNotMatch(traditionalChinese, /無法(?:接觸|寫入|修改)(?:你的)?檔案系統/);
 });
 
 test("FAQ identity answers preserve the independent-project disclaimer", () => {

--- a/tests/privacy-doc.test.mjs
+++ b/tests/privacy-doc.test.mjs
@@ -171,10 +171,14 @@ test("current comparison and parity docs follow shipped behavior", () => {
 
 test("current comparison recommends the approved high-intent GitHub topic set", () => {
   const comparison = read("docs", "COMPARISON.md");
-  const section = comparison.match(/## Recommended GitHub Topics\r?\n\r?\n([^\r\n]+)/);
+  const heading = "## Recommended GitHub Topics";
+  const sectionStart = comparison.indexOf(heading);
 
-  assert.ok(section, "docs/COMPARISON.md has no Recommended GitHub Topics section");
-  const actual = [...section[1].matchAll(/`([^`]+)`/g)].map((match) => match[1]).sort();
+  assert.notEqual(sectionStart, -1, "docs/COMPARISON.md has no Recommended GitHub Topics section");
+  const sectionBodyStart = sectionStart + heading.length;
+  const nextSectionStart = comparison.indexOf("\n## ", sectionBodyStart);
+  const section = comparison.slice(sectionBodyStart, nextSectionStart === -1 ? undefined : nextSectionStart);
+  const actual = [...section.matchAll(/`([^`]+)`/g)].map((match) => match[1]).sort();
   assert.deepEqual(actual, RECOMMENDED_GITHUB_TOPICS);
 });
 
@@ -245,11 +249,11 @@ test("FAQ trust-boundary answers reject universal read-only and sandbox claims",
   assert.match(traditionalChinese, /不提供可一概而論的此類邊界/);
 
   assert.doesNotMatch(english, /\b(?:all|every)\s+review commands?\s+are\s+read-only\b/i);
-  assert.doesNotMatch(english, /\bfully sandboxed\b/i);
-  assert.doesNotMatch(english, /\bcannot (?:touch|write to|modify) (?:your |the )?filesystem\b/i);
+  assert.doesNotMatch(english, /(?<!not )\b(?:all|every)\s+(?:delegated\s+)?engines?\s+(?:is|are)\s+fully sandboxed\b/i);
+  assert.doesNotMatch(english, /(?<!not )\b(?:all|every)\s+(?:delegated\s+)?engines?\s+cannot (?:touch|write to|modify) (?:your |the )?filesystem\b/i);
   assert.doesNotMatch(traditionalChinese, /所有審查命令(?:都是|一律)(?:唯讀|只讀)/);
-  assert.doesNotMatch(traditionalChinese, /(?:完全沙箱化|完全受到沙箱保護|一律唯讀)/);
-  assert.doesNotMatch(traditionalChinese, /無法(?:接觸|寫入|修改)(?:你的)?檔案系統/);
+  assert.doesNotMatch(traditionalChinese, /(?:所有|每個)(?:受委派的)?引擎(?:都是|一律)(?:完全沙箱化|完全受到沙箱保護)/);
+  assert.doesNotMatch(traditionalChinese, /(?:所有|每個)(?:受委派的)?引擎(?:都|一律)?無法(?:接觸|寫入|修改)(?:你的)?檔案系統/);
 });
 
 test("FAQ pinning answers preserve the remove, reinstall, and reload sequence", () => {

--- a/tests/privacy-doc.test.mjs
+++ b/tests/privacy-doc.test.mjs
@@ -41,6 +41,32 @@ const RECOMMENDED_GITHUB_TOPICS = [
   "task-delegation"
 ].sort();
 
+const UNIVERSAL_CLAIM_RULES = {
+  english: [
+    /\b(?:all|every)\s+review commands?\s+are\s+read-only\b/gi,
+    /\b(?:all|every)\s+(?:delegated\s+)?engines?\s+(?:is|are)\s+fully sandboxed\b/gi,
+    /\b(?:all|every)\s+(?:delegated\s+)?engines?\s+cannot (?:touch|write to|modify) (?:your |the )?filesystem\b/gi
+  ],
+  traditionalChinese: [
+    /所有審查命令(?:都是|一律)(?:唯讀|只讀)/g,
+    /(?:所有|每個)(?:受委派的)?引擎(?:都是|一律)(?:完全沙箱化|完全受到沙箱保護)/g,
+    /(?:所有|每個)(?:受委派的)?引擎(?:都|一律)?無法(?:接觸|寫入|修改)(?:你的)?檔案系統/g
+  ]
+};
+
+function affirmativeUniversalClaims(text, patterns, negators) {
+  const claims = [];
+
+  for (const pattern of patterns) {
+    for (const match of text.matchAll(pattern)) {
+      const prefix = text.slice(0, match.index).toLowerCase();
+      if (!negators.some((negator) => prefix.endsWith(negator))) claims.push(match[0]);
+    }
+  }
+
+  return claims;
+}
+
 function faqSections(text) {
   const entries = [...text.matchAll(/^## ([^\r\n]+)\r?$/gm)];
   return entries.map((entry, index) => ({
@@ -248,12 +274,67 @@ test("FAQ trust-boundary answers reject universal read-only and sandbox claims",
   assert.match(traditionalChinese, /無法保證每種引擎設定都會阻止寫入/);
   assert.match(traditionalChinese, /不提供可一概而論的此類邊界/);
 
-  assert.doesNotMatch(english, /\b(?:all|every)\s+review commands?\s+are\s+read-only\b/i);
-  assert.doesNotMatch(english, /(?<!not )\b(?:all|every)\s+(?:delegated\s+)?engines?\s+(?:is|are)\s+fully sandboxed\b/i);
-  assert.doesNotMatch(english, /(?<!not )\b(?:all|every)\s+(?:delegated\s+)?engines?\s+cannot (?:touch|write to|modify) (?:your |the )?filesystem\b/i);
-  assert.doesNotMatch(traditionalChinese, /所有審查命令(?:都是|一律)(?:唯讀|只讀)/);
-  assert.doesNotMatch(traditionalChinese, /(?:所有|每個)(?:受委派的)?引擎(?:都是|一律)(?:完全沙箱化|完全受到沙箱保護)/);
-  assert.doesNotMatch(traditionalChinese, /(?:所有|每個)(?:受委派的)?引擎(?:都|一律)?無法(?:接觸|寫入|修改)(?:你的)?檔案系統/);
+  assert.deepEqual(affirmativeUniversalClaims(english, UNIVERSAL_CLAIM_RULES.english, ["not "]), []);
+  assert.deepEqual(
+    affirmativeUniversalClaims(
+      traditionalChinese,
+      UNIVERSAL_CLAIM_RULES.traditionalChinese,
+      ["並非", "並不是", "不是", "未必", "不見得"]
+    ),
+    []
+  );
+});
+
+test("universal-claim classification separates affirmative claims from direct negations", () => {
+  const englishAffirmative = [
+    "All review commands are read-only.",
+    "Every delegated engine is fully sandboxed.",
+    "Every delegated engine cannot touch your filesystem."
+  ];
+  const englishNegated = [
+    "Not all review commands are read-only.",
+    "The delegated engine is not fully sandboxed.",
+    "Not every delegated engine is fully sandboxed.",
+    "Not every delegated engine cannot touch your filesystem."
+  ];
+  const traditionalChineseAffirmative = [
+    "所有審查命令都是唯讀。",
+    "所有受委派的引擎都是完全沙箱化。",
+    "每個引擎都無法寫入檔案系統。"
+  ];
+  const traditionalChineseNegated = [
+    "並非所有審查命令都是唯讀。",
+    "並非所有受委派的引擎都是完全沙箱化。",
+    "並不是每個引擎都無法寫入檔案系統。"
+  ];
+
+  for (const claim of englishAffirmative) {
+    assert.ok(affirmativeUniversalClaims(claim, UNIVERSAL_CLAIM_RULES.english, ["not "]).length > 0, claim);
+  }
+  for (const claim of englishNegated) {
+    assert.deepEqual(affirmativeUniversalClaims(claim, UNIVERSAL_CLAIM_RULES.english, ["not "]), [], claim);
+  }
+  for (const claim of traditionalChineseAffirmative) {
+    assert.ok(
+      affirmativeUniversalClaims(
+        claim,
+        UNIVERSAL_CLAIM_RULES.traditionalChinese,
+        ["並非", "並不是", "不是", "未必", "不見得"]
+      ).length > 0,
+      claim
+    );
+  }
+  for (const claim of traditionalChineseNegated) {
+    assert.deepEqual(
+      affirmativeUniversalClaims(
+        claim,
+        UNIVERSAL_CLAIM_RULES.traditionalChinese,
+        ["並非", "並不是", "不是", "未必", "不見得"]
+      ),
+      [],
+      claim
+    );
+  }
 });
 
 test("FAQ pinning answers preserve the remove, reinstall, and reload sequence", () => {

--- a/tests/privacy-doc.test.mjs
+++ b/tests/privacy-doc.test.mjs
@@ -252,6 +252,16 @@ test("FAQ trust-boundary answers reject universal read-only and sandbox claims",
   assert.doesNotMatch(traditionalChinese, /無法(?:接觸|寫入|修改)(?:你的)?檔案系統/);
 });
 
+test("FAQ pinning answers preserve the remove, reinstall, and reload sequence", () => {
+  const english = read("docs", "FAQ.md");
+  const traditionalChinese = read("docs", "FAQ.zh-TW.md");
+
+  assert.match(english, /remove the existing marketplace first \(which also uninstalls the plugin\)/);
+  assert.match(english, /add it again at the new tag, reinstall the plugin, and run `\/reload-plugins`/);
+  assert.match(traditionalChinese, /先移除現有 marketplace（這也會解除安裝該 marketplace 的外掛）/);
+  assert.match(traditionalChinese, /再以新 tag 重新加入、重新安裝外掛，並執行 `\/reload-plugins`/);
+});
+
 test("FAQ identity answers preserve the independent-project disclaimer", () => {
   assert.match(read("docs", "FAQ.md"), /not affiliated with, endorsed by, or sponsored by Google or Anthropic/);
   assert.match(read("docs", "FAQ.zh-TW.md"), /與 Google、Anthropic 均無隸屬、背書或贊助關係/);


### PR DESCRIPTION
## Outcome

Closes the contradiction found by Issue #121 P1-D and folds in the deferred P1-B hardening follow-ups without changing runtime behavior.

Progresses #121; does not close it.

## What changed

- Replaces the stale 19-topic recommendation in the current comparison reference with the live, approved 12-topic set.
- Expands English and Traditional Chinese version-pinning answers to name the remove/re-add/reinstall/reload sequence and the uninstall side effect.
- Adds contracts that freeze the complete approved topic section and the bilingual pinning move sequence.
- Rejects added affirmative universal read-only and sandbox claims.
- Classifies negation separately from universal-claim matching so correct English and Traditional Chinese safety disclaimers remain legal.
- Adds direct positive/negative classifier cases to prevent a future asymmetric regression.

## Scope

Exactly four files:

- `docs/COMPARISON.md`
- `docs/FAQ.md`
- `docs/FAQ.zh-TW.md`
- `tests/privacy-doc.test.mjs`

No runtime, command, engine, MCP, hook, dependency, version, release, privacy/security specification, workflow, package metadata, or benchmark change.

## Verification

Fresh local evidence on the integrated diff:

- `node --test tests/privacy-doc.test.mjs tests/contract.test.mjs`: 34 passed, 0 failed.
- Same focused suite with all four changed files converted to CRLF: 34 passed, 0 failed.
- `npm test`: 688 tests, 677 passed, 11 platform skips, 0 failed.
- `npm run verify-contracts`: passed.
- `npm run check-version`: passed.
- `npm run bench:aeo`: 6/6 measured, 3 manually adjudicated, 0 pending, 0 unmeasured.
- `node --check tests/privacy-doc.test.mjs`: passed.
- `git diff --check`: passed.

Regression sensitivity:

- Adding an extra topic on a second line fails the exact-section contract.
- Affirmative English and Traditional Chinese universal read-only, sandbox, and filesystem claims are rejected.
- Directly negated versions of those same claims are accepted in both languages.
- Six affirmative classifier cases are caught and seven correct negated cases are accepted.
- The old 19-topic recommendation fails and identifies every extra and missing topic.

## Review corrections

- Addressed the automated review findings about multi-line topic drift and over-broad `fully sandboxed` matching.
- Addressed independent blocker `P1D-GUARD-01`: negation handling now applies consistently to all English and Traditional Chinese patterns instead of only two English regexes.

## P1-D audit context

Verified against base `9d88fa6fa105be27cb48ac49f6257abaaeed37b1`:

- Canonical English descriptions are exact across README, packaged README, package metadata, marketplace metadata, plugin manifest, and live GitHub About.
- English and Traditional Chinese FAQ identity and trust-boundary claims remain materially aligned.
- Privacy, security, and threat-model statements consistently describe write detection as after-the-fact rather than an enforced sandbox.
- Latest release and all version metadata agree on v0.24.1.
- Live GitHub Topics match the approved 12-topic set exactly.
- P0 evaluator, frozen baseline, and benchmark semantics remain unchanged.

P1-D stays incomplete until this PR is independently re-reviewed at the latest head, exact-head CI is green, and the correction is merged.