### PR TITLE
chore: commit the shared Claude Code settings, ignore the per-machine ones

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(npm run check-version)",
+      "Bash(npm run verify-contracts)",
+      "Bash(npm run test:seo)",
+      "Bash(npm run bench:aeo)",
+      "Bash(where.exe *)",
+      "PowerShell(dir *)",
+      "PowerShell(Get-ChildItem *)",
+      "PowerShell(Test-Path *)"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,11 @@ Thumbs.db
 
 # Scratch working notes
 scratch/
+
+# Claude Code project settings. `settings.json` is the shared half and is
+# committed; these two are per-machine and must not be. `settings.local.json`
+# accumulates permission grants as one person works, so committing it would hand
+# every clone whatever that person happened to approve -- here, entries as wide
+# as `Bash(git push *)` and absolute paths under one user's home.
+.claude/settings.local.json
+.claude/worktrees/


### PR DESCRIPTION
`.claude/` was untracked **and** unignored: the shared half was not being shared, and the per-machine half was one `git add -A` away from being committed.

## Committed

`.claude/settings.json` — 313 bytes, eight narrow permission entries: this repository's own gates (`npm run check-version`, `verify-contracts`, `test:seo`, `bench:aeo`) plus read-only path lookups (`where.exe`, `dir`, `Get-ChildItem`, `Test-Path`). These are what a collaborator runs here anyway; pre-approving them is what the shared file is for.

## Ignored

`.claude/settings.local.json` and `.claude/worktrees/`.

The local file is 5KB of permission grants one person accumulated over weeks. It holds **no secrets**, but it does hold entries as wide as `Bash(git push *)`, `Bash(node *)`, `Bash(agy *)` and `Bash(gh api *)`, plus absolute `Read(...)` paths under one user's home directory. Committing it would hand every clone whatever that person happened to approve at some point — not a decision a repository should make on a collaborator's behalf.

## Verification

741 tests, 733 pass, 0 fail, 8 skipped. `check-version` and `verify-contracts` green at v0.24.3. `git check-ignore` confirms both new patterns match.

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WPRqf4z7QMD9cHQb1Y9kYy