### PR TITLE
fix(agy): give an AGY turn the same ten minutes gemini gets

### DIFF
--- a/plugins/gemini/CHANGELOG.md
+++ b/plugins/gemini/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 ## 0.25.0 - Unreleased
 
+- **AGY turns now get ten minutes, the same as Gemini CLI.** The old two-minute
+  cap was defending against AGY 1.0.3, whose `agy --print` returned nothing over
+  a pipe in non-interactive use; a ten-minute spawn against that version would
+  have hung silently, so the cap made it fail fast instead. The 1.1.12 floor now
+  refuses 1.0.3 at engine detection, and a stalled turn is visible anyway, since
+  1.1.8 and newer stream the envelope as they go. The cap outlived what it was
+  guarding.
+
+  What it did in the meantime was kill work that was going to finish. A
+  read-only audit of three files in this repository timed out three times at the
+  default and completed in 223 seconds at `--timeout 600` — same prompt, same
+  scope, one variable. Narrowing the scope fourfold in token cost did not help;
+  only the budget did. Codex answered the identical prompt in 155 seconds, so
+  this is what an agentic pass over three files costs, not something slow about
+  AGY.
+
+  The failure message pointed away from the fix, and now names it. "Retry later,
+  reduce prompt size or review scope, or run it on the other engine" offered
+  three suggestions, none of which addresses a budget that is simply too small.
+  It now leads with `--timeout <seconds>` and keeps the rest, because an
+  oversized prompt and a stalled engine remain real causes.
+
+  `--print-timeout`, which AGY self-terminates on, is derived from the budget and
+  follows it up to 585 seconds. Neither bound on `--timeout` moved: 30 to 3600
+  seconds, as before.
 - **An unreadable job store no longer reads as "nothing to gate".** `listJobs`
   answers `[]` both for a store with no jobs in it and for one it could not
   read, and an empty list is exactly why the stop gate lets Stop through. A

--- a/plugins/gemini/commands/adversarial-review.md
+++ b/plugins/gemini/commands/adversarial-review.md
@@ -72,7 +72,7 @@ Argument handling:
 - Unlike `/gemini:review`, it can take extra focus text after the flags.
 - `--engines gemini,agy` queues the same blind prompt on both available engines as a background group. The jobs share a group ID but do not receive each other's identity or output. Do not combine `--engines` with `--engine` or `--wait`.
 - If one requested engine is unavailable, the runtime prints a degradation warning to stderr and queues the remaining engine as a normal single job. If neither is available, it fails without creating a job.
-- `--timeout <seconds>` is not only how long the run may take: it is also a ceiling on how much output can be produced, because a turn that cannot finish emitting inside the window is killed. Raise it for a large scope or a batch; the AGY default is 120 seconds.
+- `--timeout <seconds>` is not only how long the run may take: it is also a ceiling on how much output can be produced, because a turn that cannot finish emitting inside the window is killed. Raise it for a large scope or a batch; both engines default to 600 seconds.
 - `--deep` runs an **agentic** review: Gemini uses its read-only tools to inspect repo context beyond the diff (dependency manifests, untracked files, callers) before producing the same JSON findings. Slower and higher-token; omit it for the fast, diff-scoped default. Pair `--deep` with `--background` for larger changes.
 
 Foreground flow:

--- a/plugins/gemini/commands/review.md
+++ b/plugins/gemini/commands/review.md
@@ -62,7 +62,7 @@ Argument handling:
 - The companion script handles `--background` itself: it enqueues the review and spawns a detached `review-worker`, so the result outlives the foreground command. It does not outlive the session: `SessionEnd` removes this session's job records, finished ones included, so collect it with `/gemini:result` before the session ends. Do not use Claude's `run_in_background: true` for it.
 - `/gemini:review` is native-review only. It does not take custom focus text.
 - For an adversarial review that challenges design decisions, use `/gemini:adversarial-review`.
-- `--timeout <seconds>` is not only how long the run may take: it is also a ceiling on how much output can be produced, because a turn that cannot finish emitting inside the window is killed. Raise it for a large scope or a batch; the AGY default is 120 seconds.
+- `--timeout <seconds>` is not only how long the run may take: it is also a ceiling on how much output can be produced, because a turn that cannot finish emitting inside the window is killed. Raise it for a large scope or a batch; both engines default to 600 seconds.
 - `--deep` runs an **agentic** review: Gemini uses its read-only tools to inspect repo context beyond the diff (dependency manifests, untracked files, callers) before producing the same JSON findings. It is slower and uses more tokens; omit it for the fast, diff-scoped default. Pair `--deep` with `--background` for larger changes.
 
 Foreground flow:

--- a/plugins/gemini/scripts/gemini-mcp.mjs
+++ b/plugins/gemini/scripts/gemini-mcp.mjs
@@ -48,9 +48,9 @@ function enumSchema(values, defaultValue) {
   return { type: "string", enum: values, ...(defaultValue ? { default: defaultValue } : {}) };
 }
 
-// The AGY default is 2 minutes, and it is this plugin's number rather than AGY's
-// own (AGY defaults --print-timeout to 5m). It doubles as a ceiling on output
-// size: a turn that produces more than it can emit inside the window is killed,
+// Both engines default to 10 minutes. AGY's used to be 2, which was this
+// plugin's number rather than AGY's own; see the note on AGY_SPAWN_TIMEOUT_MS
+// for why it went. The budget doubles as a ceiling on output size: a turn that produces more than it can emit inside the window is killed,
 // which is what both 2026-08-17 timeout incidents actually hit. The CLI has
 // accepted `--timeout` since it was added; only the two surfaces a user reaches
 // it through did not offer it. Bounds come from the runtime constants so the
@@ -59,7 +59,7 @@ const timeoutSchema = () => ({
   type: "integer",
   minimum: MIN_TURN_TIMEOUT_SECONDS,
   maximum: MAX_TURN_TIMEOUT_SECONDS,
-  description: `Seconds this turn may run before it is killed (default 120 on AGY, 600 on Gemini CLI). Also a ceiling on how much output can be produced: raise it for large batches or deep reviews. ${MIN_TURN_TIMEOUT_SECONDS}-${MAX_TURN_TIMEOUT_SECONDS}.`
+  description: `Seconds this turn may run before it is killed (default 600 on both engines). Also a ceiling on how much output can be produced: raise it for large batches or deep reviews. ${MIN_TURN_TIMEOUT_SECONDS}-${MAX_TURN_TIMEOUT_SECONDS}.`
 });
 
 export const TOOLS = [

--- a/plugins/gemini/scripts/lib/failures.mjs
+++ b/plugins/gemini/scripts/lib/failures.mjs
@@ -49,7 +49,12 @@ const DEFAULTS = {
     // only AGY timing out and pointed at gemini, which left a gemini timeout with
     // no engine advice at all -- the case in field note gi-2026-08-24-b7c1, where
     // gemini stalled for minutes on a diff AGY answered in about 25 seconds.
-    nextStep: "Retry later, reduce prompt size or review scope, or run it on the other engine (`--engine agy` or `--engine gemini`)."
+    // `--timeout` comes first because it is the only one of these that addresses
+    // the cause when the budget itself is what was too small — issue #153, where
+    // three runs were spent narrowing scope before the timeout turned out to be
+    // the binding constraint. Scope and engine stay, since a genuinely oversized
+    // prompt and a stalled engine are both still real causes.
+    nextStep: "Raise the budget with `--timeout <seconds>`, reduce prompt size or review scope, or run it on the other engine (`--engine agy` or `--engine gemini`)."
   },
   "prompt-too-long": {
     retryable: false,

--- a/plugins/gemini/scripts/lib/gemini.mjs
+++ b/plugins/gemini/scripts/lib/gemini.mjs
@@ -23,11 +23,17 @@ import { readAgyStream } from "./agy-stream.mjs";
 import { describeReadOnlyWrites, detectWrites, snapshotWorkspace } from "./readonly-guard.mjs";
 
 const DEFAULT_SPAWN_TIMEOUT_MS = 600_000; // 10 minutes (gemini)
-// AGY's `agy --print` does not stream its response over a pipe in non-interactive
-// use (verified empty stdout / hang on 1.0.3), so a 10-minute spawn would simply
-// hang silently. Cap AGY far shorter so the plugin fails fast instead. This also
-// feeds AGY's own `--print-timeout` via buildCliArgs.
-const AGY_SPAWN_TIMEOUT_MS = 120_000; // 2 minutes
+// AGY is given the same budget as gemini. It used to be capped at 2 minutes so
+// the plugin would fail fast rather than hang on AGY 1.0.3, whose `agy --print`
+// returned nothing over a pipe in non-interactive use — a version the declared
+// floor (1.1.12) now refuses at engine detection, so that hang cannot reach the
+// runtime any more. The cap outlived it, and was measured to be the binding
+// constraint rather than a safety net: an agentic read-only pass over three
+// files of this repo timed out three times at 120s and finished in 223s at
+// `--timeout 600` (2026-09-07, AGY 1.1.27, issue #153). A silent hang is also
+// visible now, because 1.1.8+ streams its envelope as it goes. This also feeds
+// AGY's own `--print-timeout` via buildCliArgs.
+const AGY_SPAWN_TIMEOUT_MS = 600_000; // 10 minutes
 // How much earlier AGY's own --print-timeout lands, so it self-terminates and
 // flushes its final transcript row before spawnSync SIGKILLs it.
 const AGY_FLUSH_GRACE_MS = 15_000;
@@ -249,7 +255,7 @@ function annotateFailureWithProgress(failure, structured) {
     ? failure
     : { ...failure, summary: `${failure.summary} (${notes.join("; ")})` };
 
-  // The default next step for a timeout is "retry later, reduce prompt size".
+  // The default next step for a timeout is "raise --timeout, reduce prompt size".
   // For a run whose response block finished before the kill, that advice buys a
   // second copy of an answer already sitting in front of the user at full price
   // (field note gi-2026-08-17-c4a1: seven findings, both closing sections,

--- a/tests/agy-envelope.test.mjs
+++ b/tests/agy-envelope.test.mjs
@@ -428,17 +428,37 @@ test("AGY's print-timeout lands before the hard kill, not on it", async () => {
   );
 });
 
+// 300 rather than 600 on purpose: 600 is now the default too, so asking for it
+// would pass whether or not --timeout was read at all.
 test("--timeout raises both the hard kill and AGY's own window", async () => {
   const runCommandFn = stubRun({ stdout: `${JSON.stringify(SUCCESS_ENVELOPE)}\n` });
 
-  await runGeminiTurn("/repo", { prompt: "hi", write: false, timeoutSeconds: 600 }, {
+  await runGeminiTurn("/repo", { prompt: "hi", write: false, timeoutSeconds: 300 }, {
     runCommandFn,
     detectEngineFn: agyEngine()
   });
 
   const [call] = runCommandFn.calls;
-  assert.equal(call.opts.timeout, 600_000);
-  assert.equal(call.args[call.args.indexOf("--print-timeout") + 1], "585s");
+  assert.equal(call.opts.timeout, 300_000);
+  assert.equal(call.args[call.args.indexOf("--print-timeout") + 1], "285s");
+});
+
+// The 2-minute AGY default was defending against AGY 1.0.3, whose `agy --print`
+// returned nothing over a pipe; the 1.1.12 floor refuses that version before it
+// can spawn. What the cap did instead was kill work that was going to finish: an
+// agentic read-only pass over three files of this repo timed out three times at
+// 120s and completed in 223s at `--timeout 600` (issue #153). A budget below
+// that measurement is the defect returning.
+test("an AGY turn with no --timeout gets the same budget as gemini", async () => {
+  const runCommandFn = stubRun({ stdout: `${JSON.stringify(SUCCESS_ENVELOPE)}\n` });
+
+  await runGeminiTurn("/repo", { prompt: "hi", write: false }, {
+    runCommandFn,
+    detectEngineFn: agyEngine()
+  });
+
+  const [call] = runCommandFn.calls;
+  assert.equal(call.opts.timeout, 600_000, "the measured 223s run must fit inside the default");
 });
 
 // Subtracting a flat 15s and flooring the result at 30s made the grace window

--- a/tests/agy-stream.test.mjs
+++ b/tests/agy-stream.test.mjs
@@ -357,7 +357,7 @@ test("the plain-json path still shows output that arrived and failed to parse", 
 //
 // gi-2026-08-17-c4a1: the run produced its entire deliverable — seven findings,
 // both closing sections, nothing truncated — and was stored as `failed` with
-// "Retry later, reduce prompt size or review scope", which for that run buys a
+// the generic timeout advice ("reduce prompt size or review scope"), which for that run buys a
 // second identical answer at full price. The envelope is still the authority on
 // completeness (a SUCCESS response is what makes a run successful, and that is
 // unchanged), so this does not become a success. It stops being a bare failure.
@@ -378,7 +378,7 @@ test("a run cut off after a finished response block is not told to retry", async
   assert.equal(result.partial, true);
   assert.equal(result.finalMessage, "the whole deliverable");
   assert.match(result.failure.summary, /the recovered response block is complete/);
-  assert.doesNotMatch(result.failure.nextStep, /Retry later/);
+  assert.doesNotMatch(result.failure.nextStep, /reduce prompt size/);
   assert.match(result.failure.nextStep, /Read the recovered response below/);
 });
 
@@ -391,7 +391,7 @@ test("a run cut off mid-answer is partial but still says the text was truncated"
   assert.equal(result.partial, true);
   assert.match(result.failure.summary, /partial output preserved/);
   assert.doesNotMatch(result.failure.summary, /response block is complete/);
-  assert.match(result.failure.nextStep, /Retry later/, "there is nothing complete to read instead");
+  assert.match(result.failure.nextStep, /reduce prompt size/, "there is nothing complete to read instead");
 });
 
 test("a run with nothing to show is a failure, not a partial one", async () => {

--- a/tests/failures.test.mjs
+++ b/tests/failures.test.mjs
@@ -79,6 +79,15 @@ test("classifyCliFailure identifies timeout failures", () => {
   assert.equal(failure.retryable, true);
 });
 
+// Issue #153: the advice pointed away from the fix. Three runs were spent
+// narrowing the scope, which the measurements showed does not help, before the
+// budget itself turned out to be what was too small, and `--timeout`, the flag
+// that raises it, was the one thing the message never named.
+test("a timeout's next step names the flag that raises the budget", () => {
+  const failure = classifyCliFailure({ error: Object.assign(new Error("spawn timed out"), { code: "ETIMEDOUT" }) });
+  assert.match(failure.nextStep, /--timeout/, `the fix must be named: ${failure.nextStep}`);
+});
+
 test("classifyCliFailure identifies model-unavailable failures", () => {
   const failure = classifyCliFailure({ stderr: "ModelNotFoundError: Requested entity was not found. code: 404" });
   assert.equal(failure.category, "model-unavailable");

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -951,7 +951,10 @@ test("an AGY task sends a long prompt only on stdin", { skip: process.platform =
   assert.equal(capture.stdin, marker);
   assert.ok(!capture.args.includes("--print"));
   assert.ok(!capture.args.includes(marker));
-  assert.deepEqual(capture.args.slice(-2), ["--print-timeout", "105s"]);
+  // Derived from the AGY default budget, not chosen: 600s minus the 15s flush
+  // grace. It moved with the default in #153, and the literal is kept so a
+  // change to either one has to be looked at rather than absorbed.
+  assert.deepEqual(capture.args.slice(-2), ["--print-timeout", "585s"]);
 });
 
 // --- AGY >=1.1.8 structured output supersedes transcript recovery ---


### PR DESCRIPTION
Closes #153.

## What changed

`AGY_SPAWN_TIMEOUT_MS` goes from 120s to 600s, matching gemini's. The
timeout failure's next step now leads with `--timeout <seconds>` instead
of advice that points away from the fix.

## Why the fence came down

The cap was defending against AGY 1.0.3, whose `agy --print` returned
nothing over a pipe in non-interactive use — a ten-minute spawn against
that version would have hung silently. Two things make that reason void:
the 1.1.12 floor refuses 1.0.3 at engine detection, and 1.1.8+ streams
its envelope as it goes, so a stall is visible rather than silent.

What the cap did in the meantime was kill work that was going to finish.
A read-only audit of three files in this repo timed out three times at
the default and completed in **223s** at `--timeout 600` — same prompt,
same scope, one variable. Narrowing the scope fourfold in token cost did
not help; only the budget did. Codex answered the identical prompt in
155s, so this is what an agentic pass over three files costs, not
something slow about AGY.

## The message

"Retry later, reduce prompt size or review scope, or run it on the other
engine" offered three suggestions, none of which addresses a budget that
is simply too small — and three runs were spent following the scope one
before the real cause surfaced. Scope and engine stay, since an oversized
prompt and a stalled engine remain real causes; `--timeout` now goes
first.

## Verification

825 tests, 0 failures (6 more than before). Both new tests were
mutation-checked:

- restoring `120_000` → only "an AGY turn with no --timeout gets the same
  budget as gemini" goes red
- dropping `--timeout` from the message → only "a timeout's next step
  names the flag that raises the budget" goes red

The existing `--timeout raises both the hard kill and AGY's own window`
test now asks for 300 rather than 600: 600 is the default now, so it
would have passed whether or not the flag was read at all.

`resolveAgyPrintTimeoutMs(600_000)` yields 585s, identical to what an
explicit `--timeout 600` already produced, so the coupling introduces
nothing new.

The issue listed "whether any test pins 120" as unverified. My first answer
to that was wrong: `runtime.test.mjs` pinned the *derived* value,
`--print-timeout 105s`, so searching for "120" missed it — and that test
skips on Windows, so the local suite stayed green and CI on ubuntu and macos
found it. It follows the default now (`d1c7451`).

## Not verified

- 223s is n=1: one prompt, one repository. 600 is parity with gemini, not
  a measured optimum.
- AGY self-terminating at `--print-timeout 585s` under a real 600s run was
  not exercised; that path has stub coverage only.
- Only grep was used to confirm no other surface documents the 120s value;
  `docs/THREAT-MODEL.md` and the skill files were not read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QqFf49oKbvhjsdzz7WTCbQ


