### PR TITLE
chore(release): 0.24.4

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,13 +7,13 @@
   },
   "metadata": {
     "description": "agy-plugin-cc is a Claude Code companion for running Gemini CLI or Antigravity CLI (agy) as a cross-model task delegate and code reviewer, with pragmatic and adversarial review, MCP tools, and background jobs.",
-    "version": "0.24.3"
+    "version": "0.24.4"
   },
   "plugins": [
     {
       "name": "gemini",
       "description": "agy-plugin-cc is a Claude Code companion for running Gemini CLI or Antigravity CLI (agy) as a cross-model task delegate and code reviewer, with pragmatic and adversarial review, MCP tools, and background jobs.",
-      "version": "0.24.3",
+      "version": "0.24.4",
       "author": {
         "name": "arcobaleno64",
         "email": "arcobaleno830623@gmail.com"

--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -21,7 +21,7 @@ belong to.
 | [sakibsadmanshajib/gemini-plugin-cc](https://github.com/sakibsadmanshajib/gemini-plugin-cc) | 24 | 2026-05-22 | v1.0.1, archived | Gemini CLI | ACP |
 | [sakibsadmanshajib/antigravity-plugin](https://github.com/sakibsadmanshajib/antigravity-plugin) | 19 | 2026-05-22 | none | AGY only | `agy --print` |
 | [m-ghalib/gemini-plugin-cc](https://github.com/m-ghalib/gemini-plugin-cc) | 18 | 2026-04-24 | v0.1.0 | Gemini CLI, setup installs 0.38.2 | ACP |
-| **this project** | 10 | 2026-09-02 | v0.24.3 | Gemini CLI **and** AGY | direct spawn, structured JSON |
+| **this project** | 10 | 2026-09-03 | v0.24.4 | Gemini CLI **and** AGY | direct spawn, structured JSON |
 
 | Surface | Slash commands | MCP tools | Skills | Test files (`*.test.*`) |
 |---|---|---|---|---|

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@arcobaleno64/agy-plugin-cc",
-  "version": "0.24.3",
+  "version": "0.24.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@arcobaleno64/agy-plugin-cc",
-      "version": "0.24.3",
+      "version": "0.24.4",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arcobaleno64/agy-plugin-cc",
-  "version": "0.24.3",
+  "version": "0.24.4",
   "private": true,
   "type": "module",
   "description": "agy-plugin-cc is a Claude Code companion for running Gemini CLI or Antigravity CLI (agy) as a cross-model task delegate and code reviewer, with pragmatic and adversarial review, MCP tools, and background jobs.",

--- a/plugins/gemini/.claude-plugin/plugin.json
+++ b/plugins/gemini/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gemini",
-  "version": "0.24.3",
+  "version": "0.24.4",
   "description": "agy-plugin-cc is a Claude Code companion for running Gemini CLI or Antigravity CLI (agy) as a cross-model task delegate and code reviewer, with pragmatic and adversarial review, MCP tools, and background jobs.",
   "author": {
     "name": "arcobaleno64",

--- a/plugins/gemini/CHANGELOG.md
+++ b/plugins/gemini/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.24.4 - Unreleased
+## 0.24.4 - 2026-09-03 - Four things only using it could find
 
 - **The reviewer walkthrough stops competing with the job it is waiting for.**
   `waitForRunningJob` and `waitForJob` in `scripts/reviewer-demo.mjs` polled by


### PR DESCRIPTION
Cuts 0.24.4. Four fixes, all found by using the plugin rather than by reading it:

- the reviewer walkthrough's poll competing with the job it waits for (#138)
- the empty-store message promising jobs that are not there (#134)
- an AGY review dying on a rate limit that clears in under a minute (#142)
- a failed AGY turn discarding what AGY said (#141)

Also refreshes this project's own row in `docs/COMPARISON.md`, which is kept current on release, and records the AGY 1.1.24 model listing in `docs/MODEL_COMPARISON.md` §D (landed earlier on the #134 branch).

## Gates on this commit

- `npm test`: 770 tests, **762 pass, 0 fail**, 8 skipped
- `npm run bench`: scorecard written
- `npm run check-version`: all six version locations match 0.24.4
- `npm run verify-contracts`: passed at 0.24.4

The bump alone publishes nothing — the annotated `v0.24.4` tag is what triggers `release.yml`, and it goes on the squash-merge commit after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WPRqf4z7QMD9cHQb1Y9kYy