### PR TITLE
bench: capture post-change search observations

### DIFF
--- a/bench/aeo-responses/2026-09-08-web-search/ADVERSARIAL_REVIEW_DISCOVERY.md
+++ b/bench/aeo-responses/2026-09-08-web-search/ADVERSARIAL_REVIEW_DISCOVERY.md
@@ -1,0 +1,22 @@
+# Search results
+
+1. My current AI Code Review Workflow
+   https://guissmo.com/blog/my-current-ai-code-review-workflow/
+2. Adversarial Coding — Using Competing Models as Reviewers
+   https://www.subaud.io/adversarial-coding-competing-models-reviewers/
+3. adversarial reviews are stupidly easy and unfairly useful
+   https://www.reddit.com/r/ClaudeCode/comments/1rnfn9p/protip_adversarial_reviews_are_stupidly_easy_and/
+4. Adversarial Code Review: Why the Maker Shouldn't Grade Its Own Work
+   https://www.augmentcode.com/guides/adversarial-code-review
+5. Auto-claude-code-research-in-sleep (ARIS)
+   https://github.com/wanshuiyin/auto-claude-code-research-in-sleep
+6. Building with Claude AI using adversarial mode and review
+   https://www.facebook.com/groups/claudeaicommunity/posts/1260159912817840/
+7. Claude Code vs Gemini CLI for Code Review: 2026 Head-to-Head
+   https://gitautoreview.com/blog/claude-code-vs-gemini-cli-code-review
+8. Review AI-generated code - Warp docs
+   https://docs.warp.dev/guides/agent-workflows/how-to-review-ai-generated-code/
+9. AI Code Review Export for ChatGPT, Claude, Gemini
+   https://marketplace.visualstudio.com/items?itemName=diffscribe.diffscribe
+10. Meld (software)
+    https://en.wikipedia.org/wiki/Meld_%28software%29

--- a/bench/aeo-responses/2026-09-08-web-search/BRAND_IDENTITY.md
+++ b/bench/aeo-responses/2026-09-08-web-search/BRAND_IDENTITY.md
@@ -1,0 +1,20 @@
+# Search results
+
+1. agy · GitHub Topics
+   https://github.com/topics/agy
+2. Use Antigravity CLI inside Claude Code (without leaving editor)
+   https://www.reddit.com/r/coolgithubprojects/comments/1tpadx2/opensource_plugin_use_antigravity_cli_inside/
+3. Antigravity CLI Course #13: agy plugin
+   https://www.youtube.com/watch?v=YVc9o2vn86I
+4. Where does Antigravity look for Plugins?
+   https://medium.com/google-cloud/where-does-antigravity-look-for-plugins-0bc7e9d99028
+5. Operate the Antigravity CLI (agy): plugins, auth, sandbox
+   https://hermes-agent.nousresearch.com/docs/user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-antigravity-cli
+6. Idun-Group/antigravity-plugin-cc
+   https://github.com/Idun-Group/antigravity-plugin-cc
+7. Plugins & Skills | Google Antigravity Docs
+   https://antigravity.google/docs/cli/plugins/
+8. Is invoking the official Antigravity CLI (agy --print) from a third-party developer tool an acceptable use?
+   https://discuss.ai.google.dev/t/is-invoking-the-official-antigravity-cli-agy-print-from-a-third-party-developer-tool-an-acceptable-use/175462
+9. antigravity-plugin-cc
+   https://app.unpkg.com/antigravity-plugin-cc%400.6.3

--- a/bench/aeo-responses/2026-09-08-web-search/DATA_HANDLING_BOUNDARY.md
+++ b/bench/aeo-responses/2026-09-08-web-search/DATA_HANDLING_BOUNDARY.md
@@ -1,0 +1,20 @@
+# Search results
+
+1. simplybychris/antigravity-plugin-cc: Use Google Antigravity CLI inside Claude Code
+   https://github.com/simplybychris/antigravity-plugin-cc
+2. Using the Antigravity CLI (agy) as a sub-agent inside Claude Code
+   https://www.reddit.com/r/google_antigravity/comments/1ubr67l/using_the_antigravity_cli_agy_as_a_subagent/
+3. Where does Antigravity look for Plugins?
+   https://medium.com/google-cloud/where-does-antigravity-look-for-plugins-0bc7e9d99028
+4. Operate the Antigravity CLI (agy): plugins, auth, sandbox
+   https://hermes-agent.nousresearch.com/docs/user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-antigravity-cli
+5. Is invoking the official Antigravity CLI (agy --print) from a third-party developer tool an acceptable use?
+   https://discuss.ai.google.dev/t/is-invoking-the-official-antigravity-cli-agy-print-from-a-third-party-developer-tool-an-acceptable-use/175462
+6. Antigravity CLI Course #13: agy plugin
+   https://www.youtube.com/watch?v=YVc9o2vn86I
+7. Antigravity CLI (agy): Commands, Modes, and Auto-Approve
+   https://www.aibuilderclub.com/blog/antigravity-cli-guide
+8. Spec-Driven Development with Antigravity CLI - Codelabs
+   https://codelabs.developers.google.com/sdd-agy-cli
+9. Antigravity 2.0 is here! A massive update including CLI, plugins, and sandboxing
+   https://note.com/masa_wunder/n/n8f6e732e1237?hl=en

--- a/bench/aeo-responses/2026-09-08-web-search/DUAL_ENGINE_DISCOVERY.md
+++ b/bench/aeo-responses/2026-09-08-web-search/DUAL_ENGINE_DISCOVERY.md
@@ -1,0 +1,22 @@
+# Search results
+
+1. sakibsadmanshajib/gemini-plugin-cc: Claude Code ...
+   https://github.com/sakibsadmanshajib/gemini-plugin-cc
+2. Using Claude Code and Antigravity CLI together. Having issues
+   https://www.reddit.com/r/ClaudeAI/comments/1v3eqwz/using_claude_code_and_antigravity_cli_together/
+3. Gemini CLI vs. Claude Code: Differences and Use Cases
+   https://www.datacamp.com/blog/gemini-cli-vs-claude-code
+4. Antigravity CLI vs Claude Code: Cost & Verdict (2026)
+   https://codegen.com/comparisons/antigravity-cli-vs-claude-code/
+5. Hiting Claude Code Limits? Offload Boring Tasks to Gemini
+   https://www.homedock.cloud/blog/reviews/borderline-delegate-boring-tasks-claude-to-gemini/
+6. What is Gemini CLI feedback for Codex and Claude users?
+   https://www.facebook.com/groups/vibecodinglife/posts/1996665784255282/
+7. I Tested (New) Google Antigravity CLI (It's Not What You Expect)
+   https://medium.com/ai-software-engineer/i-tested-new-google-antigravity-cli-its-not-what-you-expect-ec98892094d7
+8. Antigravity CLI Shocked Me... Better Than Claude Code & Gemini CLI?
+   https://www.youtube.com/watch?v=RMVcepSOeL8
+9. An important update: Transitioning Gemini CLI to Antigravity CLI
+   https://github.com/google-gemini/gemini-cli/discussions/27274
+10. Qodo
+    https://en.wikipedia.org/wiki/Qodo

--- a/bench/aeo-responses/2026-09-08-web-search/MCP_SCOPE.md
+++ b/bench/aeo-responses/2026-09-08-web-search/MCP_SCOPE.md
@@ -1,0 +1,22 @@
+# Search results
+
+1. Claude Code - Sub Agents can invoke MCPs & have write permissions
+   https://www.reddit.com/r/ClaudeAI/comments/1llrg2f/claude_code_sub_agents_can_invoke_mcps_have_write/
+2. MCP connector - Claude Platform Docs
+   https://platform.claude.com/docs/en/agents-and-tools/mcp-connector
+3. Bringing Claude Code's Sub-agents to Any MCP-Compatible Tool
+   https://dev.to/shinpr/bringing-claude-codes-sub-agents-to-any-mcp-compatible-tool-1hb9
+4. Custom Subagents Cannot Access Project-Scoped MCP Servers
+   https://github.com/anthropics/claude-code/issues/13898
+5. Sync Codex and Claude Code configs: skills, agents, MCP, permissions
+   https://community.openai.com/t/sync-codex-and-claude-code-configs-skills-agents-mcp-permissions/1380517
+6. This Claude MCP GitHub AI AGENT Changes EVERYTHING!
+   https://www.youtube.com/watch?v=FiirOCVrPOk
+7. Effective Claude Code troubleshooting strategies for job lifecycle
+   https://www.facebook.com/groups/vibecodinglife/posts/2117236545531538/
+8. Skills, MCP, Hooks, Subagents, Agent Teams & Plugins
+   https://pub.towardsai.net/claude-code-extensions-explained-skills-mcp-hooks-subagents-agent-teams-plugins-9294907e84ff
+9. Claude Code Deep Dive - Plug and Play
+   https://medium.com/%40the.gigi/claude-code-deep-dive-plug-and-play-af03f77c6568
+10. Model Context Protocol
+    https://en.wikipedia.org/wiki/Model_Context_Protocol

--- a/bench/aeo-responses/2026-09-08-web-search/WRITE_AND_SANDBOX_BOUNDARY.md
+++ b/bench/aeo-responses/2026-09-08-web-search/WRITE_AND_SANDBOX_BOUNDARY.md
@@ -1,0 +1,22 @@
+# Search results
+
+1. Beyond permission prompts: making Claude Code more secure and autonomous
+   https://www.anthropic.com/engineering/claude-code-sandboxing
+2. Managing Files in AI Sandbox Environments
+   https://www.daytona.io/dotfiles/managing-files-in-ai-sandbox-environments
+3. Idun-Group/antigravity-plugin-cc
+   https://github.com/Idun-Group/antigravity-plugin-cc
+4. Antigravity 2.0 is here! A massive update including CLI, plugins, and sandboxing
+   https://note.com/masa_wunder/n/n8f6e732e1237?hl=en
+5. Configure the sandboxed Bash tool - Claude Code Docs
+   https://code.claude.com/docs/en/sandboxing
+6. Operate the Antigravity CLI (agy): plugins, auth, sandbox
+   https://hermes-agent.nousresearch.com/docs/zh-Hans/user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-antigravity-cli
+7. The Design Space of Today's and Future AI Agent Systems
+   https://arxiv.org/html/2604.14228v2
+8. Claude Code Sandbox Bypass, When Agent Egress Controls Fail
+   https://www.penligent.ai/hackinglabs/claude-code-sandbox-bypass/
+9. This Sandbox Tool Makes Claude Code Unstoppable
+   https://www.youtube.com/watch?v=t78-JUnTK5Q
+10. Firejail
+    https://en.wikipedia.org/wiki/Firejail

--- a/bench/aeo-responses/2026-09-08-web-search/manual-adjudication.json
+++ b/bench/aeo-responses/2026-09-08-web-search/manual-adjudication.json
@@ -1,0 +1,41 @@
+{
+  "schemaVersion": 1,
+  "subjectCommit": "bb19c7330a033855ef680d6f2aae6bbf9ee7ca50",
+  "reviewedAt": "2026-09-08T10:20:00Z",
+  "adjudications": [
+    {
+      "queryId": "WRITE_AND_SANDBOX_BOUNDARY",
+      "status": "not-detected",
+      "rationale": "The results concern Claude Code sandboxing, AGY, or other plugins. None identifies the canonical project or answers whether it can write or supplies a filesystem sandbox.",
+      "evidencePaths": [
+        "plugins/gemini/scripts/lib/engine.mjs",
+        "plugins/gemini/scripts/lib/readonly-guard.mjs",
+        "tests/gemini-mcp.test.mjs",
+        "tests/runtime.test.mjs",
+        "docs/THREAT-MODEL.md"
+      ]
+    },
+    {
+      "queryId": "DATA_HANDLING_BOUNDARY",
+      "status": "not-detected",
+      "rationale": "The results concern other AGY plugins or generic AGY behavior. None identifies arcobaleno64/agy-plugin-cc or answers its hosted-service and data-handling boundary.",
+      "evidencePaths": [
+        "PRIVACY.md",
+        "docs/THREAT-MODEL.md",
+        "plugins/gemini/scripts/lib/git.mjs",
+        "plugins/gemini/scripts/lib/prompts.mjs",
+        "tests/runtime.test.mjs"
+      ]
+    },
+    {
+      "queryId": "MCP_SCOPE",
+      "status": "not-detected",
+      "rationale": "The results are generic MCP guidance and unrelated projects. None identifies the canonical project or its verified MCP tool surface.",
+      "evidencePaths": [
+        "plugins/gemini/.mcp.json",
+        "plugins/gemini/scripts/gemini-mcp.mjs",
+        "tests/gemini-mcp.test.mjs"
+      ]
+    }
+  ]
+}

--- a/bench/aeo-responses/active-manifest.json
+++ b/bench/aeo-responses/active-manifest.json
@@ -1,15 +1,15 @@
 {
   "schemaVersion": 1,
-  "captureSetId": "2026-08-29-chatgpt-web-search",
-  "subjectCommit": "d7d68e2f508c3deae11158601733df26b50abcdc",
-  "evaluatorCommit": "52acf3b1801db7ede10403484105507fbe41e3f6",
+  "captureSetId": "2026-09-08-chatgpt-work-web-search",
+  "subjectCommit": "bb19c7330a033855ef680d6f2aae6bbf9ee7ca50",
+  "evaluatorCommit": "bb19c7330a033855ef680d6f2aae6bbf9ee7ca50",
   "provenanceLevel": "self-attested",
-  "surface": "ChatGPT web search",
-  "capturedAt": "2026-08-29T11:15:00Z",
-  "captureMethod": "Each benchmark query was submitted verbatim as an independent web search. The ordered title and URL of each returned organic result were transcribed; news results and snippets were excluded.",
+  "surface": "ChatGPT Work web search",
+  "capturedAt": "2026-09-08T10:13:08Z",
+  "captureMethod": "Each benchmark query was submitted verbatim as an independent web-search request. The ordered title and URL of each returned organic result were transcribed; news results and snippets were excluded.",
   "resultPolicy": "First 10 organic results, or every organic result when fewer than 10 were returned.",
-  "manualAdjudicationFile": "2026-08-29-web-search/manual-adjudication.json",
-  "manualAdjudicationSha256": "7cd7c2917aa4372b42df073cbf6871f50a35ab84a1bcd73212ad0b6c0d6f0c16",
+  "manualAdjudicationFile": "2026-09-08-web-search/manual-adjudication.json",
+  "manualAdjudicationSha256": "838c7dd7f17a78408634f3266b76716df1dbb3d29f05fe75e43d9f106ef04bbc",
   "session": {
     "fresh": true,
     "webSearch": "on"
@@ -19,33 +19,33 @@
   "captures": [
     {
       "queryId": "BRAND_IDENTITY",
-      "responseFile": "2026-08-29-web-search/BRAND_IDENTITY.md",
-      "responseSha256": "80851a9d5428d99184bb72d34b92314a9b4bfe1eec1addf9330eb4dea775e9c9"
+      "responseFile": "2026-09-08-web-search/BRAND_IDENTITY.md",
+      "responseSha256": "adc20674ffb22067d62be58e4a474b7baf40ba7259ca14d5cd6ea815ecc867da"
     },
     {
       "queryId": "DUAL_ENGINE_DISCOVERY",
-      "responseFile": "2026-08-29-web-search/DUAL_ENGINE_DISCOVERY.md",
-      "responseSha256": "56123259205a9dd0e1e43b672e5212b3097cc0a5a39c5f92ef0501abad6da758"
+      "responseFile": "2026-09-08-web-search/DUAL_ENGINE_DISCOVERY.md",
+      "responseSha256": "8ced1024e971a2b68baa78d63f7c434b83380d58f0e3144d3367be6c758d9e2d"
     },
     {
       "queryId": "ADVERSARIAL_REVIEW_DISCOVERY",
-      "responseFile": "2026-08-29-web-search/ADVERSARIAL_REVIEW_DISCOVERY.md",
-      "responseSha256": "174b5bbd07bcc3ced1b8d8b539a0f97663c2107d88416efe26b8cce01157dcde"
+      "responseFile": "2026-09-08-web-search/ADVERSARIAL_REVIEW_DISCOVERY.md",
+      "responseSha256": "dc7902fe5a8794de1714d0bc2219c54aed7bf364b86b6bd118b47947fe5ff1b5"
     },
     {
       "queryId": "WRITE_AND_SANDBOX_BOUNDARY",
-      "responseFile": "2026-08-29-web-search/WRITE_AND_SANDBOX_BOUNDARY.md",
-      "responseSha256": "b67eb0f8576678ee9ea0efc55b5f49125990c41f7732d89a7e91e089fdd5e92b"
+      "responseFile": "2026-09-08-web-search/WRITE_AND_SANDBOX_BOUNDARY.md",
+      "responseSha256": "0fe7a564e196a5618427ab8b24776c372048b3bdf6ec79c3bdf0f37bcbec8d30"
     },
     {
       "queryId": "DATA_HANDLING_BOUNDARY",
-      "responseFile": "2026-08-29-web-search/DATA_HANDLING_BOUNDARY.md",
-      "responseSha256": "55ea8ad142ef8d0fbc1e1e24b0daaf34aad9cb9431ef10094216f92ec2d87857"
+      "responseFile": "2026-09-08-web-search/DATA_HANDLING_BOUNDARY.md",
+      "responseSha256": "341a305b6f0edb2d9caa56ce49b30beccda22df63bac3076ff349941c009835a"
     },
     {
       "queryId": "MCP_SCOPE",
-      "responseFile": "2026-08-29-web-search/MCP_SCOPE.md",
-      "responseSha256": "22ef273d22afec4a5238f4ebb4a6e75dcb59300d2c669856c86da4f5ad931bd8"
+      "responseFile": "2026-09-08-web-search/MCP_SCOPE.md",
+      "responseSha256": "68d725c8947b25f94297930cf7d29fb12db6d5f9ba72dd58009bc93f8407b7b3"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- preserve the frozen 2026-08-29 baseline and add a new 2026-09-08 post-change observation set
- submit the six unchanged benchmark queries as independent ChatGPT Work web-search requests
- record ordered organic-result titles and URLs, per-file SHA-256 digests, subject/evaluator commits, UTC capture time, surface, method, result policy, and session state
- manually adjudicate the three safety/capability observations against their existing evidence paths
- point the explicit active manifest at the new set without changing evaluator semantics

## Observed result

- 6/6 measured
- 0 candidate violations
- 3 manually adjudicated
- 0 needing manual review
- 0 unmeasured
- none of the six captures contains the canonical repository-root URL in a form the evaluator counts as canonical visibility

This is a dated, surface-specific negative/neutral observation. It does not establish an overall visibility rate, ranking improvement, or causal effect from prior documentation changes. The capture is `self-attested` because the search result pages do not expose stable capture URLs; the result URLs themselves are preserved.

## Scope

Only:

- `bench/aeo-responses/active-manifest.json`
- `bench/aeo-responses/2026-09-08-web-search/**`

No runtime, evaluator, query, rubric, documentation, release, security, privacy, workflow, dependency, or site change.

## Verification

- `npm run bench:aeo`
- `node --test tests/aeo-benchmark.test.mjs` — 24/24
- `npm test`
- `npm run verify-contracts`
- `npm run check-version`
- `git diff --check`

Issue #121 remains open. Its P3 re-capture item must remain unchecked until this PR is independently reviewed and merged.