### PR TITLE
docs: record rejected discoverability tactics

### DIFF
--- a/docs/DISCOVERABILITY-DECISIONS.md
+++ b/docs/DISCOVERABILITY-DECISIONS.md
@@ -1,0 +1,44 @@
+# Discoverability decision record
+
+This reference records discoverability tactics that the project deliberately rejects or defers, and why. It is not a ranking playbook, a crawler policy, or evidence that any search or assistant surface will use the repository.
+
+The controlling scope is [Issue #121](https://github.com/arcobaleno64/agy-plugin-cc/issues/121). Product behavior and trust boundaries remain authoritative in the [README](../README.md), [FAQ](FAQ.md), [privacy policy](../PRIVACY.md), [security policy](../SECURITY.md), and [threat model](THREAT-MODEL.md).
+
+## Decision rule
+
+A tactic is accepted only when it improves a truthful public surface or produces reproducible evidence without changing runtime behavior merely for discoverability. A green metric is not enough: the result must still identify the canonical repository, preserve claim-to-evidence links, and avoid implying causation from a small or self-authored sample.
+
+Each decision below can be revisited only when its stated trigger becomes true. Until then, repeating the tactic is not new evidence.
+
+## Rejected tactics
+
+| Tactic | Decision | Why | Revisit only when |
+|---|---|---|---|
+| Keyword stuffing, doorway pages, artificial backlinks, mass directory submissions, or engagement manipulation | Reject | These can inflate proxy metrics without improving product truth, create maintenance and platform-policy risk, and make canonical identity less clear. | Never as a project-maintained tactic. |
+| Unsupported superlatives, rankings, adoption claims, or “official” positioning | Reject | The repository has no evidence for “best,” “leading,” broad adoption, or endorsement by Google, Anthropic, or OpenAI. | Independent, attributable evidence exists and the wording remains narrowly factual. |
+| Universal read-only, filesystem confinement, or sandbox guarantees | Reject | Review mode expresses intent and performs checks; it is not a permission boundary. Delegated engines may write, and the plugin does not supply a filesystem sandbox. | Only after a separately reviewed security-boundary change with adversarial tests and updated security documentation. |
+| Treating self-authored fixtures as independent visibility evidence | Reject | Fixtures can test evaluator behavior but cannot establish what an external search or assistant returned. Optimizing the fixture would optimize the measurement rather than discoverability. | Never; use dated captures with explicit provenance instead. |
+| Converting one surface-specific observation into a visibility rate, trend, or causal SEO/AEO/GEO claim | Reject | Search surfaces can disagree sharply, and a six-query capture cannot support population-level or causal conclusions. | A predeclared, repeated, multi-surface design with sufficient independent observations supports the claimed inference. |
+| Publishing transient competitor rankings or weaknesses as permanent project copy | Reject | Competitor state and result ordering decay quickly; permanent prose would become stale and incentives would shift toward comparison theater. | A dated measurement needs a factual update in a dated record, not evergreen promotional copy. |
+| Adding runtime features solely to improve discoverability | Reject | Discoverability does not justify expanding product behavior, permissions, dependencies, privacy exposure, or release risk. | A separate product need is accepted on its own merits in a separate issue and PR. |
+| Automatically treating benchmark success, mentions, citations, stars, or checklist completion as product quality | Reject | These are proxies and can improve while correctness, safety, or usefulness does not. | Never without direct claim-evidence and behavior verification. |
+
+## Deferred tactics
+
+| Tactic | Current decision | Why deferred | Activation gate |
+|---|---|---|---|
+| Repository-owned `robots.txt` for the GitHub Pages project site | Defer | Robots rules are read from the hosted origin root. This repository publishes under `/agy-plugin-cc/` and cannot establish an origin-root policy by adding `site/robots.txt` at the project path. It is also not a security control. | Control of `https://arcobaleno64.github.io/robots.txt`, or migration to an origin whose root this repository controls. |
+| Machine-readable files before a canonical site exists | Defer until the site exists | `sitemap.xml`, structured data, and `llms.txt` need a live canonical target and factual visible evidence; publishing them first creates unsupported or stale declarations. | A canonical page is live, its metadata is verified, and every machine-readable claim is traceable to visible or authoritative content. |
+| Broad third-party directory expansion | Defer | Directory presence is useful only when the listing is maintained, canonical, and accurately scoped. More listings also create more stale surfaces to audit. | A relevant directory has a verified audience, permits accurate independent-project wording, and has an owner and update path. |
+
+The second row is a sequencing rule, not a claim that these files remain deferred: the canonical site now exists and the repository has separately verified its sitemap, factual SoftwareApplication JSON-LD, and curated `llms.txt`.
+
+## Evidence discipline
+
+- Preserve negative and neutral observations, not only favorable ones.
+- Record query text, date, surface, result URLs, subject/evaluator commits, and hashes where the capture format supports them.
+- Label self-attested captures as self-attested.
+- Keep dated records immutable; select a newer active capture instead of rewriting history.
+- Require human review for semantic claim support and safety/capability conclusions.
+- Treat cross-surface disagreement as a boundary on the conclusion, not as noise to discard.
+- Keep Issue #121 open until its remaining work and the final methodology are independently verified.

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,7 @@ Start with the [README](../README.md). Nothing here is required reading to use t
 | [`version-sources.md`](version-sources.md) | Which file is authoritative for each version string, and what keeps them in lockstep. |
 | [`verifying-without-credentials.md`](verifying-without-credentials.md) | How to exercise the engine paths without a Gemini or AGY account. |
 | [`evidence.md`](evidence.md) | The rule this repository investigates by: nothing counts as evidence until it has been seen to fail. Includes the traps already paid for. |
+| [`DISCOVERABILITY-DECISIONS.md`](DISCOVERABILITY-DECISIONS.md) | Rejected and deferred discoverability tactics, the evidence-based reason for each decision, and the condition required to revisit it. |
 | [`ROADMAP.md`](ROADMAP.md) | Every item in the handover playbook, triaged against HEAD: already done, premise verified and worth doing, blocked on something that does not exist, wrong as written, or a non-goal. Read this before acting on the playbook. Traditional Chinese. |
 
 ## Dated records — never rewritten

--- a/docs/README.zh-TW.md
+++ b/docs/README.zh-TW.md
@@ -20,6 +20,7 @@ English: [`README.md`](README.md)
 | [`version-sources.md`](version-sources.md) | 每個版本字串以哪個檔案為準，以及靠什麼維持一致。 |
 | [`verifying-without-credentials.md`](verifying-without-credentials.md) | 沒有 Gemini 或 AGY 帳號時，如何演練引擎路徑。 |
 | [`evidence.md`](evidence.md) | 本 repo 的調查規則：沒看過它紅過的東西，不算證據。附已經付過學費的陷阱清單。 |
+| [`DISCOVERABILITY-DECISIONS.md`](DISCOVERABILITY-DECISIONS.md) | 被拒絕或延後的可見度策略、每項決策的證據理由，以及允許重新評估的條件。 |
 | [`ROADMAP.md`](ROADMAP.md) | 交接手冊裡的每一項，對 HEAD 逐項分類：已經做掉、前提成立該做、前置條件不存在、內容有錯、不做。動手之前先讀這份。 |
 
 ## 有日期的記錄——永不重寫


### PR DESCRIPTION
## Summary

- add a current decision record for discoverability tactics that Issue #121 rejects or defers
- record the evidence-based reason and explicit revisit condition for each tactic
- distinguish rejected tactics from sequencing constraints that have since been satisfied
- index the reference from both documentation indexes

## Boundaries

This PR changes documentation only. It does not change runtime behavior, benchmark queries or evaluator semantics, captures, website content, repository metadata, workflows, versions, releases, security, or privacy behavior.

The document does not claim ranking improvement, visibility rate, crawler adoption, or causal SEO/AEO/GEO impact. It keeps `robots.txt` deferred because a GitHub Pages project repository does not control the hosted origin root.

## Verification

- exact changed-path review
- `node --test tests/privacy-doc.test.mjs tests/contract.test.mjs`
- `npm test`
- `npm run verify-contracts`
- `npm run check-version`
- `npm run bench:aeo`
- `git diff --check`

Issue #121 remains open. Its “Document rejected tactics” item must remain unchecked until this PR is independently reviewed and merged.