### PR TITLE
chore(ship): script the mechanical half of the ship sequence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,9 @@ Thumbs.db
 # Editor
 .vscode/
 *.swp
+
+# Ship inputs (changelog / commit / PR prose handed to scripts/ship.mjs)
+.ship/
+
+# Scratch working notes
+scratch/

--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -25,7 +25,7 @@ belong to.
 
 | Surface | Slash commands | MCP tools | Skills | Test files (`*.test.*`) |
 |---|---|---|---|---|
-| **this project** | 8 | **6** | 3 | 37 |
+| **this project** | 8 | **6** | 3 | 38 |
 | abiswas97 | 8 | 0 | 3 | 13 |
 | m-ghalib | 7 | 0 | 3 | 12 |
 | sakibsadmanshajib/antigravity-plugin | 6 | 0 | 0 | 12 |

--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -25,7 +25,7 @@ belong to.
 
 | Surface | Slash commands | MCP tools | Skills | Test files (`*.test.*`) |
 |---|---|---|---|---|
-| **this project** | 8 | **6** | 3 | 38 |
+| **this project** | 8 | **6** | 3 | 39 |
 | abiswas97 | 8 | 0 | 3 | 13 |
 | m-ghalib | 7 | 0 | 3 | 12 |
 | sakibsadmanshajib/antigravity-plugin | 6 | 0 | 0 | 12 |

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -61,6 +61,7 @@ function usage() {
     "",
     "Options:",
     "  --check       Verify manifest versions. Uses package.json when version is omitted.",
+    "  --list-targets Print every file this script can rewrite, one per line.",
     "  --root <dir>  Run against a different repository root.",
     "  --help        Print this help."
   ].join("\n");
@@ -73,6 +74,8 @@ function parseArgs(argv) {
     const arg = argv[i];
     if (arg === "--check") {
       options.check = true;
+    } else if (arg === "--list-targets") {
+      options.listTargets = true;
     } else if (arg === "--root") {
       const root = argv[i + 1];
       if (!root) {
@@ -196,6 +199,17 @@ function main() {
   const options = parseArgs(process.argv.slice(2));
   if (options.help) {
     console.log(usage());
+    return;
+  }
+
+  // Named so a caller can stage exactly what a bump rewrites without keeping a
+  // second copy of this list. A bump that changes nothing (a re-run at the same
+  // version) reports no files, and a caller relying on that report would then
+  // stage nothing at all.
+  if (options.listTargets) {
+    for (const target of TARGETS) {
+      console.log(target.file);
+    }
     return;
   }
 

--- a/scripts/ship.mjs
+++ b/scripts/ship.mjs
@@ -266,10 +266,18 @@ function applyChangelog(options) {
   step(`changelog entry for ${options.version}`);
   const fragment = readInput(options.root, options.changelogFile, "changelog");
   const target = path.resolve(options.root, CHANGELOG_FILE);
+  if (!fs.existsSync(target)) {
+    // Reachable through --root. Without this the run dies on a raw ENOENT with
+    // exit 1, outside the per-step set the header tells callers they can branch on.
+    throw new ShipError(EXIT.missingInput, `No changelog to insert into: ${CHANGELOG_FILE} does not exist under ${options.root}.`);
+  }
   const existing = fs.readFileSync(target, "utf8");
   if (hasChangelogHeading(existing, options.version)) {
+    // Still returned for staging. This is the retry case -- run 1 wrote the entry
+    // and then failed a gate -- and the edit is sitting unstaged in the tree. A
+    // release commit that omits it passes every gate, because they read the tree.
     console.log(`already has a \`## ${options.version}\` heading; leaving it alone`);
-    return [];
+    return [CHANGELOG_FILE];
   }
   const next = insertChangelogEntry(existing, fragment);
   if (options.dryRun) {
@@ -299,7 +307,15 @@ function bump(options) {
   const result = mustRun(EXIT.bumpFailed, `bump-version rejected ${options.version}.`,
     process.execPath, ["scripts/bump-version.mjs", options.version], options);
   console.log(result.stdout);
-  return bumpedFiles(result.stdout);
+  // Every manifest a bump can touch, not the ones this run happened to change.
+  // A retry after a failed gate finds the manifests already at the target version
+  // and reports "no files changed", so staging the report would produce a release
+  // commit with no version bump in it -- and check-version reads the working tree,
+  // so every gate would still pass. Same reason applyChangelog returns the
+  // changelog even when the entry is already there.
+  const targets = mustRun(EXIT.bumpFailed, "bump-version could not list its targets.",
+    process.execPath, ["scripts/bump-version.mjs", "--list-targets"], options);
+  return targets.stdout.split("\n").map((line) => line.trim()).filter(Boolean);
 }
 
 // bump-version names the manifests it rewrote. Parsing that beats keeping a
@@ -433,6 +449,11 @@ function main() {
   }
   if (!options.commitFile) {
     throw new ShipError(EXIT.usage, `Missing --commit.\n\n${usage()}`);
+  }
+  // Silently doing nothing with --pr reads as "no --pr was given" in the summary,
+  // and preflight has already spent a gh check on it.
+  if (options.noPush && options.prFile) {
+    throw new ShipError(EXIT.usage, "--pr needs the push: a PR cannot be opened or commented on a branch origin has not seen. Drop one of --no-push and --pr.");
   }
   if (options.version && !options.changelogFile) {
     throw new ShipError(EXIT.usage, "--version needs --changelog: a release with no entry tells the user nothing about what changed.");

--- a/scripts/ship.mjs
+++ b/scripts/ship.mjs
@@ -115,9 +115,26 @@ export function insertChangelogEntry(existing, fragment) {
     );
   }
   const eol = existing.includes("\r\n") ? "\r\n" : "\n";
-  const before = lines.slice(0, index).join("\n");
+  // Each preceding line keeps its own terminator. Joining them and relying on
+  // `entry` to supply the break swallows the blank line under the title, gluing
+  // the new heading to it -- and every later release inherits the damage.
+  const before = lines.slice(0, index).map((line) => `${line}\n`).join("");
   const after = lines.slice(index).join("\n");
   return `${before}${entry}\n${after}`.split(/\r?\n/).join(eol);
+}
+
+// Compared token by token rather than by a regex built from the version. Escaping
+// `.` and leaving `\` unescaped is a real hole (CodeQL js/incomplete-sanitization
+// and js/regex-injection, both high, on the first version of this), and the
+// answer here is not a better escape -- it is not building a pattern out of an
+// argument at all. Matches bump-version --check, which splits on whitespace and
+// compares the second token.
+export function hasChangelogHeading(text, version) {
+  return text.split(/\r?\n/).some((line) => {
+    if (!line.startsWith("## ")) return false;
+    const token = line.split(/\s+/)[1];
+    return token === version || token === `v${version}`;
+  });
 }
 
 export function summariseTests(output) {
@@ -196,6 +213,15 @@ function step(label) {
 function preflight(options) {
   step("preflight");
   const branch = mustRun(EXIT.usage, "Not a git repository.", "git", ["branch", "--show-current"], options).stdout;
+  // Detached HEAD prints an empty name and exits 0. Left unchecked the run
+  // reaches `git push -u origin ""` and fails there -- after a commit that is
+  // orphaned the moment the user checks out a branch.
+  if (!branch) {
+    throw new ShipError(
+      EXIT.onDefaultBranch,
+      "HEAD is detached, so there is no branch to push. Check out a branch first; a commit made here is orphaned as soon as you leave it."
+    );
+  }
   if (DEFAULT_BRANCHES.has(branch)) {
     throw new ShipError(
       EXIT.onDefaultBranch,
@@ -218,7 +244,20 @@ function preflight(options) {
   if (options.prFile && !run("gh", ["auth", "status"], options).ok) {
     throw new ShipError(EXIT.ghUnavailable, "gh is not authenticated, so the PR step would fail after the push. Run `gh auth login`.");
   }
+  // The gates run against the working tree; the commit is the index. An unstaged
+  // edit can hold the tests green for a commit that is red in CI, and this script
+  // will not stage it for you -- so say so rather than reporting a green run that
+  // tested something other than what was pushed.
+  const unstaged = run("git", ["diff", "--name-only"], options).stdout.split("\n").filter((line) => line.trim());
   console.log(`branch ${branch}, ${stagedFiles.length} staged file(s)`);
+  if (unstaged.length > 0) {
+    console.log(
+      `warning: ${unstaged.length} unstaged change(s) -- the gates below test the working tree, `
+      + `but the commit is the index, so a green run here does not prove the pushed commit is green:\n  `
+      + unstaged.slice(0, 10).join("\n  ")
+      + (unstaged.length > 10 ? `\n  ...and ${unstaged.length - 10} more` : "")
+    );
+  }
   return { branch };
 }
 
@@ -228,17 +267,22 @@ function applyChangelog(options) {
   const fragment = readInput(options.root, options.changelogFile, "changelog");
   const target = path.resolve(options.root, CHANGELOG_FILE);
   const existing = fs.readFileSync(target, "utf8");
-  if (new RegExp(`^## v?${options.version.replace(/\./g, "\\.")}\\b`, "m").test(existing)) {
+  if (hasChangelogHeading(existing, options.version)) {
     console.log(`already has a \`## ${options.version}\` heading; leaving it alone`);
     return [];
   }
   const next = insertChangelogEntry(existing, fragment);
   if (options.dryRun) {
     console.log(`would insert ${fragment.split("\n").length} line(s) into ${CHANGELOG_FILE}`);
-    return;
+    return [];
   }
   fs.writeFileSync(target, next, "utf8");
   console.log(`inserted into ${CHANGELOG_FILE}`);
+  // Returned so commit() stages it. bump-version rewrites only the four JSON
+  // manifests and never the changelog, so nothing else would, and check-version
+  // reads the working tree rather than the index -- a release commit could go out
+  // with the entry written on disk and absent from the diff.
+  return [CHANGELOG_FILE];
 }
 
 function bump(options) {
@@ -347,7 +391,17 @@ function pullRequest(options, branch, subject) {
   readInput(options.root, options.prFile, "PR body");
   const bodyFile = path.resolve(options.root, options.prFile);
   const existing = run("gh", ["pr", "list", "--head", branch, "--json", "number", "--jq", ".[].number"], options);
-  const number = existing.ok ? existing.stdout.split("\n")[0]?.trim() : "";
+  // A gh failure here is not "no PR exists". Treating it as one makes the script
+  // call `gh pr create` on a branch that already has an open PR, which fails --
+  // after the push has already landed.
+  if (!existing.ok) {
+    throw new ShipError(
+      EXIT.prFailed,
+      `Could not list PRs for ${branch}, so it is unknown whether one is already open. The push succeeded; open or comment on the PR by hand.`,
+      existing.stderr
+    );
+  }
+  const number = existing.stdout.split("\n")[0]?.trim();
   if (options.dryRun) {
     console.log(number ? `would comment on PR #${number}` : `would open a PR titled ${JSON.stringify(options.title ?? subject ?? "")}`);
     return null;

--- a/scripts/ship.mjs
+++ b/scripts/ship.mjs
@@ -1,0 +1,396 @@
+#!/usr/bin/env node
+// The mechanical half of the ship sequence: changelog insert, bump, gates,
+// commit, push, PR. It stops at the PR on purpose. Everything after that --
+// triaging review findings, reading CI failures, deciding to merge -- needs a
+// judgement this script cannot make, and pretending otherwise would turn a
+// blocking finding into an exit code nobody reads.
+//
+// The prose is the caller's job. This script takes it as files rather than
+// generating it, because a changelog entry summarising its own diff is the one
+// part of a release that has to actually be thought about.
+//
+//   node scripts/ship.mjs --commit .ship/commit.txt \
+//                         --changelog .ship/changelog.md --version 0.24.4 \
+//                         --pr .ship/pr.md --title "fix(x): ..."
+//
+// Exit codes are per-step so a caller can branch on the failure instead of
+// re-reading the log. See EXIT below.
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+export const EXIT = {
+  ok: 0,
+  usage: 2,
+  // Preflight -- nothing has been written yet.
+  onDefaultBranch: 10,
+  nothingToCommit: 11,
+  missingInput: 12,
+  ghUnavailable: 13,
+  // Release metadata.
+  changelogInsertFailed: 20,
+  bumpFailed: 21,
+  // Gates. Split apart because "tests are red" and "you forgot the changelog"
+  // are different problems with different next steps.
+  testsFailed: 30,
+  versionCheckFailed: 31,
+  contractsFailed: 32,
+  // Publishing.
+  commitFailed: 40,
+  pushFailed: 41,
+  prFailed: 42
+};
+
+const CHANGELOG_FILE = "plugins/gemini/CHANGELOG.md";
+const DEFAULT_BRANCHES = new Set(["main", "master"]);
+
+class ShipError extends Error {
+  constructor(code, message, detail) {
+    super(message);
+    this.code = code;
+    this.detail = detail;
+  }
+}
+
+export function usage() {
+  return [
+    "Usage: node scripts/ship.mjs --commit <file> [options]",
+    "",
+    "  --commit <file>     Commit message (required). Read as-is, never generated.",
+    "  --changelog <file>  Changelog entry to insert above the newest one.",
+    "                      Required with --version; ignored without it.",
+    "  --version <x.y.z>   Bump every manifest to this version. Omit for a",
+    "                      release-less ship (docs, tests, a follow-up fix).",
+    "  --pr <file>         PR body. New PR when the branch has none; posted as a",
+    "                      comment when it already has one.",
+    "  --title <text>      PR title. Defaults to the commit subject.",
+    "  --no-push           Stop after the commit.",
+    "  --dry-run           Report what each step would do and change nothing.",
+    "",
+    "Stops at the PR. Review triage and CI reading are deliberately left out."
+  ].join("\n");
+}
+
+export function parseArgs(argv) {
+  const options = { root: process.cwd() };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const take = () => {
+      const value = argv[i + 1];
+      if (value === undefined || value.startsWith("--")) {
+        throw new ShipError(EXIT.usage, `${arg} needs a value.`);
+      }
+      i += 1;
+      return value;
+    };
+    switch (arg) {
+      case "--help": case "-h": options.help = true; break;
+      case "--commit": options.commitFile = take(); break;
+      case "--changelog": options.changelogFile = take(); break;
+      case "--pr": options.prFile = take(); break;
+      case "--title": options.title = take(); break;
+      case "--version": options.version = take(); break;
+      case "--root": options.root = take(); break;
+      case "--dry-run": options.dryRun = true; break;
+      case "--no-push": options.noPush = true; break;
+      default: throw new ShipError(EXIT.usage, `Unknown argument: ${arg}\n\n${usage()}`);
+    }
+  }
+  return options;
+}
+
+// Insert above the first `## ` heading rather than appending: the changelog is
+// newest-first, so a fragment appended to the end is invisible to every reader
+// and to `bump-version --check`, which only scans headings.
+export function insertChangelogEntry(existing, fragment) {
+  const entry = `${fragment.trim()}\n`;
+  const lines = existing.split(/\r?\n/);
+  const index = lines.findIndex((line) => line.startsWith("## "));
+  if (index === -1) {
+    throw new ShipError(
+      EXIT.changelogInsertFailed,
+      `${CHANGELOG_FILE} has no \`## \` heading to insert above. Refusing to guess where the entry belongs.`
+    );
+  }
+  const eol = existing.includes("\r\n") ? "\r\n" : "\n";
+  const before = lines.slice(0, index).join("\n");
+  const after = lines.slice(index).join("\n");
+  return `${before}${entry}\n${after}`.split(/\r?\n/).join(eol);
+}
+
+export function summariseTests(output) {
+  const parts = ["tests", "pass", "fail", "skipped"].map((label) => {
+    const value = output.match(new RegExp(`^[^\\n]*\\b${label}\\s+(\\d+)\\s*$`, "m"))?.[1];
+    return value === undefined ? null : `${label} ${value}`;
+  }).filter(Boolean);
+  return parts.length ? parts.join(", ") : "tests passed";
+}
+
+export function tail(text, lines) {
+  return text.split(/\r?\n/).filter(Boolean).slice(-lines).join("\n");
+}
+
+function run(command, args, { root, shell = false } = {}) {
+  const result = spawnSync(command, args, { cwd: root, encoding: "utf8", stdio: "pipe", shell });
+  return {
+    ok: result.status === 0,
+    stdout: (result.stdout ?? "").trim(),
+    // A command that never started produces no stderr, and reporting a bare
+    // "failed" for it sends the reader looking at their own changes. Node
+    // refuses to spawn a .cmd without a shell on Windows (EINVAL), which is
+    // exactly how this surfaced.
+    stderr: (result.stderr ?? "").trim() || (result.error ? `${command}: ${result.error.message}` : "")
+  };
+}
+
+// npm is a .cmd on Windows, which node will not spawn without a shell. The
+// argument lists here are constants defined in this file -- nothing from the
+// caller reaches the shell.
+function runNpm(args, options) {
+  const npm = process.platform === "win32" ? "npm.cmd" : "npm";
+  return run(npm, args, { ...options, shell: process.platform === "win32" });
+}
+
+function mustRun(code, message, command, args, options) {
+  const result = run(command, args, options);
+  if (!result.ok) {
+    throw new ShipError(code, message, [result.stdout, result.stderr].filter(Boolean).join("\n"));
+  }
+  return result;
+}
+
+function readInput(root, file, label) {
+  const resolved = path.resolve(root, file);
+  if (!fs.existsSync(resolved)) {
+    throw new ShipError(EXIT.missingInput, `${label} file not found: ${file}`);
+  }
+  const text = fs.readFileSync(resolved, "utf8").trim();
+  if (!text) {
+    throw new ShipError(EXIT.missingInput, `${label} file is empty: ${file}. An empty ${label} is never what was meant.`);
+  }
+  return text;
+}
+
+function step(label) {
+  process.stdout.write(`\n== ${label}\n`);
+}
+
+function preflight(options) {
+  step("preflight");
+  const branch = mustRun(EXIT.usage, "Not a git repository.", "git", ["branch", "--show-current"], options).stdout;
+  if (DEFAULT_BRANCHES.has(branch)) {
+    throw new ShipError(
+      EXIT.onDefaultBranch,
+      `On ${branch}. Ship works through a branch and a PR; committing here bypasses both.`
+    );
+  }
+  // What goes into the commit is the caller's decision, not this script's. It
+  // stages nothing on their behalf -- an `add -u` would silently drop a new file
+  // (this script's first dry run dropped itself), and an `add -A` would sweep in
+  // whatever else happens to be sitting in the tree. Both are the kind of error a
+  // reviewer sees only after the push.
+  const staged = mustRun(EXIT.usage, "git diff failed.", "git", ["diff", "--cached", "--name-only"], options).stdout;
+  const stagedFiles = staged.split("\n").filter((line) => line.trim());
+  if (stagedFiles.length === 0 && !options.version) {
+    throw new ShipError(
+      EXIT.nothingToCommit,
+      "Nothing staged, and no --version to bump. Stage what belongs in this commit first (`git add <paths>`), then run ship."
+    );
+  }
+  if (options.prFile && !run("gh", ["auth", "status"], options).ok) {
+    throw new ShipError(EXIT.ghUnavailable, "gh is not authenticated, so the PR step would fail after the push. Run `gh auth login`.");
+  }
+  console.log(`branch ${branch}, ${stagedFiles.length} staged file(s)`);
+  return { branch };
+}
+
+function applyChangelog(options) {
+  if (!options.version) return [];
+  step(`changelog entry for ${options.version}`);
+  const fragment = readInput(options.root, options.changelogFile, "changelog");
+  const target = path.resolve(options.root, CHANGELOG_FILE);
+  const existing = fs.readFileSync(target, "utf8");
+  if (new RegExp(`^## v?${options.version.replace(/\./g, "\\.")}\\b`, "m").test(existing)) {
+    console.log(`already has a \`## ${options.version}\` heading; leaving it alone`);
+    return [];
+  }
+  const next = insertChangelogEntry(existing, fragment);
+  if (options.dryRun) {
+    console.log(`would insert ${fragment.split("\n").length} line(s) into ${CHANGELOG_FILE}`);
+    return;
+  }
+  fs.writeFileSync(target, next, "utf8");
+  console.log(`inserted into ${CHANGELOG_FILE}`);
+}
+
+function bump(options) {
+  if (!options.version) {
+    step("version");
+    console.log("no --version; shipping without a release");
+    return [];
+  }
+  step(`bump to ${options.version}`);
+  if (options.dryRun) {
+    console.log("would run bump-version");
+    return [];
+  }
+  const result = mustRun(EXIT.bumpFailed, `bump-version rejected ${options.version}.`,
+    process.execPath, ["scripts/bump-version.mjs", options.version], options);
+  console.log(result.stdout);
+  return bumpedFiles(result.stdout);
+}
+
+// bump-version names the manifests it rewrote. Parsing that beats keeping a
+// second copy of the list here, which would go stale the first time a manifest
+// is added and stage nothing while still reporting success.
+export function bumpedFiles(output) {
+  const listed = output.match(/^Set version metadata to [^:]+: (.+)\.$/m)?.[1];
+  if (!listed || /^no files changed$/.test(listed)) return [];
+  return listed.split(",").map((file) => file.trim()).filter(Boolean);
+}
+
+// Run after the bump, never before: the version is an assertion target for
+// check-version and for a doc test that pins the release row, so a green run
+// from before the bump has not tested this commit.
+function gates(options) {
+  step("gates");
+  if (options.dryRun) {
+    console.log("would run: npm test, check-version, verify-contracts");
+    return;
+  }
+  const test = runNpm(["test"], options);
+  if (!test.ok) {
+    const output = `${test.stdout}\n${test.stderr}`;
+    const hint = /COMPARISON/i.test(output)
+      ? "\n\nHint: docs/COMPARISON.md pins this project's release row. Refresh the version AND the date in that row -- both are asserted, and a stale date is the easier one to miss."
+      : "";
+    throw new ShipError(EXIT.testsFailed, `Tests failed.${hint}`, tail(output, 40).slice(-4000));
+  }
+  console.log(summariseTests(test.stdout));
+  const version = runNpm(["run", "check-version"], options);
+  if (!version.ok) {
+    throw new ShipError(EXIT.versionCheckFailed, "check-version failed.", tail(`${version.stdout}\n${version.stderr}`, 20));
+  }
+  const contracts = runNpm(["run", "verify-contracts"], options);
+  if (!contracts.ok) {
+    throw new ShipError(EXIT.contractsFailed, "verify-contracts failed.", tail(`${contracts.stdout}\n${contracts.stderr}`, 20));
+  }
+  console.log("check-version and verify-contracts pass");
+}
+
+function commit(options, writtenFiles) {
+  step("commit");
+  const messageFile = path.resolve(options.root, options.commitFile);
+  if (options.dryRun) {
+    console.log(`would stage ${writtenFiles.length} file(s) this script wrote, then commit with the message in ${options.commitFile}`);
+    return null;
+  }
+  // Stage only what this script itself wrote. Everything else was staged by the
+  // caller, deliberately, before ship ran.
+  if (writtenFiles.length > 0) {
+    mustRun(EXIT.commitFailed, "git add failed.", "git", ["add", "--", ...writtenFiles], options);
+  }
+  const result = run("git", ["commit", "-F", messageFile], options);
+  if (!result.ok) {
+    throw new ShipError(
+      EXIT.commitFailed,
+      "git commit failed. A rejecting hook is a reason to fix the cause, not to pass --no-verify.",
+      `${result.stdout}\n${result.stderr}`.trim()
+    );
+  }
+  const sha = run("git", ["rev-parse", "--short", "HEAD"], options).stdout;
+  const subject = run("git", ["log", "-1", "--pretty=%s"], options).stdout;
+  console.log(`${sha} ${subject}`);
+  return { sha, subject };
+}
+
+function push(options, branch) {
+  if (options.noPush) {
+    step("push");
+    console.log("skipped (--no-push)");
+    return false;
+  }
+  step("push");
+  if (options.dryRun) {
+    console.log(`would push ${branch} to origin`);
+    return false;
+  }
+  mustRun(EXIT.pushFailed, `Failed to push ${branch}.`, "git", ["push", "-u", "origin", branch], options);
+  console.log(`pushed ${branch}`);
+  return true;
+}
+
+function pullRequest(options, branch, subject) {
+  if (!options.prFile) return null;
+  step("pull request");
+  readInput(options.root, options.prFile, "PR body");
+  const bodyFile = path.resolve(options.root, options.prFile);
+  const existing = run("gh", ["pr", "list", "--head", branch, "--json", "number", "--jq", ".[].number"], options);
+  const number = existing.ok ? existing.stdout.split("\n")[0]?.trim() : "";
+  if (options.dryRun) {
+    console.log(number ? `would comment on PR #${number}` : `would open a PR titled ${JSON.stringify(options.title ?? subject ?? "")}`);
+    return null;
+  }
+  // An open PR was already updated by the push; a second `create` would fail,
+  // and a comment is what tells the reviewer what arrived since they last looked.
+  if (number) {
+    const result = mustRun(EXIT.prFailed, `Failed to comment on PR #${number}.`,
+      "gh", ["pr", "comment", number, "--body-file", bodyFile], options);
+    console.log(`commented on #${number}`);
+    return { url: result.stdout, updated: true };
+  }
+  const title = options.title ?? subject;
+  if (!title) {
+    throw new ShipError(EXIT.prFailed, "No PR title: pass --title, or let the commit supply its subject.");
+  }
+  const result = mustRun(EXIT.prFailed, "Failed to open the PR.",
+    "gh", ["pr", "create", "--title", title, "--body-file", bodyFile], options);
+  const url = result.stdout.split("\n").filter(Boolean).pop() ?? "";
+  console.log(`opened ${url}`);
+  return { url, updated: false };
+}
+
+function main() {
+  const options = parseArgs(process.argv.slice(2));
+  if (options.help) {
+    console.log(usage());
+    return;
+  }
+  if (!options.commitFile) {
+    throw new ShipError(EXIT.usage, `Missing --commit.\n\n${usage()}`);
+  }
+  if (options.version && !options.changelogFile) {
+    throw new ShipError(EXIT.usage, "--version needs --changelog: a release with no entry tells the user nothing about what changed.");
+  }
+  readInput(options.root, options.commitFile, "commit message");
+  if (options.prFile) readInput(options.root, options.prFile, "PR body");
+
+  const { branch } = preflight(options);
+  const written = [...applyChangelog(options), ...bump(options)];
+  gates(options);
+  const committed = commit(options, written);
+  const pushed = push(options, branch);
+  const pr = pushed || options.dryRun ? pullRequest(options, branch, committed?.subject) : null;
+
+  step("done");
+  console.log(`commit  ${committed ? `${committed.sha} ${committed.subject}` : "(dry run)"}`);
+  console.log(`pr      ${pr ? `${pr.url} (${pr.updated ? "updated" : "new"})` : "(none)"}`);
+  console.log("\nNot done by this script, on purpose: code review, CI, merge.");
+}
+
+const SELF_PATH = fileURLToPath(import.meta.url);
+if (process.argv[1] && path.resolve(process.argv[1]) === SELF_PATH) {
+  try {
+    main();
+  } catch (error) {
+    if (error instanceof ShipError) {
+      console.error(`\n${error.message}`);
+      if (error.detail) console.error(`\n${error.detail}`);
+      process.exit(error.code);
+    }
+    console.error(error instanceof Error ? error.stack : String(error));
+    process.exit(1);
+  }
+}

--- a/scripts/ship.mjs
+++ b/scripts/ship.mjs
@@ -145,10 +145,26 @@ function run(command, args, { root, shell = false } = {}) {
   };
 }
 
-// npm is a .cmd on Windows, which node will not spawn without a shell. The
-// argument lists here are constants defined in this file -- nothing from the
-// caller reaches the shell.
+// npm is a .cmd on Windows, which node refuses to spawn without a shell, and
+// passing args through a shell is deprecated (DEP0190) because they are
+// concatenated rather than escaped. Running npm's own entry script under this
+// node avoids both: no shell, no .cmd, and the same npm that is on PATH.
+export function npmCliCandidates(execPath, env = {}) {
+  const dir = path.dirname(execPath);
+  return [
+    // Set when ship itself was started by an npm script.
+    env.npm_execpath && env.npm_execpath.endsWith(".js") ? env.npm_execpath : null,
+    path.join(dir, "node_modules", "npm", "bin", "npm-cli.js"),          // Windows layout
+    path.join(dir, "..", "lib", "node_modules", "npm", "bin", "npm-cli.js") // POSIX prefix layout
+  ].filter(Boolean);
+}
+
 function runNpm(args, options) {
+  const cli = npmCliCandidates(process.execPath, process.env).find((candidate) => fs.existsSync(candidate));
+  if (cli) return run(process.execPath, [cli, ...args], options);
+  // No npm entry script where it should be -- an unusual install rather than a
+  // broken one, so fall back rather than fail. The argument lists are constants
+  // defined in this file; nothing from the caller reaches the shell.
   const npm = process.platform === "win32" ? "npm.cmd" : "npm";
   return run(npm, args, { ...options, shell: process.platform === "win32" });
 }
@@ -263,7 +279,10 @@ function gates(options) {
   const test = runNpm(["test"], options);
   if (!test.ok) {
     const output = `${test.stdout}\n${test.stderr}`;
-    const hint = /COMPARISON/i.test(output)
+    // Matched on the test's own name, not on the filename: the string
+    // "docs/COMPARISON.md" appears in other suites' captured output, and a hint
+    // pointing at the wrong file is worse than none.
+    const hint = /comparison and parity docs/i.test(output)
       ? "\n\nHint: docs/COMPARISON.md pins this project's release row. Refresh the version AND the date in that row -- both are asserted, and a stale date is the easier one to miss."
       : "";
     throw new ShipError(EXIT.testsFailed, `Tests failed.${hint}`, tail(output, 40).slice(-4000));

--- a/tests/ship-release-path.test.mjs
+++ b/tests/ship-release-path.test.mjs
@@ -62,10 +62,15 @@ function makeRepo(t) {
   fs.writeFileSync(path.join(dir, "scripts", "bump-version.mjs"), [
     "import fs from 'node:fs';",
     "const version = process.argv[2];",
+    "if (process.argv.includes('--list-targets')) { console.log('package.json'); process.exit(0); }",
     "const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));",
+    // Reports only what it actually changed, exactly as the real bump-version
+    // does. A stub that always claims a rewrite hides the retry case, where the
+    // manifests already hold the target version and the report is empty.
+    "const changed = pkg.version !== version;",
     "pkg.version = version;",
-    "fs.writeFileSync('package.json', `${JSON.stringify(pkg, null, 2)}\\n`);",
-    "console.log(`Set version metadata to ${version}: package.json.`);"
+    "if (changed) fs.writeFileSync('package.json', `${JSON.stringify(pkg, null, 2)}\\n`);",
+    "console.log(`Set version metadata to ${version}: ${changed ? 'package.json' : 'no files changed'}.`);"
   ].join("\n"), "utf8");
   git(dir, "add", "-A");
   git(dir, "commit", "-qm", "init");
@@ -90,6 +95,25 @@ test("a --version dry run reaches the end instead of throwing", (t) => {
   assert.equal(result.status, 0);
   // A dry run that edited the file would be a dry run in name only.
   assert.match(fs.readFileSync(path.join(dir, "plugins", "gemini", "CHANGELOG.md"), "utf8"), /^# Changelog\n\n## 0\.1\.0/);
+});
+
+// ship stages this list rather than the one a bump reports, so the two must not
+// drift: a target missing here is a manifest that silently stays out of release
+// commits made on a retry.
+test("bump-version --list-targets names every manifest it can rewrite", () => {
+  const result = spawnSync(process.execPath, [path.join(ROOT, "scripts", "bump-version.mjs"), "--list-targets"],
+    { cwd: ROOT, encoding: "utf8" });
+  assert.equal(result.status, 0, result.stderr);
+  const listed = result.stdout.split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
+  assert.deepEqual(listed, [
+    "package.json",
+    "package-lock.json",
+    "plugins/gemini/.claude-plugin/plugin.json",
+    ".claude-plugin/marketplace.json"
+  ]);
+  for (const file of listed) {
+    assert.ok(fs.existsSync(path.join(ROOT, file)), `${file} is listed but does not exist`);
+  }
 });
 
 test("preflight refuses a detached HEAD before anything is written", (t) => {
@@ -153,4 +177,57 @@ test("a second run does not insert the same version twice", (t) => {
   ship(dir, args);
   const changelog = fs.readFileSync(path.join(dir, "plugins", "gemini", "CHANGELOG.md"), "utf8");
   assert.equal(changelog.match(/## 0\.2\.0/g)?.length, 1, changelog);
+});
+
+// The retry after a failed gate is the dangerous run, and it is dangerous
+// precisely because it looks fine: run 1 wrote the changelog and bumped the
+// manifests, then died at a gate, leaving both unstaged. On the retry the
+// changelog entry is already present and bump-version reports "no files
+// changed", so a script that stages what THIS run wrote stages neither -- and
+// every gate still passes, because they read the working tree rather than the
+// index. The result is a release commit containing only the caller's code.
+test("a retry after a failed gate still commits the release, not just the code", (t) => {
+  const dir = makeRepo(t);
+  fs.writeFileSync(path.join(dir, "code.txt"), "after\n", "utf8");
+  git(dir, "add", "code.txt");
+  const args = ["--commit", ".ship-commit", "--changelog", ".ship-changelog", "--version", "0.2.0", "--no-push"];
+
+  const pkg = path.join(dir, "package.json");
+  const original = fs.readFileSync(pkg, "utf8");
+  const failing = JSON.parse(original);
+  failing.scripts.test = "node -e \"process.exit(1)\"";
+  fs.writeFileSync(pkg, `${JSON.stringify(failing, null, 2)}\n`, "utf8");
+
+  const first = ship(dir, args);
+  assert.equal(first.status, 30, `expected the gate to fail: ${first.stdout}${first.stderr}`);
+  assert.equal(git(dir, "log", "--oneline").split("\n").length, 1, "nothing is committed on a failed gate");
+
+  // Repair the gate the way a caller would, leaving run 1's release edits in the
+  // tree, and let the version stay bumped as run 1 left it.
+  const repaired = JSON.parse(fs.readFileSync(pkg, "utf8"));
+  repaired.scripts.test = JSON.parse(original).scripts.test;
+  fs.writeFileSync(pkg, `${JSON.stringify(repaired, null, 2)}\n`, "utf8");
+
+  const second = ship(dir, args);
+  assert.equal(second.status, 0, `${second.stdout}${second.stderr}`);
+  const committed = git(dir, "show", "--pretty=", "--name-only", "HEAD").split("\n");
+  assert.ok(committed.includes("plugins/gemini/CHANGELOG.md"), `retry commit lost the changelog: ${committed.join(", ")}`);
+  assert.ok(committed.includes("package.json"), `retry commit lost the bump: ${committed.join(", ")}`);
+  assert.equal(git(dir, "status", "--porcelain", "plugins/gemini/CHANGELOG.md"), "", "and left nothing behind unstaged");
+});
+
+test("--pr with --no-push is refused rather than silently skipped", (t) => {
+  const dir = makeRepo(t);
+  fs.writeFileSync(path.join(dir, ".ship-pr"), "body\n", "utf8");
+  const result = ship(dir, ["--commit", ".ship-commit", "--pr", ".ship-pr", "--no-push"]);
+  assert.equal(result.status, 2);
+  assert.match(result.stderr, /--no-push/);
+});
+
+test("a missing changelog fails with a documented exit code, not a raw ENOENT", (t) => {
+  const dir = makeRepo(t);
+  fs.rmSync(path.join(dir, "plugins", "gemini", "CHANGELOG.md"));
+  const result = ship(dir, ["--commit", ".ship-commit", "--changelog", ".ship-changelog", "--version", "0.2.0", "--no-push"]);
+  assert.equal(result.status, 12);
+  assert.doesNotMatch(result.stderr, /ENOENT/);
 });

--- a/tests/ship-release-path.test.mjs
+++ b/tests/ship-release-path.test.mjs
@@ -1,0 +1,156 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const SHIP = path.join(ROOT, "scripts", "ship.mjs");
+
+// The unit tests cover ship.mjs's pure helpers, and that is precisely how a
+// crash on every `--version` run reached a PR: `applyChangelog` fell off the end
+// returning undefined, `main` spread it, and nothing that imported a function
+// ever executed that path. These tests run the script as a process against a
+// throwaway git repository, which is the only thing that would have caught it.
+//
+// Scope: the steps before the network. Each run passes --no-push, so nothing
+// here contacts origin or gh.
+
+function git(cwd, ...args) {
+  const result = spawnSync("git", args, { cwd, encoding: "utf8" });
+  assert.equal(result.status, 0, `git ${args.join(" ")} failed: ${result.stderr}`);
+  return result.stdout.trim();
+}
+
+function makeRepo(t) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "ship-release-"));
+  t.after(() => {
+    try {
+      fs.rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 });
+    } catch {
+      // Windows can still hold a handle; temp is reclaimed by the OS.
+    }
+  });
+  git(dir, "init", "-q", "-b", "work");
+  git(dir, "config", "user.email", "ship-test@example.invalid");
+  git(dir, "config", "user.name", "ship test");
+  // Only what ship touches before the gates: a changelog to insert into, and a
+  // file to stand in for the caller's own staged change.
+  fs.mkdirSync(path.join(dir, "plugins", "gemini"), { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, "plugins", "gemini", "CHANGELOG.md"),
+    "# Changelog\n\n## 0.1.0 - 2026-01-01 - First\n\n- something\n",
+    "utf8"
+  );
+  fs.writeFileSync(path.join(dir, "code.txt"), "before\n", "utf8");
+  // Stand-ins for the project's own tooling, so the release path can be run to
+  // the end. They assert nothing; what is under test is ship's sequencing --
+  // that it bumps before it gates, and stages what it wrote before it commits.
+  fs.writeFileSync(path.join(dir, "package.json"), `${JSON.stringify({
+    name: "ship-release-fixture",
+    version: "0.1.0",
+    private: true,
+    scripts: {
+      test: "node -e \"console.log('ℹ tests 1\\\\nℹ pass 1\\\\nℹ fail 0')\"",
+      "check-version": "node -e \"console.log('ok')\"",
+      "verify-contracts": "node -e \"console.log('ok')\""
+    }
+  }, null, 2)}\n`, "utf8");
+  fs.mkdirSync(path.join(dir, "scripts"), { recursive: true });
+  fs.writeFileSync(path.join(dir, "scripts", "bump-version.mjs"), [
+    "import fs from 'node:fs';",
+    "const version = process.argv[2];",
+    "const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));",
+    "pkg.version = version;",
+    "fs.writeFileSync('package.json', `${JSON.stringify(pkg, null, 2)}\\n`);",
+    "console.log(`Set version metadata to ${version}: package.json.`);"
+  ].join("\n"), "utf8");
+  git(dir, "add", "-A");
+  git(dir, "commit", "-qm", "init");
+  fs.writeFileSync(path.join(dir, ".ship-commit"), "chore: a commit\n", "utf8");
+  fs.writeFileSync(path.join(dir, ".ship-changelog"), "## 0.2.0 - 2026-02-02 - Second\n\n- a new thing\n", "utf8");
+  return dir;
+}
+
+function ship(dir, args) {
+  return spawnSync(process.execPath, [SHIP, "--root", dir, ...args], { cwd: dir, encoding: "utf8" });
+}
+
+test("a --version dry run reaches the end instead of throwing", (t) => {
+  const dir = makeRepo(t);
+  fs.writeFileSync(path.join(dir, "code.txt"), "after\n", "utf8");
+  git(dir, "add", "code.txt");
+  const result = ship(dir, [
+    "--commit", ".ship-commit", "--changelog", ".ship-changelog", "--version", "0.2.0", "--dry-run", "--no-push"
+  ]);
+  assert.doesNotMatch(result.stderr, /TypeError|not iterable/, result.stderr);
+  assert.match(result.stdout, /== done/, `${result.stdout}\n${result.stderr}`);
+  assert.equal(result.status, 0);
+  // A dry run that edited the file would be a dry run in name only.
+  assert.match(fs.readFileSync(path.join(dir, "plugins", "gemini", "CHANGELOG.md"), "utf8"), /^# Changelog\n\n## 0\.1\.0/);
+});
+
+test("preflight refuses a detached HEAD before anything is written", (t) => {
+  const dir = makeRepo(t);
+  git(dir, "checkout", "-q", "--detach");
+  const result = ship(dir, ["--commit", ".ship-commit", "--no-push"]);
+  assert.equal(result.status, 10);
+  assert.match(result.stderr, /detached/i);
+});
+
+test("preflight refuses the default branch", (t) => {
+  const dir = makeRepo(t);
+  git(dir, "branch", "-m", "main");
+  const result = ship(dir, ["--commit", ".ship-commit", "--no-push"]);
+  assert.equal(result.status, 10);
+  assert.match(result.stderr, /main/);
+});
+
+test("nothing staged and no version is refused, not committed empty", (t) => {
+  const dir = makeRepo(t);
+  const result = ship(dir, ["--commit", ".ship-commit", "--no-push"]);
+  assert.equal(result.status, 11);
+  assert.equal(git(dir, "log", "--oneline").split("\n").length, 1);
+});
+
+test("an unstaged change is reported, because the gates test it and the commit will not", (t) => {
+  const dir = makeRepo(t);
+  fs.writeFileSync(path.join(dir, "code.txt"), "staged\n", "utf8");
+  git(dir, "add", "code.txt");
+  fs.writeFileSync(path.join(dir, "code.txt"), "staged, then edited again\n", "utf8");
+  const result = ship(dir, ["--commit", ".ship-commit", "--no-push", "--dry-run"]);
+  assert.match(result.stdout, /unstaged change/);
+  assert.match(result.stdout, /code\.txt/);
+});
+
+test("the changelog entry is staged, so a release commit cannot omit it", (t) => {
+  const dir = makeRepo(t);
+  fs.writeFileSync(path.join(dir, "code.txt"), "after\n", "utf8");
+  git(dir, "add", "code.txt");
+  // bump-version rewrites only the manifests it reports, never the changelog, and
+  // check-version reads the working tree rather than the index -- so if ship does
+  // not stage the entry itself, the release commit goes out without it and every
+  // gate still passes.
+  const result = ship(dir, ["--commit", ".ship-commit", "--changelog", ".ship-changelog", "--version", "0.2.0", "--no-push"]);
+  assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+  const committed = git(dir, "show", "--pretty=", "--name-only", "HEAD").split("\n");
+  assert.ok(
+    committed.includes("plugins/gemini/CHANGELOG.md"),
+    `release commit has no changelog entry; it contains: ${committed.join(", ")}`
+  );
+  assert.ok(committed.includes("package.json"), committed.join(", "));
+  assert.ok(committed.includes("code.txt"), "the caller's own staged change must still be in the commit");
+});
+
+test("a second run does not insert the same version twice", (t) => {
+  const dir = makeRepo(t);
+  fs.writeFileSync(path.join(dir, "code.txt"), "after\n", "utf8");
+  git(dir, "add", "code.txt");
+  const args = ["--commit", ".ship-commit", "--changelog", ".ship-changelog", "--version", "0.2.0", "--no-push"];
+  ship(dir, args);
+  ship(dir, args);
+  const changelog = fs.readFileSync(path.join(dir, "plugins", "gemini", "CHANGELOG.md"), "utf8");
+  assert.equal(changelog.match(/## 0\.2\.0/g)?.length, 1, changelog);
+});

--- a/tests/ship-script.test.mjs
+++ b/tests/ship-script.test.mjs
@@ -1,0 +1,119 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { EXIT, bumpedFiles, insertChangelogEntry, parseArgs, summariseTests, tail } from "../scripts/ship.mjs";
+
+// The script's own steps spawn git, npm and gh, so they are exercised by running
+// it. What is unit-tested here is the part that decides WHERE prose lands and
+// WHICH exit code a caller sees -- the two things a wrong answer would hide
+// rather than announce.
+
+const CHANGELOG = ["# Changelog", "", "## 0.24.3 - 2026-09-02 - Older entry", "", "- something", ""].join("\n");
+
+test("insertChangelogEntry puts the new entry above the newest one", () => {
+  const next = insertChangelogEntry(CHANGELOG, "## 0.24.4 - 2026-09-03 - New\n\n- new thing");
+  const headings = next.split("\n").filter((line) => line.startsWith("## "));
+  assert.deepEqual(headings, ["## 0.24.4 - 2026-09-03 - New", "## 0.24.3 - 2026-09-02 - Older entry"]);
+});
+
+test("insertChangelogEntry keeps the title above the first heading", () => {
+  const next = insertChangelogEntry(CHANGELOG, "## 0.24.4 - x");
+  assert.equal(next.split("\n")[0], "# Changelog");
+});
+
+// A fragment appended to the END of a newest-first changelog is invisible to
+// readers and still satisfies `bump-version --check`, which only scans for the
+// heading anywhere in the file. That combination is why placement is asserted.
+test("insertChangelogEntry does not append", () => {
+  const next = insertChangelogEntry(CHANGELOG, "## 0.24.4 - x");
+  assert.ok(next.indexOf("## 0.24.4") < next.indexOf("## 0.24.3"));
+});
+
+test("insertChangelogEntry preserves CRLF files", () => {
+  const crlf = CHANGELOG.split("\n").join("\r\n");
+  const next = insertChangelogEntry(crlf, "## 0.24.4 - x");
+  assert.ok(next.includes("\r\n"));
+  assert.ok(!/[^\r]\n/.test(next), "mixed line endings would show up as a whole-file diff");
+});
+
+test("insertChangelogEntry refuses a changelog with no heading to anchor on", () => {
+  assert.throws(() => insertChangelogEntry("# Changelog\n\nnothing yet\n", "## 1.0.0 - x"), (error) => {
+    assert.equal(error.code, EXIT.changelogInsertFailed);
+    return true;
+  });
+});
+
+test("parseArgs reads every documented flag", () => {
+  const options = parseArgs([
+    "--commit", "c.txt", "--changelog", "cl.md", "--pr", "pr.md",
+    "--title", "fix: x", "--version", "1.2.3", "--dry-run", "--no-push"
+  ]);
+  assert.equal(options.commitFile, "c.txt");
+  assert.equal(options.changelogFile, "cl.md");
+  assert.equal(options.prFile, "pr.md");
+  assert.equal(options.title, "fix: x");
+  assert.equal(options.version, "1.2.3");
+  assert.equal(options.dryRun, true);
+  assert.equal(options.noPush, true);
+});
+
+// `--title --dry-run` must not silently make the title "--dry-run": that
+// swallows the flag AND ships a PR titled with an argument name. Asserted with a
+// trailing boolean flag on purpose -- `--title --version 1.2.3` would throw
+// anyway, on the leftover `1.2.3`, so it cannot tell the guard from its absence.
+test("parseArgs rejects a flag used as another flag's value", () => {
+  assert.throws(() => parseArgs(["--title", "--dry-run"]), (error) => {
+    assert.equal(error.code, EXIT.usage);
+    return true;
+  });
+});
+
+test("parseArgs rejects an unknown argument rather than ignoring it", () => {
+  assert.throws(() => parseArgs(["--force"]), (error) => {
+    assert.equal(error.code, EXIT.usage);
+    return true;
+  });
+});
+
+test("every exit code is distinct", () => {
+  const codes = Object.values(EXIT);
+  assert.equal(new Set(codes).size, codes.length, "a shared code makes the failure unbranchable");
+});
+
+test("summariseTests reads the node:test tallies", () => {
+  const output = ["ℹ tests 704", "ℹ suites 0", "ℹ pass 696", "ℹ fail 0", "ℹ skipped 8"].join("\n");
+  assert.equal(summariseTests(output), "tests 704, pass 696, fail 0, skipped 8");
+});
+
+test("summariseTests degrades to a plain statement when the format changes", () => {
+  assert.equal(summariseTests("all good"), "tests passed");
+});
+
+test("tail keeps the END of the output, where the failure is", () => {
+  const text = Array.from({ length: 50 }, (_, i) => `line ${i}`).join("\n");
+  const kept = tail(text, 3).split("\n");
+  assert.deepEqual(kept, ["line 47", "line 48", "line 49"]);
+});
+
+// The script stages only what it wrote itself, and it learns that list by
+// parsing bump-version's own report rather than keeping a second copy of the
+// manifest list. A parse that silently returns [] would leave the bumped
+// manifests unstaged and still exit 0 -- a release commit with no version in it.
+test("bumpedFiles reads the manifest list out of bump-version's report", () => {
+  const output = "Set version metadata to 0.24.4: package.json, package-lock.json, "
+    + "plugins/gemini/.claude-plugin/plugin.json, .claude-plugin/marketplace.json.";
+  assert.deepEqual(bumpedFiles(output), [
+    "package.json",
+    "package-lock.json",
+    "plugins/gemini/.claude-plugin/plugin.json",
+    ".claude-plugin/marketplace.json"
+  ]);
+});
+
+test("bumpedFiles returns nothing when bump-version changed nothing", () => {
+  assert.deepEqual(bumpedFiles("Set version metadata to 0.24.4: no files changed."), []);
+});
+
+test("bumpedFiles returns nothing for unrecognised output", () => {
+  assert.deepEqual(bumpedFiles("something else entirely"), []);
+});

--- a/tests/ship-script.test.mjs
+++ b/tests/ship-script.test.mjs
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { EXIT, bumpedFiles, npmCliCandidates, insertChangelogEntry, parseArgs, summariseTests, tail } from "../scripts/ship.mjs";
+import { EXIT, bumpedFiles, hasChangelogHeading, npmCliCandidates, insertChangelogEntry, parseArgs, summariseTests, tail } from "../scripts/ship.mjs";
 
 // The script's own steps spawn git, npm and gh, so they are exercised by running
 // it. What is unit-tested here is the part that decides WHERE prose lands and
@@ -19,6 +19,15 @@ test("insertChangelogEntry puts the new entry above the newest one", () => {
 test("insertChangelogEntry keeps the title above the first heading", () => {
   const next = insertChangelogEntry(CHANGELOG, "## 0.24.4 - x");
   assert.equal(next.split("\n")[0], "# Changelog");
+});
+
+// Joining the preceding lines and letting the entry supply the break swallows
+// the blank line under the title, gluing the new heading to it -- and every
+// later release inherits the damage. Asserting only that line 0 is still the
+// title passes either way, which is how the first version of this shipped.
+test("insertChangelogEntry keeps the blank line under the title", () => {
+  const next = insertChangelogEntry(CHANGELOG, "## 0.24.4 - x");
+  assert.deepEqual(next.split("\n").slice(0, 3), ["# Changelog", "", "## 0.24.4 - x"]);
 });
 
 // A fragment appended to the END of a newest-first changelog is invisible to
@@ -41,6 +50,29 @@ test("insertChangelogEntry refuses a changelog with no heading to anchor on", ()
     assert.equal(error.code, EXIT.changelogInsertFailed);
     return true;
   });
+});
+
+// The first version built `new RegExp("^## v?" + version.replace(/\./g, "\\."))`
+// and CodeQL flagged it twice, high: an unescaped backslash, and a pattern built
+// from a command-line argument. The fix is not a better escape; it is comparing
+// tokens so no pattern is built at all.
+test("hasChangelogHeading matches the version and its v-prefixed form", () => {
+  assert.equal(hasChangelogHeading(CHANGELOG, "0.24.3"), true);
+  assert.equal(hasChangelogHeading("## v1.2.3 - x", "1.2.3"), true);
+  assert.equal(hasChangelogHeading(CHANGELOG, "0.24.4"), false);
+});
+
+test("hasChangelogHeading does not treat a version as a pattern", () => {
+  const text = "## 1x2x3 - x\n";
+  // `.` as a wildcard would match here; a token comparison does not.
+  assert.equal(hasChangelogHeading(text, "1.2.3"), false);
+  // A backslash in the argument must not be able to reach a regex engine.
+  assert.doesNotThrow(() => hasChangelogHeading(text, "1.2.3\\"));
+  assert.equal(hasChangelogHeading(text, "("), false);
+});
+
+test("hasChangelogHeading ignores a version mentioned in prose", () => {
+  assert.equal(hasChangelogHeading("- fixed in 0.24.4, see notes\n", "0.24.4"), false);
 });
 
 test("parseArgs reads every documented flag", () => {

--- a/tests/ship-script.test.mjs
+++ b/tests/ship-script.test.mjs
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { EXIT, bumpedFiles, insertChangelogEntry, parseArgs, summariseTests, tail } from "../scripts/ship.mjs";
+import { EXIT, bumpedFiles, npmCliCandidates, insertChangelogEntry, parseArgs, summariseTests, tail } from "../scripts/ship.mjs";
 
 // The script's own steps spawn git, npm and gh, so they are exercised by running
 // it. What is unit-tested here is the part that decides WHERE prose lands and
@@ -116,4 +116,24 @@ test("bumpedFiles returns nothing when bump-version changed nothing", () => {
 
 test("bumpedFiles returns nothing for unrecognised output", () => {
   assert.deepEqual(bumpedFiles("something else entirely"), []);
+});
+
+// Running npm's entry script under this node is what keeps the gates off a
+// shell: node will not spawn npm.cmd without one, and shell args are
+// concatenated rather than escaped (DEP0190). A candidate list that missed the
+// real install would fall back to exactly the shell this avoids.
+test("npmCliCandidates prefers an npm_execpath handed down by npm itself", () => {
+  const candidates = npmCliCandidates("/usr/bin/node", { npm_execpath: "/opt/npm/bin/npm-cli.js" });
+  assert.equal(candidates[0], "/opt/npm/bin/npm-cli.js");
+});
+
+test("npmCliCandidates ignores an npm_execpath that is not a script", () => {
+  const candidates = npmCliCandidates("/usr/bin/node", { npm_execpath: "/opt/npm/bin/npm.cmd" });
+  assert.ok(!candidates.includes("/opt/npm/bin/npm.cmd"));
+});
+
+test("npmCliCandidates covers both the Windows and POSIX install layouts", () => {
+  const candidates = npmCliCandidates("/usr/bin/node", {}).map((p) => p.split("\\").join("/"));
+  assert.ok(candidates.some((p) => p.endsWith("/usr/bin/node_modules/npm/bin/npm-cli.js")), candidates.join(" | "));
+  assert.ok(candidates.some((p) => p.endsWith("/usr/lib/node_modules/npm/bin/npm-cli.js")), candidates.join(" | "));
 });


### PR DESCRIPTION
Scripts the mechanical half of `/ship`, and stops where judgement starts.

## Why

The recurring failure is an ordering one: bump the version, then run the gates. The version is an assertion target for `check-version` and for the `docs/COMPARISON.md` release row, so a green test run from *before* the bump has not tested the commit being shipped. Twice this week that was caught by remembering, not by anything structural.

## What it does

`node scripts/ship.mjs --commit <file> [--changelog <file> --version <x.y.z>] [--pr <file>]`

preflight -> changelog insert -> bump -> gates -> commit -> push -> PR, with a distinct exit code per step (`EXIT` in the script) so a caller can branch on the failure instead of re-reading the log.

## What it deliberately does not do

Code review triage, CI reading, and merge. Findings need a fix/no-fix decision per item; an exit code cannot carry one, and a blocking finding buried in a non-zero status is worse than no automation.

## Two decisions worth reviewing

**It stages nothing on the caller's behalf.** The first dry run of this script left the script itself out of the commit, because `git add -u` stages tracked files only. `add -A` fixes that and introduces a worse failure -- sweeping in whatever else is in the tree. So: the caller stages their own changes, and ship stages only the changelog plus the manifests `bump-version` reports rewriting (parsed from its output rather than duplicated as a list that would go stale).

**The prose stays an input.** Changelog entry, commit message and PR body are files the script reads. This PR was shipped with them.

## Verification

`tests/ship-script.test.mjs` (15 tests) covers the parts where a wrong answer hides rather than announces itself: changelog placement, argument parsing, exit-code distinctness, and the `bump-version` output parse.

Mutation-checked, three sites:

| mutation | result |
|---|---|
| append the changelog entry instead of inserting it | 2 tests red |
| drop the "flag used as another flag's value" guard | 1 test red |
| give two steps the same exit code | 1 test red |

The flag-guard test was rewritten after the first version passed under mutation: `--title --version 1.2.3` throws either way, on the leftover `1.2.3`. It now uses `--title --dry-run`, which does not.

The steps that spawn `git`, `npm` and `gh` are covered by running the script -- this PR was created by it.
