### PR TITLE
fix(demo): stop the reviewer walkthrough's poll from competing with the job it waits for (#138)

### DIFF
--- a/plugins/gemini/CHANGELOG.md
+++ b/plugins/gemini/CHANGELOG.md
@@ -19,6 +19,16 @@
   and the degraded path prints "the worker never reported a running process",
   which reads as a broken plugin rather than a busy machine.
 
+  Two things the `status` command did for free had to move here, both found by
+  adversarial review of the first commit: it reconciled a job whose worker had
+  died into `failed`, and it turned an unreadable file into a terminal state. A
+  plain file read has neither, so a dead worker or a corrupt file would have
+  stalled to the full budget where they used to end at once. The waits now check
+  pid liveness with the same predicate the runtime reconciles on, and treat a
+  present-but-unparseable file as terminal after a five-poll grace — absent
+  still means "not written yet". Both paths are unit-tested rather than hoped
+  for; each test fails when its check is removed.
+
   Honest about what was verified: the original failure is load-dependent and
   did **not** reproduce here — five runs under a full-suite load passed both
   with and without the change, so that experiment discriminates nothing. The

--- a/plugins/gemini/CHANGELOG.md
+++ b/plugins/gemini/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 ## 0.24.4 - Unreleased
 
+- **The reviewer walkthrough stops competing with the job it is waiting for.**
+  `waitForRunningJob` and `waitForJob` in `scripts/reviewer-demo.mjs` polled by
+  spawning a full `gemini-companion.mjs status` process per iteration. Measured
+  on this machine while the suite was running: **245 ms per spawn against
+  0.05 ms for reading the job file** — roughly 4,900x, and on top of the nominal
+  200 ms interval, so a 30 s budget bought about 67 polls and spent some 16 s of
+  Node startup on the same machine the worker was trying to start on. Both waits
+  now read the job file directly, poll every 100 ms, and get 60 s. The reads use
+  a local null-on-error helper rather than `state.mjs`'s `readJobFile`, which
+  synthesises a `failed` job for an unreadable file — a poller would read that
+  as terminal and stop on a half-written write.
+
+  This matters beyond a flake: the walkthrough is the evidence a directory
+  reviewer runs in place of a testing account (Software Directory Policy 3.D),
+  and the degraded path prints "the worker never reported a running process",
+  which reads as a broken plugin rather than a busy machine.
+
+  Honest about what was verified: the original failure is load-dependent and
+  did **not** reproduce here — five runs under a full-suite load passed both
+  with and without the change, so that experiment discriminates nothing. The
+  case for the fix is the measured per-poll cost, not a repro.
+
 - **The empty-store message no longer promises jobs that are not there.** It was
   unconditional, and lied in two directions. `/gemini:result --all` against an
   empty store told the user to run the flag they had just run, and called the

--- a/scripts/reviewer-demo.mjs
+++ b/scripts/reviewer-demo.mjs
@@ -39,6 +39,7 @@ import process from "node:process";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
+import { resolveJobsDir } from "../plugins/gemini/scripts/lib/state.mjs";
 import { installFakeGemini } from "../tests/fake-gemini-fixture.mjs";
 import { initGitRepo } from "../tests/helpers.mjs";
 
@@ -186,20 +187,47 @@ function installSlowGemini(binDir, seconds = 120) {
   }
 }
 
-function waitForJob(env, cwd, jobId, timeoutMs = 60_000) {
+// Both waits below read the job file directly instead of spawning `status` on
+// every poll. That spawn was part of what they were waiting out: a whole Node
+// process per iteration, on a machine already running the rest of the suite, so
+// the loop competed with the worker it was waiting for. A file read costs
+// nothing, which is what lets the interval drop and the budget mean what it
+// says. The polls were never shown to the reviewer -- only the `show()` calls
+// are -- so nothing about the walkthrough's evidence changes.
+//
+// resolveStateDir reads GEMINI_COMPANION_DATA from process.env, and the demo
+// sets that only on the CHILD env. Borrow it for this one pure call rather than
+// rebuilding the slug/hash layout here, which would break silently the day
+// resolveStateDir changes.
+function resolveDemoJobsDir(dataDir, cwd) {
+  const previous = process.env.GEMINI_COMPANION_DATA;
+  process.env.GEMINI_COMPANION_DATA = dataDir;
+  try {
+    return resolveJobsDir(cwd);
+  } finally {
+    if (previous === undefined) delete process.env.GEMINI_COMPANION_DATA;
+    else process.env.GEMINI_COMPANION_DATA = previous;
+  }
+}
+
+// Deliberately NOT state.mjs's readJobFile: that one turns an unreadable file
+// into a synthetic `failed` job, which a poller would read as a terminal state
+// and stop on. A half-written file means "not yet", so this returns null and
+// the caller keeps waiting.
+function readDemoJob(jobsDir, jobId) {
+  try {
+    return JSON.parse(fs.readFileSync(path.join(jobsDir, `${jobId}.json`), "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function waitForJob(jobsDir, jobId, timeoutMs = 60_000) {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
-    const probe = spawnSync(process.execPath, ["--no-deprecation", COMPANION, "status", jobId, "--json"], {
-      cwd, env, encoding: "utf8", windowsHide: true
-    });
-    try {
-      const payload = JSON.parse(probe.stdout);
-      const job = payload.job ?? payload.jobs?.[0] ?? payload;
-      if (job && ["completed", "failed", "cancelled", "canceled"].includes(String(job.status))) return job.status;
-    } catch {
-      // status not written yet — keep waiting
-    }
-    sleep(400);
+    const job = readDemoJob(jobsDir, jobId);
+    if (job && ["completed", "failed", "cancelled", "canceled"].includes(String(job.status))) return job.status;
+    sleep(100);
   }
   return "timed-out";
 }
@@ -228,31 +256,23 @@ function waitForJob(env, cwd, jobId, timeoutMs = 60_000) {
 // "worker" — a worker is up but its engine never reported in; cancel still has
 // something to terminate, and the step says so rather than pretending.
 // "none"   — nothing to go on.
-function waitForRunningJob(env, cwd, jobId, timeoutMs = 30_000) {
+function waitForRunningJob(jobsDir, jobId, timeoutMs = 60_000) {
   const deadline = Date.now() + timeoutMs;
   let sawWorker = false;
   while (Date.now() < deadline) {
-    const probe = spawnSync(process.execPath, ["--no-deprecation", COMPANION, "status", jobId, "--json"], {
-      cwd, env, encoding: "utf8", windowsHide: true
-    });
-    try {
-      const payload = JSON.parse(probe.stdout);
-      const job = payload.job ?? payload.jobs?.[0] ?? payload;
-      const status = String(job?.status ?? "");
-      const phase = String(job?.phase ?? "");
-      if (status === "running" && job.pid) {
-        sawWorker = true;
-        if (phase === "running" || phase === "reviewing") return "engine";
-      }
-      // Anything neither queued nor running has finished, and will never reach
-      // running. Phrased as the complement of "still active" rather than as a
-      // list of terminal states, which would need updating every time the
-      // runtime gains one.
-      if (status && status !== "queued" && status !== "running") return sawWorker ? "worker" : "none";
-    } catch {
-      // status not written yet — keep waiting
+    const job = readDemoJob(jobsDir, jobId);
+    const status = String(job?.status ?? "");
+    const phase = String(job?.phase ?? "");
+    if (status === "running" && job.pid) {
+      sawWorker = true;
+      if (phase === "running" || phase === "reviewing") return "engine";
     }
-    sleep(200);
+    // Anything neither queued nor running has finished, and will never reach
+    // running. Phrased as the complement of "still active" rather than as a
+    // list of terminal states, which would need updating every time the
+    // runtime gains one.
+    if (status && status !== "queued" && status !== "running") return sawWorker ? "worker" : "none";
+    sleep(100);
   }
   return sawWorker ? "worker" : "none";
 }
@@ -312,6 +332,7 @@ function main() {
   installFakeGemini(binDir, "task");
   const repo = buildWorkspace(root);
   const env = buildEnv(binDir, dataDir);
+  const jobsDir = resolveDemoJobsDir(dataDir, repo);
 
   process.stdout.write(`${c(BOLD, "agy-plugin-cc — credential-free functional walkthrough")}\n`);
   process.stdout.write(`${c(DIM, `workspace: ${root}`)}\n`);
@@ -334,7 +355,7 @@ function main() {
     const started = show(["task", "--background", "add a regression test for the empty case"], { cwd: repo, env });
     const jobId = (started.body.match(JOB_ID) ?? [])[1];
     if (jobId) {
-      const status = waitForJob(env, repo, jobId);
+      const status = waitForJob(jobsDir, jobId);
       process.stdout.write(`${c(DIM, `  (waited for ${jobId} → ${status})`)}\n`);
       show(["status", "--all"], { cwd: repo, env });
       show(["result", jobId], { cwd: repo, env, allowFailure: true });
@@ -356,7 +377,7 @@ function main() {
     const toCancel = show(["task", "--background", "a job that will be cancelled"], { cwd: repo, env });
     const cancelId = (toCancel.body.match(JOB_ID) ?? [])[1];
     if (cancelId) {
-      const ready = waitForRunningJob(env, repo, cancelId);
+      const ready = waitForRunningJob(jobsDir, cancelId);
       if (ready === "worker") {
         note("The engine never reported its turn; cancelling the worker anyway.");
       } else if (ready === "none") {

--- a/scripts/reviewer-demo.mjs
+++ b/scripts/reviewer-demo.mjs
@@ -39,6 +39,7 @@ import process from "node:process";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
+import { isPidAlive } from "../plugins/gemini/scripts/lib/process.mjs";
 import { resolveJobsDir } from "../plugins/gemini/scripts/lib/state.mjs";
 import { installFakeGemini } from "../tests/fake-gemini-fixture.mjs";
 import { initGitRepo } from "../tests/helpers.mjs";
@@ -211,22 +212,53 @@ function resolveDemoJobsDir(dataDir, cwd) {
 }
 
 // Deliberately NOT state.mjs's readJobFile: that one turns an unreadable file
-// into a synthetic `failed` job, which a poller would read as a terminal state
-// and stop on. A half-written file means "not yet", so this returns null and
-// the caller keeps waiting.
+// into a synthetic `failed` job, and a poller would read that as a terminal
+// state and stop on it mid-write.
+//
+// But "unreadable" and "not there yet" are not the same answer, and collapsing
+// them into null would trade a fast failure for a full-budget stall whenever a
+// file is genuinely corrupt. Absent means not yet; present-but-unparseable is
+// reported as such, and the callers give it a short grace before believing it,
+// because a rename can be observed mid-flight.
+const UNREADABLE = Symbol("unreadable job file");
+const UNREADABLE_GRACE_POLLS = 5;
+
 function readDemoJob(jobsDir, jobId) {
+  let raw;
   try {
-    return JSON.parse(fs.readFileSync(path.join(jobsDir, `${jobId}.json`), "utf8"));
+    raw = fs.readFileSync(path.join(jobsDir, `${jobId}.json`), "utf8");
   } catch {
     return null;
   }
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return UNREADABLE;
+  }
 }
 
-function waitForJob(jobsDir, jobId, timeoutMs = 60_000) {
+// The one thing the `status` command did that a file read does not: it
+// reconciles an active job whose worker is gone, marking it failed. Without
+// that, a worker that dies without recording a terminal state leaves the file
+// saying `running` forever, and a wait that used to end in a moment would sit
+// out its whole budget before reaching the same verdict. So check liveness
+// here, with the same predicate the runtime reconciles on. A job with no pid
+// yet is not dead — it has not started.
+function workerIsGone(job) {
+  return Boolean(job) && job !== UNREADABLE && Number.isFinite(job.pid) && !isPidAlive(job.pid);
+}
+
+export function waitForJob(jobsDir, jobId, timeoutMs = 60_000) {
   const deadline = Date.now() + timeoutMs;
+  let unreadable = 0;
   while (Date.now() < deadline) {
     const job = readDemoJob(jobsDir, jobId);
-    if (job && ["completed", "failed", "cancelled", "canceled"].includes(String(job.status))) return job.status;
+    unreadable = job === UNREADABLE ? unreadable + 1 : 0;
+    if (unreadable >= UNREADABLE_GRACE_POLLS) return "unreadable";
+    if (job && job !== UNREADABLE && ["completed", "failed", "cancelled", "canceled"].includes(String(job.status))) {
+      return job.status;
+    }
+    if (workerIsGone(job)) return "abandoned";
     sleep(100);
   }
   return "timed-out";
@@ -256,11 +288,15 @@ function waitForJob(jobsDir, jobId, timeoutMs = 60_000) {
 // "worker" — a worker is up but its engine never reported in; cancel still has
 // something to terminate, and the step says so rather than pretending.
 // "none"   — nothing to go on.
-function waitForRunningJob(jobsDir, jobId, timeoutMs = 60_000) {
+export function waitForRunningJob(jobsDir, jobId, timeoutMs = 60_000) {
   const deadline = Date.now() + timeoutMs;
   let sawWorker = false;
+  let unreadable = 0;
   while (Date.now() < deadline) {
-    const job = readDemoJob(jobsDir, jobId);
+    const raw = readDemoJob(jobsDir, jobId);
+    unreadable = raw === UNREADABLE ? unreadable + 1 : 0;
+    if (unreadable >= UNREADABLE_GRACE_POLLS) return sawWorker ? "worker" : "none";
+    const job = raw === UNREADABLE ? null : raw;
     const status = String(job?.status ?? "");
     const phase = String(job?.phase ?? "");
     if (status === "running" && job.pid) {
@@ -272,6 +308,7 @@ function waitForRunningJob(jobsDir, jobId, timeoutMs = 60_000) {
     // list of terminal states, which would need updating every time the
     // runtime gains one.
     if (status && status !== "queued" && status !== "running") return sawWorker ? "worker" : "none";
+    if (workerIsGone(job)) return sawWorker ? "worker" : "none";
     sleep(100);
   }
   return sawWorker ? "worker" : "none";
@@ -423,4 +460,8 @@ function main() {
   }
 }
 
-main();
+// Guarded so the waits above can be imported and tested directly. Without it,
+// importing this module to reach one function would run the entire walkthrough.
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/tests/reviewer-demo.test.mjs
+++ b/tests/reviewer-demo.test.mjs
@@ -4,7 +4,13 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { fileURLToPath } from "node:url";
 
-import { run } from "./helpers.mjs";
+import { makeTempDir, run } from "./helpers.mjs";
+import { waitForJob, waitForRunningJob } from "../scripts/reviewer-demo.mjs";
+
+// A pid that cannot be running: the kernel reserves 0, and process.kill(0, 0)
+// addresses the calling process group rather than a process, so a real-looking
+// but unused high pid is used instead and checked once here.
+const DEAD_PID = 0x7ffffffe;
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const SCRIPT = path.join(ROOT, "scripts", "reviewer-demo.mjs");
@@ -53,6 +59,35 @@ function findJobLog(kept, marker) {
     if (body.includes(marker)) return body;
   }
   return null;}
+
+// The waits poll the job file rather than spawning `status` per iteration
+// (#138). Two things that command did for free now have to be done here, and
+// both are failure paths a normal run never takes -- so they are exercised
+// directly rather than hoped for.
+
+test("waitForRunningJob gives up when the worker's pid is gone", () => {
+  const dir = makeTempDir();
+  fs.writeFileSync(
+    path.join(dir, "task-dead.json"),
+    JSON.stringify({ id: "task-dead", status: "running", phase: "starting", pid: DEAD_PID })
+  );
+  const started = Date.now();
+  assert.equal(waitForRunningJob(dir, "task-dead", 10_000), "worker");
+  assert.ok(Date.now() - started < 5_000, "it waited out the budget instead of noticing the dead pid");
+});
+
+test("waitForJob reports a corrupt job file instead of waiting out its budget", () => {
+  const dir = makeTempDir();
+  fs.writeFileSync(path.join(dir, "task-corrupt.json"), "{ this is not json");
+  const started = Date.now();
+  assert.equal(waitForJob(dir, "task-corrupt", 10_000), "unreadable");
+  assert.ok(Date.now() - started < 5_000, "it waited out the budget instead of reporting the corrupt file");
+});
+
+test("waitForJob keeps waiting while the job file does not exist yet", () => {
+  const dir = makeTempDir();
+  assert.equal(waitForJob(dir, "task-absent", 500), "timed-out");
+});
 
 test("reviewer-demo lists its steps without running anything", () => {
   const result = run("node", [SCRIPT, "--list"], { cwd: ROOT });


### PR DESCRIPTION
Closes #138.

`waitForRunningJob` and `waitForJob` in `scripts/reviewer-demo.mjs` polled by spawning a full `gemini-companion.mjs status` process per iteration — on the machine the background worker was trying to start on.

## The measurement

Taken on this machine with the suite running:

| per poll | cost |
|---|---|
| `spawnSync(node, [companion, "status", id, "--json"])` | **245.4 ms** |
| `JSON.parse(fs.readFileSync(jobFile))` | **0.050 ms** |

~4,900x. On top of the nominal 200 ms interval, the 30 s budget bought about 67 polls and spent roughly 16 s of Node startup competing with the worker.

## The change

Both waits read the job file directly, poll every 100 ms, and get 60 s. The read is a local null-on-error helper rather than `state.mjs`'s `readJobFile`, which synthesises a `failed` job for an unreadable file — a poller would take that as terminal and stop on a half-written write.

The state directory is resolved by borrowing `GEMINI_COMPANION_DATA` around one pure `resolveJobsDir` call, rather than rebuilding the slug/hash layout in the demo where it could drift.

The polls were never part of what the walkthrough shows a reviewer — only the `show()` calls are — so its evidence is unchanged.

## Verification, and its limit

- `npm test`: 767 tests, **759 pass, 0 fail**, 8 skipped
- `tests/reviewer-demo.test.mjs`: 3/3

The original failure is load-dependent and **did not reproduce here**: five demo runs under a full-suite load reached the engine both with and without the change, so that experiment discriminates nothing. The case for the fix is the measured per-poll cost, not a repro. Per the issue, "passes in isolation" is expected rather than evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WPRqf4z7QMD9cHQb1Y9kYy