### PR TITLE
An unreadable job store read as "nothing to gate"

### DIFF
--- a/plugins/gemini/CHANGELOG.md
+++ b/plugins/gemini/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 ## 0.25.0 - Unreleased
 
+- **An unreadable job store no longer reads as "nothing to gate".** `listJobs`
+  answers `[]` both for a store with no jobs in it and for one it could not
+  read, and an empty list is exactly why the stop gate lets Stop through. A
+  permissions problem, a lock, or a clobbered directory therefore disarmed the
+  gate without a word.
+
+  `listJobs` is unchanged. Making it throw would turn a read failure into a
+  crash at fourteen call sites, and for thirteen of them the merge is right — a
+  status listing with nothing to show reads the same either way. Only the gate
+  treats "no jobs" as a licence to skip, so only the gate asks the new
+  `jobStoreUnreadableReason`, and only on the path where the answer changes
+  anything. It still fails open; it now says why, in the same shape as the
+  review-failure warning beside it.
+
+  ENOENT is deliberately not a failure: the directory is created on first write,
+  so its absence is the ordinary state of a workspace that has run no jobs yet.
+  That carve-out has a test of its own, added because a mutation proved nothing
+  else covered it — the neighbouring no-warning test seeds a job, and seeding is
+  what creates the directory. Without it, the new warning would fire on every
+  Stop for anyone who had not used the plugin yet.
+
+  The unreadable case is reproduced portably by putting a file where the jobs
+  directory belongs: readdir answers ENOTDIR everywhere, where a chmod does
+  nothing on Windows.
 - **BREAKING: AGY 1.1.12 or newer is now required, and an older AGY is refused by
   name.** Run `agy update`. This replaces seven capability gates
   (`supportsAgyStdinPrompt` 1.1.2, `supportsAgyStructuredOutput` 1.1.8,

--- a/plugins/gemini/scripts/lib/state.mjs
+++ b/plugins/gemini/scripts/lib/state.mjs
@@ -251,6 +251,29 @@ function readJobEntry(jobFile) {
   }
 }
 
+// `listJobs` answers [] for two different situations: a store with no jobs in
+// it, and a store it could not read. For almost every caller that is the right
+// merge — a status listing with nothing to show reads the same either way, and
+// throwing would turn a permissions problem into a crash on fourteen call
+// sites. The stop gate is the exception. There, "no jobs" is the reason it lets
+// Stop through, so a directory it failed to read disarms the gate and says
+// nothing. This reports which of the two it was, without changing what
+// `listJobs` returns to anyone.
+//
+// A store that was never created is empty, not unreadable: the directory is made
+// on first write, so ENOENT is the ordinary state of a workspace that has run no
+// jobs yet.
+export function jobStoreUnreadableReason(cwd) {
+  const jobsDir = path.join(resolveStateDir(cwd), JOBS_DIR_NAME);
+  try {
+    fs.readdirSync(jobsDir);
+    return null;
+  } catch (error) {
+    if (error?.code === "ENOENT") return null;
+    return error?.code ? String(error.code) : String(error?.message ?? error);
+  }
+}
+
 export function listJobs(cwd) {
   // resolveStateDir shells out to git to find the workspace root, so resolve it
   // once for the whole call. `/gemini:status --wait` polls this every two

--- a/plugins/gemini/scripts/stop-review-gate-hook.mjs
+++ b/plugins/gemini/scripts/stop-review-gate-hook.mjs
@@ -6,7 +6,7 @@ import process from "node:process";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { getConfig, listJobs, upsertJob } from "./lib/state.mjs";
+import { getConfig, jobStoreUnreadableReason, listJobs, upsertJob } from "./lib/state.mjs";
 import { resolveWorkspaceRoot } from "./lib/workspace.mjs";
 
 const SELF_PATH = fileURLToPath(import.meta.url);
@@ -146,6 +146,20 @@ async function main() {
   const jobs = listJobs(workspaceRoot);
   const pending = pendingGateWriteTasks(jobs);
   if (pending.length === 0) {
+    // An empty list is the reason this lets Stop through, and `listJobs` gives
+    // the same empty list for a store it could not read. Untangled here rather
+    // than in `listJobs` because only this caller treats "no jobs" as a licence
+    // to skip the gate; everywhere else an unreadable store and an empty one
+    // really do render the same.
+    const unreadable = jobStoreUnreadableReason(workspaceRoot);
+    if (unreadable) {
+      const warning =
+        `Gemini review gate skipped: the job store could not be read (${unreadable}), so the gate cannot tell whether anything needs reviewing. Run /gemini:adversarial-review --wait before stopping if you changed code.`;
+      process.stderr.write(`${warning}
+`);
+      emitDecision({ systemMessage: warning });
+      return;
+    }
     emitDecision({});
     return;
   }

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -2029,6 +2029,56 @@ test("stop-gate proceeds without a warning when enabled but no write task comple
   assert.ok(!decision.systemMessage, "no skip warning when there is nothing to review");
 });
 
+test("stop-gate says so when it cannot read the job store", () => {
+  // `listJobs` returns [] for a store it could not read, which is the same
+  // answer it gives for a store with nothing in it — and an empty list is
+  // exactly why this hook lets Stop through. A permissions problem or a
+  // clobbered directory therefore disarmed the gate in silence. Failing open is
+  // still right; being quiet about it is not.
+  //
+  // The store is made unreadable portably by putting a FILE where the jobs
+  // directory belongs: readdir answers ENOTDIR on every platform, where a chmod
+  // would do nothing on Windows.
+  const workspace = makeTempDir();
+  const stateFile = seedState(workspace, [], { stopReviewGateEnabled: true });
+  fs.writeFileSync(path.join(path.dirname(stateFile), "jobs"), "not a directory", "utf8");
+
+  const result = runStopGate(workspace, envWithoutSession());
+
+  assert.equal(result.status, 0, result.stderr);
+  const decision = JSON.parse(result.stdout);
+  assert.ok(!("decision" in decision), "fail open: an unreadable store must not trap the user at Stop");
+  assert.match(
+    decision.systemMessage ?? "",
+    /job store could not be read/i,
+    "an unreadable store is a skipped gate, and the skip has to be visible"
+  );
+  assert.match(result.stderr, /job store could not be read/i);
+});
+
+test("stop-gate is quiet in a workspace that has never run a job", () => {
+  // The store's directory is created on first write, so its absence is the
+  // ordinary state of a fresh workspace — not a store that could not be read.
+  // Without that carve-out the unreadable-store warning above fires on every
+  // Stop for anyone who has not used the plugin yet, which is the failure mode
+  // of adding it. Nothing else in this file covers it: the neighbouring
+  // no-warning test seeds a job, and seeding creates the directory.
+  const workspace = makeTempDir();
+  const stateFile = seedState(workspace, [], { stopReviewGateEnabled: true });
+  assert.ok(
+    !fs.existsSync(path.join(path.dirname(stateFile), "jobs")),
+    "the premise: seeding no jobs must leave no jobs directory"
+  );
+
+  const result = runStopGate(workspace, envWithoutSession());
+
+  assert.equal(result.status, 0, result.stderr);
+  const decision = JSON.parse(result.stdout);
+  assert.ok(!("decision" in decision));
+  assert.ok(!decision.systemMessage, "an unused workspace is not a broken one");
+  assert.equal(result.stderr.trim(), "");
+});
+
 test("stop-gate fails OPEN with a visible warning when the review cannot run", () => {
   // A completed --write task arms the gate, but the review is forced to fail:
   // unavailable engines + a non-git workspace guarantee the companion errors,


### PR DESCRIPTION
Fixes #152. Same class as #151: a stop gate that skips in silence.

`listJobs` answers `[]` for two different situations — a store with no jobs in
it, and a store it could not read (`lib/state.mjs`, the `catch` around
`readdirSync`). An empty list is exactly why the gate lets Stop through, so a
permissions problem, a lock, or a clobbered directory disarmed it without a
word.

## Where the fix goes, and where it does not

`listJobs` is unchanged. Making it throw would turn a read failure into a crash
at fourteen call sites, and for thirteen of them merging the two cases is right:
a status listing with nothing to show reads the same either way. Only the gate
treats "no jobs" as a licence to skip.

So the discrimination is a separate export, `jobStoreUnreadableReason`, asked by
the gate alone and only on the path where the answer changes what happens. The
gate still fails open — it now says why, in the same shape as the
review-failure warning beside it.

## ENOENT is not a failure

The jobs directory is created on first write, so its absence is the ordinary
state of a workspace that has run no jobs yet. Without that carve-out the new
warning fires on every Stop for anyone who has not used the plugin.

That carve-out has a test of its own, and it exists because a mutation found the
gap: removing the ENOENT branch left every existing test green. The neighbouring
no-warning test seeds a job, and seeding is what creates the directory, so it
never reaches the absent-directory case.

## Tests

Two, mutation-checked independently:

| Mutation | Turns red |
|---|---|
| gate stops asking whether the store is readable | only the unreadable-store test |
| `jobStoreUnreadableReason` stops excusing ENOENT | only the fresh-workspace test |

The unreadable state is produced portably by putting a file where the jobs
directory belongs — readdir answers ENOTDIR everywhere, while a chmod does
nothing on Windows.

`npm test`: 823 tests, 817 pass, 0 fail, 6 skipped.

## Not covered

- Only ENOTDIR is exercised. EACCES and EBUSY take the same branch by
  construction, but neither is reproduced here.
- The warning text itself is matched loosely (`/job store could not be read/`),
  not pinned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QqFf49oKbvhjsdzz7WTCbQ
