### PR TITLE
fix(gate,retry): stop the review gate re-arming and the spend cap retrying

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,13 +7,13 @@
   },
   "metadata": {
     "description": "agy-plugin-cc is a Claude Code companion for running Gemini CLI or Antigravity CLI (agy) as a cross-model task delegate and code reviewer, with pragmatic and adversarial review, MCP tools, and background jobs.",
-    "version": "0.24.1"
+    "version": "0.24.2"
   },
   "plugins": [
     {
       "name": "gemini",
       "description": "agy-plugin-cc is a Claude Code companion for running Gemini CLI or Antigravity CLI (agy) as a cross-model task delegate and code reviewer, with pragmatic and adversarial review, MCP tools, and background jobs.",
-      "version": "0.24.1",
+      "version": "0.24.2",
       "author": {
         "name": "arcobaleno64",
         "email": "arcobaleno830623@gmail.com"

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Delegates a task to Gemini. Reads from stdin if no prompt is given.
 |---|---|
 | `--background` | Run detached; returns a job ID immediately |
 | `--write` | State that edits are expected. Off by default. On gemini it adds `--yolo`, which genuinely gates whether write tools exist. On AGY it selects `--new-project` over `--add-dir`; both orient the run on your repository and **neither withholds write**, so there it is a statement of intent, not a boundary — see [Security](#security) |
-| `--resume-last` | Continue the most recent Gemini session |
+| `--resume-last` | Continue the most recent Gemini session. **Refused with `--write` on the gemini engine**: `gemini --resume` accepts only `latest` or an index, so it cannot name a conversation, and the run it continues may belong to another project — which would receive the edits. Use `--engine agy` (which pins by id), or resume without `--write`. |
 | `--fresh` | Force a new Gemini session, ignoring any resumable thread |
 | `--engine <gemini\|agy\|auto>` | Override engine selection |
 | `--model <alias\|id>` | Model override. Gemini resolves its aliases; AGY 1.1.10+ requires an exact model ID from `agy models`. AGY model selection cannot be combined with `--effort` or a dual-engine (`--engines gemini,agy`) review. |
@@ -190,7 +190,7 @@ Exports current workspace context (git diff, status, instructions) and generates
 |---|---|
 | `--engine <gemini\|agy\|auto>` | Which handoff commands to print. `auto` (default) prints both |
 | `--model <id>` | Model override carried into the generated command. AGY requires an exact ID from `agy models` |
-| `--effort <low\|medium\|high\|xhigh>` | Reasoning effort carried into the generated AGY command. Cannot be combined with `--model` |
+| `--effort <low\|medium\|high\|xhigh>` | Reasoning effort carried into the generated AGY command. Cannot be combined with `--model`. **AGY accepts only `low`, `medium`, `high`** — `xhigh` produces a command AGY rejects. The generated **gemini** command carries no effort flag at all |
 
 ### `/gemini:review`
 
@@ -205,6 +205,7 @@ Runs a standard, pragmatic review over the current working tree or branch diff �
 | `--engine <gemini\|agy\|auto>` | Override engine |
 | `--model <alias\|id>` | Model override |
 | `--effort <level>` | Model selection on Gemini; native reasoning effort on AGY 1.1.10+ (`low`, `medium`, `high`) when no AGY model is selected |
+| `--engines gemini,agy` | Run both engines concurrently as independent blind reviews. Mutually exclusive with `--engine`, and cannot be combined with an AGY model selection |
 
 ### `/gemini:adversarial-review [focus]`
 
@@ -238,7 +239,7 @@ Lists active and recent background jobs. Pass a job ID to inspect a single job.
 
 | Flag | Description |
 |---|---|
-| `--wait` | Block until the job completes (requires a job ID) |
+| `--wait` | Block until the job completes (requires a job ID). Gives up after 4 minutes and reports the job's state at that point — the job itself keeps running, so re-run `--wait` or collect it later with `/gemini:result` |
 | `--all` | Show all jobs, not just this session's |
 
 ### `/gemini:result [job-id]`
@@ -276,13 +277,19 @@ The plugin also ships an MCP server (`.mcp.json` → `scripts/gemini-mcp.mjs`), 
 
 ### Slash-only, by omission
 
-Listed so the gap is visible rather than discovered: `/gemini:setup` and its probe flags (interactive by design), `/gemini:transfer` (it writes a workspace-local snapshot and needs the model to author the instructions file), `--resume-last`, and `--engines gemini,agy` are not on this surface — use the slash command or the CLI. Each of the three turn-spending MCP tools accepts an integer `timeout`; when omitted, the per-engine default applies. Every `gemini_rescue` starts a fresh turn. The [Review Gate](#review-gate-optional) is configured through `/gemini:setup` and then applies to the whole session, whichever surface queued the job.
+Listed so the gap is visible rather than discovered: `/gemini:setup` and its probe flags (interactive by design), `/gemini:transfer` (it writes a workspace-local snapshot and needs the model to author the instructions file), `--resume-last`, and `--engines gemini,agy` are not on this surface — use the slash command or the CLI. Each of the three turn-spending MCP tools accepts an integer `timeout`; when omitted, the per-engine default applies. Every `gemini_rescue` starts a fresh turn. The [Review Gate](#review-gate-optional) is configured through `/gemini:setup`, and the setting is stored per workspace, so it persists across sessions and must be enabled again in each repository.
 
 ---
 
 ## Review Gate (Optional)
 
-An optional stop-time gate that runs an adversarial review before Claude Code can stop, whenever a `--write` task completed or returned partial output in the session. Disabled by default; partial counts because edits may already exist.
+An optional gate that runs an adversarial review before Claude Code can stop, whenever a `--write` task completed or returned partial output. Disabled by default; partial counts because edits may already exist.
+
+Three things about its scope are easy to get wrong:
+
+- **It runs at the end of every agent turn**, not once when the session ends — Claude Code's `Stop` hook fires per turn.
+- **The `--write` task it looks for is any one in this workspace**, not only one from the current session (`stop-review-gate-hook.mjs` reads the whole workspace job store). A write task queued through the MCP tools carries no session id and is never cleaned up at session end, so it keeps arming the gate until the 50-job store evicts it.
+- **The enable/disable setting is per workspace and lives on disk**, so it survives restarts and must be enabled again in each repository.
 
 Enable or disable via `/gemini:setup`:
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -176,7 +176,7 @@ AGY 請用 `/gemini:setup --engine agy` 驗證所選引擎；auto／Gemini 請�
 |---|---|
 | `--background` | 分離執行；立即回傳工作 ID |
 | `--write` | 宣告本次執行預期會修改檔案。預設關閉。gemini 上它加的是 `--yolo`，那確實決定寫入工具是否存在；AGY 上它只是在 `--add-dir` 與 `--new-project` 之間擇一，兩者都會將執行定位到你的版本庫，且**都不會限制寫入能力**，故在 AGY 上這是意圖宣告而非邊界——詳見 [安全性](#安全性) |
-| `--resume-last` | 繼續最近一次的 Gemini 工作階段 |
+| `--resume-last` | 繼續最近一次的 Gemini 工作階段。**在 gemini 引擎上與 `--write` 併用會被拒絕**：`gemini --resume` 只接受 `latest` 或索引數字，無法指名特定對話，接續到的可能是別的專案——而編輯會落到那裡。請改用 `--engine agy`（以 id 釘住對話），或不帶 `--write` 接續。 |
 | `--fresh` | 強制開啟全新 Gemini 工作階段，忽略可接續的執行緒 |
 | `--engine <gemini\|agy\|auto>` | 覆蓋引擎選擇 |
 | `--model <別名\|ID>` | 指定模型。Gemini 解析其別名；AGY 1.1.10+ 要求使用 `agy models` 列出的精確 model ID。AGY 的模型選擇不可與 `--effort` 或雙引擎（`--engines gemini,agy`）審查合併。 |
@@ -190,7 +190,7 @@ AGY 請用 `/gemini:setup --engine agy` 驗證所選引擎；auto／Gemini 請�
 |---|---|
 | `--engine <gemini\|agy\|auto>` | 決定輸出哪一種接手命令；`auto`（預設）兩種都印 |
 | `--model <ID>` | 帶入產生命令的模型指定。AGY 要求使用 `agy models` 列出的精確 ID |
-| `--effort <low\|medium\|high\|xhigh>` | 帶入產生之 AGY 命令的推理強度，不可與 `--model` 併用 |
+| `--effort <low\|medium\|high\|xhigh>` | 帶入產生之 AGY 命令的推理強度，不可與 `--model` 併用。**AGY 只接受 `low`、`medium`、`high`**——`xhigh` 產生的命令會被 AGY 拒絕。產生的 **gemini** 命令則完全不帶 effort 旗標 |
 
 ### `/gemini:review`
 
@@ -205,6 +205,7 @@ AGY 請用 `/gemini:setup --engine agy` 驗證所選引擎；auto／Gemini 請�
 | `--engine <gemini\|agy\|auto>` | 覆蓋引擎 |
 | `--model <別名\|ID>` | 指定模型 |
 | `--effort <level>` | Gemini 的模型選擇；未指定 AGY model 時的 AGY 1.1.10+ 原生推理強度（`low`、`medium`、`high`） |
+| `--engines gemini,agy` | 同時以兩個引擎各跑一次獨立的盲審。與 `--engine` 互斥，且不可與 AGY 的模型選擇併用 |
 
 ### `/gemini:adversarial-review [焦點]`
 
@@ -238,7 +239,7 @@ AGY 請用 `/gemini:setup --engine agy` 驗證所選引擎；auto／Gemini 請�
 
 | 旗標 | 說明 |
 |---|---|
-| `--wait` | 阻塞直到工作完成（需提供工作 ID） |
+| `--wait` | 阻塞直到工作完成（需提供工作 ID）。等待 4 分鐘後放棄並回報當下狀態——工作本身仍在跑，可再次 `--wait` 或稍後用 `/gemini:result` 收取 |
 | `--all` | 顯示所有工作，不限本次會話 |
 
 ### `/gemini:result [工作-ID]`
@@ -276,13 +277,19 @@ AGY 請用 `/gemini:setup --engine agy` 驗證所選引擎；auto／Gemini 請�
 
 ### 僅限斜線命令（明列缺口）
 
-列出來是為了讓缺口可見，而不是等人踩到：`/gemini:setup` 與其 probe 旗標（本質上是互動式的）、`/gemini:transfer`（會寫入工作區內的快照，且需要模型自行撰寫 instructions 檔）、`--resume-last`、`--engines gemini,agy` 都不在這個介面上——請改用斜線命令或 CLI。三個會花費 turn 的 MCP 工具都接受整數 `timeout`；省略時採各引擎預設值。每次 `gemini_rescue` 都是全新的 turn。[Review Gate](#review-gate可選) 由 `/gemini:setup` 設定，之後對整個 session 生效，與工作由哪個介面排入無關。
+列出來是為了讓缺口可見，而不是等人踩到：`/gemini:setup` 與其 probe 旗標（本質上是互動式的）、`/gemini:transfer`（會寫入工作區內的快照，且需要模型自行撰寫 instructions 檔）、`--resume-last`、`--engines gemini,agy` 都不在這個介面上——請改用斜線命令或 CLI。三個會花費 turn 的 MCP 工具都接受整數 `timeout`；省略時採各引擎預設值。每次 `gemini_rescue` 都是全新的 turn。[Review Gate](#review-gate可選) 由 `/gemini:setup` 設定，該設定**以 workspace 為單位存放在磁碟上**，因此跨 session 持續有效，並且在每個版本庫都要各自啟用一次。
 
 ---
 
 ## Review Gate（可選）
 
-可選的停止時審查閘門，當本次 session 有 `--write` 工作完成或帶著 partial output 返回時，在 Claude Code 停止前自動執行對抗性審查。預設停用；partial 也計入，因為檔案可能已被修改。
+可選的閘門，當有 `--write` 工作完成或帶著 partial output 返回時，在 Claude Code 停止前自動執行對抗性審查。預設停用；partial 也計入，因為檔案可能已被修改。
+
+它的作用域有三點容易誤解：
+
+- **每個 agent turn 結束都會跑**，不是 session 結束才跑一次——Claude Code 的 `Stop` hook 是逐 turn 觸發的。
+- **它找的 `--write` 工作是整個 workspace 裡的任何一個**，不限本次 session（`stop-review-gate-hook.mjs` 讀的是整個 workspace job store）。透過 MCP 工具排入的 write 工作不帶 session id，session 結束時不會被清掉，因此會持續讓閘門保持武裝，直到 50 筆的 job store 把它擠掉。
+- **啟用／停用的設定以 workspace 為單位存在磁碟上**，重啟後仍有效，且每個版本庫都要各自啟用一次。
 
 透過 `/gemini:setup` 啟用或停用：
 

--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -21,7 +21,7 @@ belong to.
 | [sakibsadmanshajib/gemini-plugin-cc](https://github.com/sakibsadmanshajib/gemini-plugin-cc) | 24 | 2026-05-22 | v1.0.1, archived | Gemini CLI | ACP |
 | [sakibsadmanshajib/antigravity-plugin](https://github.com/sakibsadmanshajib/antigravity-plugin) | 19 | 2026-05-22 | none | AGY only | `agy --print` |
 | [m-ghalib/gemini-plugin-cc](https://github.com/m-ghalib/gemini-plugin-cc) | 18 | 2026-04-24 | v0.1.0 | Gemini CLI, setup installs 0.38.2 | ACP |
-| **this project** | 10 | 2026-08-28 | v0.24.1 | Gemini CLI **and** AGY | direct spawn, structured JSON |
+| **this project** | 10 | 2026-09-02 | v0.24.2 | Gemini CLI **and** AGY | direct spawn, structured JSON |
 
 | Surface | Slash commands | MCP tools | Skills | Test files (`*.test.*`) |
 |---|---|---|---|---|

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@arcobaleno64/agy-plugin-cc",
-  "version": "0.24.1",
+  "version": "0.24.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@arcobaleno64/agy-plugin-cc",
-      "version": "0.24.1",
+      "version": "0.24.2",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arcobaleno64/agy-plugin-cc",
-  "version": "0.24.1",
+  "version": "0.24.2",
   "private": true,
   "type": "module",
   "description": "agy-plugin-cc is a Claude Code companion for running Gemini CLI or Antigravity CLI (agy) as a cross-model task delegate and code reviewer, with pragmatic and adversarial review, MCP tools, and background jobs.",

--- a/plugins/gemini/.claude-plugin/plugin.json
+++ b/plugins/gemini/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gemini",
-  "version": "0.24.1",
+  "version": "0.24.2",
   "description": "agy-plugin-cc is a Claude Code companion for running Gemini CLI or Antigravity CLI (agy) as a cross-model task delegate and code reviewer, with pragmatic and adversarial review, MCP tools, and background jobs.",
   "author": {
     "name": "arcobaleno64",

--- a/plugins/gemini/CHANGELOG.md
+++ b/plugins/gemini/CHANGELOG.md
@@ -1,5 +1,102 @@
 # Changelog
 
+## 0.24.2 - 2026-09-02 - The stop gate stops re-arming, and a spend cap stops being retried
+
+- **A write task now arms the stop-review gate once, not on every turn forever.**
+  The gate reads the whole workspace job store on purpose — a write task queued
+  through the MCP tools carries no session id, so a session-scoped predicate
+  would leave exactly those edits ungated — but nothing consumed the trigger,
+  and `SessionEnd` never evicts an untagged job. One MCP `--write` task therefore
+  re-ran an adversarial review at the end of every agent turn, indefinitely.
+  Jobs are now stamped `gateReviewedAt` once a review returns a verdict, and
+  re-arm only when the job reaches a terminal state again. The mark is compared
+  against `completedAt`, not `updatedAt`: `upsertJob` stamps `updatedAt` on every
+  write, so a mark compared against it is stale the instant it is recorded and the
+  gate re-arms every turn regardless — the defect this fix exists to remove. A
+  review that fails still fails
+  open **without** marking, so edits it could not check are not silently
+  forgiven. New `pendingGateWriteTasks` export; `hasCompletedWriteTask` is kept
+  as a predicate over it. (`stop-review-gate-hook.mjs`)
+
+- **The gate's review mark no longer evicts a newer result.** `listJobs` sorts by
+  `updatedAt` and `pruneJobStore` evicts everything past the 50-job cap, so
+  stamping the mark through a normal `upsertJob` promoted an old reviewed job to
+  the head of the list and evicted a NEWER finished result in its place.
+  `upsertJob` takes `{ touch: false }` for patches that record something about a
+  job rather than something the job did. (`lib/state.mjs`,
+  `stop-review-gate-hook.mjs`)
+
+- **Cancelling an already-finished job no longer reports it as missing.**
+  `resolveCancelableJob` searched only active jobs with the throwing form of
+  `matchJobReference`, so its own `No active job found` branch was unreachable and
+  a finished id came back as `No job found` — pointing at /gemini:status, which
+  then displayed the job. It now names the job and its status. (`lib/job-control.mjs`)
+
+- **An exhausted spend cap is no longer retried three times.** Google returns
+  `Your project has exceeded its monthly spending cap` with code 429, and none of
+  `quota`, `billing`, or `RESOURCE_EXHAUSTED` appear in it, so `classifyCliFailure`
+  fell through to `rate-limit` (retryable) and the review wrapper's transport
+  heuristic re-ran the review. Measured: three full attempts over 10m46s to reach
+  the same refusal. The classifier now matches `spend(ing) cap` as `quota`, and
+  `isTransientReviewFailure` consults `classifyCliFailure` before its own
+  heuristic, so any failure classified non-retryable ends the run immediately. A
+  plain `429 Too Many Requests` still retries. (`lib/failures.mjs`, `lib/gemini.mjs`)
+
+- **Docs corrected where they described the gate's scope wrongly.** The `Stop`
+  hook runs at the end of every agent turn, not once at session end; the gate's
+  enable/disable setting is stored per workspace on disk, so it persists across
+  sessions and must be enabled again in each repository; the `--write` task that
+  arms it is any one in the workspace, not only one from the current session; and
+  `SessionEnd` removes a session's finished job records too, so a background
+  result must be collected before the session ends rather than after.
+  (`README.md`, `README.zh-TW.md`, `plugins/gemini/README.md`,
+  `commands/review.md`, `commands/adversarial-review.md`, `lib/render.mjs`)
+
+- **`/gemini:result` no longer printed a resume command that cannot run.** The
+  gemini branch emitted `gemini --resume <session-id>`, but that flag accepts only
+  `latest` or an index number — the id is not addressable, as the runtime's own
+  `--resume-last --write` refusal already explained. The session id is still
+  shown; the paste-ready line is replaced by a note pointing at `--resume-last`.
+  New `resumeLine` helper, so a null command cannot render as the literal
+  `null`. (`lib/render.mjs`)
+
+- **`/gemini:result` on a running job said "No job found".** `resolveResultJob`
+  probes twice — finished first, then active — so it can answer "still running"
+  instead of "not found", but the first probe threw on no-match and the second was
+  unreachable. Measured through `gemini_job_result`: a job whose file was on disk
+  and which `/gemini:status` was listing as `running` came back as missing, with a
+  next step (`/gemini:status`) that then showed the job. `matchJobReference` takes
+  a `missing` mode, and the two probes inside `resolveResultJob` pass `"null"`;
+  every other caller keeps the throw. (`lib/job-control.mjs`)
+
+- **`/gemini:result` with nothing to show no longer overstates its scope.** The
+  message said no finished jobs existed "for this repository" while the search was
+  filtered to the current session, sending users to look for a job-store fault
+  that was not there. It now says "for this session" and names `--all`.
+  (`lib/job-control.mjs`)
+
+- **Flag documentation corrected where it under-reported the runtime.**
+  `--resume-last` is refused with `--write` on the gemini engine (README said
+  nothing); `--engines gemini,agy` was missing from the adversarial-review flag
+  table; `--effort` was missing from both review commands' argument hints;
+  `status --wait` gives up after 4 minutes rather than blocking indefinitely;
+  `transfer --effort xhigh` produces a command AGY rejects and the generated
+  gemini command carries no effort flag at all; and the CLI help for `task`
+  listed only `low|medium|high` when `none`, `minimal`, and `xhigh` are accepted.
+  (`README.md`, `README.zh-TW.md`, `commands/*.md`, `gemini-companion.mjs`)
+
+- **The rescue subagent no longer maps `flash` / `pro` to `--model` on AGY.**
+  Those are Gemini aliases; `normalizeAgyRequestedModel` refuses them before
+  spawn, so the instruction produced a guaranteed fatal error whenever the engine
+  was AGY. It is now conditioned on the engine, with `--effort` named as the AGY
+  route. (`agents/gemini-rescue.md`)
+
+- The comment justifying "agy is never retried" no longer cites agy's
+  transcript-recovery path: from AGY 1.1.8 on, `supportsAgyStructuredOutput`
+  routes to the native JSON envelope and that path never runs. The behaviour is
+  unchanged — the fail-fast timeout and respawn cost still hold it up — but the
+  stale half of the rationale is removed rather than left to be trusted.
+
 ## 0.24.1 - 2026-08-28 - Readonly guard now detects untracked submodule writes on Linux
 
 - **Readonly review jobs now fail when a submodule's untracked content changes.**

--- a/plugins/gemini/README.md
+++ b/plugins/gemini/README.md
@@ -89,8 +89,8 @@ The plugin spawns child processes (`git`, and the engine CLI you installed) and 
 | Hook | What it does | Default |
 |---|---|---|
 | `SessionStart` | Exports `GEMINI_COMPANION_SESSION_ID` so jobs can be attributed to a session. | Always on |
-| `SessionEnd` | Terminates **this session's** still-running background jobs and removes their records. Other sessions' jobs are untouched. | Always on |
-| `Stop` | Optional review gate: runs an adversarial review before the session ends, and can block the stop. | **Off** |
+| `SessionEnd` | Terminates **this session's** still-running background jobs and removes **all** of that session's job records — finished ones included, so their results are no longer retrievable. Other sessions' jobs, and jobs queued through the MCP tools (which carry no session id), are untouched. | Always on |
+| `Stop` | Optional review gate: runs an adversarial review at the end of **every agent turn**, not once at session end, and can block the stop. | **Off** |
 
 The Stop gate is the only thing that reaches the engine without a command you typed, and it is **off unless you turn it on** (`/gemini:setup --enable-review-gate`). It fires only after a `--write` task has completed or returned partial output in that workspace; partial counts because edits may already exist. It fails **open** when the review cannot run — the stop proceeds with a visible notice rather than trapping you.
 

--- a/plugins/gemini/agents/gemini-rescue.md
+++ b/plugins/gemini/agents/gemini-rescue.md
@@ -27,8 +27,9 @@ Forwarding rules:
 - Do not call `adversarial-review`, `status`, `result`, or `cancel`. This subagent only forwards to `task`.
 - Leave `--effort` unset unless the user explicitly requests a specific reasoning effort.
 - Leave model unset by default. Only add `--model` when the user explicitly asks for a specific model.
-- If the user asks for `flash`, map that to `--model flash`.
-- If the user asks for `pro` or `deep`, map that to `--model pro`.
+- If the user asks for `flash`, map that to `--model flash` — **only when the engine is gemini**.
+- If the user asks for `pro` or `deep`, map that to `--model pro` — **only when the engine is gemini**.
+- `flash` and `pro` are Gemini aliases. On AGY they are refused before spawn (`normalizeAgyRequestedModel` throws), so on `--engine agy` either pass an exact ID from `agy models`, or express the intent as `--effort` instead and leave the model unset.
 - If the user asks for a concrete model name such as `gemini-2.5-pro`, pass it through with `--model`.
 - Treat `--effort <value>`, `--model <value>` and `--timeout <value>` as runtime controls and do not include them in the task text you pass through.
 - Do NOT add `--write` unless the user asked for edits. Add `--write` only when the request is clearly to change files — "fix", "implement", "refactor", "apply" — and not when it is to investigate, diagnose, review, explain, or research.

--- a/plugins/gemini/commands/adversarial-review.md
+++ b/plugins/gemini/commands/adversarial-review.md
@@ -1,6 +1,6 @@
 ---
 description: Run an adversarial Gemini code review that challenges the implementation approach and design choices
-argument-hint: '[--wait|--background] [--deep] [--base <ref>] [--scope auto|working-tree|branch] [--engine <agy|gemini> | --engines gemini,agy] [--model <flash|pro>] [--timeout <seconds>] [focus ...]'
+argument-hint: '[--wait|--background] [--deep] [--base <ref>] [--scope auto|working-tree|branch] [--engine <agy|gemini> | --engines gemini,agy] [--model <flash|pro>] [--effort <level>] [--timeout <seconds>] [focus ...]'
 disable-model-invocation: true
 allowed-tools: Read, Glob, Grep, Bash(node:*), Bash(git:*), AskUserQuestion
 ---
@@ -65,7 +65,7 @@ Argument handling:
 - Preserve the user's arguments exactly.
 - Do not strip `--wait` or `--background` yourself.
 - Do not weaken the adversarial framing or rewrite the user's focus text.
-- The companion script handles `--background` itself: it enqueues the review and spawns a detached `review-worker`, so the result persists even if this session ends. Do not use Claude's `run_in_background: true` for it.
+- The companion script handles `--background` itself: it enqueues the review and spawns a detached `review-worker`, so the result outlives the foreground command. It does not outlive the session: `SessionEnd` removes this session's job records, finished ones included, so collect it with `/gemini:result` before the session ends. Do not use Claude's `run_in_background: true` for it.
 - `/gemini:adversarial-review` uses the same review target selection as `/gemini:review` (including `--base <ref>` and `--scope`).
 - Unlike `/gemini:review`, it can take extra focus text after the flags.
 - `--engines gemini,agy` queues the same blind prompt on both available engines as a background group. The jobs share a group ID but do not receive each other's identity or output. Do not combine `--engines` with `--engine` or `--wait`.

--- a/plugins/gemini/commands/review.md
+++ b/plugins/gemini/commands/review.md
@@ -1,6 +1,6 @@
 ---
 description: Run a standard Gemini code review of recent git changes
-argument-hint: '[--wait|--background] [--deep] [--base <ref>] [--scope auto|working-tree|branch] [--engine <agy|gemini>] [--model <flash|pro>] [--timeout <seconds>]'
+argument-hint: '[--wait|--background] [--deep] [--base <ref>] [--scope auto|working-tree|branch] [--engine <agy|gemini>] [--model <flash|pro>] [--effort <level>] [--timeout <seconds>]'
 disable-model-invocation: true
 allowed-tools: Read, Glob, Grep, Bash(node:*), Bash(git:*), AskUserQuestion
 ---
@@ -58,7 +58,7 @@ Argument handling:
 - Preserve the user's arguments exactly.
 - Do not strip `--wait` or `--background` yourself.
 - Do not add extra review instructions or rewrite the user's intent.
-- The companion script handles `--background` itself: it enqueues the review and spawns a detached `review-worker`, so the result persists even if this session ends. Do not use Claude's `run_in_background: true` for it.
+- The companion script handles `--background` itself: it enqueues the review and spawns a detached `review-worker`, so the result outlives the foreground command. It does not outlive the session: `SessionEnd` removes this session's job records, finished ones included, so collect it with `/gemini:result` before the session ends. Do not use Claude's `run_in_background: true` for it.
 - `/gemini:review` is native-review only. It does not take custom focus text.
 - For an adversarial review that challenges design decisions, use `/gemini:adversarial-review`.
 - `--timeout <seconds>` is not only how long the run may take: it is also a ceiling on how much output can be produced, because a turn that cannot finish emitting inside the window is killed. Raise it for a large scope or a batch; the AGY default is 120 seconds.

--- a/plugins/gemini/scripts/gemini-companion.mjs
+++ b/plugins/gemini/scripts/gemini-companion.mjs
@@ -115,7 +115,7 @@ function printUsage() {
       "  node scripts/gemini-companion.mjs setup [--json] [--probe-agy] [--probe-gemini] [--enable-review-gate|--disable-review-gate]",
       "  node scripts/gemini-companion.mjs adversarial-review [--wait|--background] [--deep] [--base <ref>] [--scope <auto|working-tree|branch>] [--model <model>] [--effort <level>] [--engine agy|gemini|auto] [--engines gemini,agy] [--timeout <seconds>] [focus text]",
       "  node scripts/gemini-companion.mjs review [--wait|--background] [--deep] [--base <ref>] [--scope <auto|working-tree|branch>] [--model <model>] [--effort <level>] [--engine agy|gemini|auto] [--timeout <seconds>]",
-      "  node scripts/gemini-companion.mjs task [--background] [--write] [--resume-last|--resume|--fresh] [--model <model>] [--effort <low|medium|high>] [--engine agy|gemini|auto] [--timeout <seconds>] [prompt]",
+      "  node scripts/gemini-companion.mjs task [--background] [--write] [--resume-last|--resume|--fresh] [--model <model>] [--effort <none|minimal|low|medium|high|xhigh>] [--engine agy|gemini|auto] [--timeout <seconds>] [prompt]",
       "  node scripts/gemini-companion.mjs status [job-id] [--all] [--json]",
       "  node scripts/gemini-companion.mjs result [job-id] [--json]",
       "  node scripts/gemini-companion.mjs cancel [job-id] [--json]",

--- a/plugins/gemini/scripts/lib/failures.mjs
+++ b/plugins/gemini/scripts/lib/failures.mjs
@@ -222,7 +222,11 @@ export function classifyCliFailure(input = {}) {
   ) {
     return normalizeFailure("auth", data);
   }
-  if (/quota|billing|RESOURCE_EXHAUSTED/i.test(structuredText)) {
+  // `spend(ing) cap` is matched explicitly: it is the wording Google actually
+  // returns for a project over its monthly limit, it arrives with code 429, and
+  // none of the other three words appear in it — so without this it fell through
+  // to `rate-limit` and was reported (and retried) as a passing flake.
+  if (/quota|billing|RESOURCE_EXHAUSTED|spend(ing)? cap/i.test(structuredText)) {
     return normalizeFailure("quota", data);
   }
   if (/\b429\b|too many requests|rate.?limit/i.test(structuredText)) {

--- a/plugins/gemini/scripts/lib/gemini.mjs
+++ b/plugins/gemini/scripts/lib/gemini.mjs
@@ -932,6 +932,15 @@ export function isTransientReviewFailure({ reviewJson, reviewText, stderr } = {}
   if (reviewJson != null) return false;                       // got structured findings — success
   const out = (reviewText ?? "").trim();
   const err = (stderr ?? "").trim();
+  // Asked BEFORE the transient heuristic, because the two overlap and only one
+  // of them is right: TRANSPORT_REVIEW_RE matches `429` and `resource_exhausted`
+  // on the theory that they are a passing rate limit, but the SAME words carry a
+  // spend cap or an exhausted billing quota, which no number of retries fixes.
+  // classifyCliFailure already separates those (`quota` is retryable:false and is
+  // tested ahead of `rate-limit`), so defer to it rather than keeping a second
+  // opinion here. Measured: a project over its monthly spend cap burned three full
+  // review attempts over 10m46s before reporting a non-retryable failure.
+  if (err && classifyCliFailure({ stderr: err }).retryable === false) return false;
   if (!out && !err) return true;                              // empty stdout+stderr — nothing usable
   if (ENVELOPE_REVIEW_RE.test(`${out}\n${err}`)) return true; // envelope — trusted on either channel
   if (TRANSPORT_REVIEW_RE.test(err)) return true;             // transport flake — trusted on stderr only
@@ -942,8 +951,11 @@ export function isTransientReviewFailure({ reviewJson, reviewText, stderr } = {}
 // idempotent (no side effects), so a transient empty / `Invalid stream` envelope is
 // safe to re-run. The gemini CLI flakes intermittently on this in practice
 // (observed needing 2-3 attempts for the SAME input); retrying here removes that
-// flakiness from the caller. agy is NOT retried — its transcript-recovery path and
-// fail-fast timeout handle its distinct failure mode, and re-spawning it is costly.
+// flakiness from the caller. agy is NOT retried — its fail-fast timeout handles its
+// distinct failure mode and re-spawning it is costly. (The original rationale also
+// cited agy's transcript-recovery path; that no longer applies from AGY 1.1.8 on,
+// where `supportsAgyStructuredOutput` routes to the native JSON envelope and the
+// transcript path never runs. The remaining two reasons are what holds it up now.)
 // Composes with runGeminiReview's inline GA-fallback (model-not-found) retry: that
 // fixes a deterministic wrong-model error within a single attempt; this re-runs the
 // whole review only when no usable result came back at all.

--- a/plugins/gemini/scripts/lib/job-control.mjs
+++ b/plugins/gemini/scripts/lib/job-control.mjs
@@ -306,7 +306,13 @@ export function reconcileActiveJobs(workspaceRoot, jobs, options = {}) {
   return changed ? listJobs(workspaceRoot) : reconciled;
 }
 
-function matchJobReference(jobs, reference, predicate = () => true) {
+// `missing: "throw"` is the default because most callers have nothing better to
+// say than "that id is not here". resolveResultJob does: it probes with a
+// finished-only predicate first and then with an active one, so a throw on the
+// first probe hides the "still running" answer the second probe exists to give.
+// That is exactly what `gemini_job_result` on a running job reported — "No job
+// found" for a job whose file was on disk and which /gemini:status was listing.
+function matchJobReference(jobs, reference, predicate = () => true, { missing = "throw" } = {}) {
   const filtered = jobs.filter(predicate);
   if (!reference) {
     return filtered[0] ?? null;
@@ -325,6 +331,9 @@ function matchJobReference(jobs, reference, predicate = () => true) {
     throw new Error(`Job reference "${reference}" is ambiguous. Use a longer job id.`);
   }
 
+  if (missing === "null") {
+    return null;
+  }
   throw new Error(`No job found for "${reference}". Run /gemini:status to list known jobs.`);
 }
 
@@ -390,14 +399,20 @@ export function resolveResultJob(cwd, reference, options = {}) {
   const selected = matchJobReference(
     jobs,
     reference,
-    (job) => job.status === "completed" || job.status === "failed" || job.status === "partial" || job.status === "cancelled"
+    (job) => job.status === "completed" || job.status === "failed" || job.status === "partial" || job.status === "cancelled",
+    { missing: "null" }
   );
 
   if (selected) {
     return { workspaceRoot, job: selected };
   }
 
-  const active = matchJobReference(jobs, reference, (job) => job.status === "queued" || job.status === "running");
+  const active = matchJobReference(
+    jobs,
+    reference,
+    (job) => job.status === "queued" || job.status === "running",
+    { missing: "null" }
+  );
   if (active) {
     throw new Error(`Job ${active.id} is still ${active.status}. Check /gemini:status and try again once it finishes.`);
   }
@@ -406,7 +421,15 @@ export function resolveResultJob(cwd, reference, options = {}) {
     throw new Error(`No finished job found for "${reference}". Run /gemini:status to inspect active jobs.`);
   }
 
-  throw new Error("No finished Gemini jobs found for this repository yet.");
+  // Scope honestly: the candidates were filtered to THIS session, so a finished
+  // job from ANOTHER session exists in the repository and is reachable with
+  // --all. Claiming the repository has none sends the user looking for a
+  // job-store problem that is not there. MCP-queued jobs are NOT among the
+  // hidden ones: filterJobsForCurrentSession includes untagged jobs by default
+  // (`includeUnattributed !== false`), so they are already listed here.
+  throw new Error(
+    "No finished Gemini jobs found for this session yet. Another session's jobs are not listed here — run `/gemini:result --all` to include them."
+  );
 }
 
 export function resolveResultJobs(cwd, reference, options = {}) {
@@ -470,8 +493,18 @@ export function resolveCancelableJob(cwd, reference, options = {}) {
   const activeJobs = jobs.filter((job) => job.status === "queued" || job.status === "running");
 
   if (reference) {
-    const selected = matchJobReference(activeJobs, reference);
+    // missing:"null" so the branch below is reachable. With the default throw,
+    // cancelling an id that has already finished reported `No job found` — the
+    // job plainly exists, it is simply past cancelling, and the generic message
+    // sent the user to /gemini:status to look for a store fault that is not there.
+    const selected = matchJobReference(activeJobs, reference, () => true, { missing: "null" });
     if (!selected) {
+      const finished = matchJobReference(jobs, reference, () => true, { missing: "null" });
+      if (finished) {
+        throw new Error(
+          `Job ${finished.id} is already ${finished.status} and cannot be cancelled. Read it with /gemini:result ${finished.id}.`
+        );
+      }
       throw new Error(`No active job found for "${reference}".`);
     }
     return { workspaceRoot, job: selected };

--- a/plugins/gemini/scripts/lib/render.mjs
+++ b/plugins/gemini/scripts/lib/render.mjs
@@ -127,7 +127,25 @@ function resumeInfo(engine, threadId) {
   if (engine === "agy") {
     return { idLabel: "AGY conversation ID", resumeLabel: "Resume in AGY", command: `agy --conversation ${threadId}` };
   }
-  return { idLabel: "Gemini session ID", resumeLabel: "Resume in Gemini", command: `gemini --resume ${threadId}` };
+  // No command for gemini: its `--resume` accepts only "latest" or an index
+  // number, never a session id, so `gemini --resume <uuid>` is a command that
+  // cannot work. The id is still worth showing (it identifies the run in
+  // gemini's own history); what is not worth showing is a paste-ready line that
+  // fails. `--resume-last` is the supported route, and it is refused with
+  // `--write` for the reason engine.mjs states.
+  return {
+    idLabel: "Gemini session ID",
+    resumeLabel: "Resume in Gemini",
+    command: null,
+    note: "gemini --resume takes only \"latest\" or an index, not this id — use /gemini:rescue --resume-last (not available with --write)."
+  };
+}
+
+// The resume line, for engines that can be resumed by id and for the one that
+// cannot. gemini has no addressable resume, so it carries a `note` instead of a
+// `command`; printing `resume.command` unguarded rendered the literal "null".
+function resumeLine(resume) {
+  return `${resume.resumeLabel}: ${resume.command ?? resume.note}`;
 }
 
 function appendActiveJobsTable(lines, jobs) {
@@ -163,7 +181,7 @@ function pushJobDetails(lines, job, options = {}) {
   const resume = resumeInfo(job.engine, job.threadId);
   if (resume) {
     lines.push(`  ${resume.idLabel}: ${job.threadId}`);
-    lines.push(`  ${resume.resumeLabel}: ${resume.command}`);
+    lines.push(`  ${resumeLine(resume)}`);
   }
   if (job.logFile && options.showLog) {
     lines.push(`  Log: ${job.logFile}`);
@@ -427,7 +445,7 @@ export function renderStatusReport(report) {
 
   if (report.needsReview) {
     lines.push("The stop-time review gate is enabled.");
-    lines.push("Ending the session will trigger a fresh Gemini adversarial review and block if it finds issues.");
+    lines.push("Each turn that ends will trigger a fresh Gemini adversarial review and block if it finds issues.");
   }
 
   return `${lines.join("\n").trimEnd()}\n`;
@@ -474,7 +492,7 @@ export function renderStoredJobResult(job, storedJob) {
     if (!resume) {
       return output;
     }
-    return `${output}\n${resume.idLabel}: ${threadId}\n${resume.resumeLabel}: ${resume.command}\n`;
+    return `${output}\n${resume.idLabel}: ${threadId}\n${resumeLine(resume)}\n`;
   }
 
   const rawOutput =
@@ -489,7 +507,7 @@ export function renderStoredJobResult(job, storedJob) {
     if (!resume) {
       return `${output}${failureOutput}`;
     }
-    return `${output}${failureOutput}\n${resume.idLabel}: ${threadId}\n${resume.resumeLabel}: ${resume.command}\n`;
+    return `${output}${failureOutput}\n${resume.idLabel}: ${threadId}\n${resumeLine(resume)}\n`;
   }
 
   if (storedJob?.rendered) {
@@ -497,7 +515,7 @@ export function renderStoredJobResult(job, storedJob) {
     if (!resume) {
       return output;
     }
-    return `${output}\n${resume.idLabel}: ${threadId}\n${resume.resumeLabel}: ${resume.command}\n`;
+    return `${output}\n${resume.idLabel}: ${threadId}\n${resumeLine(resume)}\n`;
   }
 
   const lines = [
@@ -509,7 +527,7 @@ export function renderStoredJobResult(job, storedJob) {
 
   if (resume) {
     lines.push(`${resume.idLabel}: ${threadId}`);
-    lines.push(`${resume.resumeLabel}: ${resume.command}`);
+    lines.push(resumeLine(resume));
   }
 
   if (job.summary) {

--- a/plugins/gemini/scripts/lib/state.mjs
+++ b/plugins/gemini/scripts/lib/state.mjs
@@ -189,13 +189,19 @@ export function generateJobId(prefix = "job") {
 // Merge a patch into the job's own file. Nothing else is touched, so two
 // workers patching two different jobs cannot interfere at all, and a worker
 // patching its own job is the only writer of that file.
-export function upsertJob(cwd, jobPatch) {
+// `touch: false` records a patch WITHOUT moving `updatedAt`. listJobs sorts by
+// `updatedAt` descending and pruneJobStore evicts everything past MAX_JOBS, so a
+// bookkeeping write on an old job would promote it to the head of the list and
+// evict a NEWER finished result in its place. Only for patches that record
+// something about a job rather than something the job did — the stop gate's
+// review mark is the case this exists for.
+export function upsertJob(cwd, jobPatch, { touch = true } = {}) {
   ensureStateDir(cwd);
   const jobFile = resolveJobFile(cwd, jobPatch.id);
   const existing = fs.existsSync(jobFile) ? readJobFile(jobFile) : null;
   const timestamp = nowIso();
   const next = existing
-    ? { ...existing, ...jobPatch, updatedAt: timestamp }
+    ? { ...existing, ...jobPatch, updatedAt: touch ? timestamp : (existing.updatedAt ?? timestamp) }
     : { createdAt: timestamp, ...jobPatch, updatedAt: timestamp };
   atomicWriteJson(jobFile, next);
   return next;

--- a/plugins/gemini/scripts/stop-review-gate-hook.mjs
+++ b/plugins/gemini/scripts/stop-review-gate-hook.mjs
@@ -6,7 +6,7 @@ import process from "node:process";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { getConfig, listJobs } from "./lib/state.mjs";
+import { getConfig, listJobs, upsertJob } from "./lib/state.mjs";
 import { resolveWorkspaceRoot } from "./lib/workspace.mjs";
 
 const SELF_PATH = fileURLToPath(import.meta.url);
@@ -29,13 +29,54 @@ function emitDecision(payload) {
   process.stdout.write(`${JSON.stringify(payload)}\n`);
 }
 
-// Exported for test: this predicate decides whether a session that edited the
+// Exported for test: this predicate decides whether a turn that edited the
 // repository is reviewed before it ends, so which statuses count is a claim that
 // has to be pinned rather than read off the line.
-export function hasCompletedWriteTask(jobs) {
-  return jobs.some(
-    (job) => job.write === true && (job.status === "completed" || job.status === "partial") && job.jobClass === "task"
+//
+// The store it reads is the whole WORKSPACE, deliberately: a write task queued
+// through the MCP tools carries no session id, so a session-scoped predicate
+// would leave exactly those edits ungated. The cost of that scope is that the
+// trigger has to be CONSUMED, or one write task arms the gate on every turn
+// forever (SessionEnd never evicts an untagged job). `gateReviewedAt` is that
+// consumption mark.
+//
+// It is compared against `completedAt`, NOT `updatedAt`. `upsertJob` stamps
+// `updatedAt` with its own `nowIso()` on every write, so the very call that
+// records the mark moves `updatedAt` past it — a mark compared against
+// `updatedAt` is stale the instant it is written, and the gate re-arms every
+// turn exactly as before. `completedAt` is written once when the job reaches a
+// terminal state and is not touched by a later patch, so it is the timestamp
+// that identifies WHICH finished result was reviewed. A job that finishes again
+// (a resumed or re-run id) gets a newer `completedAt` and re-arms correctly.
+export function pendingGateWriteTasks(jobs) {
+  return jobs.filter(
+    (job) =>
+      job.write === true &&
+      (job.status === "completed" || job.status === "partial") &&
+      job.jobClass === "task" &&
+      !(job.gateReviewedAt && job.completedAt && job.gateReviewedAt >= job.completedAt)
   );
+}
+
+export function hasCompletedWriteTask(jobs) {
+  return pendingGateWriteTasks(jobs).length > 0;
+}
+
+// Marked only AFTER the review actually produced a verdict. A failed review
+// fails open (below) without marking, so the edits it could not check still arm
+// the gate on the next turn rather than being silently forgiven.
+function markGateReviewed(workspaceRoot, jobs) {
+  const stamp = new Date().toISOString();
+  for (const job of jobs) {
+    try {
+      // touch:false — this records that the gate reviewed the job, not that the
+      // job did anything, and bumping updatedAt would reorder the LRU and evict
+      // a newer result in this one's place.
+      upsertJob(workspaceRoot, { id: job.id, gateReviewedAt: stamp }, { touch: false });
+    } catch {
+      // A job whose file vanished mid-turn needs no mark.
+    }
+  }
 }
 
 function runAdversarialReview(cwd) {
@@ -103,7 +144,8 @@ async function main() {
   }
 
   const jobs = listJobs(workspaceRoot);
-  if (!hasCompletedWriteTask(jobs)) {
+  const pending = pendingGateWriteTasks(jobs);
+  if (pending.length === 0) {
     emitDecision({});
     return;
   }
@@ -120,6 +162,12 @@ async function main() {
     emitDecision({ systemMessage: warning });
     return;
   }
+
+  // The review ran and returned a verdict, so these edits have now been checked.
+  // Mark before acting on the verdict: a `needs-attention` block that did not
+  // mark would re-review the same edits on every subsequent turn, which is the
+  // loop this consumption mark exists to end.
+  markGateReviewed(workspaceRoot, pending);
 
   const verdict = payload?.result?.verdict;
   if (verdict === "needs-attention") {

--- a/tests/job-control.test.mjs
+++ b/tests/job-control.test.mjs
@@ -234,3 +234,47 @@ test("a groupId whose members have all finished says so instead of \"no job foun
     "the group exists; saying it was not found sends the user after an id they gave correctly"
   );
 });
+
+// ---------------------------------------------------------------------------
+// A running job is not a missing job. resolveResultJob probes twice — finished
+// first, then active — so that it can say "still running" instead of "not
+// found". The finished probe used to THROW on no-match, which meant the active
+// probe was unreachable and gemini_job_result reported "No job found" for a job
+// whose file was on disk and which /gemini:status was listing at that moment.
+// ---------------------------------------------------------------------------
+
+test("resolveResultJob says a running job is still running, not missing", () => {
+  const cwd = makeTempDir();
+  upsertJob(cwd, {
+    id: "task-running-1",
+    title: "Gemini Task",
+    workspaceRoot: cwd,
+    jobClass: "task",
+    status: "running",
+    phase: "reviewing"
+  });
+
+  assert.throws(
+    () => resolveResultJob(cwd, "task-running-1", { all: true }),
+    /task-running-1 is still running/
+  );
+});
+
+test("resolveResultJob still reports a genuinely absent id as not found", () => {
+  const cwd = makeTempDir();
+  assert.throws(() => resolveResultJob(cwd, "task-nope", { all: true }), /No finished job found for "task-nope"/);
+});
+
+test("cancelling a finished job says it is finished, not that it is missing", async () => {
+  const cwd = makeTempDir();
+  await runTrackedJob(
+    { id: "task-done-cancel", title: "Gemini Task", workspaceRoot: cwd, jobClass: "task" },
+    () => ({ exitStatus: 0, payload: { rawOutput: "done" }, rendered: "done", summary: "s" })
+  );
+
+  const { resolveCancelableJob } = await import("../plugins/gemini/scripts/lib/job-control.mjs");
+  assert.throws(
+    () => resolveCancelableJob(cwd, "task-done-cancel", { all: true }),
+    /already completed and cannot be cancelled/
+  );
+});

--- a/tests/parse-robustness.test.mjs
+++ b/tests/parse-robustness.test.mjs
@@ -87,3 +87,33 @@ test("isTransientReviewFailure: a real prose review mentioning HTTP codes is NOT
   const prose = "The handler returns a 500 and ignores the rate limit; it is unavailable under load.";
   assert.equal(isTransientReviewFailure({ reviewJson: null, reviewText: prose, stderr: "" }), false);
 });
+
+// ---------------------------------------------------------------------------
+// Quota is not a flake. `429` and `resource_exhausted` are in the transport
+// heuristic because a passing rate limit says them — but so does a project over
+// its spend cap, and retrying that spends wall-clock to reach the same refusal
+// three times. classifyCliFailure is the tiebreak: it ranks `quota`
+// (retryable:false) ahead of `rate-limit` (retryable:true), and these pin that
+// the retry wrapper actually consults it.
+// ---------------------------------------------------------------------------
+
+test("isTransientReviewFailure: an exhausted spend cap is NOT transient", () => {
+  const stderr =
+    '{"type":"Error","message":"Your project has exceeded its monthly spending cap. Please go to AI Studio to manage your project spend cap.","code":429}';
+  assert.equal(isTransientReviewFailure({ reviewJson: null, reviewText: "", stderr }), false);
+});
+
+test("isTransientReviewFailure: RESOURCE_EXHAUSTED is NOT transient", () => {
+  assert.equal(
+    isTransientReviewFailure({ reviewJson: null, reviewText: "", stderr: "RESOURCE_EXHAUSTED: quota exceeded" }),
+    false
+  );
+});
+
+test("isTransientReviewFailure: a plain rate limit with no quota wording stays transient", () => {
+  // The guard must not swallow the case the retry was built for.
+  assert.equal(
+    isTransientReviewFailure({ reviewJson: null, reviewText: "", stderr: "429 Too Many Requests" }),
+    true
+  );
+});

--- a/tests/render.test.mjs
+++ b/tests/render.test.mjs
@@ -196,7 +196,10 @@ test("renderStoredJobResult falls back to result.gemini.stdout and appends the r
   );
   assert.match(out, /RAW OUTPUT/);
   assert.match(out, /Gemini session ID: sess-1/);
-  assert.match(out, /Resume in Gemini: gemini --resume sess-1/);
+  // Not a runnable command: gemini's `--resume` takes only "latest" or an
+  // index, so a session id can never be handed to it. The id is still shown.
+  assert.match(out, /Resume in Gemini: gemini --resume takes only "latest" or an index, not this id/);
+  assert.doesNotMatch(out, /Resume in Gemini: gemini --resume sess-1/);
 });
 
 test("renderStoredJobResult uses the AGY conversation resume hint for agy jobs", () => {
@@ -215,7 +218,8 @@ test("renderStoredJobResult defaults to the gemini resume hint when no engine is
     { id: "task-4", status: "completed", title: "Task" },
     { threadId: "sess-2", result: { rawOutput: "OUT" } }
   );
-  assert.match(out, /Resume in Gemini: gemini --resume sess-2/);
+  assert.match(out, /Resume in Gemini: gemini --resume takes only "latest" or an index, not this id/);
+  assert.doesNotMatch(out, /gemini --resume sess-2/);
 });
 
 test("renderStoredJobResult reads engine from the index job when the stored file lacks it", () => {

--- a/tests/review-gate.test.mjs
+++ b/tests/review-gate.test.mjs
@@ -65,7 +65,7 @@ test("an untruncated review reports the summary and the count", () => {
 // did not exist before it.
 // ---------------------------------------------------------------------------
 
-import { hasCompletedWriteTask } from "../plugins/gemini/scripts/stop-review-gate-hook.mjs";
+import { hasCompletedWriteTask, pendingGateWriteTasks } from "../plugins/gemini/scripts/stop-review-gate-hook.mjs";
 
 const writeTask = (status) => ({ write: true, status, jobClass: "task" });
 
@@ -85,4 +85,124 @@ test("a running or failed write task does not arm the gate", () => {
 test("a partial job that is not a write task leaves the gate alone", () => {
   assert.equal(hasCompletedWriteTask([{ write: false, status: "partial", jobClass: "task" }]), false);
   assert.equal(hasCompletedWriteTask([{ write: true, status: "partial", jobClass: "review" }]), false);
+});
+
+// ---------------------------------------------------------------------------
+// Consuming the trigger. The gate reads the whole workspace job store on
+// purpose (an MCP-queued write task carries no session id, so a session-scoped
+// predicate would leave those edits ungated) — but without a consumption mark
+// that same job re-arms the gate on EVERY turn forever, because SessionEnd only
+// evicts jobs that carry a session id. These pin the mark, not the scope.
+// ---------------------------------------------------------------------------
+
+const stamped = (status, { completedAt, gateReviewedAt }) => ({
+  id: "task-1",
+  write: true,
+  status,
+  jobClass: "task",
+  completedAt,
+  gateReviewedAt
+});
+
+test("a write task already reviewed by the gate does not arm it again", () => {
+  const job = stamped("completed", {
+    completedAt: "2026-09-02T00:00:00.000Z",
+    gateReviewedAt: "2026-09-02T00:00:05.000Z"
+  });
+  assert.equal(hasCompletedWriteTask([job]), false);
+  assert.deepEqual(pendingGateWriteTasks([job]), []);
+});
+
+test("a write task that finished again after its review re-arms the gate", () => {
+  const job = stamped("completed", {
+    completedAt: "2026-09-02T00:10:00.000Z",
+    gateReviewedAt: "2026-09-02T00:00:05.000Z"
+  });
+  assert.equal(hasCompletedWriteTask([job]), true);
+});
+
+test("an unreviewed write task still arms the gate", () => {
+  const job = stamped("completed", { completedAt: "2026-09-02T00:00:00.000Z", gateReviewedAt: undefined });
+  assert.equal(hasCompletedWriteTask([job]), true);
+  assert.equal(pendingGateWriteTasks([job]).length, 1);
+});
+
+test("pendingGateWriteTasks returns only the jobs that still need reviewing", () => {
+  const reviewed = { ...stamped("completed", { completedAt: "2026-09-02T00:00:00.000Z", gateReviewedAt: "2026-09-02T00:00:01.000Z" }), id: "task-reviewed" };
+  const fresh = { ...stamped("partial", { completedAt: "2026-09-02T00:05:00.000Z", gateReviewedAt: undefined }), id: "task-fresh" };
+  assert.deepEqual(pendingGateWriteTasks([reviewed, fresh]).map((j) => j.id), ["task-fresh"]);
+});
+
+// ---------------------------------------------------------------------------
+// Through the REAL write path. The literal-object tests above pin the intended
+// semantics; this one pins what actually happens on disk, and it is the test
+// that catches the version of this fix that compared the mark against
+// `updatedAt`: upsertJob stamps `updatedAt` with its own nowIso() on every
+// write, so the call that records the mark moves the field it was compared
+// against, and the gate re-armed on every turn exactly as before the fix.
+// ---------------------------------------------------------------------------
+
+import { makeTempDir } from "./helpers.mjs";
+import { listJobs, upsertJob } from "../plugins/gemini/scripts/lib/state.mjs";
+
+test("the mark survives its own write: a marked job stays consumed on re-read", () => {
+  const cwd = makeTempDir();
+  upsertJob(cwd, {
+    id: "task-write-1",
+    write: true,
+    jobClass: "task",
+    status: "completed",
+    completedAt: "2026-09-02T00:00:00.000Z"
+  });
+
+  assert.equal(hasCompletedWriteTask(listJobs(cwd)), true, "arms the gate before it is reviewed");
+
+  // Exactly what markGateReviewed does: stamp taken before the write, so the
+  // write's own updatedAt lands after it.
+  upsertJob(cwd, { id: "task-write-1", gateReviewedAt: new Date().toISOString() });
+
+  assert.equal(
+    hasCompletedWriteTask(listJobs(cwd)),
+    false,
+    "a job the gate has already reviewed must not arm it again on the next turn"
+  );
+});
+
+test("a marked job that finishes again re-arms the gate through the real store", () => {
+  const cwd = makeTempDir();
+  upsertJob(cwd, {
+    id: "task-write-2",
+    write: true,
+    jobClass: "task",
+    status: "completed",
+    completedAt: "2026-09-02T00:00:00.000Z"
+  });
+  upsertJob(cwd, { id: "task-write-2", gateReviewedAt: "2026-09-02T00:00:01.000Z" });
+  assert.equal(hasCompletedWriteTask(listJobs(cwd)), false);
+
+  upsertJob(cwd, { id: "task-write-2", completedAt: "2026-09-02T01:00:00.000Z" });
+  assert.equal(hasCompletedWriteTask(listJobs(cwd)), true, "new edits, new review");
+});
+
+test("the review mark does not reorder the job store's eviction queue", () => {
+  const cwd = makeTempDir();
+  // An OLD write task, and a NEWER unrelated job. listJobs sorts by updatedAt
+  // descending and pruneJobStore evicts from the tail, so if marking the old job
+  // moves it to the head, the newer job is the one that gets evicted.
+  upsertJob(cwd, {
+    id: "task-old",
+    write: true,
+    jobClass: "task",
+    status: "completed",
+    completedAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z"
+  });
+  upsertJob(cwd, { id: "task-new", jobClass: "task", status: "completed", updatedAt: "2026-09-01T00:00:00.000Z" });
+
+  const before = listJobs(cwd).map((j) => j.id);
+  upsertJob(cwd, { id: "task-old", gateReviewedAt: new Date().toISOString() }, { touch: false });
+  const after = listJobs(cwd).map((j) => j.id);
+
+  assert.deepEqual(after, before, "marking a job as reviewed must not change its eviction position");
+  assert.equal(after[0], "task-new", "the newest job stays at the head");
 });

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -1537,7 +1537,8 @@ test("result returns the stored output and resume hint for the latest finished j
   assert.equal(result.status, 0, result.stderr);
   assert.match(result.stdout, /Handled the requested task\./);
   assert.match(result.stdout, /Gemini session ID: thr_finished/);
-  assert.match(result.stdout, /Resume in Gemini: gemini --resume thr_finished/);
+  assert.match(result.stdout, /Resume in Gemini: gemini --resume takes only "latest" or an index, not this id/);
+  assert.doesNotMatch(result.stdout, /gemini --resume thr_finished/);
 });
 
 test("status and result aggregate adversarial-review jobs by groupId", () => {
@@ -1907,7 +1908,10 @@ test("result is scoped to the current session and needs --all to read another se
 
   const blocked = run("node", [SCRIPT, "result", "task-other"], { cwd: workspace, env });
   assert.notEqual(blocked.status, 0);
-  assert.match(blocked.stderr, /No job found/i);
+  // "No finished job found", not "No job found": the finished probe now returns
+  // null so the active probe can answer, and the wording it falls through to says
+  // which question was asked. Still hidden without --all, which is the point here.
+  assert.match(blocked.stderr, /No finished job found for "task-other"/);
 
   const crossed = run("node", [SCRIPT, "result", "task-other", "--all"], { cwd: workspace, env });
   assert.equal(crossed.status, 0, crossed.stderr);
@@ -1934,7 +1938,11 @@ test("cancel is scoped to the current session and will not target another sessio
   // By id: the job belongs to another session, so it is not a candidate.
   const byId = run("node", [SCRIPT, "cancel", "task-other"], { cwd: workspace, env });
   assert.notEqual(byId.status, 0);
-  assert.match(byId.stderr, /No job found/i);
+  // "No active job found": the finished-job branch added for a cancellable id
+  // searches the SAME session-scoped list, so another session's job is still
+  // invisible here — the message must not name it or reveal its status.
+  assert.match(byId.stderr, /No active job found for "task-other"/);
+  assert.doesNotMatch(byId.stderr, /running|Other session task/);
 
   // No id: the only active job belongs to another session, so there is nothing
   // in scope to cancel (it must NOT silently grab the other session's job).


### PR DESCRIPTION
Ships as **0.24.2**. Six runtime defects plus the documentation that described the same areas wrongly, found by a read-only audit of code-versus-docs and then a verification pass over the fixes themselves.

## Runtime

| Fix | Why it mattered |
|---|---|
| The stop-review gate consumes its trigger (`gateReviewedAt`) | One MCP-queued `--write` task armed an adversarial review at the end of **every agent turn, indefinitely**. The gate reads the whole workspace store deliberately — an MCP job carries no session id, so a session-scoped predicate would leave exactly those edits ungated — but nothing marked the trigger spent, and `SessionEnd` never evicts an untagged job. |
| The mark compares against `completedAt`, not `updatedAt` | `upsertJob` stamps `updatedAt` on every write, so the call recording the mark moves the field it was compared against. A mark compared against `updatedAt` is stale as written and the gate re-arms exactly as before — the first version of this fix had that bug, and the literal-object unit tests did not catch it. There is now a test that goes through the real `upsertJob` path. |
| `upsertJob` takes `{ touch: false }` | `listJobs` sorts by `updatedAt` and `pruneJobStore` evicts past the 50-job cap, so a bookkeeping write promoted an old reviewed job to the head and evicted a **newer** finished result in its place. |
| An exhausted spend cap is no longer retried | Google returns `Your project has exceeded its monthly spending cap` with code 429, matching none of `quota`/`billing`/`RESOURCE_EXHAUSTED`, so it classified as `rate-limit` and the review re-ran **three times over 10m46s** to reach the same refusal. `isTransientReviewFailure` now consults `classifyCliFailure` before its own heuristic; a plain `429 Too Many Requests` still retries. |
| `/gemini:result` reports a running job as running | Its finished-job probe threw on no-match, so the active probe that says "still running" was unreachable. A job whose file was on disk and which `/gemini:status` was listing came back as `No job found`. |
| Cancelling a finished job names it | `resolveCancelableJob`'s own `No active job found` branch was dead code for the same reason. |
| The gemini resume line drops the unrunnable command | It printed `gemini --resume <uuid>`; that flag accepts only `latest` or an index, as the runtime's own `--resume-last --write` refusal already explains. |

## Docs

The `Stop` hook runs at the end of **every agent turn**, not once at session end. The gate's enable/disable setting is stored **per workspace on disk**, so it persists across sessions and must be enabled again in each repository. The `--write` task arming it is any one in the workspace. `SessionEnd` removes a session's **finished** job records too, so a background result must be collected before the session ends.

Also corrected: `--resume-last` is refused with `--write` on gemini; `--engines gemini,agy` was missing from the flag table; `--effort` was missing from both review argument hints; `status --wait` gives up after 4 minutes; `transfer --effort xhigh` produces a command AGY rejects; the `task` CLI help under-reported its effort levels; and the rescue subagent mapped `flash`/`pro` to `--model` on AGY, where those aliases are refused before spawn. English and Traditional Chinese kept in sync.

## Verification

- **703 tests, 695 pass, 0 fail, 8 skipped**; `check-version` and `verify-contracts` pass at 0.24.2.
- Every new predicate was **mutation-tested**: reverting it turns the guarding test red. That is how the `updatedAt` defect above was caught.
- **Five existing tests asserted the defects** (`gemini --resume <uuid>`, `No job found`) and were updated to assert the fixed behaviour, with reverse assertions so the old strings cannot come back. The cross-session isolation test keeps a check that the new message does not leak another session's job or its status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WPRqf4z7QMD9cHQb1Y9kYy
