### PR TITLE
fix(retry): let an AGY review survive a rate limit that clears in a minute

### DIFF
--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -25,7 +25,7 @@ belong to.
 
 | Surface | Slash commands | MCP tools | Skills | Test files (`*.test.*`) |
 |---|---|---|---|---|
-| **this project** | 8 | **6** | 3 | 39 |
+| **this project** | 8 | **6** | 3 | 40 |
 | abiswas97 | 8 | 0 | 3 | 13 |
 | m-ghalib | 7 | 0 | 3 | 12 |
 | sakibsadmanshajib/antigravity-plugin | 6 | 0 | 0 | 12 |

--- a/plugins/gemini/CHANGELOG.md
+++ b/plugins/gemini/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## 0.24.4 - Unreleased
 
+- **An AGY review survives a rate limit that clears in under a minute.**
+  `runGeminiReviewResilient` returned on `engine === "agy"` unconditionally, so a
+  limit AGY itself reports as `Resets in 58s` ended the review outright. Two of
+  the three reasons for that blanket exclusion still hold; the one that was meant
+  to cover this case does not — a fail-fast timeout answers a hang, and a rate
+  limit is a clean ERROR envelope arriving in six seconds with every token count
+  at zero (measured, AGY 1.1.24). The exclusion is now an **allowlist**: agy
+  retries on `rate-limit` and nothing else, which keeps `tool-permission-denied`
+  and brain-root `transcript-missing` unreachable — neither is in
+  `ACCOUNT_STATE_FAILURES` and no heuristic names them, so a denylist would have
+  exposed both. A retry happens only when AGY states when the limit clears, and
+  waits that long (ceiling 90s, one-second grace); with no stated reset there is
+  no retry, because this wrapper has no backoff and three immediate attempts
+  would finish in seconds at the same refusal. The wrapper also now forwards its
+  spawn seams, without which its own branching could not be tested at all. (#142)
+
 - **A failed AGY turn now shows what AGY said.** `classifyCliFailure` read AGY's
   structured `error` to pick a category and then dropped it, so the rendered
   failure carried only this plugin's own words — which come from a table keyed by

--- a/plugins/gemini/CHANGELOG.md
+++ b/plugins/gemini/CHANGELOG.md
@@ -15,8 +15,22 @@
   exposed both. A retry happens only when AGY states when the limit clears, and
   waits that long (ceiling 90s, one-second grace); with no stated reset there is
   no retry, because this wrapper has no backoff and three immediate attempts
-  would finish in seconds at the same refusal. The wrapper also now forwards its
-  spawn seams, without which its own branching could not be tested at all. (#142)
+  would finish in seconds at the same refusal. Nor is a compound duration
+  half-read: `Resets in 1m 30s` is refused rather than taken as 61s, which would
+  have retried 29 seconds early into the same limit. The reset is looked for on
+  both the engine detail and stderr, since a detail truncated at 2000 characters
+  can be non-null while no longer carrying the sentence.
+
+  Two further bounds. A rate-limited attempt that already produced parsed
+  findings is kept rather than retried away — under stream-json an ERROR envelope
+  with an empty `response` still yields salvaged text that can parse, so a review
+  can be complete and rate-limited at once. And the wait is **opt-in with a
+  budget spent across the whole call**, defaulting to none: a foreground
+  `/gemini:review` is a single Bash call under the host's default 120s timeout, so
+  sleeping there would turn a clean six-second "rate limited" into a killed
+  command reporting nothing. Only a detached worker, which is polled through
+  `/gemini:status`, passes a budget. The wrapper also now forwards its spawn
+  seams, without which its own branching could not be tested at all. (#142)
 
 - **A failed AGY turn now shows what AGY said.** `classifyCliFailure` read AGY's
   structured `error` to pick a category and then dropped it, so the rendered

--- a/plugins/gemini/scripts/gemini-companion.mjs
+++ b/plugins/gemini/scripts/gemini-companion.mjs
@@ -56,6 +56,7 @@ import {
 import {
   runGeminiTurn,
   runGeminiReviewResilient,
+  AGY_RATE_LIMIT_MAX_WAIT_MS,
   getGeminiAvailability,
   getAgyAvailability,
   getGeminiLoginStatus,
@@ -753,6 +754,10 @@ async function executeReviewRun(request) {
     deep: Boolean(request.deep),
     timeoutSeconds: request.timeoutSeconds ?? null,
     onProgress: request.onProgress
+  }, {
+    // Only a detached worker can afford to sleep out an AGY rate limit; see the
+    // note on request.detached in runStoredJobWorker.
+    rateLimitWaitBudgetMs: request.detached ? AGY_RATE_LIMIT_MAX_WAIT_MS : 0
   });
 
   const parsed = result.reviewJson
@@ -1452,6 +1457,12 @@ async function runStoredJobWorker(argv, { executor, label }) {
   if (!request || typeof request !== "object") {
     throw new Error(`Stored job ${options["job-id"]} is missing its request payload.`);
   }
+  // Marks the run as detached, which is what makes a blocking rate-limit wait
+  // affordable: a foreground review is a single Bash call under the host's
+  // default 120s timeout, so sleeping there converts a clean "rate limited" into
+  // a killed command that reports nothing. A worker has no such ceiling — it is
+  // polled through /gemini:status — so it is the only caller allowed to wait.
+  request.detached = true;
 
   const { logFile, progress } = createTrackedProgress(
     {

--- a/plugins/gemini/scripts/lib/gemini.mjs
+++ b/plugins/gemini/scripts/lib/gemini.mjs
@@ -970,24 +970,83 @@ export function isTransientReviewFailure({ reviewJson, reviewText, stderr } = {}
   return false;                                               // real non-transient output (e.g. prose review) — keep it
 }
 
+// AGY states when a rate limit clears, in its own words: `Individual quota
+// reached. Please upgrade your subscription to increase your limits. Resets in
+// 58s.` (measured on 1.1.24). That sentence is the whole reason an AGY retry can
+// be safe -- it turns "retry and hope" into "wait exactly this long, then retry
+// once". Returns null when no reset is stated, and the caller must then NOT
+// retry: an immediate re-run against a limit that has not cleared burns the
+// attempts in seconds and reports the same refusal, which is worse than failing
+// once. Deliberately no default guess.
+export const AGY_RATE_LIMIT_MAX_WAIT_MS = 90_000;
+
+export function parseRateLimitResetMs(text) {
+  const match = /resets? in\s+(\d+)\s*(s|sec|secs|seconds?|m|min|mins|minutes?)\b/i.exec(String(text ?? ""));
+  if (!match) return null;
+  const value = Number(match[1]);
+  if (!Number.isFinite(value) || value <= 0) return null;
+  const ms = /^m/i.test(match[2]) ? value * 60_000 : value * 1000;
+  // A grace second: the reset is reported as a whole number and a retry that
+  // lands on the same tick is refused again for no reason.
+  const waitMs = ms + 1000;
+  return waitMs > AGY_RATE_LIMIT_MAX_WAIT_MS ? null : waitMs;
+}
+
 // Resilient wrapper around runGeminiReview: a READ-ONLY adversarial review is
 // idempotent (no side effects), so a transient empty / `Invalid stream` envelope is
 // safe to re-run. The gemini CLI flakes intermittently on this in practice
 // (observed needing 2-3 attempts for the SAME input); retrying here removes that
-// flakiness from the caller. agy is NOT retried — its fail-fast timeout handles its
-// distinct failure mode and re-spawning it is costly. (The original rationale also
-// cited agy's transcript-recovery path; that no longer applies from AGY 1.1.8 on,
-// where `supportsAgyStructuredOutput` routes to the native JSON envelope and the
-// transcript path never runs. The remaining two reasons are what holds it up now.)
-// Composes with runGeminiReview's inline GA-fallback (model-not-found) retry: that
-// fixes a deterministic wrong-model error within a single attempt; this re-runs the
-// whole review only when no usable result came back at all.
-export async function runGeminiReviewResilient(cwd, options = {}, { maxAttempts = 3 } = {}) {
+// flakiness from the caller. Composes with runGeminiReview's inline GA-fallback
+// (model-not-found) retry: that fixes a deterministic wrong-model error within a
+// single attempt; this re-runs the whole review only when no usable result came
+// back at all.
+//
+// agy is still not subject to the heuristics above, and the reasons are worth
+// keeping straight, because one of the two that used to hold up a blanket
+// exclusion turned out not to cover the case that motivated #142:
+//
+//   - "its fail-fast timeout handles its distinct failure mode" — true, and it
+//     covers a hang. It does not cover a clean structured ERROR envelope that
+//     arrives in six seconds, which is what a rate limit is.
+//   - "re-spawning it is costly" — true of a review that runs; a refusal came
+//     back in 6s and 11s with every token count at zero (measured, AGY 1.1.24).
+//   - (a third, agy's transcript-recovery path, stopped applying at AGY 1.1.8,
+//     where supportsAgyStructuredOutput routes to the native JSON envelope.)
+//
+// So the exclusion is narrowed rather than removed, and narrowed by ALLOWLIST:
+// agy retries on `rate-limit` and nothing else. That matters for the warning in
+// isTransientReviewFailure — `tool-permission-denied` and brain-root
+// `transcript-missing` sit outside ACCOUNT_STATE_FAILURES and are caught by none
+// of the heuristics, and they were safe only because agy returned before reaching
+// them. An allowlist keeps them unreachable; a denylist would have exposed both.
+// Widening this set means adding them to ACCOUNT_STATE_FAILURES first.
+//
+// And it retries only when AGY says when the limit clears, waiting that long.
+// Without a stated reset there is no retry: this wrapper has no backoff, so three
+// immediate attempts against a 58-second limit finish in seconds and report the
+// same refusal — worse than failing once.
+export async function runGeminiReviewResilient(cwd, options = {}, deps = {}) {
+  // The spawn seams are forwarded rather than dropped: without this the wrapper's
+  // own retry decisions -- the part with the branching -- could only be tested by
+  // spawning a real engine, which is why they were not tested at all.
+  const { maxAttempts = 3, sleepFn = null, ...reviewDeps } = deps;
+  const sleep = sleepFn ?? ((ms) => new Promise((resolve) => setTimeout(resolve, ms)));
   let last = null;
   let prevText = null;
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-    last = await runGeminiReview(cwd, options);
-    if (last.engine === "agy") return { ...last, attempts: attempt };
+    last = await runGeminiReview(cwd, options, reviewDeps);
+    if (last.engine === "agy") {
+      const waitMs = last.failure?.category === "rate-limit"
+        ? parseRateLimitResetMs(last.failure?.detail ?? last.stderr)
+        : null;
+      if (waitMs === null || attempt >= maxAttempts) return { ...last, attempts: attempt };
+      options.onProgress?.({
+        message: `AGY rate limit; it reports clearing in ${Math.round((waitMs - 1000) / 1000)}s (attempt ${attempt}/${maxAttempts}). Waiting, then retrying...`,
+        phase: "reviewing"
+      });
+      await sleep(waitMs);
+      continue;
+    }
     if (!isTransientReviewFailure(last)) return { ...last, attempts: attempt };
     // Backstop for a residual stderr-side false positive: identical non-empty review
     // text across attempts is deterministic output that merely tripped the heuristic,

--- a/plugins/gemini/scripts/lib/gemini.mjs
+++ b/plugins/gemini/scripts/lib/gemini.mjs
@@ -981,8 +981,17 @@ export function isTransientReviewFailure({ reviewJson, reviewText, stderr } = {}
 export const AGY_RATE_LIMIT_MAX_WAIT_MS = 90_000;
 
 export function parseRateLimitResetMs(text) {
-  const match = /resets? in\s+(\d+)\s*(s|sec|secs|seconds?|m|min|mins|minutes?)\b/i.exec(String(text ?? ""));
+  const source = String(text ?? "");
+  const match = /resets? in\s+(\d+)\s*(s|sec|secs|seconds?|m|min|mins|minutes?)\b/i.exec(source);
   if (!match) return null;
+  // A compound duration is refused rather than half-read. `Resets in 1m 30s`
+  // matched only the leading `1m` and returned 61s, so the retry fired 29 seconds
+  // early, was refused again, and burned an attempt plus a full minute of wall
+  // clock — precisely the "retry into a limit that has not cleared" failure the
+  // no-guess rule above exists to prevent. Reading only the first unit is a guess
+  // wearing a measurement's clothes.
+  const rest = source.slice(match.index + match[0].length);
+  if (/^\s*\d+\s*(s|sec|secs|seconds?|m|min|mins|minutes?)\b/i.test(rest)) return null;
   const value = Number(match[1]);
   if (!Number.isFinite(value) || value <= 0) return null;
   const ms = /^m/i.test(match[2]) ? value * 60_000 : value * 1000;
@@ -1029,17 +1038,45 @@ export async function runGeminiReviewResilient(cwd, options = {}, deps = {}) {
   // The spawn seams are forwarded rather than dropped: without this the wrapper's
   // own retry decisions -- the part with the branching -- could only be tested by
   // spawning a real engine, which is why they were not tested at all.
-  const { maxAttempts = 3, sleepFn = null, ...reviewDeps } = deps;
+  const { maxAttempts = 3, sleepFn = null, rateLimitWaitBudgetMs = 0, ...reviewDeps } = deps;
   const sleep = sleepFn ?? ((ms) => new Promise((resolve) => setTimeout(resolve, ms)));
+  // Default 0: no caller waits unless it says it can afford to. Worst case for a
+  // caller that opts in is this budget in total sleep, plus the spawns.
+  let waitBudgetMs = rateLimitWaitBudgetMs;
   let last = null;
   let prevText = null;
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     last = await runGeminiReview(cwd, options, reviewDeps);
     if (last.engine === "agy") {
-      const waitMs = last.failure?.category === "rate-limit"
-        ? parseRateLimitResetMs(last.failure?.detail ?? last.stderr)
+      // Output first, exactly like every other branch here. Under stream-json an
+      // ERROR envelope with an empty `response` still yields salvaged partial
+      // text, which runGeminiReview turns into reviewText and can parse into
+      // reviewJson — while `failure` stays non-null because the exit was non-zero.
+      // So a run CAN come back rate-limited mid-stream with the findings already
+      // in hand, and retrying would throw away a usable review to wait a minute
+      // for a bare refusal. isTransientReviewFailure returns false the moment
+      // reviewJson exists; this branch has to make the same check itself.
+      // reviewJson ONLY. Measured: on a pure AGY failure `reviewText` holds the
+      // raw envelope JSON rather than a review, so treating non-empty text as
+      // "we got something" suppresses every retry — the fix disabling itself.
+      // Parsed findings are the one signal that means a review actually exists,
+      // which is why isTransientReviewFailure keys on the same thing.
+      const produced = Boolean(last.reviewJson);
+      const waitMs = !produced && last.failure?.category === "rate-limit"
+        // Both channels, not `detail ?? stderr`: `??` only falls back when detail
+        // is nullish, and a detail truncated at 2000 characters is non-null while
+        // possibly having lost the sentence naming the reset.
+        ? parseRateLimitResetMs(`${last.failure?.detail ?? ""}\n${last.stderr ?? ""}`)
         : null;
-      if (waitMs === null || attempt >= maxAttempts) return { ...last, attempts: attempt };
+      // The wait is opt-in and budgeted across the WHOLE call, not per attempt.
+      // A foreground `/gemini:review` is one Bash call under the host's default
+      // 120s timeout, so sleeping there turns a clean six-second "rate limited"
+      // into a killed command that reports nothing — strictly worse than the
+      // failure this change set out to improve. Only a detached run, which has no
+      // such ceiling, passes a budget.
+      const affordable = waitMs !== null && waitMs <= waitBudgetMs;
+      if (!affordable || attempt >= maxAttempts) return { ...last, attempts: attempt };
+      waitBudgetMs -= waitMs;
       options.onProgress?.({
         message: `AGY rate limit; it reports clearing in ${Math.round((waitMs - 1000) / 1000)}s (attempt ${attempt}/${maxAttempts}). Waiting, then retrying...`,
         phase: "reviewing"

--- a/tests/agy-rate-limit-retry.test.mjs
+++ b/tests/agy-rate-limit-retry.test.mjs
@@ -1,0 +1,159 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  parseRateLimitResetMs,
+  AGY_RATE_LIMIT_MAX_WAIT_MS,
+  runGeminiReviewResilient
+} from "../plugins/gemini/scripts/lib/gemini.mjs";
+
+// AGY's verbatim wording, measured on 1.1.24. The retry in #142 is safe only
+// because this sentence exists: it turns "retry and hope" into "wait exactly this
+// long, then retry".
+const AGY_RATE_LIMIT =
+  "Individual quota reached. Please upgrade your subscription to increase your limits. Resets in 58s.";
+
+test("the reset AGY states is read out of its own message", () => {
+  // 58s plus the one-second grace: a retry landing on the same tick is refused
+  // again for nothing.
+  assert.equal(parseRateLimitResetMs(AGY_RATE_LIMIT), 59_000);
+  assert.equal(parseRateLimitResetMs("Resets in 8s."), 9_000);
+  assert.equal(parseRateLimitResetMs("resets in 1 minute"), 61_000);
+});
+
+// The whole design rests on not guessing. This wrapper has no backoff, so an
+// immediate retry against a limit that has not cleared burns every attempt in
+// seconds and reports the same refusal -- worse than failing once.
+test("a message that does not say when it clears yields no wait, not a default", () => {
+  assert.equal(parseRateLimitResetMs("Individual quota reached."), null);
+  assert.equal(parseRateLimitResetMs("429 Too Many Requests"), null);
+  assert.equal(parseRateLimitResetMs(""), null);
+  assert.equal(parseRateLimitResetMs(null), null);
+  assert.equal(parseRateLimitResetMs("Resets in 0s"), null);
+});
+
+test("a reset further out than the ceiling is not waited for", () => {
+  assert.equal(parseRateLimitResetMs("Resets in 3600s"), null);
+  assert.equal(parseRateLimitResetMs("Resets in 30 minutes"), null);
+  // And the ceiling is a real bound, not a comment.
+  const justUnder = parseRateLimitResetMs(`Resets in ${Math.floor((AGY_RATE_LIMIT_MAX_WAIT_MS - 1000) / 1000)}s`);
+  assert.ok(justUnder !== null && justUnder <= AGY_RATE_LIMIT_MAX_WAIT_MS, `got ${justUnder}`);
+});
+
+// ---------------------------------------------------------------------------
+// The wrapper's own branching. Before #142 an AGY review returned on attempt 1
+// unconditionally, so a limit AGY itself said would clear in 58 seconds ended the
+// review outright. These pin both halves of the narrowed exclusion: it retries
+// the rate limit, and it still retries nothing else.
+// ---------------------------------------------------------------------------
+
+function agyEnvelope(error) {
+  return `${JSON.stringify({
+    conversation_id: "", status: "ERROR", response: "", error,
+    duration_seconds: 0, num_turns: 0,
+    usage: { input_tokens: 0, output_tokens: 0, thinking_tokens: 0, cache_read_tokens: 0, total_tokens: 0 }
+  })}\n`;
+}
+
+function stubAgy(errors) {
+  const calls = [];
+  return {
+    calls,
+    detectEngineFn: () => ({ engine: "agy", binary: "/fake/agy.exe", version: "1.1.24" }),
+    runCommandFn: (binary, args) => {
+      calls.push(args);
+      const error = errors[Math.min(calls.length - 1, errors.length - 1)];
+      return { status: 1, stdout: agyEnvelope(error), stderr: "", signal: null, error: null };
+    }
+  };
+}
+
+const RATE_LIMIT = "Individual quota reached. Please upgrade your subscription to increase your limits. Resets in 58s.";
+const NO_RESET = "Individual quota reached. Please upgrade your subscription to increase your limits.";
+const BAD_MODEL = 'invalid model selection (--model "x"): model x is not recognized as a known model or custom model in settings';
+
+test("an AGY rate limit that states its reset is waited out and retried", async () => {
+  const stub = stubAgy([RATE_LIMIT]);
+  const waits = [];
+  const result = await runGeminiReviewResilient("/repo", { prompt: "p", engine: "agy" }, {
+    ...stub, maxAttempts: 3, sleepFn: async (ms) => { waits.push(ms); }
+  });
+  assert.equal(stub.calls.length, 3, "all three attempts are used");
+  assert.deepEqual(waits, [59_000, 59_000], "and each retry waits the stated reset, not zero");
+  assert.equal(result.attempts, 3);
+});
+
+test("an AGY rate limit with no stated reset is not retried", async () => {
+  // No backoff exists here, so retrying without a stated reset burns the attempts
+  // in seconds and reaches the same refusal.
+  const stub = stubAgy([NO_RESET]);
+  const waits = [];
+  const result = await runGeminiReviewResilient("/repo", { prompt: "p", engine: "agy" }, {
+    ...stub, maxAttempts: 3, sleepFn: async (ms) => { waits.push(ms); }
+  });
+  assert.equal(stub.calls.length, 1);
+  assert.deepEqual(waits, []);
+  assert.equal(result.attempts, 1);
+});
+
+test("AGY still fails fast on everything that is not a rate limit", async () => {
+  // The allowlist is what keeps `tool-permission-denied` and brain-root
+  // `transcript-missing` unreachable -- neither is in ACCOUNT_STATE_FAILURES and
+  // none of the heuristics name them, so a denylist would have exposed both.
+  const stub = stubAgy([BAD_MODEL]);
+  const result = await runGeminiReviewResilient("/repo", { prompt: "p", engine: "agy" }, {
+    ...stub, maxAttempts: 3, sleepFn: async () => { throw new Error("must not wait"); }
+  });
+  assert.equal(stub.calls.length, 1, "no retry for a deterministic refusal");
+  assert.equal(result.failure.category, "model-unavailable");
+});
+
+test("a rate-limited AGY review that clears returns the review, not the refusal", async () => {
+  const stub = stubAgy([RATE_LIMIT]);
+  let call = 0;
+  stub.runCommandFn = (binary, args) => {
+    stub.calls.push(args);
+    call += 1;
+    if (call === 1) return { status: 1, stdout: agyEnvelope(RATE_LIMIT), stderr: "", signal: null, error: null };
+    return {
+      status: 0, stderr: "", signal: null, error: null,
+      stdout: `${JSON.stringify({
+        conversation_id: "c1", status: "SUCCESS",
+        response: JSON.stringify({ verdict: "pass", summary: "ok", findings: [] }),
+        duration_seconds: 1, num_turns: 1,
+        usage: { input_tokens: 1, output_tokens: 1, thinking_tokens: 0, cache_read_tokens: 0, total_tokens: 2 }
+      })}\n`
+    };
+  };
+  const result = await runGeminiReviewResilient("/repo", { prompt: "p", engine: "agy" }, {
+    ...stub, maxAttempts: 3, sleepFn: async () => {}
+  });
+  assert.equal(result.attempts, 2, "the second attempt is the one that counts");
+  assert.equal(result.status, 0);
+  assert.ok(result.reviewJson, "and the review it produced is what comes back");
+});
+
+// This is the test that actually pins the allowlist, and it exists because the
+// first version of this file did not. Mutating `category === "rate-limit"` into a
+// condition that admits every category left the suite green: the only fixture for
+// "not a rate limit" was a bad-model message, which carries no reset either, so
+// the RESET PARSER was doing the rejecting and the allowlist was never exercised.
+//
+// A refusal that both is outside the allowlist and states a reset separates them.
+// `tool-permission-denied` is the case the fence in isTransientReviewFailure names
+// by hand: it is outside ACCOUNT_STATE_FAILURES, no heuristic matches it, and it
+// was safe only while agy returned before any of that was consulted. Retrying it
+// never helps -- the permission cannot be granted headlessly, so a wait changes
+// nothing and costs a minute.
+test("a non-rate-limit refusal is not retried even when it states a reset", async () => {
+  const stub = stubAgy([
+    "A tool was auto-denied: headless mode cannot prompt for permission. Resets in 30s."
+  ]);
+  const waits = [];
+  const result = await runGeminiReviewResilient("/repo", { prompt: "p", engine: "agy" }, {
+    ...stub, maxAttempts: 3, sleepFn: async (ms) => { waits.push(ms); }
+  });
+  assert.equal(result.failure.category, "tool-permission-denied", "fixture must hit the category under test");
+  assert.equal(stub.calls.length, 1, "the allowlist, not the reset parser, must stop this");
+  assert.deepEqual(waits, []);
+});

--- a/tests/agy-rate-limit-retry.test.mjs
+++ b/tests/agy-rate-limit-retry.test.mjs
@@ -76,7 +76,7 @@ test("an AGY rate limit that states its reset is waited out and retried", async 
   const stub = stubAgy([RATE_LIMIT]);
   const waits = [];
   const result = await runGeminiReviewResilient("/repo", { prompt: "p", engine: "agy" }, {
-    ...stub, maxAttempts: 3, sleepFn: async (ms) => { waits.push(ms); }
+    ...stub, maxAttempts: 3, rateLimitWaitBudgetMs: 200_000, sleepFn: async (ms) => { waits.push(ms); }
   });
   assert.equal(stub.calls.length, 3, "all three attempts are used");
   assert.deepEqual(waits, [59_000, 59_000], "and each retry waits the stated reset, not zero");
@@ -89,7 +89,7 @@ test("an AGY rate limit with no stated reset is not retried", async () => {
   const stub = stubAgy([NO_RESET]);
   const waits = [];
   const result = await runGeminiReviewResilient("/repo", { prompt: "p", engine: "agy" }, {
-    ...stub, maxAttempts: 3, sleepFn: async (ms) => { waits.push(ms); }
+    ...stub, maxAttempts: 3, rateLimitWaitBudgetMs: 200_000, sleepFn: async (ms) => { waits.push(ms); }
   });
   assert.equal(stub.calls.length, 1);
   assert.deepEqual(waits, []);
@@ -102,7 +102,7 @@ test("AGY still fails fast on everything that is not a rate limit", async () => 
   // none of the heuristics name them, so a denylist would have exposed both.
   const stub = stubAgy([BAD_MODEL]);
   const result = await runGeminiReviewResilient("/repo", { prompt: "p", engine: "agy" }, {
-    ...stub, maxAttempts: 3, sleepFn: async () => { throw new Error("must not wait"); }
+    ...stub, maxAttempts: 3, rateLimitWaitBudgetMs: 200_000, sleepFn: async () => { throw new Error("must not wait"); }
   });
   assert.equal(stub.calls.length, 1, "no retry for a deterministic refusal");
   assert.equal(result.failure.category, "model-unavailable");
@@ -126,7 +126,7 @@ test("a rate-limited AGY review that clears returns the review, not the refusal"
     };
   };
   const result = await runGeminiReviewResilient("/repo", { prompt: "p", engine: "agy" }, {
-    ...stub, maxAttempts: 3, sleepFn: async () => {}
+    ...stub, maxAttempts: 3, rateLimitWaitBudgetMs: 200_000, sleepFn: async () => {}
   });
   assert.equal(result.attempts, 2, "the second attempt is the one that counts");
   assert.equal(result.status, 0);
@@ -151,9 +151,100 @@ test("a non-rate-limit refusal is not retried even when it states a reset", asyn
   ]);
   const waits = [];
   const result = await runGeminiReviewResilient("/repo", { prompt: "p", engine: "agy" }, {
-    ...stub, maxAttempts: 3, sleepFn: async (ms) => { waits.push(ms); }
+    ...stub, maxAttempts: 3, rateLimitWaitBudgetMs: 200_000, sleepFn: async (ms) => { waits.push(ms); }
   });
   assert.equal(result.failure.category, "tool-permission-denied", "fixture must hit the category under test");
   assert.equal(stub.calls.length, 1, "the allowlist, not the reset parser, must stop this");
   assert.deepEqual(waits, []);
+});
+
+// ---------------------------------------------------------------------------
+// Review round 1 on #145. Four findings, and three of them are about the retry
+// firing when it should not.
+// ---------------------------------------------------------------------------
+
+// Under stream-json an ERROR envelope with an empty `response` still yields
+// salvaged partial text, which runGeminiReview can parse into reviewJson while
+// `failure` stays non-null. So a run can come back rate-limited mid-stream with
+// the findings already in hand — and the first version of this branch keyed only
+// on the category, so it discarded them to wait a minute for a bare refusal.
+test("a rate-limited attempt that already produced findings is not retried away", async () => {
+  const stream = [
+    JSON.stringify({ event: "step_update", step_update: { conversation_id: "c1", step_index: 1,
+      state: "DONE", step_type: "agent_response",
+      text_delta: JSON.stringify({ verdict: "reject", summary: "found one", findings: [] }) } }),
+    JSON.stringify({ event: "result", result: { conversation_id: "c1", status: "ERROR", response: "",
+      error: RATE_LIMIT, duration_seconds: 1, num_turns: 1,
+      usage: { input_tokens: 1, output_tokens: 1, thinking_tokens: 0, cache_read_tokens: 0, total_tokens: 2 } } })
+  ].join("\n");
+  const calls = [];
+  const result = await runGeminiReviewResilient("/repo", { prompt: "p", engine: "agy" }, {
+    detectEngineFn: () => ({ engine: "agy", binary: "/fake/agy.exe", version: "1.1.24" }),
+    runCommandFn: (binary, args) => { calls.push(args); return { status: 1, stdout: `${stream}\n`, stderr: "", signal: null, error: null }; },
+    maxAttempts: 3, rateLimitWaitBudgetMs: 200_000,
+    sleepFn: async () => { throw new Error("must not wait when findings are already in hand"); }
+  });
+  assert.ok(result.reviewJson, "the fixture must actually produce parsed findings");
+  assert.equal(calls.length, 1, "the review in hand is kept, not thrown away");
+});
+
+// A foreground /gemini:review is one Bash call under the host's default 120s
+// timeout. Sleeping there turns a clean six-second "rate limited" into a killed
+// command reporting nothing, so the wait is opt-in and a caller that says nothing
+// gets the old fast failure.
+test("no caller waits without a budget, and the default budget is zero", async () => {
+  const stub = stubAgy([RATE_LIMIT]);
+  const result = await runGeminiReviewResilient("/repo", { prompt: "p", engine: "agy" }, {
+    ...stub, maxAttempts: 3,
+    sleepFn: async () => { throw new Error("must not wait without a budget"); }
+  });
+  assert.equal(stub.calls.length, 1);
+  assert.equal(result.attempts, 1);
+});
+
+test("the wait budget is spent across the whole call, not refreshed per attempt", async () => {
+  const stub = stubAgy([RATE_LIMIT]);
+  const waits = [];
+  // Room for one 59s wait, not two.
+  await runGeminiReviewResilient("/repo", { prompt: "p", engine: "agy" }, {
+    ...stub, maxAttempts: 3, rateLimitWaitBudgetMs: 90_000,
+    sleepFn: async (ms) => { waits.push(ms); }
+  });
+  assert.deepEqual(waits, [59_000], "the second wait is unaffordable and ends the run");
+  assert.equal(stub.calls.length, 2);
+});
+
+// normalizeDetail truncates at 2000 characters, so a long error can be non-null
+// while having lost the sentence naming the reset. `detail ?? stderr` only falls
+// back on a nullish detail and would never look at stderr in that case.
+test("the reset is found on stderr when a truncated detail no longer carries it", async () => {
+  // Quota wording first so the category survives truncation; the reset sits past
+  // the 2000-character cap and is therefore lost from `detail`.
+  const longError = `Individual quota reached. ${"noise ".repeat(500)}Resets in 20s.`;
+  const stub = stubAgy([RATE_LIMIT]);
+  stub.runCommandFn = (binary, args) => {
+    stub.calls.push(args);
+    return {
+      status: 1, signal: null, error: null,
+      stdout: `${JSON.stringify({ conversation_id: "", status: "ERROR", response: "",
+        error: longError, duration_seconds: 0, num_turns: 0,
+        usage: { input_tokens: 0, output_tokens: 0, thinking_tokens: 0, cache_read_tokens: 0, total_tokens: 0 } })}\n`,
+      stderr: "Individual quota reached. Resets in 20s."
+    };
+  };
+  const waits = [];
+  await runGeminiReviewResilient("/repo", { prompt: "p", engine: "agy" }, {
+    ...stub, maxAttempts: 2, rateLimitWaitBudgetMs: 200_000, sleepFn: async (ms) => { waits.push(ms); }
+  });
+  assert.deepEqual(waits, [21_000], "stderr carried the reset the truncated detail lost");
+});
+
+test("a compound duration is refused rather than half-read", () => {
+  // `1m 30s` read as 61s fires 29 seconds early, is refused again, and burns an
+  // attempt plus a minute of wall clock -- the exact failure the no-guess rule
+  // exists to prevent.
+  assert.equal(parseRateLimitResetMs("Resets in 1m 30s."), null);
+  assert.equal(parseRateLimitResetMs("Resets in 1 m 30 s"), null);
+  // A plain single unit still parses, and a trailing sentence is not a duration.
+  assert.equal(parseRateLimitResetMs("Resets in 30s. Try again then."), 31_000);
 });


### PR DESCRIPTION
Closes #142. Depends on #141's `detail` field (merged), which is where the reset time comes from — the same text that used to be classified and discarded.

## Reading the fence first

The AGY exclusion had three stated reasons. One (agy's transcript-recovery path) had already stopped applying at AGY 1.1.8. The other two, checked against measurement on 1.1.24:

| Reason | Holds? |
|---|---|
| "its fail-fast timeout handles its distinct failure mode" | For a **hang**, yes. Not for this: a rate limit is a clean structured ERROR envelope, back in 6s. |
| "re-spawning it is costly" | For a review that **runs**, yes. Two refusals came back in 6s and 11s with every token count at zero. |

So the exclusion is narrowed, not removed.

## Narrowed by allowlist, deliberately

agy retries on `rate-limit` and nothing else.

This is the part that keeps the fence in `isTransientReviewFailure` standing. That comment warns that `tool-permission-denied` and brain-root `transcript-missing` sit outside `ACCOUNT_STATE_FAILURES`, that no heuristic names them, and that they are safe **only** because agy returns before any of it is consulted. A denylist would have exposed both. An allowlist leaves them unreachable, and widening it later means adding them there first — the comment now says so in both places.

## And only when AGY says when to come back

A retry happens only when the message states a reset (`Resets in 58s.`), and waits that long — 90s ceiling, one-second grace. **With no stated reset there is no retry**, and there is no default guess: this wrapper has no backoff, so three immediate attempts against a 58-second limit finish in seconds at the same refusal, which is worse than failing once. That was the design objection raised in the issue, and it is the reason the parser returns `null` rather than a fallback.

## Testability

The wrapper now forwards its spawn seams to `runGeminiReview`. Without them its own branching — the part holding every decision above — could only be exercised by spawning a real engine, which is why none of it was tested.

## Verification, including a mutation that survived

The first version of the test file **did not kill the allowlist mutation**. Its only "not a rate limit" fixture was a bad-model message, which states no reset either — so the *reset parser* was doing the rejecting and the allowlist was never exercised. A fixture that is both outside the allowlist and states a reset separates them, and that test is now the one pinning it.

| Mutation | Result |
|---|---|
| Restore the blanket AGY exclusion | 2 tests fail |
| Admit every category, not just `rate-limit` | 1 test fails (only after the fixture fix) |
| Guess a wait when none is stated | 1 test fails |

758 tests, 750 pass, 0 fail, 8 skipped. `check-version` and `verify-contracts` green. `docs/COMPARISON.md` test-file count 39 → 40.

## Note

A review may now block up to ~90s waiting for a limit AGY says will clear. The alternative is failing the review, after which the user waits at least as long and re-runs by hand. Progress is reported through `onProgress` so the wait is visible rather than a stall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WPRqf4z7QMD9cHQb1Y9kYy