### PR TITLE
docs: publish canonical sitemap

### DIFF
--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://arcobaleno64.github.io/agy-plugin-cc/</loc>
+  </url>
+</urlset>

--- a/tests/contract.test.mjs
+++ b/tests/contract.test.mjs
@@ -92,9 +92,10 @@ test("the isolated canonical site stays factual, dependency-free, and motion-opt
     .filter(Boolean)
     .map((file) => path.relative("site", file))
     .sort();
-  assert.deepEqual(files, ["index.html", "styles.css"], "tracked site/ sources must remain an explicit allowlist");
+  assert.deepEqual(files, ["index.html", "sitemap.xml", "styles.css"], "tracked site/ sources must remain an explicit allowlist");
 
   const html = fs.readFileSync(path.join(siteRoot, "index.html"), "utf8");
+  const sitemap = fs.readFileSync(path.join(siteRoot, "sitemap.xml"), "utf8").replace(/\r\n/g, "\n");
   const css = fs.readFileSync(path.join(siteRoot, "styles.css"), "utf8");
   const escapedDescription = CANONICAL_DESCRIPTION.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 
@@ -111,6 +112,13 @@ test("the isolated canonical site stays factual, dependency-free, and motion-opt
   assert.ok(html.includes(`<link rel="canonical" href="${CANONICAL_SITE_URL}">`));
   assert.ok(html.includes(`<meta property="og:url" content="${CANONICAL_SITE_URL}">`));
   assert.match(html, new RegExp(`<p class="canonical-description">${escapedDescription}</p>`));
+  assert.equal(sitemap, `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>${CANONICAL_SITE_URL}</loc>
+  </url>
+</urlset>
+`);
 
   for (const command of ENTRY_INSTALL_COMMANDS) {
     assert.match(html, new RegExp(command.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")), `site omits ${command}`);
@@ -132,7 +140,7 @@ test("the isolated canonical site stays factual, dependency-free, and motion-opt
   assert.doesNotMatch(css, /@import|url\s*\(\s*["']?https?:/i, "site CSS must not load third-party assets");
   assert.match(css, /@media\s*\(prefers-reduced-motion:\s*reduce\)/);
   assert.match(css, /animation:\s*none\s*!important/);
-  assert.ok(Buffer.byteLength(html) + Buffer.byteLength(css) < 100 * 1024, "the static site must stay below 100 KiB");
+  assert.ok(Buffer.byteLength(html) + Buffer.byteLength(sitemap) + Buffer.byteLength(css) < 100 * 1024, "the static site must stay below 100 KiB");
 });
 
 test("the canonical site deploys only its allowlisted source from main", () => {


### PR DESCRIPTION
## Summary

- publish a minimal XML sitemap for the live canonical GitHub Pages origin
- list only the canonical homepage URL
- extend the existing site contract so the sitemap is allowlisted, exact, CRLF-safe, and included in the 100 KiB source budget

## Scope

Only:
- `site/sitemap.xml`
- `tests/contract.test.mjs`

Deferred by design:
- `SoftwareApplication` structured data
- `robots.txt`
- `llms.txt`
- runtime, security, privacy, release, dependency, and workflow changes

## Verification

- `node --test tests/contract.test.mjs` — 18/18 pass
- `npm test` — 690 tests, 679 pass, 0 fail, 11 skip
- `npm run verify-contracts` — pass
- `npm run check-version` — pass
- `npm run bench:aeo` — 6/6 measured, 0 candidate violations
- strict plugin validation — pass for plugin and marketplace
- mutation probes reject a wrong URL, an extra URL, and a missing sitemap
- LF and CRLF controls both pass

## Post-merge gate

Do not mark Issue #121's sitemap item complete until the Pages deployment from the squash-merge commit succeeds and `https://arcobaleno64.github.io/agy-plugin-cc/sitemap.xml` is live, valid, and contains only the canonical homepage.