### PR TITLE
The stop gate treated a review that reviewed nothing as a pass

### DIFF
--- a/plugins/gemini/CHANGELOG.md
+++ b/plugins/gemini/CHANGELOG.md
@@ -1,5 +1,40 @@
 # Changelog
 
+## Unreleased
+
+- **The stop gate no longer treats a review that reviewed nothing as a pass.**
+  The hook guarded its review result with `if (!payload)`, which asks whether the
+  process returned anything, not whether it returned a verdict. Two ways to exit
+  0 with no verdict slipped through, and both spent the gate's one-shot
+  `gateReviewedAt` mark and let Stop past in silence — the edits were recorded as
+  reviewed forever, unseen.
+
+  The first is a change that was committed before Stop fired. The gate reviews
+  `--scope working-tree` because the plugin never commits, but nothing stops the
+  agent or the user from committing first, and then the companion returns
+  `{ empty: true, result: null }` with exit 0. The second is a turn that
+  succeeded while the model wrote prose instead of the structured review:
+  `result` is null and the exit status stays 0.
+
+  The guard is now `if (!payload?.result?.verdict)`, so both land in the
+  fail-open branch that already existed — Stop is still allowed, the mark is not
+  spent, and the skip is visible. That branch's own wording was widened to match:
+  it claimed the review "could not run", which an empty scope did not.
+
+  The hole was in the one direction this file had already ruled out. The same
+  function chose `--scope working-tree` deliberately, "instead of relying on auto
+  scope (which could resolve to an empty branch diff and pass vacuously)" — the
+  vacuous pass was anticipated for branch scope and closed there, while
+  working-tree kept the identical shape. And the visible-warning design at the
+  fail-open branch says the skip must never be silent; this was the one route
+  that was.
+
+  Both routes now have an end-to-end test through the real hook, asserting on the
+  stored job that the mark is unspent. The prose route needed a fixture that did
+  not exist: `review-prose` in `tests/fixtures/fake-gemini.cjs` is a turn that
+  succeeds and answers in prose, which is the shape the engines actually produce
+  when they answer the prompt instead of obeying its output contract.
+
 ## 0.24.4 - 2026-09-03 - Four things only using it could find
 
 - **The reviewer walkthrough stops competing with the job it is waiting for.**

--- a/plugins/gemini/scripts/stop-review-gate-hook.mjs
+++ b/plugins/gemini/scripts/stop-review-gate-hook.mjs
@@ -151,13 +151,20 @@ async function main() {
   }
 
   const payload = runAdversarialReview(cwd);
-  if (!payload) {
-    // Review failed or Gemini unavailable — fail OPEN (never trap the user at
-    // Stop), but make the skip VISIBLE instead of silent so they know the gate
-    // did not actually run. `systemMessage` surfaces to the user; stderr is a
-    // belt-and-suspenders fallback for hook logs.
+  // The guard is "did it return a verdict", not "did it return anything". A
+  // review that reviewed nothing still exits 0 with a whole JSON object: the
+  // companion returns `{ empty: true, result: null }` when the scope is empty,
+  // which is what a committed change looks like to `--scope working-tree`. That
+  // payload is truthy, so `!payload` let it through as a pass — the mark was
+  // spent, Stop was allowed, and nothing was said. Same for a run whose output
+  // did not parse: `result` is null while the exit status stays 0.
+  if (!payload?.result?.verdict) {
+    // Review failed, returned no verdict, or Gemini unavailable — fail OPEN
+    // (never trap the user at Stop), but make the skip VISIBLE instead of silent
+    // so they know the gate did not actually run. `systemMessage` surfaces to
+    // the user; stderr is a belt-and-suspenders fallback for hook logs.
     const warning =
-      "Gemini review gate skipped: the adversarial review could not run (Gemini/AGY unavailable or errored). Run /gemini:adversarial-review --wait before stopping if you changed code.";
+      "Gemini review gate skipped: the adversarial review did not return a verdict (Gemini/AGY unavailable, errored, or nothing in scope to review). Run /gemini:adversarial-review --wait before stopping if you changed code.";
     process.stderr.write(`${warning}\n`);
     emitDecision({ systemMessage: warning });
     return;

--- a/tests/fixtures/fake-gemini.cjs
+++ b/tests/fixtures/fake-gemini.cjs
@@ -151,6 +151,19 @@ function respond(prompt) {
     process.stderr.write("Considering empty-state edge cases...\nCross-checking [DEP12] handling in the retry path.\nReasoning complete.\n");
   }
 
+  if (SCENARIO === "review-prose") {
+    // A turn that SUCCEEDS and still yields no review: exit 0, a well-formed CLI
+    // envelope, and prose where the structured verdict should be. The models do
+    // this when they answer the prompt instead of obeying its output contract.
+    // The plugin then carries `result: null` with an exit status of 0, which is
+    // the shape the stop gate has to tell apart from a passing review.
+    process.stdout.write(JSON.stringify({
+      session_id: sessionId,
+      response: "I looked at the diff and it seems fine to me overall. Nothing jumped out."
+    }));
+    process.exit(0);
+  }
+
   const response = buildResponse();
   process.stdout.write(JSON.stringify({ session_id: sessionId, response: response }));
   process.exit(0);

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -2105,6 +2105,71 @@ test("stop-gate fails OPEN with a visible warning when the review cannot run", (
   assert.match(result.stderr, /review gate skipped/i);
 });
 
+test("stop-gate does not consume the mark when the review had nothing to review", () => {
+  // The gate reviews `--scope working-tree` because the plugin never commits.
+  // Nothing stops the edits being committed between the write task finishing and
+  // Stop firing, and then the review returns `{ empty: true, result: null }` with
+  // exit 0. That is a truthy payload carrying no verdict: the hook used to take
+  // it for a passing review, stamp the job as reviewed, and let Stop through
+  // without a word. The edits were then marked reviewed forever, unseen.
+  const { repo, binDir } = setupRepo("adversarial");
+  commit(repo, "src/app.js", "export const value = 1;\n");
+  seedState(
+    repo,
+    [{ id: "task-empty", status: "completed", jobClass: "task", write: true, kindLabel: "rescue", title: "Gemini Task" }],
+    { stopReviewGateEnabled: true }
+  );
+
+  const result = runStopGate(repo, buildEnv(binDir));
+
+  assert.equal(result.status, 0, result.stderr);
+  const decision = JSON.parse(result.stdout);
+  assert.ok(!("decision" in decision), "fail open: a vacuous review must not trap the user at Stop");
+  assert.match(
+    decision.systemMessage ?? "",
+    /skipped/i,
+    "a review that produced no verdict is a skipped gate, and the skip has to be visible"
+  );
+
+  const job = storedJobs(repo).find((entry) => entry.id === "task-empty");
+  assert.ok(job, "the seeded write task is still in the store");
+  assert.equal(
+    job.gateReviewedAt,
+    undefined,
+    "nothing was reviewed, so the one-shot mark must still be unspent"
+  );
+});
+
+test("stop-gate does not consume the mark when the engine answered in prose", () => {
+  // The other way to exit 0 with no verdict: the turn succeeds and the model
+  // writes prose instead of the structured review. `result` is null while the
+  // exit status stays 0, so the payload is truthy and carries nothing to act on.
+  // Unlike the empty-scope case there IS an unreviewed change in the tree here,
+  // which is exactly why the mark must survive.
+  const { repo, binDir } = setupRepo("review-prose");
+  commit(repo, "src/app.js", "export const value = items[0];" + String.fromCharCode(10));
+  fs.writeFileSync(path.join(repo, "src", "app.js"), "export const value = items[0].id;" + String.fromCharCode(10));
+  seedState(
+    repo,
+    [{ id: "task-prose", status: "completed", jobClass: "task", write: true, kindLabel: "rescue", title: "Gemini Task" }],
+    { stopReviewGateEnabled: true }
+  );
+
+  const result = runStopGate(repo, buildEnv(binDir));
+
+  assert.equal(result.status, 0, result.stderr);
+  const decision = JSON.parse(result.stdout);
+  assert.ok(!("decision" in decision), "fail open: an unparseable review must not trap the user at Stop");
+  assert.match(decision.systemMessage ?? "", /skipped/i, "no verdict came back, so say the gate did not run");
+
+  const job = storedJobs(repo).find((entry) => entry.id === "task-prose");
+  assert.equal(
+    job?.gateReviewedAt,
+    undefined,
+    "the change in the tree was never actually reviewed, so it must still arm the gate"
+  );
+});
+
 test("the fixture PATH drops directories holding a real gemini or agy", () => {
   // A stand-in that merely goes first on PATH is only as isolated as the
   // resolution below it. Dropping the real installation's directory is what makes


### PR DESCRIPTION
Fixes #151.

`stop-review-gate-hook.mjs` guarded its review result with `if (!payload)` —
whether the process returned anything, not whether it returned a verdict. A
payload with no `result` is still a truthy object, so it was taken for a passing
review: the one-shot `gateReviewedAt` mark was spent, Stop was allowed, and
nothing was said. The edits stayed marked reviewed forever, unseen.

## Two ways to exit 0 with no verdict

**The change was committed before Stop fired.** The gate reviews
`--scope working-tree` because the plugin never commits — but nothing stops the
agent or the user committing first, and then `gemini-companion.mjs:737-761`
returns `{ empty: true, result: null }` with exit 0.

**The turn succeeded and the model wrote prose.** `gemini-companion.mjs:797-798`
sets `result: parsed.parsed`, null when the review text does not parse, while
`exitStatus` stays `result.status` — 0 for a CLI run that worked.

## The fix

```diff
-  if (!payload) {
+  if (!payload?.result?.verdict) {
```

Both routes now fall into the fail-open branch that already existed: Stop is
still allowed, the mark is not spent, and the skip is visible. The branch's
wording widened to match — it said the review "could not run", which is not what
an empty scope did.

## Why this reads as a defect rather than a decision

The hole is in the one direction the file had already ruled out. The same
function chose `--scope working-tree` deliberately:

> instead of relying on auto scope (which could resolve to an empty branch diff
> and pass vacuously)

The vacuous pass was anticipated for branch scope and closed there; working-tree
kept the identical shape. And the fail-open branch exists specifically to "make
the skip VISIBLE instead of silent" — this was the one route that skipped it
silently.

## Tests

Two end-to-end tests through the real hook, each asserting on the stored job
that the mark is unspent — not on the hook's stdout alone, since the silent
allow looked identical to a legitimate pass from outside.

Mutation-checked: reverting the guard to `!payload` turns exactly those two red
and leaves the other three stop-gate tests green.

The prose route needed a fixture that did not exist. `review-prose` in
`tests/fixtures/fake-gemini.cjs` is a turn that succeeds and answers in prose —
what the engines actually produce when they answer the prompt instead of obeying
its output contract. Its test keeps a real uncommitted change in the tree, so
the assertion is that a genuinely unreviewed edit still arms the gate.

`npm test`: 772 tests, 764 pass, 0 fail, 8 skipped.

## Not covered

- The two routes are tested; no test pins the `systemMessage` wording itself.
- #152 (an unreadable job store reading as "no work to gate") is the same class
  of silent fail-open and is not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QqFf49oKbvhjsdzz7WTCbQ
