### PR TITLE
ci: publish canonical site metadata via GitHub Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,45 @@
+name: Deploy canonical site
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "site/**"
+      - ".github/workflows/pages.yml"
+
+# The build can only read repository content. The deployment token is granted
+# separately below, after the allowlisted site/ artifact has been assembled.
+permissions:
+  contents: read
+
+concurrency:
+  group: github-pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
+      - name: Upload canonical site artifact
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
+        with:
+          path: site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5

--- a/tests/contract.test.mjs
+++ b/tests/contract.test.mjs
@@ -137,14 +137,19 @@ test("the isolated canonical site stays factual, dependency-free, and motion-opt
 
 test("the canonical site deploys only its allowlisted source from main", () => {
   const workflow = fs.readFileSync(path.join(ROOT, ".github", "workflows", "pages.yml"), "utf8");
+  const normalized = workflow.replace(/\r\n/g, "\n");
+  const deployStart = normalized.indexOf("\n  deploy:");
+  const deploy = normalized.slice(deployStart);
 
-  assert.match(workflow, /push:\s*\n\s+branches:\s*\[main\]/);
-  assert.doesNotMatch(workflow, /pull_request:|schedule:/);
-  assert.match(workflow, /permissions:\s*\n\s+contents:\s*read/);
+  assert.ok(normalized.includes('push:\n    branches: [main]\n    paths:\n      - "site/**"\n      - ".github/workflows/pages.yml"'));
+  assert.doesNotMatch(normalized, /pull_request(?:_target)?:|schedule:|workflow_dispatch:/);
+  assert.ok(normalized.includes("permissions:\n  contents: read\n\nconcurrency:"), "top-level permissions must remain exactly contents: read");
   assert.match(workflow, /actions\/checkout@[0-9a-f]{40}\s+# v6\.0\.2/);
   assert.match(workflow, /actions\/configure-pages@[0-9a-f]{40}\s+# v5\.0\.0/);
   assert.match(workflow, /actions\/upload-pages-artifact@[0-9a-f]{40}\s+# v4\.0\.0[\s\S]*?path:\s+site/);
-  assert.match(workflow, /deploy:\s*[\s\S]*?needs:\s+build[\s\S]*?permissions:\s*\n\s+pages:\s*write\s*\n\s+id-token:\s*write/);
+  assert.ok(deployStart >= 0);
+  assert.ok(deploy.includes("permissions:\n      pages: write\n      id-token: write\n    environment:"), "deploy permissions must remain exactly pages: write and id-token: write");
+  assert.doesNotMatch(deploy, /actions\/checkout|\n\s+run:/, "the privileged deploy job must not check out or run repository code");
   assert.match(workflow, /environment:\s*\n\s+name:\s+github-pages\s*\n\s+url:\s+\$\{\{ steps\.deployment\.outputs\.page_url \}\}/);
   assert.match(workflow, /actions\/deploy-pages@[0-9a-f]{40}\s+# v4\.0\.5/);
 });

--- a/tests/contract.test.mjs
+++ b/tests/contract.test.mjs
@@ -18,6 +18,7 @@ const ENTRY_INSTALL_COMMANDS = [
 ];
 const CANONICAL_DESCRIPTION = "agy-plugin-cc is a Claude Code companion for running Gemini CLI or Antigravity CLI (agy) as a cross-model task delegate and code reviewer, with pragmatic and adversarial review, MCP tools, and background jobs.";
 const CANONICAL_ZH_TW = "`agy-plugin-cc` 是 Claude Code 協作外掛，可透過 Gemini CLI 或 Antigravity CLI（`agy`）進行跨模型任務委派與程式碼審查，並提供務實與對抗性審查、MCP 工具及背景工作。";
+const CANONICAL_SITE_TITLE = "agy-plugin-cc — Cross-model review for Claude Code";
 const CANONICAL_SITE_URL = "https://arcobaleno64.github.io/agy-plugin-cc/";
 
 function writeJson(filePath, json) {
@@ -101,9 +102,11 @@ test("the isolated canonical site stays factual, dependency-free, and motion-opt
   assert.match(html, /<html lang="en">/);
   assert.match(html, /<meta charset="utf-8">/);
   assert.match(html, /<meta name="viewport" content="width=device-width, initial-scale=1">/);
+  assert.ok(html.includes(`<title>${CANONICAL_SITE_TITLE}</title>`));
   assert.ok(html.includes('<link rel="stylesheet" href="styles.css">'));
   assert.equal((html.match(/<link\b/gi) ?? []).length, 2, "site must not load additional link resources");
   assert.match(html, new RegExp(`<meta name="description" content="${escapedDescription}">`));
+  assert.ok(html.includes(`<meta property="og:title" content="${CANONICAL_SITE_TITLE}">`));
   assert.match(html, new RegExp(`<meta property="og:description" content="${escapedDescription}">`));
   assert.ok(html.includes(`<link rel="canonical" href="${CANONICAL_SITE_URL}">`));
   assert.ok(html.includes(`<meta property="og:url" content="${CANONICAL_SITE_URL}">`));
@@ -130,6 +133,20 @@ test("the isolated canonical site stays factual, dependency-free, and motion-opt
   assert.match(css, /@media\s*\(prefers-reduced-motion:\s*reduce\)/);
   assert.match(css, /animation:\s*none\s*!important/);
   assert.ok(Buffer.byteLength(html) + Buffer.byteLength(css) < 100 * 1024, "the static site must stay below 100 KiB");
+});
+
+test("the canonical site deploys only its allowlisted source from main", () => {
+  const workflow = fs.readFileSync(path.join(ROOT, ".github", "workflows", "pages.yml"), "utf8");
+
+  assert.match(workflow, /push:\s*\n\s+branches:\s*\[main\]/);
+  assert.doesNotMatch(workflow, /pull_request:|schedule:/);
+  assert.match(workflow, /permissions:\s*\n\s+contents:\s*read/);
+  assert.match(workflow, /actions\/checkout@[0-9a-f]{40}\s+# v6\.0\.2/);
+  assert.match(workflow, /actions\/configure-pages@[0-9a-f]{40}\s+# v5\.0\.0/);
+  assert.match(workflow, /actions\/upload-pages-artifact@[0-9a-f]{40}\s+# v4\.0\.0[\s\S]*?path:\s+site/);
+  assert.match(workflow, /deploy:\s*[\s\S]*?needs:\s+build[\s\S]*?permissions:\s*\n\s+pages:\s*write\s*\n\s+id-token:\s*write/);
+  assert.match(workflow, /environment:\s*\n\s+name:\s+github-pages\s*\n\s+url:\s+\$\{\{ steps\.deployment\.outputs\.page_url \}\}/);
+  assert.match(workflow, /actions\/deploy-pages@[0-9a-f]{40}\s+# v4\.0\.5/);
 });
 
 test("root READMEs surface setup and representative workflows before detailed positioning", () => {

--- a/tests/contract.test.mjs
+++ b/tests/contract.test.mjs
@@ -139,17 +139,24 @@ test("the canonical site deploys only its allowlisted source from main", () => {
   const workflow = fs.readFileSync(path.join(ROOT, ".github", "workflows", "pages.yml"), "utf8");
   const normalized = workflow.replace(/\r\n/g, "\n");
   const deployStart = normalized.indexOf("\n  deploy:");
-  const deploy = normalized.slice(deployStart);
+  assert.ok(deployStart >= 0);
+  const followingJob = normalized.slice(deployStart + 1).search(/\n  [a-z0-9_-]+:\n/i);
+  const deployEnd = followingJob < 0 ? normalized.length : deployStart + 1 + followingJob;
+  const deploy = normalized.slice(deployStart, deployEnd);
 
   assert.ok(normalized.includes('push:\n    branches: [main]\n    paths:\n      - "site/**"\n      - ".github/workflows/pages.yml"'));
   assert.doesNotMatch(normalized, /pull_request(?:_target)?:|schedule:|workflow_dispatch:/);
   assert.ok(normalized.includes("permissions:\n  contents: read\n\nconcurrency:"), "top-level permissions must remain exactly contents: read");
   assert.match(workflow, /actions\/checkout@[0-9a-f]{40}\s+# v6\.0\.2/);
   assert.match(workflow, /actions\/configure-pages@[0-9a-f]{40}\s+# v5\.0\.0/);
-  assert.match(workflow, /actions\/upload-pages-artifact@[0-9a-f]{40}\s+# v4\.0\.0[\s\S]*?path:\s+site/);
-  assert.ok(deployStart >= 0);
+  assert.match(normalized, /actions\/upload-pages-artifact@[0-9a-f]{40} # v4\.0\.0\n        with:\n          path: site$/m);
   assert.ok(deploy.includes("permissions:\n      pages: write\n      id-token: write\n    environment:"), "deploy permissions must remain exactly pages: write and id-token: write");
-  assert.doesNotMatch(deploy, /actions\/checkout|\n\s+run:/, "the privileged deploy job must not check out or run repository code");
+  assert.doesNotMatch(deploy, /(?:^|\n)[^\S\n]*(?:-[^\S\n]*)?run:/, "the privileged deploy job must not run repository code");
+  assert.deepEqual(
+    [...deploy.matchAll(/^\s+(?:-\s+)?uses:\s+(\S+)/gm)].map((match) => match[1]),
+    ["actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e"],
+    "the privileged deploy job must invoke only the reviewed deploy-pages action",
+  );
   assert.match(workflow, /environment:\s*\n\s+name:\s+github-pages\s*\n\s+url:\s+\$\{\{ steps\.deployment\.outputs\.page_url \}\}/);
   assert.match(workflow, /actions\/deploy-pages@[0-9a-f]{40}\s+# v4\.0\.5/);
 });


### PR DESCRIPTION
## Outcome

Adds the source and deployment contract for the canonical GitHub Pages origin:

- canonical URL: `https://arcobaleno64.github.io/agy-plugin-cc/`
- canonical title: `agy-plugin-cc — Cross-model review for Claude Code`
- canonical description remains byte-identical to the repository's approved short description
- deployment publishes only the allowlisted `site/` directory

This PR does not change product behavior, runtime boundaries, version metadata, benchmark evidence, or the site source introduced by #127.

## Scope

- `.github/workflows/pages.yml`
- `tests/contract.test.mjs`

The workflow:

- runs only after a push to `main` that changes `site/**` or the workflow itself
- has no pull-request, scheduled, or manual trigger
- keeps top-level permissions exactly `contents: read`
- separates the unprivileged build from the privileged deploy job
- gives deploy exactly `pages: write` and `id-token: write`
- uploads exactly `site/`
- pins all four GitHub Actions to reviewed full commit SHAs

The contract now enforces the complete boundary:

- artifact path is the exact scalar `site`, rejecting `.`, `site/..`, and prefix lookalikes
- the deploy job is bounded independently from following jobs
- direct and named `run:` steps are rejected
- deploy has exactly one `uses:` target: the reviewed pinned `actions/deploy-pages` action
- checkout, `actions/github-script`, and any additional action are rejected in the privileged job

## Review fixes

The blocked-head findings are resolved in the test-only commit:

- `PAGES-GUARD-01`: direct `- run:` is now rejected
- `PAGES-PATH-01`: `site/..` and `sitemap` are now rejected
- `PAGES-GUARD-02` (P2): deploy action execution is allowlisted, not denylisted
- `PAGES-SECT-01` (P3): the deploy section is bounded at the next job

No workflow or site source changed in the remediation.

## Verification

Fresh local results:

- `node --check tests/contract.test.mjs`
- `node --test tests/contract.test.mjs`: 18/18 passed
- `npm test`: 690 tests, 679 passed, 11 skipped, 0 failed
- `npm run verify-contracts`: passed
- `npm run check-version`: passed
- `npm run bench:aeo`: 6/6 measured, 0 candidate violations, 3 manually adjudicated, 0 pending, 0 unmeasured
- `npm run bench`: passed
- `git diff --check`: passed
- strict plugin validation passed for both `./plugins/gemini` and `.` using `@anthropic-ai/claude-code@2.1.222`
- CRLF fixture: 18/18 passed

The mutation matrix rejects all 17 drift cases: root/prefix artifact paths, four forbidden trigger families, additional permissions, checkout, direct/named run steps, additional actions, and canonical metadata drift. Pristine LF and CRLF controls remain green.

## Deployment gate

The canonical URL is not represented as successfully deployed before merge and Pages enablement.

Do not check the Issue #121 metadata item merely because this PR merges. After approval and merge, enable Pages with **GitHub Actions** as the source, wait for the exact-`main` deployment, and independently verify:

1. the canonical URL returns HTTP 200;
2. title, description, canonical URL, and Open Graph metadata are exact;
3. only the reviewed static `site/` artifact is served.

Issue #121 remains open.