### PR TITLE
chore(release): 0.25.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,13 +7,13 @@
   },
   "metadata": {
     "description": "agy-plugin-cc is a Claude Code companion for running Gemini CLI or Antigravity CLI (agy) as a cross-model task delegate and code reviewer, with pragmatic and adversarial review, MCP tools, and background jobs.",
-    "version": "0.24.4"
+    "version": "0.25.0"
   },
   "plugins": [
     {
       "name": "gemini",
       "description": "agy-plugin-cc is a Claude Code companion for running Gemini CLI or Antigravity CLI (agy) as a cross-model task delegate and code reviewer, with pragmatic and adversarial review, MCP tools, and background jobs.",
-      "version": "0.24.4",
+      "version": "0.25.0",
       "author": {
         "name": "arcobaleno64",
         "email": "arcobaleno830623@gmail.com"

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -5,7 +5,7 @@ sends it, and what it keeps. Every claim here is checkable against the source
 files cited beside it. If you find a statement that the code does not support,
 that is a bug — report it as described in [`SECURITY.md`](SECURITY.md).
 
-Applies to plugin version 0.24.x. Every claim below was re-checked against
+Applies to plugin version 0.25.x. Every claim below was re-checked against
 the source at that version, not carried forward.
 
 ---

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,8 +6,8 @@ Only the current MINOR line is supported. Update this table with every MINOR bum
 
 | Version | Supported |
 |---|---|
-| 0.24.x | :white_check_mark: |
-| < 0.24.0 | :x: |
+| 0.25.x | :white_check_mark: |
+| < 0.25.0 | :x: |
 
 ## Security Model & Trust Boundaries
 

--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -21,7 +21,7 @@ belong to.
 | [sakibsadmanshajib/gemini-plugin-cc](https://github.com/sakibsadmanshajib/gemini-plugin-cc) | 24 | 2026-05-22 | v1.0.1, archived | Gemini CLI | ACP |
 | [sakibsadmanshajib/antigravity-plugin](https://github.com/sakibsadmanshajib/antigravity-plugin) | 19 | 2026-05-22 | none | AGY only | `agy --print` |
 | [m-ghalib/gemini-plugin-cc](https://github.com/m-ghalib/gemini-plugin-cc) | 18 | 2026-04-24 | v0.1.0 | Gemini CLI, setup installs 0.38.2 | ACP |
-| **this project** | 10 | 2026-09-03 | v0.24.4 | Gemini CLI **and** AGY | direct spawn, structured JSON |
+| **this project** | 10 | 2026-09-07 | v0.25.0 | Gemini CLI **and** AGY | direct spawn, structured JSON |
 
 | Surface | Slash commands | MCP tools | Skills | Test files (`*.test.*`) |
 |---|---|---|---|---|

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@arcobaleno64/agy-plugin-cc",
-  "version": "0.24.4",
+  "version": "0.25.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@arcobaleno64/agy-plugin-cc",
-      "version": "0.24.4",
+      "version": "0.25.0",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arcobaleno64/agy-plugin-cc",
-  "version": "0.24.4",
+  "version": "0.25.0",
   "private": true,
   "type": "module",
   "description": "agy-plugin-cc is a Claude Code companion for running Gemini CLI or Antigravity CLI (agy) as a cross-model task delegate and code reviewer, with pragmatic and adversarial review, MCP tools, and background jobs.",

--- a/plugins/gemini/.claude-plugin/plugin.json
+++ b/plugins/gemini/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gemini",
-  "version": "0.24.4",
+  "version": "0.25.0",
   "description": "agy-plugin-cc is a Claude Code companion for running Gemini CLI or Antigravity CLI (agy) as a cross-model task delegate and code reviewer, with pragmatic and adversarial review, MCP tools, and background jobs.",
   "author": {
     "name": "arcobaleno64",

--- a/plugins/gemini/CHANGELOG.md
+++ b/plugins/gemini/CHANGELOG.md
@@ -1,56 +1,7 @@
 # Changelog
 
-## 0.25.0 - Unreleased
+## 0.25.0 - 2026-09-07 - A declared AGY floor, and a stop gate that stops guessing
 
-- **AGY turns now get ten minutes, the same as Gemini CLI.** The old two-minute
-  cap was defending against AGY 1.0.3, whose `agy --print` returned nothing over
-  a pipe in non-interactive use; a ten-minute spawn against that version would
-  have hung silently, so the cap made it fail fast instead. The 1.1.12 floor now
-  refuses 1.0.3 at engine detection, and a stalled turn is visible anyway, since
-  1.1.8 and newer stream the envelope as they go. The cap outlived what it was
-  guarding.
-
-  What it did in the meantime was kill work that was going to finish. A
-  read-only audit of three files in this repository timed out three times at the
-  default and completed in 223 seconds at `--timeout 600` — same prompt, same
-  scope, one variable. Narrowing the scope fourfold in token cost did not help;
-  only the budget did. Codex answered the identical prompt in 155 seconds, so
-  this is what an agentic pass over three files costs, not something slow about
-  AGY.
-
-  The failure message pointed away from the fix, and now names it. "Retry later,
-  reduce prompt size or review scope, or run it on the other engine" offered
-  three suggestions, none of which addresses a budget that is simply too small.
-  It now leads with `--timeout <seconds>` and keeps the rest, because an
-  oversized prompt and a stalled engine remain real causes.
-
-  `--print-timeout`, which AGY self-terminates on, is derived from the budget and
-  follows it up to 585 seconds. Neither bound on `--timeout` moved: 30 to 3600
-  seconds, as before.
-- **An unreadable job store no longer reads as "nothing to gate".** `listJobs`
-  answers `[]` both for a store with no jobs in it and for one it could not
-  read, and an empty list is exactly why the stop gate lets Stop through. A
-  permissions problem, a lock, or a clobbered directory therefore disarmed the
-  gate without a word.
-
-  `listJobs` is unchanged. Making it throw would turn a read failure into a
-  crash at fourteen call sites, and for thirteen of them the merge is right — a
-  status listing with nothing to show reads the same either way. Only the gate
-  treats "no jobs" as a licence to skip, so only the gate asks the new
-  `jobStoreUnreadableReason`, and only on the path where the answer changes
-  anything. It still fails open; it now says why, in the same shape as the
-  review-failure warning beside it.
-
-  ENOENT is deliberately not a failure: the directory is created on first write,
-  so its absence is the ordinary state of a workspace that has run no jobs yet.
-  That carve-out has a test of its own, added because a mutation proved nothing
-  else covered it — the neighbouring no-warning test seeds a job, and seeding is
-  what creates the directory. Without it, the new warning would fire on every
-  Stop for anyone who had not used the plugin yet.
-
-  The unreadable case is reproduced portably by putting a file where the jobs
-  directory belongs: readdir answers ENOTDIR everywhere, where a chmod does
-  nothing on Windows.
 - **BREAKING: AGY 1.1.12 or newer is now required, and an older AGY is refused by
   name.** Run `agy update`. This replaces seven capability gates
   (`supportsAgyStdinPrompt` 1.1.2, `supportsAgyStructuredOutput` 1.1.8,
@@ -157,6 +108,55 @@
   most of which were house voice it wanted flattened. Useful as a source of
   candidates, not as a verdict.
 
+- **AGY turns now get ten minutes, the same as Gemini CLI.** The old two-minute
+  cap was defending against AGY 1.0.3, whose `agy --print` returned nothing over
+  a pipe in non-interactive use; a ten-minute spawn against that version would
+  have hung silently, so the cap made it fail fast instead. The 1.1.12 floor now
+  refuses 1.0.3 at engine detection, and a stalled turn is visible anyway, since
+  1.1.8 and newer stream the envelope as they go. The cap outlived what it was
+  guarding.
+
+  What it did in the meantime was kill work that was going to finish. A
+  read-only audit of three files in this repository timed out three times at the
+  default and completed in 223 seconds at `--timeout 600` — same prompt, same
+  scope, one variable. Narrowing the scope fourfold in token cost did not help;
+  only the budget did. Codex answered the identical prompt in 155 seconds, so
+  this is what an agentic pass over three files costs, not something slow about
+  AGY.
+
+  The failure message pointed away from the fix, and now names it. "Retry later,
+  reduce prompt size or review scope, or run it on the other engine" offered
+  three suggestions, none of which addresses a budget that is simply too small.
+  It now leads with `--timeout <seconds>` and keeps the rest, because an
+  oversized prompt and a stalled engine remain real causes.
+
+  `--print-timeout`, which AGY self-terminates on, is derived from the budget and
+  follows it up to 585 seconds. Neither bound on `--timeout` moved: 30 to 3600
+  seconds, as before.
+- **An unreadable job store no longer reads as "nothing to gate".** `listJobs`
+  answers `[]` both for a store with no jobs in it and for one it could not
+  read, and an empty list is exactly why the stop gate lets Stop through. A
+  permissions problem, a lock, or a clobbered directory therefore disarmed the
+  gate without a word.
+
+  `listJobs` is unchanged. Making it throw would turn a read failure into a
+  crash at fourteen call sites, and for thirteen of them the merge is right — a
+  status listing with nothing to show reads the same either way. Only the gate
+  treats "no jobs" as a licence to skip, so only the gate asks the new
+  `jobStoreUnreadableReason`, and only on the path where the answer changes
+  anything. It still fails open; it now says why, in the same shape as the
+  review-failure warning beside it.
+
+  ENOENT is deliberately not a failure: the directory is created on first write,
+  so its absence is the ordinary state of a workspace that has run no jobs yet.
+  That carve-out has a test of its own, added because a mutation proved nothing
+  else covered it — the neighbouring no-warning test seeds a job, and seeding is
+  what creates the directory. Without it, the new warning would fire on every
+  Stop for anyone who had not used the plugin yet.
+
+  The unreadable case is reproduced portably by putting a file where the jobs
+  directory belongs: readdir answers ENOTDIR everywhere, where a chmod does
+  nothing on Windows.
 - **A degraded adversarial review now says why the engine dropped out.** With
   `--engines gemini,agy` and a sub-floor AGY, the warning read `unavailable:
   agy.` and stopped there — the refusal that names `agy update` was caught and


### PR DESCRIPTION
Version bump and the documents that carry the version by hand. No behaviour
changes — everything shipping in 0.25.0 was merged already (#154, #155, #157,
#158).

## Gates, locally

`npm test` (825 tests, 0 fail, 6 skipped), `npm run bench`,
`npm run check-version`, `npm run verify-contracts` — all green.

## What moved

`npm run bump-version -- 0.25.0` wrote the six version locations. Four more
documents carry it by hand:

| File | Why it has to move |
|---|---|
| `plugins/gemini/CHANGELOG.md` | Heading dated and titled; `changelog-section.mjs` reads it for the release page |
| `docs/COMPARISON.md` | The table says this project's own row is kept current on release |
| `SECURITY.md` | Supported minor line |
| `PRIVACY.md` | The minor line its claims were checked against |

`npm test` caught the last two; nothing catches the first two on its own, so
they were done from `.omc/RELEASE_RULE.md` and the COMPARISON table's own text.

## PRIVACY.md was re-checked, not renumbered

That document's value is that every claim in it can be verified against the
source, and it says so: claims are "re-checked against that version, not carried
forward". The four files this release changed under `scripts/` were checked
against the sections that describe them:

- Both hooks still read only the fields §3 lists — `stop-review-gate-hook.mjs`
  takes `input.cwd` and nothing else, `session-lifecycle-hook.mjs` takes
  `session_id`, `cwd`, `hook_event_name`.
- `transcript_path` does not appear anywhere under `plugins/gemini/scripts/`.
- §4's retention numbers hold: `MAX_JOBS = 50`, `pruneOldTransfers(maxKeep = 20)`.
- No URL, `fetch`, or socket in any of the four changed files, so §2 is intact.

The brain-directory row already said "Narrowed in 0.25.0" — its content was
updated when the version floor landed, and only the header line was left behind.

## The BREAKING entry moves to the top of the section

`build-social-announcement.mjs` takes highlights in changelog order and the X
post fits two of eighteen. The AGY 1.1.12 floor was third, so the announcement
led with a timeout change and never mentioned the one thing that breaks an
upgrade. Now:

```
agy-plugin-cc v0.25.0

• BREAKING: AGY 1.1.12 or newer is now required, and an older AGY is refused by name
• AGY turns now get ten minutes, the same as Gemini CLI
```

## Not verified

- The tag-triggered half of the release pipeline has not run this cycle. It is
  what actually publishes, and CI on this PR does not exercise it.
- `docs/llms-full.txt` was regenerated but is gitignored, so nothing here proves
  what the release job will produce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QqFf49oKbvhjsdzz7WTCbQ
