### PR TITLE
fix(retry): a 503 naming the model is a flake, not a dead model

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,13 +7,13 @@
   },
   "metadata": {
     "description": "agy-plugin-cc is a Claude Code companion for running Gemini CLI or Antigravity CLI (agy) as a cross-model task delegate and code reviewer, with pragmatic and adversarial review, MCP tools, and background jobs.",
-    "version": "0.24.2"
+    "version": "0.24.3"
   },
   "plugins": [
     {
       "name": "gemini",
       "description": "agy-plugin-cc is a Claude Code companion for running Gemini CLI or Antigravity CLI (agy) as a cross-model task delegate and code reviewer, with pragmatic and adversarial review, MCP tools, and background jobs.",
-      "version": "0.24.2",
+      "version": "0.24.3",
       "author": {
         "name": "arcobaleno64",
         "email": "arcobaleno830623@gmail.com"

--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -21,7 +21,7 @@ belong to.
 | [sakibsadmanshajib/gemini-plugin-cc](https://github.com/sakibsadmanshajib/gemini-plugin-cc) | 24 | 2026-05-22 | v1.0.1, archived | Gemini CLI | ACP |
 | [sakibsadmanshajib/antigravity-plugin](https://github.com/sakibsadmanshajib/antigravity-plugin) | 19 | 2026-05-22 | none | AGY only | `agy --print` |
 | [m-ghalib/gemini-plugin-cc](https://github.com/m-ghalib/gemini-plugin-cc) | 18 | 2026-04-24 | v0.1.0 | Gemini CLI, setup installs 0.38.2 | ACP |
-| **this project** | 10 | 2026-09-02 | v0.24.2 | Gemini CLI **and** AGY | direct spawn, structured JSON |
+| **this project** | 10 | 2026-09-02 | v0.24.3 | Gemini CLI **and** AGY | direct spawn, structured JSON |
 
 | Surface | Slash commands | MCP tools | Skills | Test files (`*.test.*`) |
 |---|---|---|---|---|

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@arcobaleno64/agy-plugin-cc",
-  "version": "0.24.2",
+  "version": "0.24.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@arcobaleno64/agy-plugin-cc",
-      "version": "0.24.2",
+      "version": "0.24.3",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arcobaleno64/agy-plugin-cc",
-  "version": "0.24.2",
+  "version": "0.24.3",
   "private": true,
   "type": "module",
   "description": "agy-plugin-cc is a Claude Code companion for running Gemini CLI or Antigravity CLI (agy) as a cross-model task delegate and code reviewer, with pragmatic and adversarial review, MCP tools, and background jobs.",

--- a/plugins/gemini/.claude-plugin/plugin.json
+++ b/plugins/gemini/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gemini",
-  "version": "0.24.2",
+  "version": "0.24.3",
   "description": "agy-plugin-cc is a Claude Code companion for running Gemini CLI or Antigravity CLI (agy) as a cross-model task delegate and code reviewer, with pragmatic and adversarial review, MCP tools, and background jobs.",
   "author": {
     "name": "arcobaleno64",

--- a/plugins/gemini/CHANGELOG.md
+++ b/plugins/gemini/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 0.24.3 - 2026-09-02 - A 503 is a flake again
+
+- **A transport 503 that names the model is retried again.** 0.24.2 stopped a
+  spend cap from burning three review attempts by asking `classifyCliFailure`
+  first and refusing to retry anything it called non-retryable. That test was
+  too wide: `model-unavailable` is non-retryable and matches on the bare word
+  `unavailable`, which is exactly what a 503 says. Measured — stderr
+  `503: model gemini-3-pro is temporarily unavailable, try again later` was
+  classified `model-unavailable` and returned on the first attempt, losing the
+  flake absorption `runGeminiReviewResilient` exists for. The guard now names
+  the categories it is about (`quota`, `auth`, `binary-missing`,
+  `prompt-too-long`); every other category stays subject to the transport and
+  envelope heuristics. Both directions are pinned by tests: reverting to the
+  wide test turns the 503 case red, deleting the guard turns the spend-cap
+  cases red. (#132)
+
 ## 0.24.2 - 2026-09-02 - The stop gate stops re-arming, and a spend cap stops being retried
 
 - **A write task now arms the stop-review gate once, not on every turn forever.**

--- a/plugins/gemini/scripts/lib/gemini.mjs
+++ b/plugins/gemini/scripts/lib/gemini.mjs
@@ -928,6 +928,11 @@ export async function runGeminiReview(cwd, options = {}, { runCommandFn = runCom
 const ENVELOPE_REVIEW_RE = /invalid stream|malformed tool call|empty response|no response/i;
 const TRANSPORT_REVIEW_RE = /resource[_ ]?exhausted|unavailable|deadline|temporarily|try again|rate.?limit|\b(429|500|502|503|504)\b|econnreset|socket hang|stream closed/i;
 
+// Refusals that come from the account or the input rather than the wire: no
+// number of re-runs changes the answer, so a review must not spend attempts on
+// them. Deliberately excludes `model-unavailable` -- see the note below.
+const ACCOUNT_STATE_FAILURES = new Set(["quota", "auth", "binary-missing", "prompt-too-long"]);
+
 export function isTransientReviewFailure({ reviewJson, reviewText, stderr } = {}) {
   if (reviewJson != null) return false;                       // got structured findings — success
   const out = (reviewText ?? "").trim();
@@ -940,7 +945,14 @@ export function isTransientReviewFailure({ reviewJson, reviewText, stderr } = {}
   // tested ahead of `rate-limit`), so defer to it rather than keeping a second
   // opinion here. Measured: a project over its monthly spend cap burned three full
   // review attempts over 10m46s before reporting a non-retryable failure.
-  if (err && classifyCliFailure({ stderr: err }).retryable === false) return false;
+  //
+  // Named categories, NOT `retryable === false`: the broad test also caught
+  // `model-unavailable`, which matches on `unavailable` / `404` -- the same words
+  // `503: model X is temporarily unavailable, try again later` carries, and that
+  // IS the transport flake this wrapper exists to absorb (issue #132). Only the
+  // account-state and input-shape refusals belong here; every category outside
+  // this set stays subject to the heuristics below.
+  if (err && ACCOUNT_STATE_FAILURES.has(classifyCliFailure({ stderr: err }).category)) return false;
   if (!out && !err) return true;                              // empty stdout+stderr — nothing usable
   if (ENVELOPE_REVIEW_RE.test(`${out}\n${err}`)) return true; // envelope — trusted on either channel
   if (TRANSPORT_REVIEW_RE.test(err)) return true;             // transport flake — trusted on stderr only

--- a/plugins/gemini/scripts/lib/gemini.mjs
+++ b/plugins/gemini/scripts/lib/gemini.mjs
@@ -952,6 +952,13 @@ export function isTransientReviewFailure({ reviewJson, reviewText, stderr } = {}
   // IS the transport flake this wrapper exists to absorb (issue #132). Only the
   // account-state and input-shape refusals belong here; every category outside
   // this set stays subject to the heuristics below.
+  //
+  // `tool-permission-denied` and brain-root `transcript-missing` are also outside
+  // the set, and that is safe only because both are AGY-only and
+  // runGeminiReviewResilient returns on `engine === "agy"` before this function is
+  // ever reached. Neither refusal is fixed by a retry, so if AGY retry is ever
+  // enabled they must be added here -- the heuristics below name nothing that
+  // would catch them.
   if (err && ACCOUNT_STATE_FAILURES.has(classifyCliFailure({ stderr: err }).category)) return false;
   if (!out && !err) return true;                              // empty stdout+stderr — nothing usable
   if (ENVELOPE_REVIEW_RE.test(`${out}\n${err}`)) return true; // envelope — trusted on either channel

--- a/tests/parse-robustness.test.mjs
+++ b/tests/parse-robustness.test.mjs
@@ -117,3 +117,20 @@ test("isTransientReviewFailure: a plain rate limit with no quota wording stays t
     true
   );
 });
+
+// Regression, issue #132: the guard above was first written as
+// `classifyCliFailure(...).retryable === false`, which also caught
+// `model-unavailable` -- and that category matches on the bare word
+// `unavailable`, which is exactly what a 503 says. Measured on the broad guard:
+// this stderr returned false (no retry) on the first attempt, losing the flake
+// absorption the resilient wrapper exists for.
+test("isTransientReviewFailure: a 503 naming the model is still a transport flake", () => {
+  assert.equal(
+    isTransientReviewFailure({
+      reviewJson: null,
+      reviewText: "",
+      stderr: "503: model gemini-3-pro is temporarily unavailable, try again later"
+    }),
+    true
+  );
+});


### PR DESCRIPTION
Closes #132. Fixes a regression introduced by #131.

## What was wrong

0.24.2 added this ahead of the transient heuristics, to stop a spend cap burning three review attempts over 10m46s:

```js
if (err && classifyCliFailure({ stderr: err }).retryable === false) return false;
```

`retryable === false` is wider than the problem. `model-unavailable` is non-retryable and matches on the bare word `unavailable` / `404` — which is what a 503 says.

Measured:

| stderr | category | 0.24.2 | now |
|---|---|---|---|
| `503: model gemini-3-pro is temporarily unavailable, try again later` | `model-unavailable` | **not retried** | retried |
| `...exceeded its monthly spending cap...` (429) | `quota` | not retried | not retried |
| `RESOURCE_EXHAUSTED: quota exceeded` | `quota` | not retried | not retried |
| `429 Too Many Requests` | `rate-limit` | retried | retried |

## The fix

The guard now names the categories it is about — `quota`, `auth`, `binary-missing`, `prompt-too-long` — so every other category stays subject to `TRANSPORT_REVIEW_RE` and `ENVELOPE_REVIEW_RE`.

## Verification

Gates, all green:

```
ℹ tests 704   ℹ pass 696   ℹ fail 0   ℹ skipped 8
All version metadata matches 0.24.3, and the changelog has an entry for it.
Contract verification passed for gemini@agy-plugin-cc v0.24.3.
```

Mutation-checked in both directions, so the new test is not decorative:

- Revert the guard to `retryable === false` → `a 503 naming the model is still a transport flake` fails.
- Delete the guard entirely → `an exhausted spend cap is NOT transient` and `RESOURCE_EXHAUSTED is NOT transient` fail.

A third candidate test (an auth refusal is not transient) was written and then **deleted**: neither mutation turned it red, because the existing heuristics already return false for that string. It asserted nothing the rest of the file did not.

Version 0.24.2 → 0.24.3, changelog entry written, `docs/COMPARISON.md` row updated (a test pins it).