### PR TITLE
docs: add factual SoftwareApplication metadata

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -11,6 +11,16 @@
   <meta property="og:description" content="agy-plugin-cc is a Claude Code companion for running Gemini CLI or Antigravity CLI (agy) as a cross-model task delegate and code reviewer, with pragmatic and adversarial review, MCP tools, and background jobs.">
   <meta property="og:url" content="https://arcobaleno64.github.io/agy-plugin-cc/">
   <meta name="twitter:card" content="summary">
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "agy-plugin-cc",
+    "description": "agy-plugin-cc is a Claude Code companion for running Gemini CLI or Antigravity CLI (agy) as a cross-model task delegate and code reviewer, with pragmatic and adversarial review, MCP tools, and background jobs.",
+    "url": "https://arcobaleno64.github.io/agy-plugin-cc/",
+    "sameAs": "https://github.com/arcobaleno64/agy-plugin-cc"
+  }
+  </script>
   <link rel="stylesheet" href="styles.css">
 </head>
 <body>

--- a/tests/contract.test.mjs
+++ b/tests/contract.test.mjs
@@ -20,6 +20,7 @@ const CANONICAL_DESCRIPTION = "agy-plugin-cc is a Claude Code companion for runn
 const CANONICAL_ZH_TW = "`agy-plugin-cc` 是 Claude Code 協作外掛，可透過 Gemini CLI 或 Antigravity CLI（`agy`）進行跨模型任務委派與程式碼審查，並提供務實與對抗性審查、MCP 工具及背景工作。";
 const CANONICAL_SITE_TITLE = "agy-plugin-cc — Cross-model review for Claude Code";
 const CANONICAL_SITE_URL = "https://arcobaleno64.github.io/agy-plugin-cc/";
+const CANONICAL_REPOSITORY_URL = "https://github.com/arcobaleno64/agy-plugin-cc";
 
 function writeJson(filePath, json) {
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
@@ -98,6 +99,7 @@ test("the isolated canonical site stays factual, dependency-free, and motion-opt
   const sitemap = fs.readFileSync(path.join(siteRoot, "sitemap.xml"), "utf8").replace(/\r\n/g, "\n");
   const css = fs.readFileSync(path.join(siteRoot, "styles.css"), "utf8");
   const escapedDescription = CANONICAL_DESCRIPTION.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const jsonLdScripts = [...html.matchAll(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/g)];
 
   assert.match(html, /^<!doctype html>/i);
   assert.match(html, /<html lang="en">/);
@@ -112,6 +114,18 @@ test("the isolated canonical site stays factual, dependency-free, and motion-opt
   assert.ok(html.includes(`<link rel="canonical" href="${CANONICAL_SITE_URL}">`));
   assert.ok(html.includes(`<meta property="og:url" content="${CANONICAL_SITE_URL}">`));
   assert.match(html, new RegExp(`<p class="canonical-description">${escapedDescription}</p>`));
+  assert.ok(html.includes("<span>agy-plugin-cc</span>"), "structured application name must remain visible");
+  assert.ok(html.includes(`href="${CANONICAL_REPOSITORY_URL}"`), "structured repository identity must remain visible");
+  assert.equal((html.match(/<script\b/gi) ?? []).length, 1, "site must contain only the reviewed JSON-LD script");
+  assert.equal(jsonLdScripts.length, 1, "site must contain one SoftwareApplication JSON-LD block");
+  assert.deepEqual(JSON.parse(jsonLdScripts[0][1]), {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    name: "agy-plugin-cc",
+    description: CANONICAL_DESCRIPTION,
+    url: CANONICAL_SITE_URL,
+    sameAs: CANONICAL_REPOSITORY_URL,
+  });
   assert.equal(sitemap, `<?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
@@ -131,7 +145,7 @@ test("the isolated canonical site stays factual, dependency-free, and motion-opt
   assert.match(html, /<ol class="workflow-steps" role="list">/);
   assert.match(html, /<pre tabindex="0"><code>/);
 
-  assert.doesNotMatch(html, /<(?:script|iframe|img|picture|video|audio|source|object|embed)\b/i);
+  assert.doesNotMatch(html, /<(?:iframe|img|picture|video|audio|source|object|embed)\b/i);
   assert.doesNotMatch(html, /\b(?:SEO|AEO|GEO|ranking|ranked|best|leading|official plugin)\b/i);
   assert.doesNotMatch(html, /\b(?:all|every)\s+review commands?\s+are\s+read-only\b/i);
   assert.doesNotMatch(html, /\breview commands?\s+are\s+always\s+read-only\b/i);


### PR DESCRIPTION
## Summary

- add one in-page `SoftwareApplication` JSON-LD block to the canonical site
- limit the graph to facts already visible on the page: name, canonical description, canonical URL, and repository identity
- harden the existing site contract so the graph is exact, unique, parseable JSON, visibly supported, and the only allowed script

## Scope

Only:
- `site/index.html`
- `tests/contract.test.mjs`

Deliberately omitted:
- offers, price, ratings, reviews, download counts
- operating-system or version claims
- author or organization claims
- `applicationCategory`
- `robots.txt`, `llms.txt`, and any ranking or rich-result guarantee

## Evidence policy

The markup follows [Schema.org SoftwareApplication](https://schema.org/SoftwareApplication) and Google's requirement that structured data describe visible page content. It is machine-readable identity metadata, not evidence of indexing, ranking, recommendation, or rich-result eligibility.

## Verification

- focused contract: 18/18 pass
- full suite: 690 tests, 679 pass, 0 fail, 11 skip
- contracts and version checks: pass
- AEO: 6/6 measured, 0 candidate violations
- strict plugin and marketplace validation: pass
- LF and CRLF controls: pass
- mutations reject missing or executable JSON-LD, type/field drift, extra scripts, invalid JSON, unsupported offers/ratings/OS/version/category, and removal of visible supporting content

## Post-merge gate

Do not mark Issue #121's structured-data item complete until the actual squash-merge commit deploys successfully and the live homepage contains the exact valid graph with no unsupported fields.