### PR TITLE
docs: add isolated canonical site source

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -42,7 +42,7 @@
         <p class="independent-note"><strong>Independent project.</strong> agy-plugin-cc is community-maintained and is not affiliated with, endorsed by, or sponsored by Google LLC or Anthropic.</p>
       </div>
 
-      <div class="hero-visual" aria-label="Claude Code delegates to either Gemini CLI or Antigravity CLI, receives review evidence, and continues the development loop.">
+      <div class="hero-visual" role="img" aria-label="Claude Code delegates to either Gemini CLI or Antigravity CLI, receives review evidence, and continues the development loop.">
         <svg class="workflow-orbit" viewBox="0 0 620 460" aria-hidden="true" focusable="false">
           <defs>
             <linearGradient id="line-gradient" x1="0" y1="0" x2="1" y2="1">
@@ -106,7 +106,7 @@
         <h2 id="start-title">Three commands, then choose an engine.</h2>
         <p>You need Claude Code, Node.js 18 or newer, and one separately installed and authenticated engine. You do not need both engines.</p>
       </div>
-      <div class="terminal" aria-label="Plugin installation commands">
+      <div class="terminal" role="group" aria-label="Plugin installation commands">
         <div class="terminal-bar" aria-hidden="true"><span></span><span></span><span></span></div>
         <pre><code><span class="comment"># Add the marketplace</span>
 /plugin marketplace add arcobaleno64/agy-plugin-cc
@@ -161,7 +161,7 @@
           <p>MCP annotations describe a conservative worst case. They are hints, not guarantees about engine behavior or every MCP client.</p>
         </article>
       </div>
-      <div class="evidence-links" aria-label="Project evidence and policies">
+      <div class="evidence-links" role="group" aria-label="Project evidence and policies">
         <a href="https://github.com/arcobaleno64/agy-plugin-cc/blob/main/docs/FAQ.md">FAQ</a>
         <a href="https://github.com/arcobaleno64/agy-plugin-cc/blob/main/docs/FAQ.zh-TW.md" lang="zh-TW">繁體中文 FAQ</a>
         <a href="https://github.com/arcobaleno64/agy-plugin-cc/blob/main/PRIVACY.md">Privacy</a>

--- a/site/index.html
+++ b/site/index.html
@@ -81,7 +81,7 @@
         <h2 id="workflow-title">Delegate, challenge, inspect, continue.</h2>
         <p>The visual motion is optional. The workflow remains the same when animation is disabled.</p>
       </div>
-      <ol class="workflow-steps">
+      <ol class="workflow-steps" role="list">
         <li>
           <span class="step-number">01</span>
           <h3>Choose one engine</h3>
@@ -108,7 +108,7 @@
       </div>
       <div class="terminal" role="group" aria-label="Plugin installation commands">
         <div class="terminal-bar" aria-hidden="true"><span></span><span></span><span></span></div>
-        <pre><code><span class="comment"># Add the marketplace</span>
+        <pre tabindex="0"><code><span class="comment"># Add the marketplace</span>
 /plugin marketplace add arcobaleno64/agy-plugin-cc
 
 <span class="comment"># Install and reload</span>

--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,179 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>agy-plugin-cc — Cross-model review for Claude Code</title>
+  <meta name="description" content="agy-plugin-cc is a Claude Code companion for running Gemini CLI or Antigravity CLI (agy) as a cross-model task delegate and code reviewer, with pragmatic and adversarial review, MCP tools, and background jobs.">
+  <link rel="canonical" href="https://arcobaleno64.github.io/agy-plugin-cc/">
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="agy-plugin-cc — Cross-model review for Claude Code">
+  <meta property="og:description" content="agy-plugin-cc is a Claude Code companion for running Gemini CLI or Antigravity CLI (agy) as a cross-model task delegate and code reviewer, with pragmatic and adversarial review, MCP tools, and background jobs.">
+  <meta property="og:url" content="https://arcobaleno64.github.io/agy-plugin-cc/">
+  <meta name="twitter:card" content="summary">
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <a class="skip-link" href="#main">Skip to content</a>
+
+  <header class="site-header">
+    <a class="brand" href="https://github.com/arcobaleno64/agy-plugin-cc" aria-label="agy-plugin-cc repository">
+      <span class="brand-mark" aria-hidden="true">agy</span>
+      <span>agy-plugin-cc</span>
+    </a>
+    <nav aria-label="Primary navigation">
+      <a href="#workflow">Workflow</a>
+      <a href="#start">Start here</a>
+      <a href="#boundaries">Boundaries</a>
+      <a href="https://github.com/arcobaleno64/agy-plugin-cc">GitHub</a>
+    </nav>
+  </header>
+
+  <main id="main">
+    <section class="hero" aria-labelledby="hero-title">
+      <div class="hero-copy">
+        <p class="eyebrow">Claude Code companion · Gemini CLI + Antigravity CLI</p>
+        <h1 id="hero-title">Bring a second model into the review loop.</h1>
+        <p class="canonical-description">agy-plugin-cc is a Claude Code companion for running Gemini CLI or Antigravity CLI (agy) as a cross-model task delegate and code reviewer, with pragmatic and adversarial review, MCP tools, and background jobs.</p>
+        <div class="hero-actions">
+          <a class="button primary" href="#start">Install the plugin</a>
+          <a class="button secondary" href="https://github.com/arcobaleno64/agy-plugin-cc">View the repository</a>
+        </div>
+        <p class="independent-note"><strong>Independent project.</strong> agy-plugin-cc is community-maintained and is not affiliated with, endorsed by, or sponsored by Google LLC or Anthropic.</p>
+      </div>
+
+      <div class="hero-visual" aria-label="Claude Code delegates to either Gemini CLI or Antigravity CLI, receives review evidence, and continues the development loop.">
+        <svg class="workflow-orbit" viewBox="0 0 620 460" aria-hidden="true" focusable="false">
+          <defs>
+            <linearGradient id="line-gradient" x1="0" y1="0" x2="1" y2="1">
+              <stop offset="0" stop-color="#70d6ff"></stop>
+              <stop offset="0.5" stop-color="#a78bfa"></stop>
+              <stop offset="1" stop-color="#ff70a6"></stop>
+            </linearGradient>
+          </defs>
+          <path class="orbit-base" d="M310 73 C478 73 548 173 510 286 C471 401 291 423 157 349 C30 279 73 115 205 82 C240 73 274 71 310 73 Z"></path>
+          <path class="orbit-signal signal-one" d="M310 73 C478 73 548 173 510 286 C471 401 291 423 157 349 C30 279 73 115 205 82 C240 73 274 71 310 73 Z"></path>
+          <path class="orbit-signal signal-two" d="M310 73 C478 73 548 173 510 286 C471 401 291 423 157 349 C30 279 73 115 205 82 C240 73 274 71 310 73 Z"></path>
+
+          <g class="node node-claude" transform="translate(310 73)">
+            <circle r="66"></circle>
+            <text text-anchor="middle" y="-5">Claude Code</text>
+            <text class="node-caption" text-anchor="middle" y="19">coordinates</text>
+          </g>
+          <g class="node node-engine" transform="translate(502 276)">
+            <circle r="72"></circle>
+            <text text-anchor="middle" y="-12">Gemini CLI</text>
+            <text text-anchor="middle" y="12">or AGY</text>
+            <text class="node-caption" text-anchor="middle" y="36">reviews</text>
+          </g>
+          <g class="node node-evidence" transform="translate(154 330)">
+            <circle r="68"></circle>
+            <text text-anchor="middle" y="-5">Evidence</text>
+            <text class="node-caption" text-anchor="middle" y="19">returns</text>
+          </g>
+        </svg>
+      </div>
+    </section>
+
+    <section id="workflow" class="section workflow-section" aria-labelledby="workflow-title">
+      <div class="section-heading">
+        <p class="eyebrow">One deliberate cycle</p>
+        <h2 id="workflow-title">Delegate, challenge, inspect, continue.</h2>
+        <p>The visual motion is optional. The workflow remains the same when animation is disabled.</p>
+      </div>
+      <ol class="workflow-steps">
+        <li>
+          <span class="step-number">01</span>
+          <h3>Choose one engine</h3>
+          <p>Use Gemini CLI when you have supported access, or AGY as the practical path for personal accounts.</p>
+        </li>
+        <li>
+          <span class="step-number">02</span>
+          <h3>Ask for another view</h3>
+          <p>Run a pragmatic review, challenge the approach adversarially, or delegate a longer investigation.</p>
+        </li>
+        <li>
+          <span class="step-number">03</span>
+          <h3>Inspect the evidence</h3>
+          <p>Claude Code receives findings and job results so you can decide what to accept, reject, or verify.</p>
+        </li>
+      </ol>
+    </section>
+
+    <section id="start" class="section start-section" aria-labelledby="start-title">
+      <div class="section-heading">
+        <p class="eyebrow">Start here</p>
+        <h2 id="start-title">Three commands, then choose an engine.</h2>
+        <p>You need Claude Code, Node.js 18 or newer, and one separately installed and authenticated engine. You do not need both engines.</p>
+      </div>
+      <div class="terminal" aria-label="Plugin installation commands">
+        <div class="terminal-bar" aria-hidden="true"><span></span><span></span><span></span></div>
+        <pre><code><span class="comment"># Add the marketplace</span>
+/plugin marketplace add arcobaleno64/agy-plugin-cc
+
+<span class="comment"># Install and reload</span>
+/plugin install gemini@agy-plugin-cc
+/reload-plugins</code></pre>
+      </div>
+      <p class="detail-link"><a href="https://github.com/arcobaleno64/agy-plugin-cc#prerequisites">Read prerequisites, authentication, update, and pinned-release details →</a></p>
+    </section>
+
+    <section class="section examples-section" aria-labelledby="examples-title">
+      <div class="section-heading">
+        <p class="eyebrow">Representative workflows</p>
+        <h2 id="examples-title">Use the loop at the level you need.</h2>
+      </div>
+      <div class="command-grid">
+        <article>
+          <h3>Pragmatic review</h3>
+          <code>/gemini:review --wait</code>
+          <p>Look for concrete defects in the current change.</p>
+        </article>
+        <article>
+          <h3>Adversarial review</h3>
+          <code>/gemini:adversarial-review --wait Focus on the retry logic</code>
+          <p>Challenge assumptions and focus the critique.</p>
+        </article>
+        <article>
+          <h3>Background delegation</h3>
+          <code>/gemini:rescue --background Investigate the failing tests</code>
+          <p>Move a longer investigation into a tracked job.</p>
+        </article>
+      </div>
+    </section>
+
+    <section id="boundaries" class="section boundaries-section" aria-labelledby="boundaries-title">
+      <div class="section-heading">
+        <p class="eyebrow">Honest boundaries</p>
+        <h2 id="boundaries-title">A companion, not a security boundary.</h2>
+      </div>
+      <div class="boundary-grid">
+        <article>
+          <h3>Write behavior</h3>
+          <p>Read-only is an intent, not an enforced filesystem boundary. The plugin checks the workspace afterward and reports detected changes.</p>
+        </article>
+        <article>
+          <h3>Data path</h3>
+          <p>The plugin operates no hosted service. The engine CLI you installed sends the assembled prompt to Google under that engine's terms.</p>
+        </article>
+        <article>
+          <h3>MCP scope</h3>
+          <p>MCP annotations describe a conservative worst case. They are hints, not guarantees about engine behavior or every MCP client.</p>
+        </article>
+      </div>
+      <div class="evidence-links" aria-label="Project evidence and policies">
+        <a href="https://github.com/arcobaleno64/agy-plugin-cc/blob/main/docs/FAQ.md">FAQ</a>
+        <a href="https://github.com/arcobaleno64/agy-plugin-cc/blob/main/docs/FAQ.zh-TW.md" lang="zh-TW">繁體中文 FAQ</a>
+        <a href="https://github.com/arcobaleno64/agy-plugin-cc/blob/main/PRIVACY.md">Privacy</a>
+        <a href="https://github.com/arcobaleno64/agy-plugin-cc/blob/main/SECURITY.md">Security</a>
+        <a href="https://github.com/arcobaleno64/agy-plugin-cc/releases">Releases</a>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <p>Community-maintained under open-source licenses. “Gemini” and “Antigravity” are trademarks of Google LLC; “Claude” is a trademark of Anthropic.</p>
+    <a href="https://github.com/arcobaleno64/agy-plugin-cc">arcobaleno64/agy-plugin-cc</a>
+  </footer>
+</body>
+</html>

--- a/site/styles.css
+++ b/site/styles.css
@@ -1,0 +1,528 @@
+:root {
+  color-scheme: dark;
+  --bg: #090b12;
+  --surface: rgba(20, 24, 38, 0.74);
+  --surface-strong: #151a2a;
+  --line: rgba(187, 199, 255, 0.16);
+  --text: #f5f7ff;
+  --muted: #aeb7cf;
+  --cyan: #70d6ff;
+  --violet: #a78bfa;
+  --pink: #ff70a6;
+  --max: 1180px;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-synthesis: none;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  min-width: 280px;
+  color: var(--text);
+  background:
+    radial-gradient(circle at 78% 8%, rgba(112, 214, 255, 0.12), transparent 29rem),
+    radial-gradient(circle at 18% 30%, rgba(167, 139, 250, 0.13), transparent 34rem),
+    var(--bg);
+  line-height: 1.65;
+}
+
+a {
+  color: inherit;
+  text-underline-offset: 0.2em;
+}
+
+a:focus-visible,
+.button:focus-visible {
+  outline: 3px solid var(--cyan);
+  outline-offset: 4px;
+}
+
+.skip-link {
+  position: fixed;
+  z-index: 20;
+  top: 0.75rem;
+  left: 0.75rem;
+  padding: 0.65rem 0.9rem;
+  color: #090b12;
+  background: var(--cyan);
+  border-radius: 0.55rem;
+  transform: translateY(-180%);
+}
+
+.skip-link:focus {
+  transform: translateY(0);
+}
+
+.site-header {
+  position: relative;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: min(calc(100% - 2rem), var(--max));
+  margin: 0 auto;
+  padding: 1.4rem 0;
+  border-bottom: 1px solid var(--line);
+}
+
+.brand {
+  display: inline-flex;
+  gap: 0.75rem;
+  align-items: center;
+  font-weight: 720;
+  text-decoration: none;
+  letter-spacing: -0.02em;
+}
+
+.brand-mark {
+  display: grid;
+  place-items: center;
+  width: 2.35rem;
+  height: 2.35rem;
+  color: #090b12;
+  background: linear-gradient(135deg, var(--cyan), var(--violet));
+  border-radius: 0.75rem;
+  font-size: 0.78rem;
+  letter-spacing: 0.02em;
+}
+
+nav {
+  display: flex;
+  gap: clamp(0.75rem, 2vw, 1.7rem);
+  color: var(--muted);
+  font-size: 0.91rem;
+}
+
+nav a {
+  text-decoration: none;
+}
+
+nav a:hover {
+  color: var(--text);
+}
+
+.hero,
+.section,
+footer {
+  width: min(calc(100% - 2rem), var(--max));
+  margin-inline: auto;
+}
+
+.hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1.04fr) minmax(25rem, 0.96fr);
+  gap: clamp(2rem, 6vw, 6rem);
+  align-items: center;
+  min-height: 43rem;
+  padding: clamp(4rem, 9vw, 8rem) 0;
+}
+
+.eyebrow {
+  margin: 0 0 1rem;
+  color: var(--cyan);
+  font-size: 0.77rem;
+  font-weight: 760;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+h3,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  max-width: 13ch;
+  margin-bottom: 1.5rem;
+  font-size: clamp(3rem, 7vw, 6.3rem);
+  line-height: 0.98;
+  letter-spacing: -0.065em;
+}
+
+h2 {
+  margin-bottom: 1rem;
+  font-size: clamp(2rem, 4vw, 3.4rem);
+  line-height: 1.08;
+  letter-spacing: -0.045em;
+}
+
+h3 {
+  margin-bottom: 0.55rem;
+  font-size: 1.05rem;
+  letter-spacing: -0.015em;
+}
+
+.canonical-description {
+  max-width: 66ch;
+  color: #d2d8e8;
+  font-size: clamp(1rem, 1.5vw, 1.15rem);
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.85rem;
+  margin: 2rem 0;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 3rem;
+  padding: 0.6rem 1.15rem;
+  border: 1px solid var(--line);
+  border-radius: 0.75rem;
+  font-weight: 720;
+  text-decoration: none;
+  transition: transform 160ms ease, border-color 160ms ease, background 160ms ease;
+}
+
+.button:hover {
+  transform: translateY(-2px);
+}
+
+.button.primary {
+  color: #090b12;
+  background: linear-gradient(120deg, var(--cyan), #b7a3ff);
+  border-color: transparent;
+}
+
+.button.secondary:hover {
+  border-color: rgba(112, 214, 255, 0.55);
+  background: rgba(112, 214, 255, 0.06);
+}
+
+.independent-note {
+  max-width: 65ch;
+  color: var(--muted);
+  font-size: 0.88rem;
+}
+
+.hero-visual {
+  position: relative;
+}
+
+.hero-visual::before {
+  position: absolute;
+  inset: 15% 10%;
+  content: "";
+  background: rgba(125, 104, 255, 0.12);
+  filter: blur(70px);
+  border-radius: 50%;
+}
+
+.workflow-orbit {
+  position: relative;
+  display: block;
+  width: 100%;
+  height: auto;
+  overflow: visible;
+}
+
+.orbit-base,
+.orbit-signal {
+  fill: none;
+  stroke-linecap: round;
+}
+
+.orbit-base {
+  stroke: rgba(177, 190, 229, 0.17);
+  stroke-width: 2;
+}
+
+.orbit-signal {
+  stroke: url(#line-gradient);
+  stroke-width: 4;
+  stroke-dasharray: 2 34;
+  animation: orbit-flow 9s linear infinite;
+}
+
+.signal-two {
+  opacity: 0.45;
+  animation-delay: -4.5s;
+}
+
+.node circle {
+  fill: rgba(16, 20, 34, 0.94);
+  stroke: rgba(191, 202, 239, 0.22);
+  stroke-width: 1.5;
+}
+
+.node text {
+  fill: var(--text);
+  font-size: 17px;
+  font-weight: 720;
+}
+
+.node .node-caption {
+  fill: var(--muted);
+  font-size: 12px;
+  font-weight: 560;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.node-engine circle {
+  stroke: rgba(112, 214, 255, 0.48);
+  animation: node-pulse 4.5s ease-in-out infinite;
+}
+
+.node-evidence circle {
+  stroke: rgba(255, 112, 166, 0.4);
+}
+
+@keyframes orbit-flow {
+  to { stroke-dashoffset: -216; }
+}
+
+@keyframes node-pulse {
+  0%, 100% { stroke-width: 1.5; }
+  50% { stroke-width: 4; }
+}
+
+.section {
+  padding: clamp(4.5rem, 9vw, 8rem) 0;
+  border-top: 1px solid var(--line);
+}
+
+.section-heading {
+  max-width: 49rem;
+  margin-bottom: 2.5rem;
+}
+
+.section-heading > p:last-child {
+  color: var(--muted);
+}
+
+.workflow-steps,
+.command-grid,
+.boundary-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.workflow-steps {
+  padding: 0;
+  list-style: none;
+  counter-reset: steps;
+}
+
+.workflow-steps li,
+.command-grid article,
+.boundary-grid article {
+  padding: clamp(1.35rem, 3vw, 2rem);
+  background: linear-gradient(145deg, rgba(25, 31, 50, 0.8), rgba(14, 17, 28, 0.72));
+  border: 1px solid var(--line);
+  border-radius: 1rem;
+}
+
+.workflow-steps p,
+.command-grid p,
+.boundary-grid p {
+  margin-bottom: 0;
+  color: var(--muted);
+  font-size: 0.94rem;
+}
+
+.step-number {
+  display: block;
+  margin-bottom: 2.2rem;
+  color: var(--violet);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.82rem;
+}
+
+.start-section {
+  display: grid;
+  grid-template-columns: minmax(0, 0.85fr) minmax(29rem, 1.15fr);
+  column-gap: clamp(2rem, 7vw, 6rem);
+  align-items: start;
+}
+
+.terminal {
+  overflow: hidden;
+  background: #0d111d;
+  border: 1px solid rgba(112, 214, 255, 0.22);
+  border-radius: 1rem;
+  box-shadow: 0 2rem 5rem rgba(0, 0, 0, 0.28);
+}
+
+.terminal-bar {
+  display: flex;
+  gap: 0.4rem;
+  padding: 0.85rem 1rem;
+  border-bottom: 1px solid var(--line);
+}
+
+.terminal-bar span {
+  width: 0.62rem;
+  height: 0.62rem;
+  background: var(--muted);
+  border-radius: 50%;
+  opacity: 0.48;
+}
+
+pre {
+  margin: 0;
+  padding: clamp(1.25rem, 3vw, 2rem);
+  overflow-x: auto;
+  color: #e8edff;
+  font-size: clamp(0.77rem, 1.25vw, 0.92rem);
+  line-height: 1.8;
+}
+
+code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+
+.comment {
+  color: #78839f;
+}
+
+.detail-link {
+  grid-column: 2;
+  margin: 1.1rem 0 0;
+  color: var(--cyan);
+  font-size: 0.9rem;
+}
+
+.command-grid code {
+  display: block;
+  margin: 1.15rem 0;
+  padding: 0.75rem;
+  overflow-wrap: anywhere;
+  color: var(--cyan);
+  background: rgba(7, 10, 18, 0.68);
+  border-radius: 0.55rem;
+  font-size: 0.78rem;
+}
+
+.boundaries-section {
+  margin-bottom: clamp(3rem, 7vw, 6rem);
+}
+
+.evidence-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.7rem;
+  margin-top: 1.5rem;
+}
+
+.evidence-links a {
+  padding: 0.45rem 0.75rem;
+  color: #dfe5f7;
+  background: rgba(255, 255, 255, 0.035);
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  font-size: 0.84rem;
+  text-decoration: none;
+}
+
+footer {
+  display: flex;
+  gap: 2rem;
+  justify-content: space-between;
+  padding: 2rem 0 3rem;
+  color: var(--muted);
+  border-top: 1px solid var(--line);
+  font-size: 0.8rem;
+}
+
+footer p {
+  max-width: 56rem;
+  margin-bottom: 0;
+}
+
+@media (max-width: 860px) {
+  .site-header {
+    align-items: flex-start;
+  }
+
+  nav a:not(:last-child) {
+    display: none;
+  }
+
+  .hero,
+  .start-section {
+    grid-template-columns: 1fr;
+  }
+
+  .hero {
+    min-height: auto;
+  }
+
+  .hero-copy {
+    order: 1;
+  }
+
+  .hero-visual {
+    order: 2;
+    max-width: 37rem;
+    margin-inline: auto;
+  }
+
+  .workflow-steps,
+  .command-grid,
+  .boundary-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .detail-link {
+    grid-column: 1;
+  }
+}
+
+@media (max-width: 520px) {
+  .hero,
+  .section,
+  footer {
+    width: min(calc(100% - 1.25rem), var(--max));
+  }
+
+  .hero {
+    padding-top: 3.5rem;
+  }
+
+  h1 {
+    font-size: clamp(2.75rem, 15vw, 4rem);
+  }
+
+  .hero-actions {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .hero-visual {
+    margin: 0 -0.4rem;
+  }
+
+  footer {
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+
+  *,
+  *::before,
+  *::after {
+    animation: none !important;
+    scroll-behavior: auto !important;
+    transition: none !important;
+  }
+}

--- a/site/styles.css
+++ b/site/styles.css
@@ -468,8 +468,8 @@ footer p {
 
   .hero-visual {
     order: 2;
-    max-width: 37rem;
-    margin-inline: auto;
+    width: min(100%, 37rem);
+    justify-self: center;
   }
 
   .workflow-steps,

--- a/site/styles.css
+++ b/site/styles.css
@@ -454,6 +454,7 @@ footer p {
 
   nav {
     width: 100%;
+    flex-wrap: wrap;
     justify-content: space-between;
   }
 

--- a/site/styles.css
+++ b/site/styles.css
@@ -39,7 +39,8 @@ a {
 }
 
 a:focus-visible,
-.button:focus-visible {
+.button:focus-visible,
+pre:focus-visible {
   outline: 3px solid var(--cyan);
   outline-offset: 4px;
 }
@@ -446,11 +447,14 @@ footer p {
 
 @media (max-width: 860px) {
   .site-header {
-    align-items: flex-start;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.75rem;
   }
 
-  nav a:not(:last-child) {
-    display: none;
+  nav {
+    width: 100%;
+    justify-content: space-between;
   }
 
   .hero,

--- a/tests/contract.test.mjs
+++ b/tests/contract.test.mjs
@@ -93,6 +93,7 @@ test("the isolated canonical site stays factual, dependency-free, and motion-opt
   const html = fs.readFileSync(path.join(siteRoot, "index.html"), "utf8");
   const css = fs.readFileSync(path.join(siteRoot, "styles.css"), "utf8");
   const escapedDescription = CANONICAL_DESCRIPTION.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const escapedSiteUrl = CANONICAL_SITE_URL.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 
   assert.match(html, /^<!doctype html>/i);
   assert.match(html, /<html lang="en">/);
@@ -100,8 +101,8 @@ test("the isolated canonical site stays factual, dependency-free, and motion-opt
   assert.match(html, /<meta name="viewport" content="width=device-width, initial-scale=1">/);
   assert.match(html, new RegExp(`<meta name="description" content="${escapedDescription}">`));
   assert.match(html, new RegExp(`<meta property="og:description" content="${escapedDescription}">`));
-  assert.match(html, new RegExp(`<link rel="canonical" href="${CANONICAL_SITE_URL}">`));
-  assert.match(html, new RegExp(`<meta property="og:url" content="${CANONICAL_SITE_URL}">`));
+  assert.match(html, new RegExp(`<link rel="canonical" href="${escapedSiteUrl}">`));
+  assert.match(html, new RegExp(`<meta property="og:url" content="${escapedSiteUrl}">`));
   assert.match(html, new RegExp(`<p class="canonical-description">${escapedDescription}</p>`));
 
   for (const command of ENTRY_INSTALL_COMMANDS) {

--- a/tests/contract.test.mjs
+++ b/tests/contract.test.mjs
@@ -92,8 +92,8 @@ test("the isolated canonical site stays factual, dependency-free, and motion-opt
 
   const html = fs.readFileSync(path.join(siteRoot, "index.html"), "utf8");
   const css = fs.readFileSync(path.join(siteRoot, "styles.css"), "utf8");
-  const escapedDescription = CANONICAL_DESCRIPTION.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  const escapedSiteUrl = CANONICAL_SITE_URL.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const escapedDescription = CANONICAL_DESCRIPTION.replace(/[.*+?^${}()|[\]\\]/g, "\\  const escapedDescription = CANONICAL_DESCRIPTION.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const escapedSiteUrl = CANONICAL_SITE_URL.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");");
 
   assert.match(html, /^<!doctype html>/i);
   assert.match(html, /<html lang="en">/);
@@ -101,8 +101,8 @@ test("the isolated canonical site stays factual, dependency-free, and motion-opt
   assert.match(html, /<meta name="viewport" content="width=device-width, initial-scale=1">/);
   assert.match(html, new RegExp(`<meta name="description" content="${escapedDescription}">`));
   assert.match(html, new RegExp(`<meta property="og:description" content="${escapedDescription}">`));
-  assert.match(html, new RegExp(`<link rel="canonical" href="${escapedSiteUrl}">`));
-  assert.match(html, new RegExp(`<meta property="og:url" content="${escapedSiteUrl}">`));
+  assert.ok(html.includes(`<link rel="canonical" href="${CANONICAL_SITE_URL}">`));
+  assert.ok(html.includes(`<meta property="og:url" content="${CANONICAL_SITE_URL}">`));
   assert.match(html, new RegExp(`<p class="canonical-description">${escapedDescription}</p>`));
 
   for (const command of ENTRY_INSTALL_COMMANDS) {

--- a/tests/contract.test.mjs
+++ b/tests/contract.test.mjs
@@ -86,6 +86,7 @@ test("the Traditional Chinese entry description stays semantically aligned", () 
 test("the isolated canonical site stays factual, dependency-free, and motion-optional", () => {
   const siteRoot = path.join(ROOT, "site");
   const files = fs.readdirSync(siteRoot, { withFileTypes: true })
+    .filter((entry) => entry.name !== ".DS_Store")
     .map((entry) => entry.name)
     .sort();
   assert.deepEqual(files, ["index.html", "styles.css"], "site/ must remain an explicit static-source allowlist");
@@ -98,6 +99,8 @@ test("the isolated canonical site stays factual, dependency-free, and motion-opt
   assert.match(html, /<html lang="en">/);
   assert.match(html, /<meta charset="utf-8">/);
   assert.match(html, /<meta name="viewport" content="width=device-width, initial-scale=1">/);
+  assert.ok(html.includes('<link rel="stylesheet" href="styles.css">'));
+  assert.equal((html.match(/<link\b/gi) ?? []).length, 2, "site must not load additional link resources");
   assert.match(html, new RegExp(`<meta name="description" content="${escapedDescription}">`));
   assert.match(html, new RegExp(`<meta property="og:description" content="${escapedDescription}">`));
   assert.ok(html.includes(`<link rel="canonical" href="${CANONICAL_SITE_URL}">`));
@@ -110,12 +113,15 @@ test("the isolated canonical site stays factual, dependency-free, and motion-opt
   assert.match(html, /not affiliated with, endorsed by, or sponsored by Google LLC or Anthropic/);
   assert.match(html, /Read-only is an intent, not an enforced filesystem boundary/);
   assert.match(html, /The plugin operates no hosted service/);
+  assert.match(html, /<div class="hero-visual" role="img" aria-label="[^"]+">/);
   assert.match(html, /<svg[^>]*aria-hidden="true"/);
   assert.match(html, /<ol class="workflow-steps"/);
 
-  assert.doesNotMatch(html, /<(?:script|iframe)\b/i);
+  assert.doesNotMatch(html, /<(?:script|iframe|img|picture|video|audio|source|object|embed)\b/i);
   assert.doesNotMatch(html, /\b(?:SEO|AEO|GEO|ranking|ranked|best|leading|official plugin)\b/i);
   assert.doesNotMatch(html, /\b(?:all|every)\s+review commands?\s+are\s+read-only\b/i);
+  assert.doesNotMatch(html, /\breview commands?\s+are\s+always\s+read-only\b/i);
+  assert.doesNotMatch(html, /\ball\s+reviews?\s+are\s+read-only\b/i);
   assert.doesNotMatch(html, /\b(?:all|every)\s+(?:delegated\s+)?engines?\s+(?:is|are)\s+fully sandboxed\b/i);
   assert.doesNotMatch(css, /@import|url\s*\(\s*["']?https?:/i, "site CSS must not load third-party assets");
   assert.match(css, /@media\s*\(prefers-reduced-motion:\s*reduce\)/);

--- a/tests/contract.test.mjs
+++ b/tests/contract.test.mjs
@@ -85,11 +85,13 @@ test("the Traditional Chinese entry description stays semantically aligned", () 
 
 test("the isolated canonical site stays factual, dependency-free, and motion-optional", () => {
   const siteRoot = path.join(ROOT, "site");
-  const files = fs.readdirSync(siteRoot, { withFileTypes: true })
-    .filter((entry) => entry.name !== ".DS_Store")
-    .map((entry) => entry.name)
+  const trackedSite = run("git", ["ls-files", "--", "site"], { cwd: ROOT });
+  assert.equal(trackedSite.status, 0, trackedSite.stderr);
+  const files = trackedSite.stdout.trim().split(/\r?\n/)
+    .filter(Boolean)
+    .map((file) => path.relative("site", file))
     .sort();
-  assert.deepEqual(files, ["index.html", "styles.css"], "site/ must remain an explicit static-source allowlist");
+  assert.deepEqual(files, ["index.html", "styles.css"], "tracked site/ sources must remain an explicit allowlist");
 
   const html = fs.readFileSync(path.join(siteRoot, "index.html"), "utf8");
   const css = fs.readFileSync(path.join(siteRoot, "styles.css"), "utf8");

--- a/tests/contract.test.mjs
+++ b/tests/contract.test.mjs
@@ -92,8 +92,7 @@ test("the isolated canonical site stays factual, dependency-free, and motion-opt
 
   const html = fs.readFileSync(path.join(siteRoot, "index.html"), "utf8");
   const css = fs.readFileSync(path.join(siteRoot, "styles.css"), "utf8");
-  const escapedDescription = CANONICAL_DESCRIPTION.replace(/[.*+?^${}()|[\]\\]/g, "\\  const escapedDescription = CANONICAL_DESCRIPTION.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  const escapedSiteUrl = CANONICAL_SITE_URL.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");");
+  const escapedDescription = CANONICAL_DESCRIPTION.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 
   assert.match(html, /^<!doctype html>/i);
   assert.match(html, /<html lang="en">/);

--- a/tests/contract.test.mjs
+++ b/tests/contract.test.mjs
@@ -115,7 +115,8 @@ test("the isolated canonical site stays factual, dependency-free, and motion-opt
   assert.match(html, /The plugin operates no hosted service/);
   assert.match(html, /<div class="hero-visual" role="img" aria-label="[^"]+">/);
   assert.match(html, /<svg[^>]*aria-hidden="true"/);
-  assert.match(html, /<ol class="workflow-steps"/);
+  assert.match(html, /<ol class="workflow-steps" role="list">/);
+  assert.match(html, /<pre tabindex="0"><code>/);
 
   assert.doesNotMatch(html, /<(?:script|iframe|img|picture|video|audio|source|object|embed)\b/i);
   assert.doesNotMatch(html, /\b(?:SEO|AEO|GEO|ranking|ranked|best|leading|official plugin)\b/i);

--- a/tests/contract.test.mjs
+++ b/tests/contract.test.mjs
@@ -18,6 +18,7 @@ const ENTRY_INSTALL_COMMANDS = [
 ];
 const CANONICAL_DESCRIPTION = "agy-plugin-cc is a Claude Code companion for running Gemini CLI or Antigravity CLI (agy) as a cross-model task delegate and code reviewer, with pragmatic and adversarial review, MCP tools, and background jobs.";
 const CANONICAL_ZH_TW = "`agy-plugin-cc` 是 Claude Code 協作外掛，可透過 Gemini CLI 或 Antigravity CLI（`agy`）進行跨模型任務委派與程式碼審查，並提供務實與對抗性審查、MCP 工具及背景工作。";
+const CANONICAL_SITE_URL = "https://arcobaleno64.github.io/agy-plugin-cc/";
 
 function writeJson(filePath, json) {
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
@@ -80,6 +81,46 @@ test("public English metadata uses one canonical short description", () => {
 
 test("the Traditional Chinese entry description stays semantically aligned", () => {
   assert.equal(readLines(path.join(ROOT, "README.zh-TW.md"))[2], CANONICAL_ZH_TW);
+});
+
+test("the isolated canonical site stays factual, dependency-free, and motion-optional", () => {
+  const siteRoot = path.join(ROOT, "site");
+  const files = fs.readdirSync(siteRoot, { withFileTypes: true })
+    .map((entry) => entry.name)
+    .sort();
+  assert.deepEqual(files, ["index.html", "styles.css"], "site/ must remain an explicit static-source allowlist");
+
+  const html = fs.readFileSync(path.join(siteRoot, "index.html"), "utf8");
+  const css = fs.readFileSync(path.join(siteRoot, "styles.css"), "utf8");
+  const escapedDescription = CANONICAL_DESCRIPTION.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+  assert.match(html, /^<!doctype html>/i);
+  assert.match(html, /<html lang="en">/);
+  assert.match(html, /<meta charset="utf-8">/);
+  assert.match(html, /<meta name="viewport" content="width=device-width, initial-scale=1">/);
+  assert.match(html, new RegExp(`<meta name="description" content="${escapedDescription}">`));
+  assert.match(html, new RegExp(`<meta property="og:description" content="${escapedDescription}">`));
+  assert.match(html, new RegExp(`<link rel="canonical" href="${CANONICAL_SITE_URL}">`));
+  assert.match(html, new RegExp(`<meta property="og:url" content="${CANONICAL_SITE_URL}">`));
+  assert.match(html, new RegExp(`<p class="canonical-description">${escapedDescription}</p>`));
+
+  for (const command of ENTRY_INSTALL_COMMANDS) {
+    assert.match(html, new RegExp(command.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")), `site omits ${command}`);
+  }
+  assert.match(html, /not affiliated with, endorsed by, or sponsored by Google LLC or Anthropic/);
+  assert.match(html, /Read-only is an intent, not an enforced filesystem boundary/);
+  assert.match(html, /The plugin operates no hosted service/);
+  assert.match(html, /<svg[^>]*aria-hidden="true"/);
+  assert.match(html, /<ol class="workflow-steps"/);
+
+  assert.doesNotMatch(html, /<(?:script|iframe)\b/i);
+  assert.doesNotMatch(html, /\b(?:SEO|AEO|GEO|ranking|ranked|best|leading|official plugin)\b/i);
+  assert.doesNotMatch(html, /\b(?:all|every)\s+review commands?\s+are\s+read-only\b/i);
+  assert.doesNotMatch(html, /\b(?:all|every)\s+(?:delegated\s+)?engines?\s+(?:is|are)\s+fully sandboxed\b/i);
+  assert.doesNotMatch(css, /@import|url\s*\(\s*["']?https?:/i, "site CSS must not load third-party assets");
+  assert.match(css, /@media\s*\(prefers-reduced-motion:\s*reduce\)/);
+  assert.match(css, /animation:\s*none\s*!important/);
+  assert.ok(Buffer.byteLength(html) + Buffer.byteLength(css) < 100 * 1024, "the static site must stay below 100 KiB");
 });
 
 test("root READMEs surface setup and representative workflows before detailed positioning", () => {


### PR DESCRIPTION
## Outcome

This is the source-only P2-A slice for Issue #121. It adds an isolated, dependency-free canonical landing page without enabling GitHub Pages or changing runtime behavior.

Progresses #121; it intentionally does not close the issue.

## What changed

- Added `site/index.html` with the canonical project title, exact short description, future project-site URL metadata, installation entry point, representative workflows, and evidence-linked trust boundaries.
- Added `site/styles.css` with a responsive dark presentation and a lightweight workflow-loop animation implemented entirely in CSS/SVG.
- Added a repository contract that:
  - limits `site/` to exactly `index.html` and `styles.css`;
  - keeps canonical description and URL metadata aligned;
  - preserves install commands and independent-project/trust-boundary disclosures;
  - rejects JavaScript, iframes, third-party CSS assets, ranking claims, and universal read-only/sandbox claims;
  - requires a semantic ordered workflow and `prefers-reduced-motion` fallback;
  - caps the complete source at 100 KiB.

The page is 18,521 bytes total and loads no external fonts, scripts, images, or animation libraries. Its SVG is decorative; the same workflow is present as an ordinary ordered list.

## Verification

Fresh local results on the exact source committed here:

- focused site contract: 1 passed, 0 failed
- complete contract suite: 17 passed, 0 failed
- `npm test`: 689 tests, 678 passed, 11 platform skips, 0 failed
- `npm run verify-contracts`: passed
- `npm run check-version`: passed
- `npm run bench:aeo`: 6/6 measured, 3 manually adjudicated, 0 pending, 0 unmeasured
- `npm run bench`: passed
- both pinned Claude plugin validations: passed
- `node --check tests/contract.test.mjs`: passed
- `git diff --check`: passed
- all seven public GitHub links: HTTP 200
- CRLF fixture: focused site contract passed
- mutation probes: canonical-description drift, missing reduced-motion handling, and an added universal read-only claim each failed for the intended assertion

## Scope

Changed paths only:

- `site/index.html`
- `site/styles.css`
- `tests/contract.test.mjs`

No workflow, Pages setting, README, FAQ, runtime, command, engine, MCP, hook, dependency, version, release, benchmark, privacy, or security-specification change is included.

## Deliberately deferred

P2-B remains separate: Pages workflow, repository Pages settings, live HTTPS verification, deployment-artifact inspection, and GitHub Homepage metadata.

This PR also omits `sitemap.xml`, `robots.txt`, JSON-LD, `llms.txt`, a custom domain, and a duplicated Traditional Chinese site. Those remain evidence-gated follow-ups, not ranking guarantees.