### PR TITLE
test: keep llms navigation linked to authoritative sources

### DIFF
--- a/tests/contract.test.mjs
+++ b/tests/contract.test.mjs
@@ -184,6 +184,30 @@ This is an independent, community-maintained project. Use the linked repository 
   assert.ok(Buffer.byteLength(html) + Buffer.byteLength(llms) + Buffer.byteLength(sitemap) + Buffer.byteLength(css) < 100 * 1024, "the static site must stay below 100 KiB");
 });
 
+test("llms navigation points to tracked authoritative source files that still exist", () => {
+  const llms = fs.readFileSync(path.join(ROOT, "site", "llms.txt"), "utf8");
+  const links = [...llms.matchAll(/\[[^\]\r\n]+\]\((https:\/\/[^)\s]+)\)/g)].map((match) => match[1]);
+  // These two live surfaces are not repository files. Their reachability stays
+  // in the post-deployment gate, not a network-dependent unit test.
+  const liveSurfaces = new Set([CANONICAL_SITE_URL, `${CANONICAL_REPOSITORY_URL}/releases`]);
+  const prefix = `${CANONICAL_REPOSITORY_URL}/blob/main/`;
+  const tracked = run("git", ["ls-files", "-z"], { cwd: ROOT });
+  assert.equal(tracked.status, 0, tracked.stderr);
+  const trackedFiles = new Set(tracked.stdout.split("\0").filter(Boolean));
+
+  assert.equal(links.length, 11, "llms navigation must retain its eleven reviewed links");
+  assert.equal(new Set(links).size, links.length, "llms navigation must not duplicate targets");
+  const sourceLinks = links.filter((url) => !liveSurfaces.has(url));
+  assert.equal(sourceLinks.length, 9, "llms navigation must retain nine repository source links");
+  for (const url of sourceLinks) {
+    assert.ok(url.startsWith(prefix), `llms source must use the canonical main branch: ${url}`);
+    const relative = url.slice(prefix.length);
+    assert.ok(trackedFiles.has(relative), `llms source is not tracked: ${relative}`);
+    assert.ok(fs.existsSync(path.join(ROOT, relative)), `llms source is missing: ${relative}`);
+    assert.ok(fs.lstatSync(path.join(ROOT, relative)).isFile(), `llms source must be a regular file: ${relative}`);
+  }
+});
+
 test("the canonical site deploys only its allowlisted source from main", () => {
   const workflow = fs.readFileSync(path.join(ROOT, ".github", "workflows", "pages.yml"), "utf8");
   const normalized = workflow.replace(/\r\n/g, "\n");


### PR DESCRIPTION
## Summary

Follow-up to #156 and Issue #121's machine-readable source synchronization item. Add one offline contract requiring all nine repository-file links in llms.txt to use the canonical main branch and resolve to tracked, existing regular files. Keep exactly eleven distinct reviewed links; the homepage and releases page remain live post-deployment checks.

## Scope

Only `tests/contract.test.mjs`: +24 / -0. No site, runtime, generator, dependencies, version, benchmark, workflow, or Pages settings changes. Existing exact-content and cross-surface canonical contracts remain intact.

This verifies source-file existence, not ongoing semantic correctness of linked prose. Human claim-evidence review is still required. No network requests are added to tests.

## Verification

Base: `555aecab4bf15c82e556fa1d7187f7dc0e642226`
Head: `0b7b6212a48c0ff15e4b56f3fb4a9828d179de35`

- Old site contract accepted a missing docs/COMPARISON.md; new contract rejects it with the exact missing path.
- Untracking the same file while retaining its bytes is rejected with the untracked-path diagnostic.
- LF and CRLF focused checks: 19/19 pass.
- Full suite on these bytes: 828 tests, 817 pass, 0 fail, 11 skip.
- verify-contracts and check-version pass for v0.25.0.
- AEO remains 6/6 measured, 0 candidate violations, 3 manually adjudicated, 0 needing review.
- git diff --check passes.
- Remote content blob matches the locally verified file: ca6f7c76e25424ba5411679fe3f6c44f610ff2d0.

## Review and completion gate

Draft for independent exact-head review. No merge or deployment is authorized by this PR. Issue #121 remains open and its synchronization item remains unchecked pending review, separate merge authorization, and verification of the final merged result. The test-only diff does not itself trigger the site-only Pages workflow.