### PR TITLE
fix(failures): stop calling a refused AGY version retryable

### DIFF
--- a/plugins/gemini/CHANGELOG.md
+++ b/plugins/gemini/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## 0.26.0 - Unreleased
+
+- **A refused AGY version is no longer filed as something worth retrying.** The
+  refusal reached the user intact — it is the job's summary, naming the floor and
+  `agy update` — but `classifyCliFailure` had no arm for it, so it landed in
+  `unknown`: marked retryable, with "retry with a narrower prompt if needed" as
+  the next step. A version floor is the one failure a retry provably cannot fix,
+  and prompt size is not what was refused.
+
+  The new `engine-unsupported` category sits ahead of `auth` rather than after
+  it, and that order is the point. When gemini has no usable credential either,
+  the refusal explains why routing reached AGY at all, and that sentence contains
+  the word "authenticate" — which the auth arm matches. Measured on both
+  variants: the auth pattern fires on that one and not the other, so an arm
+  placed later would have sent a user whose AGY is merely old to `/gemini:setup`.
+
+  Found while reproducing #150, which asked a different question and is answered
+  in a comment rather than a change: `prepareBackgroundSelection` resolves the
+  engine only when a model or an effort has to be validated against it. Detection
+  costs about 155 ms here, but cost is not the reason — with neither flag given,
+  paying it would resolve an engine in order to discard the answer.
+
 ## 0.25.0 - 2026-09-07 - A declared AGY floor, and a stop gate that stops guessing
 
 - **BREAKING: AGY 1.1.12 or newer is now required, and an older AGY is refused by

--- a/plugins/gemini/scripts/gemini-companion.mjs
+++ b/plugins/gemini/scripts/gemini-companion.mjs
@@ -1123,6 +1123,19 @@ function prepareEngineSelection(engineInfo, model, effort) {
   return { model: normalizeRequestedModel(requestedModel), effort: requestedEffort };
 }
 
+// Resolves the engine only when the request needs one to be understood. That is
+// the whole rule: prepareEngineSelection returns on the same condition one level
+// down, and normalising a model or an effort is the only thing here that has to
+// know which engine it is for -- AGY and gemini take different model IDs, and
+// "cannot combine --model with --effort" is an AGY rule alone. With neither
+// given there is nothing to validate against.
+//
+// The visible consequence (#150): on a sub-floor AGY, `--background` with a
+// model refuses before a job exists, and without one queues a job whose worker
+// hits the same refusal, which the launch message already points at with
+// `/gemini:status`. Left as it is deliberately. Detection is not free -- ~155 ms
+// measured on Windows, four to five git calls -- but cost is not the reason;
+// spending it here would resolve an engine in order to discard the answer.
 function prepareBackgroundSelection(request, detectEngineFn) {
   const model = request.model ?? null;
   const effort = request.effort ?? null;

--- a/plugins/gemini/scripts/lib/failures.mjs
+++ b/plugins/gemini/scripts/lib/failures.mjs
@@ -1,5 +1,6 @@
 export const FAILURE_CATEGORIES = new Set([
   "binary-missing",
+  "engine-unsupported",
   "auth",
   "quota",
   "rate-limit",
@@ -21,6 +22,18 @@ const DEFAULTS = {
     retryable: false,
     summary: "Required CLI binary is not available.",
     nextStep: "Install and initialize either supported engine, then select it with `--engine gemini` or `--engine agy`."
+  },
+  // The engine is installed and answers --version; the version is the problem.
+  // Not retryable in the strong sense -- the same request will be refused
+  // identically until the binary is replaced -- which is what separates it from
+  // `binary-missing`, where the retry at least has somewhere to go.
+  "engine-unsupported": {
+    retryable: false,
+    summary: "The engine is older than this plugin supports.",
+    // The refusal itself already names the floor, what breaks below it, and
+    // whether the other engine is a way out, and it survives as `summary`. This
+    // adds the one thing it cannot say about itself: retrying changes nothing.
+    nextStep: "Run `agy update`, then rerun. A version refusal cannot be retried into success; the summary says whether the other engine is a way out."
   },
   auth: {
     retryable: false,
@@ -236,6 +249,14 @@ export function classifyCliFailure(input = {}) {
 
   if (data.cancelled || /cancel(l)?ed|aborted|SIGINT/i.test(structuredText) || signal === "SIGINT") {
     return normalizeFailure("cancelled", data);
+  }
+  // Ahead of `auth` deliberately. The floor refusal's own text mentions
+  // authenticating when gemini has no usable credential either -- that sentence
+  // is there to explain why routing reached AGY at all -- and `auth` matches on
+  // `authenticat`, so a later arm would file a version refusal as a login
+  // problem and send the user to `/gemini:setup` instead of `agy update`.
+  if (/older than this plugin supports|requires AGY \d+\.\d+\.\d+ or newer/i.test(structuredText)) {
+    return normalizeFailure("engine-unsupported", data);
   }
   if (code === "ENOENT" || /command not found|not recognized as .*command|binary .*not (found|available)|No Gemini or AGY engine found|engine requested but .*binary is not available/i.test(structuredText)) {
     return normalizeFailure("binary-missing", data);

--- a/tests/failures.test.mjs
+++ b/tests/failures.test.mjs
@@ -2,6 +2,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 
 import { classifyCliFailure } from "../plugins/gemini/scripts/lib/failures.mjs";
+import { agyFloorRefusal } from "../plugins/gemini/scripts/lib/engine.mjs";
 
 test("classifyCliFailure identifies auth failures", () => {
   const failure = classifyCliFailure({ stderr: "OAuth token expired. Run gemini to authenticate." });
@@ -86,6 +87,37 @@ test("classifyCliFailure identifies timeout failures", () => {
 test("a timeout's next step names the flag that raises the budget", () => {
   const failure = classifyCliFailure({ error: Object.assign(new Error("spawn timed out"), { code: "ETIMEDOUT" }) });
   assert.match(failure.nextStep, /--timeout/, `the fix must be named: ${failure.nextStep}`);
+});
+
+// The real refusal, not a paraphrase: the classifier matches on its wording, so
+// a test writing its own sentence would keep passing after the two drift apart.
+// Found while reproducing #150 -- a queued background job did fail with the
+// refusal as its summary, but filed under `unknown`, marked retryable, and
+// advised "retry with a narrower prompt". A version floor is the one failure a
+// retry provably cannot fix.
+test("an AGY version refusal is not retryable, and says what does fix it", () => {
+  for (const geminiUsable of [true, false]) {
+    const message = agyFloorRefusal("1.0.3", { geminiUsable });
+    const failure = classifyCliFailure({ error: new Error(message), errorMessage: message });
+
+    assert.equal(failure.category, "engine-unsupported", `geminiUsable=${geminiUsable}`);
+    assert.equal(failure.retryable, false, "the same request is refused identically until the binary changes");
+    assert.match(failure.nextStep, /agy update/, failure.nextStep);
+    assert.doesNotMatch(failure.nextStep, /narrower prompt/, "prompt size is not what was refused");
+  }
+});
+
+// The ordering fence. When gemini has no usable credential either, the refusal
+// explains why routing reached AGY at all -- and that sentence says
+// "authenticate", which the `auth` arm matches. Measured: the auth pattern does
+// fire on this variant and not on the other, so an arm placed after it would
+// send a user whose AGY is merely old to `/gemini:setup`.
+test("a version refusal that mentions authenticating is still a version refusal", () => {
+  const message = agyFloorRefusal("1.0.3", { geminiUsable: false });
+  assert.match(message, /authenticate/, "the premise of this test, not an assumption");
+
+  const failure = classifyCliFailure({ error: new Error(message), errorMessage: message });
+  assert.equal(failure.category, "engine-unsupported");
 });
 
 test("classifyCliFailure identifies model-unavailable failures", () => {


### PR DESCRIPTION
Closes #150 — though not the way it was filed. See the last section.

## The defect

A background job on a sub-floor AGY does report the refusal: it is the job's
summary, naming the floor and `agy update`. But `classifyCliFailure` had no arm
for it, so it landed in `unknown`:

```json
{ "category": "unknown", "retryable": true,
  "summary": "AGY 1.0.3 is older than this plugin supports...",
  "nextStep": "Inspect the job log, run `/gemini:setup`, then retry with a narrower prompt if needed." }
```

A version floor is the one failure a retry provably cannot fix — the same
request is refused identically until the binary changes — and prompt size is not
what was refused. `retryable` and `category` are printed by `/gemini:status`
(`Failure: <category> (<retryable>)`), so both are user-visible.

## The new arm goes ahead of `auth`, and that is the point

When gemini has no usable credential either, the refusal explains why routing
reached AGY at all — and that sentence says "authenticate", which the `auth`
pattern matches. Measured on both variants of `agyFloorRefusal`:

| variant | auth arm would match |
|---|---|
| `geminiUsable: true` | no |
| `geminiUsable: false` | **yes** |

So an arm placed after `auth` would send a user whose AGY is merely old to
`/gemini:setup`. The ordering has a test of its own.

## Verification

827 tests, 0 failures. Both new tests build the message with `agyFloorRefusal`
rather than quoting it, so they break if the wording and the pattern drift
apart. Mutation-checked:

- `retryable: false` → `true` — only "an AGY version refusal is not retryable"
  goes red
- arm moved to after `auth` — both new tests go red

## #150 is answered in a comment, not a change

The issue asked whether `prepareBackgroundSelection`'s early return should go,
and guessed the fence was a cost optimisation. Reproduced first, by injecting a
refusing `detectEngineFn` (Windows needs an absolute `.exe` for AGY, and a
`node.exe` stand-in reports Node's version and passes the floor):

```
no --model/--effort  -> QUEUED jobId=task-...     job records 0 -> 1
with --model         -> THREW "AGY 1.0.3 is older than the required 1.1.12..."
```

The behaviour is as described, but the fence is not about cost. It resolves the
engine only when the request needs one to be understood: `prepareEngineSelection`
returns on the same condition one level down, and normalising a model or an
effort is the only thing there that has to know which engine it is for — AGY and
gemini take different model IDs, and "cannot combine `--model` with `--effort`"
is an AGY rule alone. With neither given there is nothing to validate against.

Detection was measured at ~155 ms on this machine (five runs each for `auto` and
`agy`, 146–180 ms), about four to five git calls against a dispatch that already
makes several. Cheap enough to pay — which is why cost is not the argument.
Paying it with neither flag given would resolve an engine in order to discard the
answer.

The launch message already points at where the answer lands: `Check
/gemini:status <id> for progress.`

## Not verified

- No end-to-end run against a real sub-floor AGY binary; the refusal was
  injected. The classifier was then driven with the real `agyFloorRefusal` output.
- The ~155 ms is one machine, and `detectEngine` under `auto` may also probe the
  OS keychain, which has its own 2 s cap.
- The MCP dispatch wrapper was not read beyond confirming it calls the same
  `dispatchBackgroundTask`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QqFf49oKbvhjsdzz7WTCbQ
